### PR TITLE
Add validation/onError contract, safeMutate wrapper, and guarded recurrence expansion

### DIFF
--- a/src/api/v1/index.ts
+++ b/src/api/v1/index.ts
@@ -60,6 +60,30 @@ export type {
   EngineRuntimeConfig,
 } from '../../core/engine/engineConfig.js';
 
+// ── Validation + error contracts + guarded mutation/recurrence ──────────────
+export type {
+  ValidationMode,
+  EventValidationCode,
+  EventValidationIssue,
+  EventValidationResult,
+  ValidateEventOptions,
+  CalendarErrorDomain,
+  CalendarErrorSeverity,
+  StructuredCalendarError,
+  OnErrorMeta,
+  OnError,
+  SafeMutateOptions,
+  SafeMutateResult,
+  ExpandRecurrenceSafeOptions,
+} from '../../core/engine/engineTypes.js';
+
+export {
+  validateEvent,
+  toStructuredError,
+  safeMutate,
+  expandRecurrenceSafe,
+} from '../../core/engine/engineTypes.js';
+
 // ── Engine state types ────────────────────────────────────────────────────────
 export type {
   CalendarView,

--- a/src/core/engine/__tests__/expandRecurrenceSafe.test.ts
+++ b/src/core/engine/__tests__/expandRecurrenceSafe.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it, vi } from 'vitest';
+import { makeEvent } from '../schema/eventSchema.js';
+import { expandRecurrenceSafe } from '../recurrence/expandRecurrenceSafe.js';
+
+describe('expandRecurrenceSafe', () => {
+  it('returns [] and emits onError for invalid ranges', () => {
+    const onError = vi.fn();
+    const event = makeEvent('e1', {
+      title: 'Bad range check',
+      start: new Date('2026-01-01T10:00:00Z'),
+      end: new Date('2026-01-01T11:00:00Z'),
+    });
+
+    const result = expandRecurrenceSafe(
+      [event],
+      new Date('invalid'),
+      new Date('2026-01-02T00:00:00Z'),
+      { onError },
+    );
+
+    expect(result).toEqual([]);
+    expect(onError).toHaveBeenCalledTimes(1);
+  });
+
+  it('skips malformed events and continues partial expansion', () => {
+    const onError = vi.fn();
+
+    const good = makeEvent('good', {
+      title: 'Valid',
+      start: new Date('2026-03-01T10:00:00Z'),
+      end: new Date('2026-03-01T11:00:00Z'),
+    });
+
+    const malformed = {
+      ...good,
+      id: 'bad',
+      end: new Date('2026-03-01T09:59:00Z'),
+    };
+
+    const result = expandRecurrenceSafe(
+      [good, malformed],
+      new Date('2026-03-01T00:00:00Z'),
+      new Date('2026-03-02T00:00:00Z'),
+      { onError },
+    );
+
+    expect(result.some(occ => occ.eventId === 'good')).toBe(true);
+    expect(result.some(occ => occ.eventId === 'bad')).toBe(false);
+    expect(onError).toHaveBeenCalledTimes(1);
+  });
+
+  it.todo('adds DST transition coverage for spring-forward + fall-back boundaries');
+});

--- a/src/core/engine/engineTypes.ts
+++ b/src/core/engine/engineTypes.ts
@@ -50,6 +50,17 @@ export {
   mergeRuntimeConfig,
 } from './engineConfig.js';
 
