### PR TITLE
Phase 2: Add schedule preview and validation safety to Add Schedule flow

### DIFF
--- a/src/WorksCalendar.jsx
+++ b/src/WorksCalendar.jsx
@@ -26,6 +26,7 @@ import { CalendarEngine }     from './core/engine/CalendarEngine.ts';
 import { UndoRedoManager }   from './core/engine/UndoRedoManager.ts';
 import { fromLegacyEvents }   from './core/engine/adapters/fromLegacyEvents.ts';
 import { occurrenceToLegacy } from './core/engine/adapters/toLegacyEvents.ts';
+import { validateOperation } from './core/engine/validation/validateOperation.ts';
 import RecurringScopeDialog   from './ui/RecurringScopeDialog.jsx';
 import { applyFilters, getCategories, getResources } from './filters/filterEngine.js';
 import { DEFAULT_FILTER_SCHEMA } from './filters/filterSchema.js';
@@ -538,7 +539,9 @@ export const WorksCalendar = forwardRef(function WorksCalendar(
 
   const handleScheduleInstantiate = useCallback((request) => {
     const template = scheduleTemplates.find(t => t.id === request.templateId);
-    if (!template) return;
+    if (!template || !Array.isArray(template.entries) || template.entries.length === 0) return;
+    const anchor = request?.anchor instanceof Date ? request.anchor : new Date(request?.anchor);
+    if (Number.isNaN(anchor.getTime())) return;
     const result = instantiateScheduleTemplate(template, request);
 
     result.generated.forEach((ev) => {
@@ -564,6 +567,61 @@ export const WorksCalendar = forwardRef(function WorksCalendar(
     });
     setScheduleOpen(false);
   }, [applyEngineOp, onEventSave, scheduleTemplates]);
+
+  const buildSchedulePreview = useCallback((request) => {
+    const template = scheduleTemplates.find(t => t.id === request.templateId);
+    if (!template) return { generated: [], conflicts: [], error: 'Selected template was not found.' };
+    if (!Array.isArray(template.entries) || template.entries.length === 0) {
+      return { generated: [], conflicts: [], error: 'Selected template does not have valid entries.' };
+    }
+
+    const anchor = request?.anchor instanceof Date ? request.anchor : new Date(request?.anchor);
+    if (Number.isNaN(anchor.getTime())) {
+      return { generated: [], conflicts: [], error: 'Enter a valid anchor date/time.' };
+    }
+
+    let generated;
+    try {
+      generated = instantiateScheduleTemplate(template, { ...request, anchor }).generated;
+    } catch {
+      return { generated: [], conflicts: [], error: 'Unable to build schedule preview.' };
+    }
+
+    const ctx = opCtxRef.current;
+    const seededEvents = [...engineRef.current.state.events.values()];
+    const conflicts = [];
+
+    generated.forEach((ev, index) => {
+      const legacy = [{
+        id: `preview:${template.id}:${index}`,
+        title: ev.title ?? '(untitled)',
+        start: ev.start,
+        end: ev.end,
+        allDay: ev.allDay ?? false,
+        resource: ev.resource ?? null,
+        category: ev.category ?? null,
+        color: ev.color ?? null,
+        status: ev.status ?? 'confirmed',
+        rrule: ev.rrule ?? null,
+        exdates: ev.exdates ?? [],
+        meta: ev.meta ?? {},
+      }];
+      const previewEvent = fromLegacyEvents(legacy)[0];
+      const op = { type: 'create', event: previewEvent };
+      const validation = validateOperation(op, { ...ctx, events: seededEvents }, seededEvents);
+      if (validation.violations.length > 0) {
+        conflicts.push({
+          index,
+          title: ev.title ?? '(untitled)',
+          severity: validation.severity,
+          violations: validation.violations,
+        });
+      }
+      seededEvents.push(previewEvent);
+    });
+
+    return { generated, conflicts, error: '' };
+  }, [scheduleTemplates]);
 
   const handleEditFromHoverCard = useCallback((ev) => {
     setSelectedEvent(null);
@@ -809,6 +867,7 @@ export const WorksCalendar = forwardRef(function WorksCalendar(
         {scheduleOpen && (
           <ScheduleTemplateDialog
             templates={scheduleTemplates}
+            onPreview={buildSchedulePreview}
             onInstantiate={handleScheduleInstantiate}
             onClose={() => setScheduleOpen(false)}
           />

--- a/src/ui/ScheduleTemplateDialog.jsx
+++ b/src/ui/ScheduleTemplateDialog.jsx
@@ -8,7 +8,29 @@ function toDatetimeLocal(date) {
   return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}`;
 }
 
-export default function ScheduleTemplateDialog({ templates = [], onInstantiate, onClose }) {
+function validateTemplate(template) {
+  if (!template) return 'Please choose a schedule template.';
+  if (!Array.isArray(template.entries) || template.entries.length === 0) {
+    return 'The selected template has no entries to generate.';
+  }
+  const hasMalformedEntry = template.entries.some((entry) => (
+    !entry
+    || typeof entry.title !== 'string'
+    || !Number.isFinite(entry.startOffsetMinutes)
+    || !Number.isFinite(entry.durationMinutes)
+  ));
+  if (hasMalformedEntry) {
+    return 'The selected template has malformed entries and cannot be instantiated.';
+  }
+  return '';
+}
+
+export default function ScheduleTemplateDialog({
+  templates = [],
+  onInstantiate,
+  onPreview,
+  onClose,
+}) {
   const [templateId, setTemplateId] = useState(() => templates[0]?.id ?? '');
   const [anchor, setAnchor] = useState(() => toDatetimeLocal(new Date()));
   const [resource, setResource] = useState('');
@@ -19,18 +41,35 @@ export default function ScheduleTemplateDialog({ templates = [], onInstantiate, 
     [templates, templateId],
   );
 
+  const anchorDate = useMemo(() => new Date(anchor), [anchor]);
+  const anchorError = Number.isNaN(anchorDate.getTime()) ? 'Enter a valid anchor start date/time.' : '';
+  const templateError = useMemo(() => validateTemplate(selectedTemplate), [selectedTemplate]);
+
+  const request = useMemo(() => ({
+    templateId: selectedTemplate?.id,
+    anchor: anchorDate,
+    resource: resource.trim() || undefined,
+    category: category.trim() || undefined,
+  }), [anchorDate, category, resource, selectedTemplate]);
+
+  const preview = useMemo(() => {
+    if (!selectedTemplate || anchorError || templateError) {
+      return { generated: [], conflicts: [], error: anchorError || templateError || '' };
+    }
+    try {
+      return onPreview?.(request) ?? { generated: [], conflicts: [], error: '' };
+    } catch {
+      return { generated: [], conflicts: [], error: 'Unable to build schedule preview.' };
+    }
+  }, [anchorError, onPreview, request, selectedTemplate, templateError]);
+
+  const submitDisabled = !!(templateError || anchorError || preview.error);
+
   function handleSubmit(e) {
     e.preventDefault();
-    if (!selectedTemplate) return;
-    const anchorDate = new Date(anchor);
-    if (Number.isNaN(anchorDate.getTime())) return;
+    if (submitDisabled || !selectedTemplate) return;
 
-    onInstantiate?.({
-      templateId: selectedTemplate.id,
-      anchor: anchorDate,
-      resource: resource.trim() || undefined,
-      category: category.trim() || undefined,
-    });
+    onInstantiate?.(request);
   }
 
   return (
@@ -76,13 +115,40 @@ export default function ScheduleTemplateDialog({ templates = [], onInstantiate, 
               <input className={styles.input} value={category} onChange={(e) => setCategory(e.target.value)} />
             </label>
 
-            <div className={styles.meta}>
+            <div className={styles.meta} role="status">
               {selectedTemplate ? `${selectedTemplate.entries.length} entries will be generated.` : 'Choose a template.'}
             </div>
 
+            {(templateError || anchorError || preview.error) && (
+              <div className={styles.error} role="alert">
+                {templateError || anchorError || preview.error}
+              </div>
+            )}
+
+            {preview.generated.length > 0 && (
+              <div className={styles.preview} aria-label="Generated schedule preview">
+                <div className={styles.previewHeader}>
+                  Preview ({preview.generated.length})
+                  {preview.conflicts.length > 0 && (
+                    <span className={styles.conflictBadge}>
+                      {preview.conflicts.length} conflict{preview.conflicts.length === 1 ? '' : 's'}
+                    </span>
+                  )}
+                </div>
+                <ul className={styles.previewList}>
+                  {preview.generated.map((ev, idx) => (
+                    <li key={`${ev.title}-${idx}`} className={styles.previewItem}>
+                      <span>{ev.title ?? '(untitled)'}</span>
+                      <span>{toDatetimeLocal(ev.start)}</span>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            )}
+
             <div className={styles.actions}>
               <button type="button" className={styles.cancelBtn} onClick={onClose}>Cancel</button>
-              <button type="submit" className={styles.submitBtn}>Create schedule</button>
+              <button type="submit" className={styles.submitBtn} disabled={submitDisabled}>Create schedule</button>
             </div>
           </form>
         )}

--- a/src/ui/ScheduleTemplateDialog.module.css
+++ b/src/ui/ScheduleTemplateDialog.module.css
@@ -71,9 +71,60 @@
   background: #2563eb;
   color: white;
 }
+.submitBtn:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+}
 
 .emptyState {
   font-size: 0.9rem;
   color: var(--wc-muted, #6b7280);
   padding: 8px 0;
+}
+
+.error {
+  border: 1px solid #fecaca;
+  background: #fef2f2;
+  color: #991b1b;
+  border-radius: 8px;
+  font-size: 0.85rem;
+  padding: 8px 10px;
+}
+
+.preview {
+  border: 1px solid var(--wc-border, #e5e7eb);
+  border-radius: 10px;
+  padding: 8px;
+  background: var(--wc-bg, #fff);
+}
+
+.previewHeader {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 0.85rem;
+  font-weight: 600;
+}
+
+.conflictBadge {
+  border-radius: 999px;
+  background: #fef3c7;
+  color: #92400e;
+  font-size: 0.75rem;
+  padding: 2px 8px;
+}
+
+.previewList {
+  margin: 8px 0 0;
+  padding-left: 18px;
+  max-height: 160px;
+  overflow: auto;
+  font-size: 0.82rem;
+}
+
+.previewItem {
+  display: flex;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 2px 0;
 }

--- a/src/ui/__tests__/ScheduleTemplateDialog.test.jsx
+++ b/src/ui/__tests__/ScheduleTemplateDialog.test.jsx
@@ -19,10 +19,12 @@ const templates = [
 describe('ScheduleTemplateDialog', () => {
   it('submits selected template and overrides', () => {
     const onInstantiate = vi.fn();
+    const onPreview = vi.fn(() => ({ generated: templates[0].entries, conflicts: [], error: '' }));
 
     render(
       <ScheduleTemplateDialog
         templates={templates}
+        onPreview={onPreview}
         onInstantiate={onInstantiate}
         onClose={() => {}}
       />,
@@ -39,5 +41,25 @@ describe('ScheduleTemplateDialog', () => {
       category: 'On-call',
     });
     expect(onInstantiate.mock.calls[0][0].anchor).toBeInstanceOf(Date);
+    expect(onPreview).toHaveBeenCalled();
+  });
+
+  it('shows an error and blocks submit when anchor is invalid', () => {
+    const onInstantiate = vi.fn();
+
+    render(
+      <ScheduleTemplateDialog
+        templates={templates}
+        onPreview={() => ({ generated: [], conflicts: [], error: '' })}
+        onInstantiate={onInstantiate}
+        onClose={() => {}}
+      />,
+    );
+
+    fireEvent.change(screen.getByLabelText('Anchor start'), { target: { value: 'bad' } });
+    expect(screen.getByRole('alert')).toHaveTextContent('Enter a valid anchor start date/time.');
+    expect(screen.getByRole('button', { name: 'Create schedule' })).toBeDisabled();
+    fireEvent.click(screen.getByRole('button', { name: 'Create schedule' }));
+    expect(onInstantiate).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
### Motivation
- Deliver Phase 2 (Preview + safety) for the Add Schedule workflow by letting users preview generated masters and surfacing obvious conflicts before committing.
- Prevent malformed inputs and invalid anchors from being instantiated to avoid silent failures or invalid engine operations.
- Reuse the existing engine validation pipeline to surface conflicts consistently with other calendar operations.

### Description
- Added a preview/validation plumbing path: `WorksCalendar` now exposes `buildSchedulePreview` and passes an `onPreview` prop into `ScheduleTemplateDialog` to compute generated masters and detect conflicts using `validateOperation` against the current engine state (file: `src/WorksCalendar.jsx`).
- Hardened instantiation: `handleScheduleInstantiate` now guards against missing/malformed templates and invalid anchor dates before calling `instantiateScheduleTemplate` (file: `src/WorksCalendar.jsx`).
- Upgraded `ScheduleTemplateDialog` to validate template payloads and the anchor, display inline error messages, show a generated preview list with a conflict count badge, and disable the submit button when the payload or preview has errors (file: `src/ui/ScheduleTemplateDialog.jsx`).
- Added styles for the error state, preview list, conflict badge, and disabled submit appearance (file: `src/ui/ScheduleTemplateDialog.module.css`).
- Tests: extended `src/ui/__tests__/ScheduleTemplateDialog.test.jsx` to assert that the preview callback is invoked and that an invalid anchor shows an error and blocks submit.

### Testing
- Ran the dialog unit test file with Vitest: `npm test -- src/ui/__tests__/ScheduleTemplateDialog.test.jsx` and the test run failed due to a missing runtime dependency (`Error: Cannot find module '@testing-library/dom'`), so automated tests did not complete successfully in this environment.
- No other automated test suites were run in this rollout.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc6d774d8c832c9c63aa53bd4be0dd)