### PR TITLE
Fix month-view pills rendering above day number

### DIFF
--- a/src/views/MonthView.module.css
+++ b/src/views/MonthView.module.css
@@ -125,6 +125,9 @@
   flex: 1;
   min-width: 0;
   position: relative;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
   padding: 4px 4px 2px;
   border-right: 1px solid var(--wc-border);
   cursor: pointer;
@@ -158,6 +161,8 @@
   display: flex;
   flex-direction: column;
   gap: 2px;
+  width: 100%;
+  margin-top: 2px;
 }
 
 .eventPill {


### PR DESCRIPTION
### Motivation
- Ensure day-cell event pills render below the date badge so on-call and other pills do not overlap the day number.

### Description
- Update `src/views/MonthView.module.css` to make `.cell` a column flex container and set `.events` to `width: 100%` with `margin-top: 2px` so pills always stack beneath the date number.

### Testing
- Ran `npm test`, which reported failures in this environment due to missing `@testing-library/dom`, Playwright import mismatches, and `ECONNREFUSED` to `localhost:3000`, and these failures are unrelated to this CSS-only fix.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc2f7c8670832cb5203a1226b0298b)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined month view calendar layout with improved event positioning and spacing within day cells, enhancing overall visual clarity and usability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->