### PR TITLE
Add schedule template scaffolding to API v1

### DIFF
--- a/src/api/v1/__tests__/adapters.test.ts
+++ b/src/api/v1/__tests__/adapters.test.ts
@@ -39,6 +39,9 @@ describe('CalendarAdapter interface', () => {
     expect(typeof adapter.deleteEvent).toBe('function');
     expect(typeof adapter.subscribe).toBe('function');
     expect(typeof adapter.exportFeed).toBe('function');
+    expect(typeof adapter.listScheduleTemplates).toBe('function');
+    expect(typeof adapter.createScheduleTemplate).toBe('function');
+    expect(typeof adapter.instantiateScheduleTemplate).toBe('function');
   });
 
   it('SupabaseAdapter implements CalendarAdapter', () => {
@@ -224,6 +227,39 @@ describe('RestAdapter.exportFeed', () => {
     const json = await a.exportFeed([ev()]);
     const parsed = JSON.parse(json) as CalendarEventV1[];
     expect(parsed[0].title).toBe('Meeting');
+  });
+});
+
+
+describe('RestAdapter schedule template scaffolding', () => {
+  it('GETs schedule templates', async () => {
+    const stub = vi.fn().mockResolvedValue({ ok: true, json: async () => [{ id: 'sched-1', name: 'Clinic', entries: [] }] });
+    const origFetch = globalThis.fetch;
+    globalThis.fetch = stub as typeof fetch;
+    try {
+      const a = new RestAdapter({ baseUrl: 'http://api/events' });
+      const templates = await a.listScheduleTemplates();
+      expect(stub.mock.calls[0][0]).toContain('/templates/schedules');
+      expect(templates[0].id).toBe('sched-1');
+    } finally {
+      globalThis.fetch = origFetch;
+    }
+  });
+
+  it('POSTs schedule template instantiation request', async () => {
+    const stub = vi.fn().mockResolvedValue({ ok: true, json: async () => ({ templateId: 'sched-1', generated: [] }) });
+    const origFetch = globalThis.fetch;
+    globalThis.fetch = stub as typeof fetch;
+    try {
+      const a = new RestAdapter({ baseUrl: 'http://api/events' });
+      const result = await a.instantiateScheduleTemplate({ templateId: 'sched-1', anchor: S.toISOString() });
+      const [url, opts] = stub.mock.calls[0] as [string, RequestInit];
+      expect(url).toContain('/schedules/instantiate');
+      expect(opts.method).toBe('POST');
+      expect(result.templateId).toBe('sched-1');
+    } finally {
+      globalThis.fetch = origFetch;
+    }
   });
 });
 

--- a/src/api/v1/__tests__/templates.test.ts
+++ b/src/api/v1/__tests__/templates.test.ts
@@ -1,0 +1,38 @@
+// @vitest-environment node
+import { describe, it, expect } from 'vitest';
+import { instantiateScheduleTemplate, type ScheduleTemplateV1 } from '../templates.js';
+
+const template: ScheduleTemplateV1 = {
+  id: 'sched-team-oncall',
+  name: 'Team on-call',
+  timezone: 'America/Chicago',
+  entries: [
+    { id: 'primary', title: 'Primary on-call', startOffsetMinutes: 0, durationMinutes: 480, rrule: 'FREQ=DAILY' },
+    { id: 'backup', title: 'Backup on-call', startOffsetMinutes: 60, durationMinutes: 480, rrule: 'FREQ=DAILY' },
+  ],
+};
+
+describe('instantiateScheduleTemplate', () => {
+  it('creates event masters anchored to the requested datetime', () => {
+    const result = instantiateScheduleTemplate(template, {
+      anchor: new Date('2026-04-20T08:00:00.000Z'),
+      resource: 'Ops Team',
+      category: 'On-call',
+      meta: { generatedBy: 'wizard' },
+    });
+
+    expect(result.templateId).toBe('sched-team-oncall');
+    expect(result.generated).toHaveLength(2);
+    expect(result.generated[0].title).toBe('Primary on-call');
+    expect(result.generated[0].resource).toBe('Ops Team');
+    expect(result.generated[0].category).toBe('On-call');
+    expect(result.generated[0].rrule).toBe('FREQ=DAILY');
+    expect(result.generated[0].start).toEqual(new Date('2026-04-20T08:00:00.000Z'));
+    expect(result.generated[1].start).toEqual(new Date('2026-04-20T09:00:00.000Z'));
+    expect(result.generated[0].meta).toMatchObject({
+      scheduleTemplateId: 'sched-team-oncall',
+      scheduleTemplateEntryId: 'primary',
+      generatedBy: 'wizard',
+    });
+  });
+});

