### PR TITLE
Fix hover card cross-day time range formatting

### DIFF
--- a/src/ui/HoverCard.jsx
+++ b/src/ui/HoverCard.jsx
@@ -1,5 +1,5 @@
 import { useState, useRef, useEffect } from 'react';
-import { format } from 'date-fns';
+import { format, isSameDay } from 'date-fns';
 import { X, Clock, Tag, Anchor, FileText, StickyNote, Pencil } from 'lucide-react';
 import { useFocusTrap } from '../hooks/useFocusTrap.js';
 import styles from './HoverCard.module.css';
@@ -24,6 +24,12 @@ export default function HoverCard({ event, config, note, onClose, onNoteSave, on
     onNoteSave?.({ eventId: event.id, body: noteText });
     setEditing(false);
   }
+
+  const timeRangeText = event.allDay
+    ? 'All day'
+    : isSameDay(event.start, event.end)
+      ? `${format(event.start, 'MMM d, h:mm a')} – ${format(event.end, 'h:mm a')}`
+      : `${format(event.start, 'MMM d, h:mm a')} – ${format(event.end, 'MMM d, h:mm a')}`;
 
   return (
     <div ref={(node) => { cardRef.current = node; trapRef.current = node; }} className={styles.card} role="dialog" aria-modal="true" aria-label={`Event details: ${event.title}`}>
@@ -51,11 +57,7 @@ export default function HoverCard({ event, config, note, onClose, onNoteSave, on
         {hc.showTime !== false && (
           <div className={styles.field}>
             <Clock size={13} className={styles.icon} />
-            <span>
-              {event.allDay
-                ? 'All day'
-                : `${format(event.start, 'MMM d, h:mm a')} – ${format(event.end, 'h:mm a')}`}
-            </span>
+            <span>{timeRangeText}</span>
           </div>
         )}
 


### PR DESCRIPTION
### Motivation
- Fix a bug where the hover card for timed events that cross midnight showed the start date but only the end time (dropping the end date), which caused the cross-day range regression to fail.

### Description
- Import `isSameDay` from `date-fns` and compute a `timeRangeText` value that renders `All day` for all-day events, `MMM d, h:mm a – h:mm a` for same-day timed events, and `MMM d, h:mm a – MMM d, h:mm a` when the start and end are on different days, and use `timeRangeText` in the time field in `HoverCard`.

### Testing
- Attempted `npx playwright test tests-e2e/calendar.regressions.spec.ts --grep "hover card shows the full cross-day range"`, which could not complete because Playwright browser binaries are not installed, and ran `npm test -- src/ui/__tests__/a11y.test.jsx`, which failed in this environment due to a missing `@testing-library/dom` dependency, so no passing automated test results are available here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc25519300832c828b7158a309b162)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined time display formatting in hover cards for clearer presentation of all-day events and improved date handling for events spanning multiple days.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->