### PR TITLE
MonthView: position spanning event bars under day numbers, sort single-day events, and adjust pill layout

### DIFF
--- a/src/views/MonthView.jsx
+++ b/src/views/MonthView.jsx
@@ -11,6 +11,7 @@ import styles from './MonthView.module.css';
 const SPAN_H   = 22;
 const SPAN_GAP = 3;
 const MAX_SPANS_VISIBLE = 3;
+const DAY_NUM_TRACK_H = 32;
 
 function isMultiDay(ev) {
   return ev.allDay || !isSameDay(ev.start, ev.end);
@@ -142,6 +143,17 @@ export default function MonthView({
       if (!map.has(key)) map.set(key, []);
       map.get(key).push(ev);
     });
+
+    map.forEach((dayEvents, key) => {
+      dayEvents.sort((a, b) => {
+        if (a.allDay !== b.allDay) return a.allDay ? -1 : 1;
+        const startDiff = a.start.getTime() - b.start.getTime();
+        if (startDiff !== 0) return startDiff;
+        return a.title.localeCompare(b.title);
+      });
+      map.set(key, dayEvents);
+    });
+
     return map;
   }, [singleDay]);
 
@@ -268,59 +280,13 @@ export default function MonthView({
               )}
 
               <div className={styles.daysArea}>
-                {/* ── Spanning event bars ── */}
-                {laneCount > 0 && (
-                  <div className={styles.spansLayer} style={{ height: spansHeight }}>
-                    {spans
-                      .filter(s => s.lane < MAX_SPANS_VISIBLE)
-                      .map(({ ev, startCol, endCol, lane, continuesBefore, continuesAfter }) => {
-                        const color = resolveColor(ev, ctx?.colorRules);
-                        const pctLeft  = (startCol / 7) * 100;
-                        const pctWidth = ((endCol - startCol + 1) / 7) * 100;
-                        const statusClass = ev.status === 'cancelled' ? styles.cancelled
-                          : ev.status === 'tentative' ? styles.tentative : '';
-                        const isDimmed = dragRef.current?.ev?.id === ev.id && dragTarget !== null;
-                        return (
-                          <button
-                            key={`${ev.id}-w${wi}`}
-                            className={[
-                              styles.spanBar,
-                              continuesBefore && styles.continuesBefore,
-                              continuesAfter  && styles.continuesAfter,
-                              statusClass,
-                              isDimmed && styles.dragging,
-                            ].filter(Boolean).join(' ')}
-                            style={{
-                              '--ev-color': color,
-                              left:   `${pctLeft}%`,
-                              width:  `${pctWidth}%`,
-                              top:    lane * (SPAN_H + SPAN_GAP),
-                              height: SPAN_H,
-                            }}
-                            onClick={e => { e.stopPropagation(); onEventClick?.(ev); }}
-                            onPointerDown={e => startPillDrag(ev, e)}
-                            onMouseEnter={(e) => {
-                              if (enlargeMonthRowOnHover) setHoveredWeekIdx(wi);
-                              if (pillHoverTitle) {
-                                const r = e.currentTarget.getBoundingClientRect();
-                                setTitleHover({ title: ev.title, color, x: r.left + r.width / 2, y: r.top });
-                              }
-                            }}
-                            onMouseLeave={() => {
-                              if (enlargeMonthRowOnHover) setHoveredWeekIdx(prev => (prev === wi ? null : prev));
-                              if (pillHoverTitle) setTitleHover(null);
-                            }}
-                            aria-label={`${ev.title}${ev.category ? `, ${ev.category}` : ''}${continuesBefore ? ', continues from previous week' : ''}${continuesAfter ? ', continues next week' : ''}`}
-                          >
-                            {!continuesBefore && ev.title}
-                          </button>
-                        );
-                      })}
-                  </div>
-                )}
-
                 {/* ── Day cells ── */}
-                <div className={styles.weekCells} role="row" aria-rowindex={wi + 2}>
+                <div
+                  className={styles.weekCells}
+                  role="row"
+                  aria-rowindex={wi + 2}
+                  style={{ '--week-span-height': `${spansHeight}px` }}
+                >
                   {week.map((day, di) => {
                     const dayKey     = format(day, 'yyyy-MM-dd');
                     const daySingles = singleByDay.get(dayKey) || [];
@@ -397,6 +363,57 @@ export default function MonthView({
                     );
                   })}
                 </div>
+
+                {/* ── Spanning event bars ── */}
+                {laneCount > 0 && (
+                  <div className={styles.spansLayer} style={{ top: DAY_NUM_TRACK_H, height: spansHeight }}>
+                    {spans
+                      .filter(s => s.lane < MAX_SPANS_VISIBLE)
+                      .map(({ ev, startCol, endCol, lane, continuesBefore, continuesAfter }) => {
+                        const color = resolveColor(ev, ctx?.colorRules);
+                        const pctLeft  = (startCol / 7) * 100;
+                        const pctWidth = ((endCol - startCol + 1) / 7) * 100;
+                        const statusClass = ev.status === 'cancelled' ? styles.cancelled
+                          : ev.status === 'tentative' ? styles.tentative : '';
+                        const isDimmed = dragRef.current?.ev?.id === ev.id && dragTarget !== null;
+                        return (
+                          <button
+                            key={`${ev.id}-w${wi}`}
+                            className={[
+                              styles.spanBar,
+                              continuesBefore && styles.continuesBefore,
+                              continuesAfter  && styles.continuesAfter,
+                              statusClass,
+                              isDimmed && styles.dragging,
+                            ].filter(Boolean).join(' ')}
+                            style={{
+                              '--ev-color': color,
+                              left:   `${pctLeft}%`,
+                              width:  `${pctWidth}%`,
+                              top:    lane * (SPAN_H + SPAN_GAP),
+                              height: SPAN_H,
+                            }}
+                            onClick={e => { e.stopPropagation(); onEventClick?.(ev); }}
+                            onPointerDown={e => startPillDrag(ev, e)}
+                            onMouseEnter={(e) => {
+                              if (enlargeMonthRowOnHover) setHoveredWeekIdx(wi);
+                              if (pillHoverTitle) {
+                                const r = e.currentTarget.getBoundingClientRect();
+                                setTitleHover({ title: ev.title, color, x: r.left + r.width / 2, y: r.top });
+                              }
+                            }}
+                            onMouseLeave={() => {
+                              if (enlargeMonthRowOnHover) setHoveredWeekIdx(prev => (prev === wi ? null : prev));
+                              if (pillHoverTitle) setTitleHover(null);
+                            }}
+                            aria-label={`${ev.title}${ev.category ? `, ${ev.category}` : ''}${continuesBefore ? ', continues from previous week' : ''}${continuesAfter ? ', continues next week' : ''}`}
+                          >
+                            {!continuesBefore && ev.title}
+                          </button>
+                        );
+                      })}
+                  </div>
+                )}
               </div>
             </div>
           );

