### PR TITLE
Add optional month-row hover expansion in Month view

### DIFF
--- a/src/core/configSchema.js
+++ b/src/core/configSchema.js
@@ -23,6 +23,7 @@ export const DEFAULT_CONFIG = {
     dayStart:     6,        // hour (0-23)
     dayEnd:       22,       // hour (0-23)
     showWeekNumbers: false,
+    enlargeMonthRowOnHover: false,
   },
 
   // Access control

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -108,6 +108,8 @@ export interface DisplayConfig {
   /** Last visible hour in week/day views (1–24). Default 22. */
   dayEnd?: number;
   showWeekNumbers?: boolean;
+  /** Month view: animate a hovered week row to 150% height for easier reading. */
+  enlargeMonthRowOnHover?: boolean;
 }
 
 export interface CalendarConfig {

--- a/src/ui/ConfigPanel.jsx
+++ b/src/ui/ConfigPanel.jsx
@@ -210,6 +210,15 @@ function DisplayTab({ config, onUpdate }) {
           onChange={e => set('showWeekNumbers', e.target.checked)} />
         <span className={styles.toggleTrack} />
       </label>
+      <label className={styles.toggle}>
+        <span>Enlarge month row on hover</span>
+        <input
+          type="checkbox"
+          checked={!!d.enlargeMonthRowOnHover}
+          onChange={e => set('enlargeMonthRowOnHover', e.target.checked)}
+        />
+        <span className={styles.toggleTrack} />
+      </label>
     </div>
   );
 }

