### PR TITLE
Add 'Add Schedule' dialog and template instantiation flow

### DIFF
--- a/docs/recurring-schedule-implementation-plan.md
+++ b/docs/recurring-schedule-implementation-plan.md
@@ -1,0 +1,42 @@
+# Recurring Schedule Templates — Implementation Plan
+
+## Goal
+Deliver a complete "Add Schedule" workflow that uses reusable schedule templates to create recurring event series safely and quickly.
+
+## Current status
+- Recurrence engine and scope-aware recurring edits already exist.
+- Event-level templates exist in `EventForm`.
+- API-level schedule template contracts and instantiation utilities exist.
+- Missing piece: first-class UI flow in the main calendar for adding schedules from templates.
+
+## Phase 1 — Foundation + MVP creation flow (in progress)
+1. Add a dedicated `Add Schedule` dialog in the main toolbar.
+2. Accept schedule templates via component props.
+3. Allow users to:
+   - pick template,
+   - pick anchor date/time,
+   - override resource/category,
+   - instantiate into event masters.
+4. Create generated masters via the engine mutation pipeline.
+5. Add focused UI tests for dialog behavior.
+
+### Definition of done
+- `Add Schedule` button is visible when templates are provided and user can add events.
+- Dialog submits valid requests and creates generated recurring masters.
+- Core callbacks (`onEventSave`) fire for generated events.
+- Tests cover template selection and instantiate callback payload.
+
+## Phase 2 — Preview + safety
+1. Add pre-submit preview list of generated masters.
+2. Highlight obvious conflicts using existing validation pipeline.
+3. Add validation for malformed anchors/template payloads and user-facing errors.
+
+## Phase 3 — Template management and backend integration
+1. Optional adapter-backed template fetching/creation flows.
+2. Owner/admin template CRUD UI.
+3. Tenant-level visibility and governance (`private/team/org`).
+
+## Phase 4 — Operational hardening
+1. Analytics hooks (template usage and failures).
+2. Performance guardrails for large generated sets.
+3. Documentation/examples and migration notes.

--- a/src/WorksCalendar.jsx
+++ b/src/WorksCalendar.jsx
@@ -37,6 +37,7 @@ import OwnerLock              from './ui/OwnerLock.jsx';
 import ConfigPanel            from './ui/ConfigPanel.jsx';
 import EventForm              from './ui/EventForm.jsx';
 import ImportZone             from './ui/ImportZone.jsx';
+import ScheduleTemplateDialog from './ui/ScheduleTemplateDialog.jsx';
 import ValidationAlert          from './ui/ValidationAlert.jsx';
 import ScreenReaderAnnouncer   from './ui/ScreenReaderAnnouncer.jsx';
 import MonthView              from './views/MonthView.jsx';
@@ -45,6 +46,7 @@ import DayView                from './views/DayView.jsx';
 import AgendaView             from './views/AgendaView.jsx';
 import TimelineView           from './views/TimelineView.jsx';
 import { exportToExcel }      from './export/excelExport.js';
+import { instantiateScheduleTemplate } from './api/v1/templates.ts';
 
 import styles from './WorksCalendar.module.css';
 