--- a/src/views/MonthView.module.css
+++ b/src/views/MonthView.module.css
@@ -1,4 +1,6 @@
 .month {
+  --month-pill-h: 22px;
+  --month-pill-gap: 3px;
   display: flex;
   flex-direction: column;
   height: 100%;
@@ -68,10 +70,12 @@
 
 /* ── Spanning event bars ── */
 .spansLayer {
-  position: relative;
+  position: absolute;
+  left: 0;
+  right: 0;
   width: 100%;
-  flex-shrink: 0;
   overflow: hidden;
+  z-index: 1;
 }
 
 .spanBar {
@@ -90,7 +94,7 @@
   overflow: hidden;
   text-overflow: ellipsis;
   box-sizing: border-box;
-  z-index: 2;
+  z-index: 0;
   transition: filter 0.1s;
 }
 .spanBar:hover { filter: brightness(1.1); }
@@ -118,13 +122,17 @@
 .weekCells {
   display: flex;
   flex: 1;
-  /* padding-top set inline to reserve space for span bars */
+  position: relative;
+  z-index: 2;
 }
 
 .cell {
   flex: 1;
   min-width: 0;
   position: relative;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
   padding: 4px 4px 2px;
   border-right: 1px solid var(--wc-border);
   cursor: pointer;
@@ -142,6 +150,8 @@
 }
 
 .dayNum {
+  position: relative;
+  z-index: 3;
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -155,15 +165,22 @@
 }
 
 .events {
+  position: relative;
+  z-index: 3;
   display: flex;
   flex-direction: column;
-  gap: 2px;
+  gap: var(--month-pill-gap);
+  width: 100%;
+  margin-top: calc(var(--week-span-height, 0px) + 2px);
 }
 
 .eventPill {
-  display: block;
+  display: flex;
+  align-items: center;
   width: 100%;
-  padding: 2px 6px;
+  min-height: var(--month-pill-h);
+  height: var(--month-pill-h);
+  padding: 0 6px;
   border-radius: var(--wc-radius-sm);
   background: var(--ev-color, var(--wc-accent));
   color: #fff;
@@ -184,9 +201,12 @@
 .eventPill.ghost { opacity: 0.5; pointer-events: none; border: 1px dashed rgba(255,255,255,0.6); }
 
 .morePill {
-  display: block;
+  display: flex;
+  align-items: center;
   width: 100%;
-  padding: 2px 6px;
+  min-height: var(--month-pill-h);
+  height: var(--month-pill-h);
+  padding: 0 6px;
   border-radius: var(--wc-radius-sm);
   background: transparent;
   color: var(--wc-text-muted);


### PR DESCRIPTION
### Motivation

- Ensure spanning multi-day event bars render beneath the day number/inline pills and do not overlap the day content by reserving space for them. 
- Provide deterministic order for single-day event pills so visible ordering is consistent across renders. 
- Standardize pill sizing and spacing to improve visual alignment and hover behavior.

### Description

- Introduced `DAY_NUM_TRACK_H` and moved the spans layer to be absolutely positioned below the day number track, and set its `top` to `DAY_NUM_TRACK_H` so spanning bars are visually separated from day content. 
- Added inline `--week-span-height` on `.weekCells` to reserve vertical space and adjusted z-indexes so day numbers and event pills sit above the spans layer. 
- Sorted `singleDay` events per day in `singleByDay` with a comparator that prioritizes `allDay`, then `start` time, then `title`. 
- Updated CSS variables and styles (`--month-pill-h`, `--month-pill-gap`, pill heights, gaps, flex alignment, and `.spansLayer` absolute positioning) to standardize pill sizing, spacing, and stacking order.

### Testing

- Ran `npm test` to execute the unit test suite and all tests passed. 
- Ran `npm run lint` and `npm run build` to validate linting and bundling, both completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc2f7c8670832cb5203a1226b0298b)