### PR TITLE
Enhance month hover projection details

### DIFF
--- a/src/ui/FilterBar.jsx
+++ b/src/ui/FilterBar.jsx
@@ -265,7 +265,7 @@ export default function FilterBar({
           className={[styles.hoverToggle, pillHoverTitle && styles.hoverToggleActive].filter(Boolean).join(' ')}
           onClick={onPillHoverTitleToggle}
           aria-pressed={pillHoverTitle}
-          title={pillHoverTitle ? 'Disable large title on hover' : 'Show large title when hovering events'}
+          title={pillHoverTitle ? 'Disable hover details projection' : 'Project date, category, resource, and notes when hovering events'}
         >
           Aa
         </button>

--- a/src/views/MonthView.jsx
+++ b/src/views/MonthView.jsx
@@ -24,7 +24,7 @@ export default function MonthView({
 }) {
   const [popoverDay,  setPopoverDay]  = useState(null);
   const [hoveredWeekIdx, setHoveredWeekIdx] = useState(null);
-  // { title, color, x, y } — position is the center-top of the hovered pill
+  // Hover projection panel state (positioned above hovered month-view pills).
   const [titleHover, setTitleHover] = useState(null);
   // Keyboard-focused day cell (roving tabindex pattern).
   const [focusedDay,  setFocusedDay]  = useState(() => startOfDay(currentDate));
@@ -161,6 +161,29 @@ export default function MonthView({
   const showWeekNumbers = config?.display?.showWeekNumbers;
   const enlargeMonthRowOnHover = !!config?.display?.enlargeMonthRowOnHover;
 
+  function buildHoverProjection(ev, color, rect) {
+    const dates = ev.allDay
+      ? (isSameDay(ev.start, ev.end)
+        ? format(ev.start, 'EEE, MMM d')
+        : `${format(ev.start, 'EEE, MMM d')} – ${format(ev.end, 'EEE, MMM d')}`)
+      : (isSameDay(ev.start, ev.end)
+        ? `${format(ev.start, 'EEE, MMM d, h:mm a')} – ${format(ev.end, 'h:mm a')}`
+        : `${format(ev.start, 'EEE, MMM d, h:mm a')} – ${format(ev.end, 'EEE, MMM d, h:mm a')}`);
+
+    const notes = ev.notes ?? ev.meta?.notes ?? ev._raw?.notes ?? '';
+
+    return {
+      title: ev.title,
+      color,
+      x: rect.left + rect.width / 2,
+      y: rect.top,
+      dates,
+      category: ev.category || null,
+      resource: ev.resource || null,
+      notes: notes ? String(notes) : null,
+    };
+  }
+
   // ── Renderers ─────────────────────────────────────────────────────────────
   function renderPill(ev, extra = {}, weekIdx = null) {
     const color       = resolveColor(ev, ctx?.colorRules);
@@ -173,7 +196,7 @@ export default function MonthView({
       if (enlargeMonthRowOnHover && weekIdx != null) setHoveredWeekIdx(weekIdx);
       if (pillHoverTitle) {
         const r = e.currentTarget.getBoundingClientRect();
-        setTitleHover({ title: ev.title, color, x: r.left + r.width / 2, y: r.top });
+        setTitleHover(buildHoverProjection(ev, color, r));
       }
     }
     function handlePillMouseLeave() {
@@ -400,7 +423,7 @@ export default function MonthView({
                               if (enlargeMonthRowOnHover) setHoveredWeekIdx(wi);
                               if (pillHoverTitle) {
                                 const r = e.currentTarget.getBoundingClientRect();
-                                setTitleHover({ title: ev.title, color, x: r.left + r.width / 2, y: r.top });
+                                setTitleHover(buildHoverProjection(ev, color, r));
                               }
                             }}
                             onMouseLeave={() => {
@@ -422,7 +445,7 @@ export default function MonthView({
       </div>
     </div>
 
-    {/* ── Pill hover title overlay ── */}
+    {/* ── Pill hover projection overlay ── */}
     {pillHoverTitle && titleHover && (
       <div
         aria-hidden="true"
@@ -433,20 +456,27 @@ export default function MonthView({
           transform:     'translate(-50%, -100%)',
           background:    titleHover.color,
           color:         '#fff',
-          fontSize:      36,
-          fontWeight:    700,
-          lineHeight:    1.1,
-          padding:       '6px 18px',
+          fontSize:      16,
+          fontWeight:    600,
+          lineHeight:    1.25,
+          padding:       '10px 14px',
           borderRadius:  10,
           pointerEvents: 'none',
           zIndex:        9999,
-          whiteSpace:    'nowrap',
+          maxWidth:      460,
           boxShadow:     '0 4px 20px rgba(0,0,0,0.28)',
-          letterSpacing: '-0.01em',
           textShadow:    '0 1px 3px rgba(0,0,0,0.25)',
         }}
       >
-        {titleHover.title}
+        <div style={{ fontSize: 22, fontWeight: 700, marginBottom: 4 }}>{titleHover.title}</div>
+        <div style={{ opacity: 0.95 }}>{titleHover.dates}</div>
+        {titleHover.category && <div>Category: {titleHover.category}</div>}
+        {titleHover.resource && <div>Resource: {titleHover.resource}</div>}
+        {titleHover.notes && (
+          <div style={{ marginTop: 4, opacity: 0.95 }}>
+            Notes: {titleHover.notes.length > 140 ? `${titleHover.notes.slice(0, 140)}…` : titleHover.notes}
+          </div>
+        )}
       </div>
     )}
     </>


### PR DESCRIPTION
### Motivation
- Provide richer hover feedback in month view so the hover toggle projects date range, category, resource and notes (not just the title) for better context when scanning events.

### Description
- Added a shared `buildHoverProjection` helper in `src/views/MonthView.jsx` to assemble a projection payload containing formatted `dates`, `category`, `resource`, and `notes` plus position/color metadata.
- Updated single-day pill and multi-day span mouse handlers to use the shared projection builder via `setTitleHover(buildHoverProjection(...))` for consistent behavior across render paths.
- Reworked the floating hover overlay in `MonthView` from a title-only banner into a compact details card that shows title, formatted dates, category, resource, and truncated notes, with adjusted sizing and max width.
- Updated the FilterBar hover toggle tooltip copy in `src/ui/FilterBar.jsx` to reflect the new projected fields.

### Testing
- `npm run build` completed successfully (build artifacts produced) ✅
- `npm test` was executed but failed in this environment due to test-environment issues: Playwright e2e suites expect a localhost server on port 3000 and some unit tests error with a missing `@testing-library/dom` dependency, causing multiple test-suite failures ⚠️
- Running `npm test -- --runInBand` fails because Vitest does not accept the `--runInBand` flag in this setup (invalid CLI option) ⚠️

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc65b5a1bc832ca8bcc51635b14679)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced hover overlays when hovering over calendar events to display comprehensive details including title, date and time range, category, resource, and event notes in a compact card format.

* **Updates**
  * Updated tooltip text for the hover details toggle button.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->