@@ -89,6 +91,7 @@ export const WorksCalendar = forwardRef(function WorksCalendar(
     fetchEvents,
     icalFeeds,
     onImport,
+    scheduleTemplates = [],
 
     // ── Identity ──
     calendarId              = 'default',
@@ -346,6 +349,7 @@ export const WorksCalendar = forwardRef(function WorksCalendar(
   const [selectedEvent,  setSelectedEvent]  = useState(null);
   const [formEvent,      setFormEvent]      = useState(null);
   const [importOpen,     setImportOpen]     = useState(false);
+  const [scheduleOpen,   setScheduleOpen]   = useState(false);
   const [pillHoverTitle, setPillHoverTitle] = useState(false);
 
   // ── Keyboard shortcuts ───────────────────────────────────────────────────
@@ -532,6 +536,35 @@ export const WorksCalendar = forwardRef(function WorksCalendar(
     setImportOpen(false);
   }, [onImport, sourceStore]);
 
+  const handleScheduleInstantiate = useCallback((request) => {
+    const template = scheduleTemplates.find(t => t.id === request.templateId);
+    if (!template) return;
+    const result = instantiateScheduleTemplate(template, request);
+
+    result.generated.forEach((ev) => {
+      const start = ev.start instanceof Date ? ev.start : new Date(ev.start);
+      const end = ev.end instanceof Date ? ev.end : new Date(ev.end);
+      applyEngineOp({
+        type: 'create',
+        event: {
+          title: ev.title ?? '(untitled)',
+          start,
+          end,
+          allDay: ev.allDay ?? false,
+          resourceId: ev.resource ?? null,
+          category: ev.category ?? null,
+          color: ev.color ?? null,
+          status: ev.status ?? 'confirmed',
+          rrule: ev.rrule ?? null,
+          exdates: ev.exdates ?? [],
+          meta: ev.meta ?? {},
+        },
+        source: 'template',
+      }, () => onEventSave?.(ev));
+    });
+    setScheduleOpen(false);
+  }, [applyEngineOp, onEventSave, scheduleTemplates]);
+
   const handleEditFromHoverCard = useCallback((ev) => {
     setSelectedEvent(null);
     setFormEvent(ev._raw ?? ev);
@@ -564,6 +597,7 @@ export const WorksCalendar = forwardRef(function WorksCalendar(
   }
 
   const hasAddButton = (showAddButton || ownerCfg.isOwner || devMode) && perms.canAddEvent;
+  const hasScheduleTemplates = Array.isArray(scheduleTemplates) && scheduleTemplates.length > 0;
   const hasImport    = !!(onImport || ownerCfg.isOwner);
   const isEmpty      = visibleEvents.length === 0;
 
@@ -625,6 +659,11 @@ export const WorksCalendar = forwardRef(function WorksCalendar(
               {hasAddButton && (
                 <button className={styles.addBtn} onClick={() => setFormEvent({})} aria-label="Add new event">
                   <Plus size={14} aria-hidden="true" /><span className={styles.addBtnLabel}> Add Event</span>
+                </button>
+              )}
+              {hasAddButton && hasScheduleTemplates && (
+                <button className={styles.addBtn} onClick={() => setScheduleOpen(true)} aria-label="Add schedule from template">
+                  <Plus size={14} aria-hidden="true" /><span className={styles.addBtnLabel}> Add Schedule</span>
                 </button>
               )}
               {hasImport && (
@@ -764,6 +803,15 @@ export const WorksCalendar = forwardRef(function WorksCalendar(
         {/* ── Import zone ── */}
         {importOpen && (
           <ImportZone onImport={handleImport} onClose={() => setImportOpen(false)} />
+        )}
+
+        {/* ── Schedule templates ── */}
+        {scheduleOpen && (
+          <ScheduleTemplateDialog
+            templates={scheduleTemplates}
+            onInstantiate={handleScheduleInstantiate}
+            onClose={() => setScheduleOpen(false)}
+          />
         )}
 
         {/* ── Recurring scope picker ── */}

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -287,6 +287,27 @@ export interface FetchEventsParams {
   signal?: AbortSignal;
 }
 
+export interface ScheduleTemplateEntry {
+  id?: string;
+  title: string;
+  startOffsetMinutes: number;
+  durationMinutes: number;
+  allDay?: boolean;
+  category?: string;
+  resource?: string;
+  rrule?: string;
+  color?: string;
+  meta?: Record<string, unknown>;
+}
+
+export interface ScheduleTemplate {
+  id: string;
+  name: string;
+  description?: string;
+  timezone?: string;
+  entries: ScheduleTemplateEntry[];
+}
+
 // ─── Imperative API ────────────────────────────────────────────────────────────
 
 export interface CalendarApi {
@@ -331,6 +352,8 @@ export interface WorksCalendarProps {
   fetchEvents?: (params: FetchEventsParams) => Promise<WorksCalendarEvent[]>;
   /** Live iCal feed URLs to subscribe to. */
   icalFeeds?: ICalFeed[];
+  /** Optional reusable templates shown in the Add Schedule flow. */
+  scheduleTemplates?: ScheduleTemplate[];
 
   // ── Identity ──
   /** Namespaces localStorage (config, profiles). Default: 'default'. */

--- a/src/ui/ScheduleTemplateDialog.jsx
+++ b/src/ui/ScheduleTemplateDialog.jsx
@@ -1,0 +1,92 @@
+import { useMemo, useState } from 'react';
+import styles from './ScheduleTemplateDialog.module.css';
+
+function toDatetimeLocal(date) {
+  const d = date instanceof Date ? date : new Date(date);
+  if (Number.isNaN(d.getTime())) return '';
+  const pad = (n) => String(n).padStart(2, '0');
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}`;
+}
+
+export default function ScheduleTemplateDialog({ templates = [], onInstantiate, onClose }) {
+  const [templateId, setTemplateId] = useState(() => templates[0]?.id ?? '');
+  const [anchor, setAnchor] = useState(() => toDatetimeLocal(new Date()));
+  const [resource, setResource] = useState('');
+  const [category, setCategory] = useState('');
+
+  const selectedTemplate = useMemo(
+    () => templates.find((t) => t.id === templateId) ?? null,
+    [templates, templateId],
+  );
+
+  function handleSubmit(e) {
+    e.preventDefault();
+    if (!selectedTemplate) return;
+    const anchorDate = new Date(anchor);
+    if (Number.isNaN(anchorDate.getTime())) return;
+
+    onInstantiate?.({
+      templateId: selectedTemplate.id,
+      anchor: anchorDate,
+      resource: resource.trim() || undefined,
+      category: category.trim() || undefined,
+    });
+  }
+
+  return (
+    <div className={styles.overlay} onClick={(e) => { if (e.target === e.currentTarget) onClose?.(); }}>
+      <div className={styles.dialog} role="dialog" aria-modal="true" aria-label="Add schedule template">
+        <div className={styles.header}>
+          <h2 className={styles.title}>Add Schedule</h2>
+        </div>
+
+        {templates.length === 0 ? (
+          <div className={styles.emptyState}>
+            No schedule templates are configured yet.
+          </div>
+        ) : (
+          <form className={styles.form} onSubmit={handleSubmit}>
+            <label className={styles.label}>
+              Template
+              <select className={styles.select} value={templateId} onChange={(e) => setTemplateId(e.target.value)}>
+                {templates.map((template) => (
+                  <option key={template.id} value={template.id}>{template.name}</option>
+                ))}
+              </select>
+            </label>
+
+            <label className={styles.label}>
+              Anchor start
+              <input
+                className={styles.input}
+                type="datetime-local"
+                value={anchor}
+                onChange={(e) => setAnchor(e.target.value)}
+                required
+              />
+            </label>
+
+            <label className={styles.label}>
+              Resource override (optional)
+              <input className={styles.input} value={resource} onChange={(e) => setResource(e.target.value)} />
+            </label>
+
+            <label className={styles.label}>
+              Category override (optional)
+              <input className={styles.input} value={category} onChange={(e) => setCategory(e.target.value)} />
+            </label>
+
+            <div className={styles.meta}>
+              {selectedTemplate ? `${selectedTemplate.entries.length} entries will be generated.` : 'Choose a template.'}
+            </div>
+
+            <div className={styles.actions}>
+              <button type="button" className={styles.cancelBtn} onClick={onClose}>Cancel</button>
+              <button type="submit" className={styles.submitBtn}>Create schedule</button>
+            </div>
+          </form>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/ui/ScheduleTemplateDialog.module.css
+++ b/src/ui/ScheduleTemplateDialog.module.css
@@ -1,0 +1,79 @@
+.overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.4);
+  display: grid;
+  place-items: center;
+  z-index: 9999;
+}
+
+.dialog {
+  width: min(540px, 92vw);
+  background: var(--wc-panel, #fff);
+  border: 1px solid var(--wc-border, #e5e7eb);
+  border-radius: 14px;
+  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.2);
+  padding: 16px;
+}
+
+.header { margin-bottom: 8px; }
+.title { margin: 0; font-size: 1.1rem; }
+
+.form {
+  display: grid;
+  gap: 10px;
+}
+
+.label {
+  display: grid;
+  gap: 6px;
+  font-size: 0.9rem;
+  color: var(--wc-muted, #4b5563);
+}
+
+.input,
+.select {
+  border: 1px solid var(--wc-border, #d1d5db);
+  border-radius: 8px;
+  padding: 8px 10px;
+  font: inherit;
+  background: var(--wc-bg, #fff);
+  color: var(--wc-text, #111827);
+}
+
+.meta {
+  font-size: 0.85rem;
+  color: var(--wc-muted, #6b7280);
+}
+
+.actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  margin-top: 8px;
+}
+
+.cancelBtn,
+.submitBtn {
+  border: 0;
+  border-radius: 8px;
+  padding: 8px 12px;
+  font: inherit;
+  cursor: pointer;
+}
+
+.cancelBtn {
+  background: #e5e7eb;
+  color: #111827;
+}
+
+.submitBtn {
+  background: #2563eb;
+  color: white;
+}
+
+.emptyState {
+  font-size: 0.9rem;
+  color: var(--wc-muted, #6b7280);
+  padding: 8px 0;
+}

--- a/src/ui/__tests__/ScheduleTemplateDialog.test.jsx
+++ b/src/ui/__tests__/ScheduleTemplateDialog.test.jsx
@@ -1,0 +1,43 @@
+// @vitest-environment happy-dom
+
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import ScheduleTemplateDialog from '../ScheduleTemplateDialog.jsx';
+
+const templates = [
+  {
+    id: 'sched-ops',
+    name: 'Ops Coverage',
+    entries: [
+      { title: 'Primary', startOffsetMinutes: 0, durationMinutes: 480, rrule: 'FREQ=DAILY' },
+      { title: 'Backup', startOffsetMinutes: 60, durationMinutes: 480, rrule: 'FREQ=DAILY' },
+    ],
+  },
+];
+
+describe('ScheduleTemplateDialog', () => {
+  it('submits selected template and overrides', () => {
+    const onInstantiate = vi.fn();
+
+    render(
+      <ScheduleTemplateDialog
+        templates={templates}
+        onInstantiate={onInstantiate}
+        onClose={() => {}}
+      />,
+    );
+
+    fireEvent.change(screen.getByLabelText('Resource override (optional)'), { target: { value: 'Ops Team' } });
+    fireEvent.change(screen.getByLabelText('Category override (optional)'), { target: { value: 'On-call' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Create schedule' }));
+
+    expect(onInstantiate).toHaveBeenCalledTimes(1);
+    expect(onInstantiate.mock.calls[0][0]).toMatchObject({
+      templateId: 'sched-ops',
+      resource: 'Ops Team',
+      category: 'On-call',
+    });
+    expect(onInstantiate.mock.calls[0][0].anchor).toBeInstanceOf(Date);
+  });
+});


### PR DESCRIPTION
### Motivation
- Provide a first-class UI flow to create recurring event series from reusable schedule templates in the main calendar toolbar.
- Surface template-driven schedule creation so users can pick a template, anchor it to a date/time, optionally override resource/category, and instantiate generated masters.

### Description
- Add a new `ScheduleTemplateDialog` component and styles (`src/ui/ScheduleTemplateDialog.jsx` and `.module.css`) to collect template selection, anchor, and overrides. 
- Integrate `scheduleTemplates` into `WorksCalendar` props and UI, exposing an `Add Schedule` toolbar button that opens the dialog and tracks `scheduleOpen` state. 
- Implement `handleScheduleInstantiate` in `WorksCalendar` which calls `instantiateScheduleTemplate`, maps generated entries into engine `create` operations via `applyEngineOp`, and invokes `onEventSave` callbacks. 
- Add TypeScript declaration types for `ScheduleTemplate` and `ScheduleTemplateEntry` in `src/index.d.ts` and include a high-level implementation plan doc `docs/recurring-schedule-implementation-plan.md`.
- Add unit tests for the dialog UI (`src/ui/__tests__/ScheduleTemplateDialog.test.jsx`).

### Testing
- Ran the new component unit test `src/ui/__tests__/ScheduleTemplateDialog.test.jsx` with Vitest and the test passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc68b1c270832cab169adfe6474a72)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Schedule templates are now accessible from the calendar interface
  * New dialog enables template selection with customizable anchor date/time and optional field overrides
  * Template-based events are created with configurable settings

* **Documentation**
  * Implementation roadmap for schedule templates feature added

* **Tests**
  * Dialog component test coverage added

<!-- end of auto-generated comment: release notes by coderabbit.ai -->