### PR TITLE
Fix month-view multiday lane collisions and clipped overflow pills

### DIFF
--- a/src/core/__tests__/layout.test.js
+++ b/src/core/__tests__/layout.test.js
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest';
+import { displayEndDay, layoutSpans } from '../layout.js';
+
+function makeEvent(start, end, allDay = false) {
+  return {
+    id: `${start.toISOString()}-${end.toISOString()}-${allDay ? 'all' : 'timed'}`,
+    title: 'ev',
+    start,
+    end,
+    allDay,
+  };
+}
+
+describe('layout span end-day behavior', () => {
+  it('treats timed cross-midnight events ending at 00:00 as exclusive of the boundary day', () => {
+    const ev = makeEvent(
+      new Date('2026-04-13T09:00:00.000Z'),
+      new Date('2026-04-15T00:00:00.000Z'),
+      false,
+    );
+
+    const endDay = displayEndDay(ev);
+    expect(endDay.toISOString()).toBe('2026-04-14T00:00:00.000Z');
+  });
+
+  it('packs back-to-back midnight-ended timed spans into one lane', () => {
+    const weekStart = new Date('2026-04-13T00:00:00.000Z'); // Monday
+    const weekEnd = new Date('2026-04-19T00:00:00.000Z');
+
+    const first = makeEvent(
+      new Date('2026-04-13T09:00:00.000Z'),
+      new Date('2026-04-15T00:00:00.000Z'),
+      false,
+    );
+    const second = makeEvent(
+      new Date('2026-04-15T00:00:00.000Z'),
+      new Date('2026-04-17T00:00:00.000Z'),
+      false,
+    );
+
+    const spans = layoutSpans([first, second], weekStart, weekEnd);
+
+    expect(spans).toHaveLength(2);
+    expect(spans[0].lane).toBe(0);
+    expect(spans[1].lane).toBe(0);
+  });
+});

--- a/src/core/layout.js
+++ b/src/core/layout.js
@@ -4,7 +4,7 @@
  *   layoutOverlaps  — column-pack timed events that share the same time slot
  *   layoutSpans     — lane-pack multi-day events for month/all-day row rendering
  */
-import { startOfDay, differenceInCalendarDays, addDays } from 'date-fns';
+import { startOfDay, differenceInCalendarDays, addDays, isSameDay } from 'date-fns';
 
 // ─── Timed event overlap layout (week / day view) ──────────────────────────
 
@@ -44,16 +44,17 @@ export function layoutOverlaps(events) {
 export function displayEndDay(ev) {
   const end = ev.end;
   const day = startOfDay(end);
+  const atMidnight = end.getHours() === 0 && end.getMinutes() === 0 && end.getSeconds() === 0;
   if (ev.allDay) {
     // All-day events use iCal's exclusive DTEND convention:
     // DTEND=Jan4 means the event covers Jan1–Jan3, not Jan4.
-    const atMidnight = end.getHours() === 0 && end.getMinutes() === 0 && end.getSeconds() === 0;
     return atMidnight ? addDays(day, -1) : day;
   }
-  // Timed events: the end timestamp is exact, not an exclusive boundary.
-  // A cross-midnight event ending at 00:00 Jan4 includes the Jan4 slot
-  // so it renders correctly in span layouts rather than silently dropping
-  // from the day it overlaps.
+  // Timed events that end exactly at midnight and started on an earlier date
+  // should not "occupy" the boundary day in month-span lane packing.
+  // This prevents adjacent back-to-back rotations from double-stacking.
+  if (atMidnight && !isSameDay(ev.start, end)) return addDays(day, -1);
+  // Otherwise, timed events use their real end day.
   return day;
 }
 

--- a/src/views/MonthView.jsx
+++ b/src/views/MonthView.jsx
@@ -12,6 +12,7 @@ const SPAN_H   = 22;
 const SPAN_GAP = 3;
 const MAX_SPANS_VISIBLE = 3;
 const DAY_NUM_TRACK_H = 32;
+const OVERFLOW_TRACK_H = SPAN_H + 4;
 
 function isMultiDay(ev) {
   return ev.allDay || !isSameDay(ev.start, ev.end);
@@ -270,7 +271,7 @@ export default function MonthView({
           const isHovered = enlargeMonthRowOnHover && hoveredWeekIdx === wi;
           const rowMinH   = Math.max(
             isHovered ? 150 : 120,
-            DAY_NUM_TRACK_H + spansHeight + SPAN_H + 6,
+            DAY_NUM_TRACK_H + spansHeight + SPAN_H + OVERFLOW_TRACK_H + 6,
           );
 
           return (


### PR DESCRIPTION
### Motivation
- Multiday pills were colliding and causing double-stacking when one event ended exactly at midnight and the next started at midnight, and single-day pills / the `+more` overflow control were getting clipped by the row height calculation.

### Description
- Adjusted `displayEndDay` in `src/core/layout.js` to treat timed events that end at `00:00` as exclusive of the boundary day when the event started on an earlier date by using `isSameDay` and subtracting one day for that case.
- Added `OVERFLOW_TRACK_H` and increased the week-row minimum height calculation in `src/views/MonthView.jsx` so the layout reserves space for both the pill row and the `+more` overflow row.
- Added unit tests in `src/core/__tests__/layout.test.js` covering midnight-boundary behavior and lane packing for back-to-back midnight-ended spans.

### Testing
- Ran the new unit tests with `npm test -- src/core/__tests__/layout.test.js` and all tests passed (2 tests, 2 passed).
- The changes were validated by the new tests which assert `displayEndDay` behavior and that `layoutSpans` packs adjacent midnight-ended spans into the same lane.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc597ccbfc832c8bed5b2d08535c59)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved display handling for events ending at midnight to ensure correct day assignment.
  * Enhanced month view week row spacing for better event overflow accommodation.

* **Tests**
  * Added test coverage for event layout spanning and cross-midnight boundary behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->