### PR TITLE
Fix npm ci lockfile sync failure by enabling legacy peer deps

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+legacy-peer-deps=true


### PR DESCRIPTION
### Motivation
- `npm ci` was failing due to peer/optional peer dependency resolution differences between the lockfile and current dependency graph, causing CI/install to abort.

### Description
- Add a repository `.npmrc` with `legacy-peer-deps=true` so `npm ci` uses legacy peer dependency resolution and avoids lockfile sync failures (`.npmrc` added at project root).

### Testing
- Ran `npm ci --dry-run` and `npm install --package-lock-only --ignore-scripts`, both completed successfully, and verified `npm ci --dry-run` again after the change; a full `npm ci` was attempted but did not finish within the allotted timeout.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc011d5760832cad548e0c80bed7dd)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated npm configuration to enable legacy peer dependency resolution, ensuring improved compatibility with project dependencies during installation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->