+// ── Error contracts ───────────────────────────────────────────────────────────
+export type {
+  CalendarErrorDomain,
+  CalendarErrorSeverity,
+  StructuredCalendarError,
+  OnErrorMeta,
+  OnError,
+} from './errors/onError.js';
+
+export { toStructuredError } from './errors/onError.js';
+
 // ── Validation types ──────────────────────────────────────────────────────────
 export type {
   Violation,
@@ -61,6 +72,16 @@ export type {
 } from './validation/validationTypes.js';
 
 export { VALID_RESULT } from './validation/validationTypes.js';
+
+export type {
+  ValidationMode,
+  EventValidationCode,
+  EventValidationIssue,
+  EventValidationResult,
+  ValidateEventOptions,
+} from './validation/validateEvent.js';
+
+export { validateEvent } from './validation/validateEvent.js';
 
 // ── Operation result ──────────────────────────────────────────────────────────
 export type {
@@ -74,6 +95,17 @@ export {
   makeRejectedResult,
   makePendingResult,
 } from './operations/operationResult.js';
+
+export type {
+  SafeMutateOptions,
+  SafeMutateResult,
+} from './operations/safeMutate.js';
+
+export { safeMutate } from './operations/safeMutate.js';
+
+// ── Recurrence guards ────────────────────────────────────────────────────────
+export type { ExpandRecurrenceSafeOptions } from './recurrence/expandRecurrenceSafe.js';
+export { expandRecurrenceSafe } from './recurrence/expandRecurrenceSafe.js';
 
 // ── Time utilities ─────────────────────────────────────────────────────────────
 export type { DateRange } from './time/rangeMath.js';

--- a/src/core/engine/errors/onError.ts
+++ b/src/core/engine/errors/onError.ts
@@ -1,0 +1,41 @@
+export type CalendarErrorDomain =
+  | 'validation'
+  | 'mutation'
+  | 'recurrence'
+  | 'source'
+  | 'render'
+  | 'perf';
+
+export type CalendarErrorSeverity = 'warning' | 'error' | 'fatal';
+
+export interface StructuredCalendarError {
+  readonly code: string;
+  readonly message: string;
+  readonly domain: CalendarErrorDomain;
+  readonly severity: CalendarErrorSeverity;
+  readonly recoverable: boolean;
+  readonly cause?: unknown;
+  readonly context?: Readonly<Record<string, unknown>>;
+  readonly timestamp: string;
+}
+
+export interface OnErrorMeta {
+  readonly sourceId?: string;
+  readonly operationId?: string;
+  readonly eventId?: string;
+  readonly phase?: 'validate' | 'mutate' | 'expand' | 'render';
+}
+
+export type OnError = (error: StructuredCalendarError, meta?: OnErrorMeta) => void;
+
+/**
+ * Helper to normalize unknown errors into the structured contract.
+ */
+export function toStructuredError(
+  params: Omit<StructuredCalendarError, 'timestamp'>,
+): StructuredCalendarError {
+  return {
+    ...params,
+    timestamp: new Date().toISOString(),
+  };
+}

--- a/src/core/engine/operations/safeMutate.ts
+++ b/src/core/engine/operations/safeMutate.ts
@@ -1,0 +1,74 @@
+import { beginTransaction } from '../transactions/beginTransaction.js';
+import { commitTransaction } from '../transactions/commitTransaction.js';
+import { rollbackTransaction } from '../transactions/rollbackTransaction.js';
+import type { EngineEvent } from '../schema/eventSchema.js';
+import type { EventChange, OperationResult } from './operationResult.js';
+import type { OnError } from '../errors/onError.js';
+import { toStructuredError } from '../errors/onError.js';
+
+export interface SafeMutateOptions {
+  readonly onError?: OnError;
+  /**
+   * true: rollback on thrown errors or failed outcomes.
+   * false: caller owns compensation strategy.
+   */
+  readonly rollbackOnError?: boolean;
+}
+
+export interface SafeMutateResult {
+  readonly result: OperationResult | null;
+  readonly events: ReadonlyMap<string, EngineEvent>;
+  readonly rolledBack: boolean;
+}
+
+/**
+ * Skeleton wrapper for safe mutation + rollback.
+ *
+ * Expected usage:
+ *   safeMutate(events, () => engine.applyMutation(...), { onError })
+ */
+export function safeMutate(
+  events: ReadonlyMap<string, EngineEvent>,
+  run: () => OperationResult,
+  opts: SafeMutateOptions = {},
+): SafeMutateResult {
+  const rollbackOnError = opts.rollbackOnError ?? true;
+  const tx = beginTransaction(events);
+
+  try {
+    const result = run();
+
+    if (result.status === 'accepted' || result.status === 'accepted-with-warnings') {
+      const next = commitTransaction(tx, events, result.changes as ReadonlyArray<EventChange>);
+      return { result, events: next.events, rolledBack: false };
+    }
+
+    if (rollbackOnError) rollbackTransaction(tx, events);
+
+    return {
+      result,
+      events,
+      rolledBack: rollbackOnError,
+    };
+  } catch (cause) {
+    if (rollbackOnError) rollbackTransaction(tx, events);
+
+    opts.onError?.(
+      toStructuredError({
+        code: 'MUTATION_SAFE_ROLLBACK',
+        message: 'safeMutate caught an exception and rolled back.',
+        domain: 'mutation',
+        severity: 'error',
+        recoverable: true,
+        cause,
+      }),
+      { phase: 'mutate' },
+    );
+
+    return {
+      result: null,
+      events,
+      rolledBack: rollbackOnError,
+    };
+  }
+}

--- a/src/core/engine/recurrence/expandRecurrenceSafe.ts
+++ b/src/core/engine/recurrence/expandRecurrenceSafe.ts
@@ -1,0 +1,100 @@
+import { expandOccurrences, type ExpandOptions } from './expandOccurrences.js';
+import type { EngineEvent } from '../schema/eventSchema.js';
+import type { EngineOccurrence } from '../schema/occurrenceSchema.js';
+import type { OnError } from '../errors/onError.js';
+import { toStructuredError } from '../errors/onError.js';
+
+export interface ExpandRecurrenceSafeOptions extends ExpandOptions {
+  readonly onError?: OnError;
+  /** Hard cap across all series for one expansion call. */
+  readonly maxTotalOccurrences?: number;
+}
+
+const DEFAULT_MAX_TOTAL = 10_000;
+
+/**
+ * Guarded recurrence expansion with malformed-input and bounds protection.
+ *
+ * TODO(team):
+ * - Attach per-series diagnostics in return value.
+ * - Add source-isolated expansion for partial rendering.
+ * - Add perf instrumentation hooks around expansion.
+ */
+export function expandRecurrenceSafe(
+  events: readonly EngineEvent[],
+  rangeStart: Date,
+  rangeEnd: Date,
+  opts: ExpandRecurrenceSafeOptions = {},
+): EngineOccurrence[] {
+  const maxTotal = opts.maxTotalOccurrences ?? DEFAULT_MAX_TOTAL;
+
+  if (!(rangeStart instanceof Date) || Number.isNaN(rangeStart.getTime())
+   || !(rangeEnd instanceof Date) || Number.isNaN(rangeEnd.getTime())
+   || rangeEnd <= rangeStart) {
+    opts.onError?.(
+      toStructuredError({
+        code: 'RECURRENCE_INVALID_RANGE',
+        message: 'expandRecurrenceSafe received an invalid range.',
+        domain: 'recurrence',
+        severity: 'error',
+        recoverable: true,
+        context: { rangeStart, rangeEnd },
+      }),
+      { phase: 'expand' },
+    );
+    return [];
+  }
+
+  const sanitized: EngineEvent[] = [];
+  for (const ev of events) {
+    if (!(ev.start instanceof Date) || !(ev.end instanceof Date) || ev.end <= ev.start) {
+      opts.onError?.(
+        toStructuredError({
+          code: 'RECURRENCE_MALFORMED_EVENT',
+          message: 'Skipping malformed event during recurrence expansion.',
+          domain: 'recurrence',
+          severity: 'warning',
+          recoverable: true,
+          context: { eventId: ev.id },
+        }),
+        { eventId: ev.id, phase: 'expand' },
+      );
+      continue;
+    }
+    sanitized.push(ev);
+  }
+
+  try {
+    const occurrences = expandOccurrences(sanitized, rangeStart, rangeEnd, opts);
+
+    if (occurrences.length > maxTotal) {
+      opts.onError?.(
+        toStructuredError({
+          code: 'RECURRENCE_MAX_TOTAL_EXCEEDED',
+          message: 'Occurrence expansion exceeded maxTotalOccurrences cap.',
+          domain: 'recurrence',
+          severity: 'warning',
+          recoverable: true,
+          context: { maxTotal, actual: occurrences.length },
+        }),
+        { phase: 'expand' },
+      );
+      return occurrences.slice(0, maxTotal);
+    }
+
+    return occurrences;
+  } catch (cause) {
+    opts.onError?.(
+      toStructuredError({
+        code: 'RECURRENCE_EXPANSION_FAILED',
+        message: 'Unhandled recurrence expansion failure.',
+        domain: 'recurrence',
+        severity: 'error',
+        recoverable: true,
+        cause,
+      }),
+      { phase: 'expand' },
+    );
+    return [];
+  }
+}

--- a/src/core/engine/validation/validateEvent.ts
+++ b/src/core/engine/validation/validateEvent.ts
@@ -1,0 +1,98 @@
+import type { EngineEvent } from '../schema/eventSchema.js';
+
+export type ValidationMode = 'strict' | 'prod';
+
+export type EventValidationCode =
+  | 'INVALID_EVENT'
+  | 'INVALID_ID'
+  | 'INVALID_TITLE'
+  | 'INVALID_START'
+  | 'INVALID_END'
+  | 'INVALID_RANGE'
+  | 'INVALID_EXDATES';
+
+export interface EventValidationIssue {
+  readonly code: EventValidationCode;
+  readonly field: keyof EngineEvent | 'event';
+  readonly message: string;
+  readonly details?: Readonly<Record<string, unknown>>;
+}
+
+export interface EventValidationResult {
+  readonly ok: boolean;
+  readonly issues: readonly EventValidationIssue[];
+}
+
+export interface ValidateEventOptions {
+  /**
+   * strict: fail on schema/shape drift and questionable values.
+   * prod: best-effort validation; allows callers to log+continue where possible.
+   */
+  readonly mode?: ValidationMode;
+}
+
+/**
+ * Drop-in skeleton validator for event payloads.
+ *
+ * TODO(team):
+ * - Expand this to full schema-driven validation (zod/io-ts/custom rules).
+ * - Add per-source policy overrides in prod mode.
+ * - Wire to onError contract for centralized telemetry.
+ */
+export function validateEvent(
+  input: unknown,
+  opts: ValidateEventOptions = {},
+): EventValidationResult {
+  const mode = opts.mode ?? 'strict';
+  const issues: EventValidationIssue[] = [];
+
+  if (!input || typeof input !== 'object') {
+    return {
+      ok: false,
+      issues: [{ code: 'INVALID_EVENT', field: 'event', message: 'Event must be an object.' }],
+    };
+  }
+
+  const ev = input as Partial<EngineEvent>;
+
+  if (typeof ev.id !== 'string' || ev.id.trim().length === 0) {
+    issues.push({ code: 'INVALID_ID', field: 'id', message: 'Event id must be a non-empty string.' });
+  }
+
+  if (typeof ev.title !== 'string' || ev.title.trim().length === 0) {
+    issues.push({ code: 'INVALID_TITLE', field: 'title', message: 'Event title must be a non-empty string.' });
+  }
+
+  if (!(ev.start instanceof Date) || Number.isNaN(ev.start.getTime())) {
+    issues.push({ code: 'INVALID_START', field: 'start', message: 'Event start must be a valid Date.' });
+  }
+
+  if (!(ev.end instanceof Date) || Number.isNaN(ev.end.getTime())) {
+    issues.push({ code: 'INVALID_END', field: 'end', message: 'Event end must be a valid Date.' });
+  }
+
+  if (ev.start instanceof Date && ev.end instanceof Date && ev.end <= ev.start) {
+    issues.push({
+      code: 'INVALID_RANGE',
+      field: 'end',
+      message: 'Event end must be after start.',
+      details: { start: ev.start.toISOString(), end: ev.end.toISOString() },
+    });
+  }
+
+  if (ev.exdates && !Array.isArray(ev.exdates)) {
+    issues.push({
+      code: 'INVALID_EXDATES',
+      field: 'exdates',
+      message: 'exdates must be an array of Date values.',
+    });
+  }
+
+  // In prod mode, callers may choose to continue with warnings; we still return
+  // all issues so policy can be decided at integration boundaries.
+  if (mode === 'prod') {
+    return { ok: issues.length === 0, issues };
+  }
+
+  return { ok: issues.length === 0, issues };
+}


### PR DESCRIPTION
### Motivation
- Provide a consistent structured error contract and telemetry-friendly surface for validation, mutation, and recurrence code paths.
- Give a safe, transaction-aware mutation wrapper to make optimistic changes roll backable on failure. 
- Harden recurrence expansion against malformed input, invalid ranges, and runaway expansion counts so views can rely on a fail-safe expansion API.

### Description
- Add a drop-in event validator skeleton `src/core/engine/validation/validateEvent.ts` with `strict`/`prod` modes and structured `EventValidationIssue` results for incremental policy wiring. 
- Introduce a structured `onError` contract in `src/core/engine/errors/onError.ts` (`StructuredCalendarError`, `OnErrorMeta`, `toStructuredError`) to normalize error reporting.
- Add `safeMutate` wrapper `src/core/engine/operations/safeMutate.ts` that uses the engine transaction helpers to commit or rollback and emits a structured error on exceptions; exposes `rollbackOnError` policy.
- Add guarded recurrence entrypoint `src/core/engine/recurrence/expandRecurrenceSafe.ts` which validates ranges, skips malformed events, enforces a `maxTotalOccurrences` cap, and reports issues through `onError`.
- Add test scaffold `src/core/engine/__tests__/expandRecurrenceSafe.test.ts` covering invalid-range and malformed-event behavior, and add exports for the new APIs via `src/core/engine/engineTypes.ts` and `src/api/v1/index.ts` for easy adoption.
- Each new file contains explicit `TODO` notes where team-specific validation rules, telemetry, and source-isolation/perf hooks should be implemented.

### Testing
- Ran `npm test -- src/core/engine/__tests__/expandRecurrenceSafe.test.ts`, which passed and reported `2 tests passed | 1 todo`.
- The added tests exercise invalid range handling and malformed-event skipping and verified `onError` invocation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc6a759a38832ca40bb4833c277d09)