--- a/src/api/v1/adapters/CalendarAdapter.ts
+++ b/src/api/v1/adapters/CalendarAdapter.ts
@@ -22,6 +22,11 @@
  */
 
 import type { CalendarEventV1 } from '../types.js';
+import type {
+  ScheduleTemplateV1,
+  ScheduleInstantiationRequestV1,
+  ScheduleInstantiationResultV1,
+} from '../templates.js';
 
 // ─── Change notification types ────────────────────────────────────────────────
 
@@ -112,4 +117,13 @@ export interface CalendarAdapter {
    * The string is suitable for file download or transmission to another system.
    */
   exportFeed?(events: CalendarEventV1[]): Promise<string>;
+
+  /** List reusable schedule templates (for Add Schedule flows). */
+  listScheduleTemplates?(): Promise<ScheduleTemplateV1[]>;
+
+  /** Create a schedule template. */
+  createScheduleTemplate?(template: Omit<ScheduleTemplateV1, 'id'>): Promise<ScheduleTemplateV1>;
+
+  /** Instantiate a schedule template into concrete master events. */
+  instantiateScheduleTemplate?(request: ScheduleInstantiationRequestV1): Promise<ScheduleInstantiationResultV1>;
 }

--- a/src/api/v1/adapters/RestAdapter.ts
+++ b/src/api/v1/adapters/RestAdapter.ts
@@ -34,6 +34,11 @@
 
 import type { CalendarAdapter, AdapterChangeCallback, AdapterUnsubscribe } from './CalendarAdapter.js';
 import type { CalendarEventV1 } from '../types.js';
+import type {
+  ScheduleTemplateV1,
+  ScheduleInstantiationRequestV1,
+  ScheduleInstantiationResultV1,
+} from '../templates.js';
 
 // ─── Options ──────────────────────────────────────────────────────────────────
 
@@ -71,6 +76,12 @@ export interface RestAdapterOptions {
    * Default: 60_000 (1 minute).  Set to null to disable polling.
    */
   readonly pollInterval?: number | null;
+
+  /** Optional base URL override for template endpoints. Default: `${baseUrl}/templates/schedules`. */
+  readonly scheduleTemplatesUrl?: string;
+
+  /** Optional endpoint override for schedule instantiation. Default: `${baseUrl}/schedules/instantiate`. */
+  readonly scheduleInstantiateUrl?: string;
 }
 
 // ─── Adapter ─────────────────────────────────────────────────────────────────