--- a/src/views/MonthView.jsx
+++ b/src/views/MonthView.jsx
@@ -21,6 +21,7 @@ export default function MonthView({
   config, weekStartDay = 0,
 }) {
   const [popoverDay,  setPopoverDay]  = useState(null);
+  const [hoveredWeekIdx, setHoveredWeekIdx] = useState(null);
   // Keyboard-focused day cell (roving tabindex pattern).
   const [focusedDay,  setFocusedDay]  = useState(() => startOfDay(currentDate));
   const gridRef = useRef(null);
@@ -143,9 +144,10 @@ export default function MonthView({
   }, [singleDay]);
 
   const showWeekNumbers = config?.display?.showWeekNumbers;
+  const enlargeMonthRowOnHover = !!config?.display?.enlargeMonthRowOnHover;
 
   // ── Renderers ─────────────────────────────────────────────────────────────
-  function renderPill(ev, extra = {}) {
+  function renderPill(ev, extra = {}, weekIdx = null) {
     const color       = resolveColor(ev, ctx?.colorRules);
     const onClick     = () => { onEventClick?.(ev); extra.onAfterClick?.(); };
     const isDimmed    = dragRef.current?.ev?.id === ev.id && dragTarget !== null;
@@ -163,6 +165,12 @@ export default function MonthView({
             onClick={e => { e.stopPropagation(); onClick(); }}
             onKeyDown={e => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); e.stopPropagation(); onClick(); } }}
             onPointerDown={e => startPillDrag(ev, e)}
+            onMouseEnter={() => {
+              if (enlargeMonthRowOnHover && weekIdx != null) setHoveredWeekIdx(weekIdx);
+            }}
+            onMouseLeave={() => {
+              if (enlargeMonthRowOnHover) setHoveredWeekIdx(prev => (prev === weekIdx ? null : prev));
+            }}
           >
             {custom}
           </div>
@@ -181,6 +189,12 @@ export default function MonthView({
         style={{ '--ev-color': color }}
         onClick={e => { e.stopPropagation(); onClick(); }}
         onPointerDown={e => startPillDrag(ev, e)}
+        onMouseEnter={() => {
+          if (enlargeMonthRowOnHover && weekIdx != null) setHoveredWeekIdx(weekIdx);
+        }}
+        onMouseLeave={() => {
+          if (enlargeMonthRowOnHover) setHoveredWeekIdx(prev => (prev === weekIdx ? null : prev));
+        }}
         aria-label={ariaLabel}
       >
         {ev.title}
@@ -235,7 +249,13 @@ export default function MonthView({
           const spansHeight = Math.min(laneCount, MAX_SPANS_VISIBLE) * (SPAN_H + SPAN_GAP);
 
           return (
-            <div key={wi} className={styles.weekRow}>
+            <div
+              key={wi}
+              className={[
+                styles.weekRow,
+                enlargeMonthRowOnHover && hoveredWeekIdx === wi && styles.weekRowHovered,
+              ].filter(Boolean).join(' ')}
+            >
               {showWeekNumbers && (
                 <div className={styles.weekNum}>{getISOWeek(week[0])}</div>
               )}
@@ -272,6 +292,12 @@ export default function MonthView({
                             }}
                             onClick={e => { e.stopPropagation(); onEventClick?.(ev); }}
                             onPointerDown={e => startPillDrag(ev, e)}
+                            onMouseEnter={() => {
+                              if (enlargeMonthRowOnHover) setHoveredWeekIdx(wi);
+                            }}
+                            onMouseLeave={() => {
+                              if (enlargeMonthRowOnHover) setHoveredWeekIdx(prev => (prev === wi ? null : prev));
+                            }}
                             aria-label={`${ev.title}${ev.category ? `, ${ev.category}` : ''}${continuesBefore ? ', continues from previous week' : ''}${continuesAfter ? ', continues next week' : ''}`}
                           >
                             {!continuesBefore && ev.title}
@@ -326,7 +352,7 @@ export default function MonthView({
                         <span className={styles.dayNum}>{format(day, 'd')}</span>
 
                         <div className={styles.events}>
-                          {daySingles.slice(0, MAX_PILLS).map(ev => renderPill(ev))}
+                          {daySingles.slice(0, MAX_PILLS).map(ev => renderPill(ev, {}, wi))}
                           {isDropTarget && renderGhostPill()}
                           {overflowCount > 0 && (
                             <button
@@ -351,7 +377,7 @@ export default function MonthView({
                               <button onClick={() => setPopoverDay(null)}>×</button>
                             </div>
                             {[...spansOnDay.map(s => s.ev), ...daySingles].map(ev =>
-                              renderPill(ev, { onAfterClick: () => setPopoverDay(null) }),
+                              renderPill(ev, { onAfterClick: () => setPopoverDay(null) }, wi),
                             )}
                           </div>
                         )}

--- a/src/views/MonthView.module.css
+++ b/src/views/MonthView.module.css
@@ -37,8 +37,13 @@
   flex: 1;
   min-height: 100px;
   border-bottom: 1px solid var(--wc-border);
+  transition: flex 0.2s ease, min-height 0.2s ease;
 }
 .weekRow:last-child { border-bottom: none; }
+.weekRowHovered {
+  flex: 1.5;
+  min-height: 150px;
+}
 
 .weekNum {
   display: flex;
@@ -240,6 +245,7 @@
 
 @media (max-width: 768px) {
   .weekRow { min-height: 72px; }
+  .weekRowHovered { min-height: 108px; }
   .cell { padding: 2px; }
   .dayNum { width: 22px; height: 22px; font-size: 11px; }
   .eventPill { font-size: 10px; padding: 1px 4px; }
@@ -250,6 +256,7 @@
 
 @media (max-width: 480px) {
   .weekRow { min-height: 56px; }
+  .weekRowHovered { min-height: 84px; }
   .cell { padding: 2px 1px; }
   .dayName { font-size: 9px; letter-spacing: 0; }
   .dayNum  { width: 20px; height: 20px; font-size: 10px; margin-bottom: 1px; }


### PR DESCRIPTION
### Motivation
- Provide an opt-in way to make a week row in Month view easier to read by enlarging the row when hovering event pills/span bars. 
- Keep the change opt-in so existing layouts are not altered by default.

### Description
- Add a new display config `enlargeMonthRowOnHover` (default `false`) to `DEFAULT_CONFIG` and `DisplayConfig` to expose the option programmatically. 
- Add a UI toggle in Calendar Settings → Display (`ConfigPanel.jsx`) to let owners enable `Enlarge month row on hover`. 
- Implement hover tracking in `MonthView.jsx` and attach `onMouseEnter`/`onMouseLeave` handlers to both span bars and single-day pills (including custom-rendered pills) to set a `hoveredWeekIdx` and pass week index into `renderPill`. 
- Add CSS `weekRowHovered` styles with a smooth transition to animate the hovered week row to ~150% height and responsive smaller variants in `MonthView.module.css`.

### Testing
- Ran the accessibility/unit test file via `npm test -- src/ui/__tests__/a11y.test.jsx` and all tests passed. 
- Ran a production build via `npm run build` and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d9aef2b5e4832c80759a0597c55f6b)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new "Enlarge month row on hover" display setting in the Display preferences panel. When enabled, hovering over a week row in the month view will smoothly enlarge that row, bringing it into focus. The enhancement includes responsive sizing adjustments tailored to different screen sizes, from mobile devices to desktop.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->