### PR TITLE
Fix month-view multi-day pill width overflow

### DIFF
--- a/src/views/MonthView.module.css
+++ b/src/views/MonthView.module.css
@@ -92,12 +92,7 @@
   box-sizing: border-box;
   z-index: 2;
   transition: filter 0.1s;
-  /* Inset 2px from left/right so adjacent spans have a gap at boundaries */
-  margin-left: 2px;
-  width: calc(100% - 4px) !important; /* overridden by inline width */
 }
-/* Use CSS custom property width trick to respect margin */
-.spanBar { margin-left: 0; }
 .spanBar:hover { filter: brightness(1.1); }
 .spanBar.continuesBefore {
   border-top-left-radius: 0;


### PR DESCRIPTION
### Motivation
- Multi-day span bars in the month view were being forced to full-row width by a CSS override, causing on-call/red pills to visually overflow week boundaries instead of matching the inline-calculated day span.

### Description
- Removed the accidental `width: calc(100% - 4px) !important` and the related margin workaround from `.spanBar` in `src/views/MonthView.module.css` so the inline `width` produced by the layout math (`startCol`/`endCol`) controls visual span length.

### Testing
- Ran `npm run test:browser -- tests-e2e/calendar.pill-rendering.spec.ts`, which could not complete because Playwright browser binaries are not installed in this environment (`npx playwright install` required), so the visual e2e assertion was not executed.
- Ran `npm test` (Vitest), which failed in this environment due to unrelated local test/runtime issues (missing `@testing-library/dom` and local connection refusals), so no full test-suite validation could be performed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc2d8abed8832c9f64112ad6690d58)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed span bar spacing and sizing in month view for improved visual consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->