### PR TITLE
Layer month-spanning event bars above day cells and reserve vertical space

### DIFF
--- a/src/views/MonthView.jsx
+++ b/src/views/MonthView.jsx
@@ -11,6 +11,7 @@ import styles from './MonthView.module.css';
 const SPAN_H   = 22;
 const SPAN_GAP = 3;
 const MAX_SPANS_VISIBLE = 3;
+const DAY_NUM_TRACK_H = 32;
 
 function isMultiDay(ev) {
   return ev.allDay || !isSameDay(ev.start, ev.end);
@@ -268,59 +269,13 @@ export default function MonthView({
               )}
 
               <div className={styles.daysArea}>
-                {/* ── Spanning event bars ── */}
-                {laneCount > 0 && (
-                  <div className={styles.spansLayer} style={{ height: spansHeight }}>
-                    {spans
-                      .filter(s => s.lane < MAX_SPANS_VISIBLE)
-                      .map(({ ev, startCol, endCol, lane, continuesBefore, continuesAfter }) => {
-                        const color = resolveColor(ev, ctx?.colorRules);
-                        const pctLeft  = (startCol / 7) * 100;
-                        const pctWidth = ((endCol - startCol + 1) / 7) * 100;
-                        const statusClass = ev.status === 'cancelled' ? styles.cancelled
-                          : ev.status === 'tentative' ? styles.tentative : '';
-                        const isDimmed = dragRef.current?.ev?.id === ev.id && dragTarget !== null;
-                        return (
-                          <button
-                            key={`${ev.id}-w${wi}`}
-                            className={[
-                              styles.spanBar,
-                              continuesBefore && styles.continuesBefore,
-                              continuesAfter  && styles.continuesAfter,
-                              statusClass,
-                              isDimmed && styles.dragging,
-                            ].filter(Boolean).join(' ')}
-                            style={{
-                              '--ev-color': color,
-                              left:   `${pctLeft}%`,
-                              width:  `${pctWidth}%`,
-                              top:    lane * (SPAN_H + SPAN_GAP),
-                              height: SPAN_H,
-                            }}
-                            onClick={e => { e.stopPropagation(); onEventClick?.(ev); }}
-                            onPointerDown={e => startPillDrag(ev, e)}
-                            onMouseEnter={(e) => {
-                              if (enlargeMonthRowOnHover) setHoveredWeekIdx(wi);
-                              if (pillHoverTitle) {
-                                const r = e.currentTarget.getBoundingClientRect();
-                                setTitleHover({ title: ev.title, color, x: r.left + r.width / 2, y: r.top });
-                              }
-                            }}
-                            onMouseLeave={() => {
-                              if (enlargeMonthRowOnHover) setHoveredWeekIdx(prev => (prev === wi ? null : prev));
-                              if (pillHoverTitle) setTitleHover(null);
-                            }}
-                            aria-label={`${ev.title}${ev.category ? `, ${ev.category}` : ''}${continuesBefore ? ', continues from previous week' : ''}${continuesAfter ? ', continues next week' : ''}`}
-                          >
-                            {!continuesBefore && ev.title}
-                          </button>
-                        );
-                      })}
-                  </div>
-                )}
-
                 {/* ── Day cells ── */}
-                <div className={styles.weekCells} role="row" aria-rowindex={wi + 2}>
+                <div
+                  className={styles.weekCells}
+                  role="row"
+                  aria-rowindex={wi + 2}
+                  style={{ '--week-span-height': `${spansHeight}px` }}
+                >
                   {week.map((day, di) => {
                     const dayKey     = format(day, 'yyyy-MM-dd');
                     const daySingles = singleByDay.get(dayKey) || [];
@@ -397,6 +352,57 @@ export default function MonthView({
                     );
                   })}
                 </div>
+
+                {/* ── Spanning event bars ── */}
+                {laneCount > 0 && (
+                  <div className={styles.spansLayer} style={{ top: DAY_NUM_TRACK_H, height: spansHeight }}>
+                    {spans
+                      .filter(s => s.lane < MAX_SPANS_VISIBLE)
+                      .map(({ ev, startCol, endCol, lane, continuesBefore, continuesAfter }) => {
+                        const color = resolveColor(ev, ctx?.colorRules);
+                        const pctLeft  = (startCol / 7) * 100;
+                        const pctWidth = ((endCol - startCol + 1) / 7) * 100;
+                        const statusClass = ev.status === 'cancelled' ? styles.cancelled
+                          : ev.status === 'tentative' ? styles.tentative : '';
+                        const isDimmed = dragRef.current?.ev?.id === ev.id && dragTarget !== null;
+                        return (
+                          <button
+                            key={`${ev.id}-w${wi}`}
+                            className={[
+                              styles.spanBar,
+                              continuesBefore && styles.continuesBefore,
+                              continuesAfter  && styles.continuesAfter,
+                              statusClass,
+                              isDimmed && styles.dragging,
+                            ].filter(Boolean).join(' ')}
+                            style={{
+                              '--ev-color': color,
+                              left:   `${pctLeft}%`,
+                              width:  `${pctWidth}%`,
+                              top:    lane * (SPAN_H + SPAN_GAP),
+                              height: SPAN_H,
+                            }}
+                            onClick={e => { e.stopPropagation(); onEventClick?.(ev); }}
+                            onPointerDown={e => startPillDrag(ev, e)}
+                            onMouseEnter={(e) => {
+                              if (enlargeMonthRowOnHover) setHoveredWeekIdx(wi);
+                              if (pillHoverTitle) {
+                                const r = e.currentTarget.getBoundingClientRect();
+                                setTitleHover({ title: ev.title, color, x: r.left + r.width / 2, y: r.top });
+                              }
+                            }}
+                            onMouseLeave={() => {
+                              if (enlargeMonthRowOnHover) setHoveredWeekIdx(prev => (prev === wi ? null : prev));
+                              if (pillHoverTitle) setTitleHover(null);
+                            }}
+                            aria-label={`${ev.title}${ev.category ? `, ${ev.category}` : ''}${continuesBefore ? ', continues from previous week' : ''}${continuesAfter ? ', continues next week' : ''}`}
+                          >
+                            {!continuesBefore && ev.title}
+                          </button>
+                        );
+                      })}
+                  </div>
+                )}
               </div>
             </div>
           );

--- a/src/views/MonthView.module.css
+++ b/src/views/MonthView.module.css
@@ -68,10 +68,12 @@
 
 /* ── Spanning event bars ── */
 .spansLayer {
-  position: relative;
+  position: absolute;
+  left: 0;
+  right: 0;
   width: 100%;
-  flex-shrink: 0;
   overflow: hidden;
+  z-index: 2;
 }
 
 .spanBar {
@@ -118,13 +120,16 @@
 .weekCells {
   display: flex;
   flex: 1;
-  /* padding-top set inline to reserve space for span bars */
+  position: relative;
 }
 
 .cell {
   flex: 1;
   min-width: 0;
   position: relative;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
   padding: 4px 4px 2px;
   border-right: 1px solid var(--wc-border);
   cursor: pointer;
@@ -158,6 +163,8 @@
   display: flex;
   flex-direction: column;
   gap: 2px;
+  width: 100%;
+  margin-top: calc(var(--week-span-height, 0px) + 2px);
 }
 
 .eventPill {


### PR DESCRIPTION
### Motivation

- Prevent spanning multi-day event bars from overlapping the day number and single-day pills by reserving vertical space and layering the spans above the cell content.

### Description

- Introduce `DAY_NUM_TRACK_H` and move the spanning bars markup below the day cells so the span layer can be absolutely positioned and layered on top of cells. 
- Expose the computed spans height to the cell stack via an inline CSS variable `--week-span-height` on the `weekCells` container and apply that offset to the single-day `.events` area using `margin-top: calc(var(--week-span-height, 0px) + 2px)`. 
- Update markup to set `style={{ top: DAY_NUM_TRACK_H, height: spansHeight }}` on `.spansLayer` and adjust event bar rendering to remain unchanged functionally. 
- Adjust CSS: make `.spansLayer` `position: absolute` with full-width `left/right`, add `z-index`, make `.weekCells` `position: relative`, and convert `.cell` to a column flex layout so the day number and event stack align correctly.

### Testing

- Ran the project test suite with `yarn test` and linting with `yarn lint`, and both completed successfully.
- Verified the change builds and the month view layout adjustments rendered without runtime errors in the dev environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc2f7c8670832cb5203a1226b0298b)