@@ -83,6 +94,8 @@ export class RestAdapter implements CalendarAdapter {
   private readonly _fromResponse: (raw: Record<string, unknown>) => CalendarEventV1;
   private readonly _toRequest: (ev: CalendarEventV1 | Partial<CalendarEventV1>) => Record<string, unknown>;
   private readonly _pollInterval: number | null;
+  private readonly _scheduleTemplatesUrl: string;
+  private readonly _scheduleInstantiateUrl: string;
 
   constructor(options: RestAdapterOptions) {
     this._base        = options.baseUrl.replace(/\/$/, '');
@@ -92,6 +105,8 @@ export class RestAdapter implements CalendarAdapter {
     this._fromResponse = options.fromResponse ?? (raw => raw as unknown as CalendarEventV1);
     this._toRequest   = options.toRequest   ?? (ev  => ev  as unknown as Record<string, unknown>);
     this._pollInterval = options.pollInterval !== undefined ? options.pollInterval : 60_000;
+    this._scheduleTemplatesUrl = options.scheduleTemplatesUrl ?? `${this._base}/templates/schedules`;
+    this._scheduleInstantiateUrl = options.scheduleInstantiateUrl ?? `${this._base}/schedules/instantiate`;
   }
 
   // ── loadRange ───────────────────────────────────────────────────────────────
@@ -182,6 +197,37 @@ export class RestAdapter implements CalendarAdapter {
       clearInterval(timer);
       controller.abort();
     };
+  }
+
+  // ── schedule templates ─────────────────────────────────────────────────────
+
+  async listScheduleTemplates(): Promise<ScheduleTemplateV1[]> {
+    const res = await fetch(this._scheduleTemplatesUrl, {
+      method: 'GET',
+      headers: this._headers,
+    });
+    if (!res.ok) throw new Error(`RestAdapter.listScheduleTemplates: ${res.status} ${res.statusText}`);
+    return await res.json() as ScheduleTemplateV1[];
+  }
+
+  async createScheduleTemplate(template: Omit<ScheduleTemplateV1, 'id'>): Promise<ScheduleTemplateV1> {
+    const res = await fetch(this._scheduleTemplatesUrl, {
+      method: 'POST',
+      headers: this._headers,
+      body: JSON.stringify(template),
+    });
+    if (!res.ok) throw new Error(`RestAdapter.createScheduleTemplate: ${res.status} ${res.statusText}`);
+    return await res.json() as ScheduleTemplateV1;
+  }
+
+  async instantiateScheduleTemplate(request: ScheduleInstantiationRequestV1): Promise<ScheduleInstantiationResultV1> {
+    const res = await fetch(this._scheduleInstantiateUrl, {
+      method: 'POST',
+      headers: this._headers,
+      body: JSON.stringify(request),
+    });
+    if (!res.ok) throw new Error(`RestAdapter.instantiateScheduleTemplate: ${res.status} ${res.statusText}`);
+    return await res.json() as ScheduleInstantiationResultV1;
   }
 
   // ── exportFeed ──────────────────────────────────────────────────────────────

--- a/src/api/v1/index.ts
+++ b/src/api/v1/index.ts
@@ -24,6 +24,9 @@ export * from './serialization.js';
 // ── Data-shape converters (CalendarEventV1 ↔ EngineEvent) ────────────────────
 export * from './converters.js';
 
+// ── Schedule template scaffolding ────────────────────────────────────────────
+export * from './templates.js';
+
 // ── Engine class + initialiser ────────────────────────────────────────────────
 export { CalendarEngine, createInitialState } from '../../core/engine/CalendarEngine.js';
 

--- a/src/api/v1/templates.ts
+++ b/src/api/v1/templates.ts
@@ -1,0 +1,102 @@
+import { addMinutes } from 'date-fns';
+import type { CalendarEventV1 } from './types.js';
+
+export type TemplateVisibility = 'private' | 'team' | 'org';
+
+export interface EventTemplateV1 {
+  readonly id: string;
+  readonly name: string;
+  readonly description?: string;
+  readonly visibility?: TemplateVisibility;
+  readonly defaults: {
+    readonly title?: string;
+    readonly durationMinutes?: number;
+    readonly allDay?: boolean;
+    readonly category?: string;
+    readonly resource?: string;
+    readonly recurrencePreset?: string;
+    readonly rrule?: string;
+    readonly color?: string;
+    readonly meta?: Record<string, unknown>;
+  };
+}
+
+export interface ScheduleTemplateEntryV1 {
+  readonly id?: string;
+  readonly title: string;
+  /** Minutes offset from the selected anchor date/time. */
+  readonly startOffsetMinutes: number;
+  readonly durationMinutes: number;
+  readonly allDay?: boolean;
+  readonly category?: string;
+  readonly resource?: string;
+  readonly rrule?: string;
+  readonly color?: string;
+  readonly meta?: Record<string, unknown>;
+}
+
+export interface ScheduleTemplateV1 {
+  readonly id: string;
+  readonly name: string;
+  readonly description?: string;
+  readonly timezone?: string;
+  readonly visibility?: TemplateVisibility;
+  readonly entries: readonly ScheduleTemplateEntryV1[];
+}
+
+export interface ScheduleInstantiationRequestV1 {
+  readonly templateId?: string;
+  readonly anchor: Date | string | number;
+  readonly resource?: string;
+  readonly category?: string;
+  readonly timezone?: string;
+  readonly meta?: Record<string, unknown>;
+}
+
+export interface ScheduleInstantiationResultV1 {
+  readonly templateId: string;
+  readonly generated: readonly CalendarEventV1[];
+}
+
+function asDate(input: Date | string | number): Date {
+  return input instanceof Date ? input : new Date(input);
+}
+
+/**
+ * Build master events from a schedule template and user-selected anchor.
+ * This is pure client-side scaffolding for "Add Schedule" flows.
+ */
+export function instantiateScheduleTemplate(
+  template: ScheduleTemplateV1,
+  request: ScheduleInstantiationRequestV1,
+): ScheduleInstantiationResultV1 {
+  const anchor = asDate(request.anchor);
+
+  const generated = template.entries.map((entry, idx) => {
+    const start = addMinutes(anchor, entry.startOffsetMinutes);
+    const end = addMinutes(start, Math.max(1, entry.durationMinutes));
+
+    return {
+      title: entry.title,
+      start,
+      end,
+      allDay: entry.allDay ?? false,
+      category: request.category ?? entry.category,
+      resource: request.resource ?? entry.resource,
+      timezone: request.timezone ?? template.timezone,
+      color: entry.color,
+      rrule: entry.rrule,
+      meta: {
+        scheduleTemplateId: template.id,
+        scheduleTemplateEntryId: entry.id ?? `${template.id}:${idx}`,
+        ...(entry.meta ?? {}),
+        ...(request.meta ?? {}),
+      },
+    } as CalendarEventV1;
+  });
+
+  return {
+    templateId: template.id,
+    generated,
+  };
+}


### PR DESCRIPTION
### Motivation
- Provide a minimal, first-class API surface and client-side helper to support "Add Schedule" flows that create multiple master events from reusable templates. 
- Define stable types and adapter contracts so host apps and adapters can list, create, and instantiate schedule templates consistently.

### Description
- Add a new `src/api/v1/templates.ts` module that defines `EventTemplateV1`, `ScheduleTemplateV1`, `ScheduleTemplateEntryV1`, instantiation request/result types, and a pure `instantiateScheduleTemplate(...)` helper that scaffolds master events from an anchor date. 
- Export the template scaffolding from the API v1 barrel via `src/api/v1/index.ts` so consumers can import `instantiateScheduleTemplate` and template types from `works-calendar/api/v1`. 
- Extend the `CalendarAdapter` interface in `src/api/v1/adapters/CalendarAdapter.ts` with optional methods `listScheduleTemplates()`, `createScheduleTemplate()`, and `instantiateScheduleTemplate()`. 
- Implement the new adapter methods in `RestAdapter` (`src/api/v1/adapters/RestAdapter.ts`) with configurable endpoints (`scheduleTemplatesUrl`, `scheduleInstantiateUrl`) and GET/POST handlers, and add unit tests for the scaffolding and REST calls.

### Testing
- Ran the focused test suite with `npm test -- --run src/api/v1/__tests__/templates.test.ts src/api/v1/__tests__/adapters.test.ts`. 
- All automated tests executed for those files passed (`42 tests`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc66f4d4c4832ca6df58d275b8cec1)