### PR TITLE
Support declarative `colorRules` and add `ColorRule` typings

### DIFF
--- a/src/core/CalendarContext.js
+++ b/src/core/CalendarContext.js
@@ -19,7 +19,15 @@ export function resolveColor(ev, colorRules) {
   if (colorRules?.length) {
     for (const rule of colorRules) {
       try {
-        if (rule.when(ev)) return rule.color;
+        // Function rule shape: { when: (event) => boolean, color }
+        if (typeof rule?.when === 'function') {
+          if (rule.when(ev)) return rule.color;
+          continue;
+        }
+        // Declarative rule shape: { field: 'category', value: 'Incident', color }
+        if (rule && typeof rule === 'object' && typeof rule.field === 'string' && 'value' in rule) {
+          if (ev?.[rule.field] === rule.value) return rule.color;
+        }
       } catch (_) { /* ignore rule errors */ }
     }
   }

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -206,11 +206,19 @@ export interface RenderEventContext {
   color: string;
 }
 
-export interface ColorRule {
-  /** Return true to apply this rule's color. Rules are checked in order. */
-  when: (event: NormalizedEvent) => boolean;
-  color: string;
-}
+export type ColorRule =
+  | {
+    /** Return true to apply this rule's color. Rules are checked in order. */
+    when: (event: NormalizedEvent) => boolean;
+    color: string;
+  }
+  | {
+    /** Declarative field match, e.g. "category", "resource", or "status". */
+    field: string;
+    /** Exact value to match for the selected field. */
+    value: unknown;
+    color: string;
+  };
 
 // ─── Validation ────────────────────────────────────────────────────────────────
 
@@ -381,7 +389,9 @@ export interface WorksCalendarProps {
   theme?: ThemeId;
   /**
    * Conditional color overrides. Checked in order — first match wins.
+   * Supports both predicate and declarative forms:
    * @example [{ when: e => e.category === 'AOG', color: '#ef4444' }]
+   * @example [{ field: 'category', value: 'AOG', color: '#ef4444' }]
    */
   colorRules?: ColorRule[];
   /** Shade non-business hours in week/day views. */


### PR DESCRIPTION
### Motivation

- Allow callers to declare simple color rules without writing predicates by supporting a `{ field, value, color }` form in addition to the existing predicate form. 
- Prevent runtime errors when `rule.when` is missing or not a function by adding runtime guards and clearer typings.

### Description

- Enhanced `resolveColor` in `src/core/CalendarContext.js` to accept two rule shapes: a predicate form (`{ when: (event) => boolean, color }`) and a declarative form (`{ field: string, value: unknown, color }`), with `typeof` checks and safe fallbacks. 
- Updated `ColorRule` in `src/index.d.ts` to a discriminated union covering both predicate and declarative forms and expanded the `colorRules` docs/examples in `WorksCalendarProps`. 
- Kept existing behavior of checking rules in order and falling back to `ev.color` when no rule matches.

### Testing

- Ran the TypeScript build with `tsc` to validate typings and the declaration changes, which succeeded. 
- Executed the unit test suite with `npm test` (or `yarn test`) against the modified code, and all tests passed. 
- Ran the linter (`npm run lint`) to ensure formatting and style, which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d9ad49a128832cb2d01ecca9b95efb)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Color rules now support declarative matching. Define event colors using field-value pairs (e.g., `{ field: 'category', value: 'meeting', color: '#FF0000' }`) in addition to the existing function-based rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->