### PR TITLE
Fix week view event click behavior and month pill layer stacking

### DIFF
--- a/src/views/MonthView.module.css
+++ b/src/views/MonthView.module.css
@@ -165,7 +165,7 @@
 
 .events {
   position: relative;
-  z-index: 3;
+  z-index: 1;
   display: flex;
   flex-direction: column;
   gap: 2px;

--- a/src/views/WeekView.jsx
+++ b/src/views/WeekView.jsx
@@ -269,7 +269,7 @@ export default function WeekView({
         onPointerDown={e => { if (e.button !== 0 || !ctx?.permissions?.canDrag) return; e.stopPropagation(); drag.startMove(ev, e, gridRef.current, days, GUTTER_W); }}
       >
         <div className={styles.resizeHandleTop}
-          onPointerDown={e => { if (e.button !== 0 || !ctx?.permissions?.canDrag) return; drag.startResizeTop(ev, e, gridRef.current, days, GUTTER_W); }}
+          onPointerDown={e => { if (e.button !== 0 || !ctx?.permissions?.canDrag) return; e.stopPropagation(); drag.startResizeTop(ev, e, gridRef.current, days, GUTTER_W); }}
           aria-hidden="true" />
         {inner ?? (
           <>
@@ -278,7 +278,7 @@ export default function WeekView({
           </>
         )}
         <div className={styles.resizeHandle}
-          onPointerDown={e => { if (e.button !== 0 || !ctx?.permissions?.canDrag) return; drag.startResize(ev, e, gridRef.current, days, GUTTER_W); }}
+          onPointerDown={e => { if (e.button !== 0 || !ctx?.permissions?.canDrag) return; e.stopPropagation(); drag.startResize(ev, e, gridRef.current, days, GUTTER_W); }}
           aria-hidden="true" />
       </div>
     );

--- a/src/views/WeekView.module.css
+++ b/src/views/WeekView.module.css
@@ -311,9 +311,10 @@
 .resizeHandle {
   position: absolute;
   bottom: 0; left: 0; right: 0;
-  height: 8px;
+  height: 5px;
   cursor: ns-resize;
   border-radius: 0 0 var(--wc-radius-sm) var(--wc-radius-sm);
+  z-index: 2;
 }
 .resizeHandle::after {
   content: '';
@@ -329,7 +330,7 @@
 .resizeHandleTop {
   position: absolute;
   top: 0; left: 0; right: 0;
-  height: 8px;
+  height: 5px;
   cursor: ns-resize;
   border-radius: var(--wc-radius-sm) var(--wc-radius-sm) 0 0;
   z-index: 2;
@@ -337,7 +338,7 @@
 .resizeHandleTop::after {
   content: '';
   position: absolute;
-  top: 2px;
+  top: 1px;
   left: 50%;
   transform: translateX(-50%);
   width: 20px; height: 2px;


### PR DESCRIPTION
### Motivation
- Clicking short timed events in Week view didn't reliably open the hover card because pointer interactions on the resize handles could trigger drag logic; multi-day span bars were being visually obscured by single-day pills in Month view.

### Description
- Stop pointer events from bubbling on the week timed-event resize handles so `onPointerDown` on the handles no longer triggers parent drag/move logic, ensuring normal clicks open the hover card (`src/views/WeekView.jsx`).
- Reduce the hitbox height of the top and bottom resize handles in week view from `8px` to `5px` and add `z-index` so the event body has a larger clickable area while resize affordance remains visible (`src/views/WeekView.module.css`).
- Lower the stacking layer of single-day pill container by changing `.events` z-index from `3` to `1` so single-day pills no longer render above multi-day span bars in Month view (`src/views/MonthView.module.css`).

### Testing
- Ran `npm run build`, which completed successfully (Vite production build succeeded).
- Ran `npm test`, which failed in this environment because several test suites attempted to connect to a local server on `localhost:3000` and aborted with `ECONNREFUSED`.
- Attempted `npm test -- --runInBand`, which failed because Vitest in this configuration does not accept the `--runInBand` flag.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc3dbe2224832cb70894d12f68cb22)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed event layering and stacking order in Month view to ensure proper element visibility
  * Improved drag handle behavior in Week view to prevent unintended event propagation during resize operations

* **Style**
  * Refined resize handle appearance with optimized dimensions and visual positioning

<!-- end of auto-generated comment: release notes by coderabbit.ai -->