### PR TITLE
Start phase 3: adapter-backed schedule templates, visibility rules, and owner template UI

### DIFF
--- a/src/WorksCalendar.jsx
+++ b/src/WorksCalendar.jsx
@@ -47,7 +47,7 @@ import DayView                from './views/DayView.jsx';
 import AgendaView             from './views/AgendaView.jsx';
 import TimelineView           from './views/TimelineView.jsx';
 import { exportToExcel }      from './export/excelExport.js';
-import { instantiateScheduleTemplate } from './api/v1/templates.ts';
+import { canViewScheduleTemplate, instantiateScheduleTemplate } from './api/v1/templates.ts';
 
 import styles from './WorksCalendar.module.css';
 
@@ -93,6 +93,7 @@ export const WorksCalendar = forwardRef(function WorksCalendar(
     icalFeeds,
     onImport,
     scheduleTemplates = [],
+    scheduleTemplateAdapter,
 
     // ── Identity ──
     calendarId              = 'default',
@@ -352,6 +353,37 @@ export const WorksCalendar = forwardRef(function WorksCalendar(
   const [importOpen,     setImportOpen]     = useState(false);
   const [scheduleOpen,   setScheduleOpen]   = useState(false);
   const [pillHoverTitle, setPillHoverTitle] = useState(false);
+  const [remoteTemplates, setRemoteTemplates] = useState([]);
+  const [templateError, setTemplateError] = useState('');
+
+  const reloadRemoteTemplates = useCallback(async () => {
+    if (!scheduleTemplateAdapter?.listScheduleTemplates) return;
+    try {
+      const templates = await scheduleTemplateAdapter.listScheduleTemplates();
+      setRemoteTemplates(Array.isArray(templates) ? templates : []);
+      setTemplateError('');
+    } catch {
+      setTemplateError('Unable to load schedule templates from adapter.');
+    }
+  }, [scheduleTemplateAdapter]);
+
+  useEffect(() => {
+    reloadRemoteTemplates();
+  }, [reloadRemoteTemplates]);
+
+  const mergedScheduleTemplates = useMemo(() => {
+    const combined = [...scheduleTemplates, ...remoteTemplates];
+    const byId = new Map();
+    combined.forEach((template) => {
+      if (template?.id) byId.set(template.id, template);
+    });
+    return Array.from(byId.values());
+  }, [remoteTemplates, scheduleTemplates]);
+
+  const visibleScheduleTemplates = useMemo(
+    () => mergedScheduleTemplates.filter((template) => canViewScheduleTemplate(template, { role, isOwner: ownerCfg.isOwner })),
+    [mergedScheduleTemplates, ownerCfg.isOwner, role],
+  );
 
   // ── Keyboard shortcuts ───────────────────────────────────────────────────
   useEffect(() => {
@@ -538,7 +570,7 @@ export const WorksCalendar = forwardRef(function WorksCalendar(
   }, [onImport, sourceStore]);
 
   const handleScheduleInstantiate = useCallback((request) => {
-    const template = scheduleTemplates.find(t => t.id === request.templateId);
+    const template = visibleScheduleTemplates.find(t => t.id === request.templateId);
     if (!template || !Array.isArray(template.entries) || template.entries.length === 0) return;
     const anchor = request?.anchor instanceof Date ? request.anchor : new Date(request?.anchor);
     if (Number.isNaN(anchor.getTime())) return;
@@ -566,10 +598,10 @@ export const WorksCalendar = forwardRef(function WorksCalendar(
       }, () => onEventSave?.(ev));
     });
     setScheduleOpen(false);
-  }, [applyEngineOp, onEventSave, scheduleTemplates]);
+  }, [applyEngineOp, onEventSave, visibleScheduleTemplates]);
 
   const buildSchedulePreview = useCallback((request) => {
-    const template = scheduleTemplates.find(t => t.id === request.templateId);
+    const template = visibleScheduleTemplates.find(t => t.id === request.templateId);
     if (!template) return { generated: [], conflicts: [], error: 'Selected template was not found.' };
     if (!Array.isArray(template.entries) || template.entries.length === 0) {
       return { generated: [], conflicts: [], error: 'Selected template does not have valid entries.' };
@@ -621,7 +653,29 @@ export const WorksCalendar = forwardRef(function WorksCalendar(
     });
 
     return { generated, conflicts, error: '' };
-  }, [scheduleTemplates]);
+  }, [visibleScheduleTemplates]);
+
+  const handleCreateScheduleTemplate = useCallback(async (template) => {
+    if (!scheduleTemplateAdapter?.createScheduleTemplate) return;
+    try {
+      await scheduleTemplateAdapter.createScheduleTemplate(template);
+      await reloadRemoteTemplates();
+      setTemplateError('');
+    } catch {
+      setTemplateError('Unable to create schedule template.');
+    }
+  }, [reloadRemoteTemplates, scheduleTemplateAdapter]);
+
+  const handleDeleteScheduleTemplate = useCallback(async (templateId) => {
+    if (!scheduleTemplateAdapter?.deleteScheduleTemplate) return;
+    try {
+      await scheduleTemplateAdapter.deleteScheduleTemplate(templateId);
+      await reloadRemoteTemplates();
+      setTemplateError('');
+    } catch {
+      setTemplateError('Unable to delete schedule template.');
+    }
+  }, [reloadRemoteTemplates, scheduleTemplateAdapter]);
 
   const handleEditFromHoverCard = useCallback((ev) => {
     setSelectedEvent(null);
@@ -655,7 +709,7 @@ export const WorksCalendar = forwardRef(function WorksCalendar(
   }
 
   const hasAddButton = (showAddButton || ownerCfg.isOwner || devMode) && perms.canAddEvent;
-  const hasScheduleTemplates = Array.isArray(scheduleTemplates) && scheduleTemplates.length > 0;
+  const hasScheduleTemplates = Array.isArray(visibleScheduleTemplates) && visibleScheduleTemplates.length > 0;
   const hasImport    = !!(onImport || ownerCfg.isOwner);
   const isEmpty      = visibleEvents.length === 0;
 
@@ -866,7 +920,7 @@ export const WorksCalendar = forwardRef(function WorksCalendar(
         {/* ── Schedule templates ── */}
         {scheduleOpen && (
           <ScheduleTemplateDialog
-            templates={scheduleTemplates}
+            templates={visibleScheduleTemplates}
             onPreview={buildSchedulePreview}
             onInstantiate={handleScheduleInstantiate}
             onClose={() => setScheduleOpen(false)}
@@ -909,6 +963,10 @@ export const WorksCalendar = forwardRef(function WorksCalendar(
             onRemoveSource={sourceStore.removeSource}
             onToggleSource={sourceStore.toggleSource}
             onUpdateSource={sourceStore.updateSource}
+            scheduleTemplates={mergedScheduleTemplates}
+            onCreateScheduleTemplate={ownerCfg.isOwner ? handleCreateScheduleTemplate : undefined}
+            onDeleteScheduleTemplate={ownerCfg.isOwner ? handleDeleteScheduleTemplate : undefined}
+            scheduleTemplateError={templateError}
           />
         )}
 

--- a/src/api/v1/__tests__/adapters.test.ts
+++ b/src/api/v1/__tests__/adapters.test.ts
@@ -41,6 +41,8 @@ describe('CalendarAdapter interface', () => {
     expect(typeof adapter.exportFeed).toBe('function');
     expect(typeof adapter.listScheduleTemplates).toBe('function');
     expect(typeof adapter.createScheduleTemplate).toBe('function');
+    expect(typeof adapter.updateScheduleTemplate).toBe('function');
+    expect(typeof adapter.deleteScheduleTemplate).toBe('function');
     expect(typeof adapter.instantiateScheduleTemplate).toBe('function');
   });
 
@@ -257,6 +259,37 @@ describe('RestAdapter schedule template scaffolding', () => {
       expect(url).toContain('/schedules/instantiate');
       expect(opts.method).toBe('POST');
       expect(result.templateId).toBe('sched-1');
+    } finally {
+      globalThis.fetch = origFetch;
+    }
+  });
+
+  it('PATCHes a schedule template', async () => {
+    const stub = vi.fn().mockResolvedValue({ ok: true, json: async () => ({ id: 'sched-1', name: 'Updated', entries: [] }) });
+    const origFetch = globalThis.fetch;
+    globalThis.fetch = stub as typeof fetch;
+    try {
+      const a = new RestAdapter({ baseUrl: 'http://api/events' });
+      const result = await a.updateScheduleTemplate('sched-1', { name: 'Updated' });
+      const [url, opts] = stub.mock.calls[0] as [string, RequestInit];
+      expect(url).toContain('/templates/schedules/sched-1');
+      expect(opts.method).toBe('PATCH');
+      expect(result.name).toBe('Updated');
+    } finally {
+      globalThis.fetch = origFetch;
+    }
+  });
+
+  it('DELETEs a schedule template', async () => {
+    const stub = vi.fn().mockResolvedValue({ ok: true });
+    const origFetch = globalThis.fetch;
+    globalThis.fetch = stub as typeof fetch;
+    try {
+      const a = new RestAdapter({ baseUrl: 'http://api/events' });
+      await a.deleteScheduleTemplate('sched-2');
+      const [url, opts] = stub.mock.calls[0] as [string, RequestInit];
+      expect(url).toContain('/templates/schedules/sched-2');
+      expect(opts.method).toBe('DELETE');
     } finally {
       globalThis.fetch = origFetch;
     }

--- a/src/api/v1/__tests__/templates.test.ts
+++ b/src/api/v1/__tests__/templates.test.ts
@@ -1,6 +1,6 @@
 // @vitest-environment node
 import { describe, it, expect } from 'vitest';
-import { instantiateScheduleTemplate, type ScheduleTemplateV1 } from '../templates.js';
+import { canViewScheduleTemplate, instantiateScheduleTemplate, type ScheduleTemplateV1 } from '../templates.js';
 
 const template: ScheduleTemplateV1 = {
   id: 'sched-team-oncall',
@@ -34,5 +34,15 @@ describe('instantiateScheduleTemplate', () => {
       scheduleTemplateEntryId: 'primary',
       generatedBy: 'wizard',
     });
+  });
+});
+
+describe('canViewScheduleTemplate', () => {
+  it('enforces private/team/org visibility', () => {
+    expect(canViewScheduleTemplate({ ...template, visibility: 'org' }, { role: 'readonly' })).toBe(true);
+    expect(canViewScheduleTemplate({ ...template, visibility: 'team' }, { role: 'user' })).toBe(true);
+    expect(canViewScheduleTemplate({ ...template, visibility: 'team' }, { role: 'readonly' })).toBe(false);
+    expect(canViewScheduleTemplate({ ...template, visibility: 'private' }, { role: 'user' })).toBe(false);
+    expect(canViewScheduleTemplate({ ...template, visibility: 'private' }, { role: 'admin' })).toBe(true);
   });
 });

--- a/src/api/v1/adapters/CalendarAdapter.ts
+++ b/src/api/v1/adapters/CalendarAdapter.ts
@@ -124,6 +124,12 @@ export interface CalendarAdapter {
   /** Create a schedule template. */
   createScheduleTemplate?(template: Omit<ScheduleTemplateV1, 'id'>): Promise<ScheduleTemplateV1>;
 
+  /** Update a schedule template. */
+  updateScheduleTemplate?(id: string, patch: Partial<ScheduleTemplateV1>): Promise<ScheduleTemplateV1>;
+
+  /** Delete a schedule template. */
+  deleteScheduleTemplate?(id: string): Promise<void>;
+
   /** Instantiate a schedule template into concrete master events. */
   instantiateScheduleTemplate?(request: ScheduleInstantiationRequestV1): Promise<ScheduleInstantiationResultV1>;
 }

--- a/src/api/v1/adapters/RestAdapter.ts
+++ b/src/api/v1/adapters/RestAdapter.ts
@@ -220,6 +220,24 @@ export class RestAdapter implements CalendarAdapter {
     return await res.json() as ScheduleTemplateV1;
   }
 
+  async updateScheduleTemplate(id: string, patch: Partial<ScheduleTemplateV1>): Promise<ScheduleTemplateV1> {
+    const res = await fetch(`${this._scheduleTemplatesUrl}/${encodeURIComponent(id)}`, {
+      method: 'PATCH',
+      headers: this._headers,
+      body: JSON.stringify(patch),
+    });
+    if (!res.ok) throw new Error(`RestAdapter.updateScheduleTemplate: ${res.status} ${res.statusText}`);
+    return await res.json() as ScheduleTemplateV1;
+  }
+
+  async deleteScheduleTemplate(id: string): Promise<void> {
+    const res = await fetch(`${this._scheduleTemplatesUrl}/${encodeURIComponent(id)}`, {
+      method: 'DELETE',
+      headers: this._headers,
+    });
+    if (!res.ok) throw new Error(`RestAdapter.deleteScheduleTemplate: ${res.status} ${res.statusText}`);
+  }
+
   async instantiateScheduleTemplate(request: ScheduleInstantiationRequestV1): Promise<ScheduleInstantiationResultV1> {
     const res = await fetch(this._scheduleInstantiateUrl, {
       method: 'POST',

--- a/src/api/v1/templates.ts
+++ b/src/api/v1/templates.ts
@@ -44,6 +44,13 @@ export interface ScheduleTemplateV1 {
   readonly entries: readonly ScheduleTemplateEntryV1[];
 }
 
+export interface ScheduleTemplateViewerContext {
+  readonly isOwner?: boolean;
+  readonly role?: 'admin' | 'user' | 'readonly';
+  readonly teamId?: string | null;
+  readonly userId?: string | null;
+}
+
 export interface ScheduleInstantiationRequestV1 {
   readonly templateId?: string;
   readonly anchor: Date | string | number;
@@ -56,6 +63,16 @@ export interface ScheduleInstantiationRequestV1 {
 export interface ScheduleInstantiationResultV1 {
   readonly templateId: string;
   readonly generated: readonly CalendarEventV1[];
+}
+
+export function canViewScheduleTemplate(
+  template: ScheduleTemplateV1,
+  viewer: ScheduleTemplateViewerContext = {},
+): boolean {
+  const visibility = template.visibility ?? 'org';
+  if (visibility === 'org') return true;
+  if (visibility === 'team') return viewer.role === 'admin' || viewer.role === 'user' || !!viewer.isOwner;
+  return !!viewer.isOwner || viewer.role === 'admin';
 }
 
 function asDate(input: Date | string | number): Date {

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -304,8 +304,15 @@ export interface ScheduleTemplate {
   id: string;
   name: string;
   description?: string;
+  visibility?: 'private' | 'team' | 'org';
   timezone?: string;
   entries: ScheduleTemplateEntry[];
+}
+
+export interface ScheduleTemplateAdapter {
+  listScheduleTemplates?: () => Promise<ScheduleTemplate[]>;
+  createScheduleTemplate?: (template: Omit<ScheduleTemplate, 'id'>) => Promise<ScheduleTemplate>;
+  deleteScheduleTemplate?: (id: string) => Promise<void>;
 }
 
 // ─── Imperative API ────────────────────────────────────────────────────────────
@@ -354,6 +361,8 @@ export interface WorksCalendarProps {
   icalFeeds?: ICalFeed[];
   /** Optional reusable templates shown in the Add Schedule flow. */
   scheduleTemplates?: ScheduleTemplate[];
+  /** Optional backend adapter for template management and tenant-governed template loading. */
+  scheduleTemplateAdapter?: ScheduleTemplateAdapter;
 
   // ── Identity ──
   /** Namespaces localStorage (config, profiles). Default: 'default'. */

--- a/src/ui/ConfigPanel.jsx
+++ b/src/ui/ConfigPanel.jsx
@@ -10,6 +10,7 @@ const TABS = [
   { id: 'eventFields', label: 'Event Fields' },
   { id: 'display',     label: 'Display' },
   { id: 'feeds',       label: 'Feeds' },
+  { id: 'templates',   label: 'Templates' },
   { id: 'access',      label: 'Access' },
 ];
 
@@ -17,6 +18,7 @@ export default function ConfigPanel({
   config, categories, onUpdate, onClose,
   // Source store props (optional — omitted when owner has no source store)
   sources, feedErrors, onAddSource, onRemoveSource, onToggleSource, onUpdateSource,
+  scheduleTemplates, onCreateScheduleTemplate, onDeleteScheduleTemplate, scheduleTemplateError,
 }) {
   const [tab, setTab] = useState('hoverCard');
   const trapRef = useFocusTrap(onClose);
@@ -55,9 +57,105 @@ export default function ConfigPanel({
               onUpdate={onUpdateSource}
             />
           )}
+          {tab === 'templates'   && (
+            <TemplateTab
+              templates={scheduleTemplates ?? []}
+              onCreate={onCreateScheduleTemplate}
+              onDelete={onDeleteScheduleTemplate}
+              error={scheduleTemplateError}
+            />
+          )}
           {tab === 'access'      && <AccessTab      config={config} onUpdate={onUpdate} />}
         </div>
       </div>
+    </div>
+  );
+}
+
+function TemplateTab({ templates, onCreate, onDelete, error }) {
+  const [name, setName] = useState('');
+  const [visibility, setVisibility] = useState('team');
+  const [title, setTitle] = useState('');
+  const [startOffsetMinutes, setStartOffsetMinutes] = useState(0);
+  const [durationMinutes, setDurationMinutes] = useState(60);
+  const [rrule, setRrule] = useState('FREQ=DAILY');
+
+  function resetForm() {
+    setName('');
+    setVisibility('team');
+    setTitle('');
+    setStartOffsetMinutes(0);
+    setDurationMinutes(60);
+    setRrule('FREQ=DAILY');
+  }
+
+  async function handleCreate() {
+    if (!onCreate) return;
+    const cleanName = name.trim();
+    const cleanTitle = title.trim();
+    if (!cleanName || !cleanTitle) return;
+    await onCreate({
+      name: cleanName,
+      visibility,
+      entries: [{
+        title: cleanTitle,
+        startOffsetMinutes: Number(startOffsetMinutes) || 0,
+        durationMinutes: Math.max(1, Number(durationMinutes) || 1),
+        rrule: rrule.trim() || undefined,
+      }],
+    });
+    resetForm();
+  }
+
+  return (
+    <div className={styles.section}>
+      <p className={styles.sectionDesc}>Create and govern schedule templates for Add Schedule flows.</p>
+
+      {error && <div className={styles.sectionDesc} role="alert">{error}</div>}
+
+      <label className={styles.formRow}>
+        <span>Template name</span>
+        <input className={styles.input} value={name} onChange={(e) => setName(e.target.value)} placeholder="Morning coverage" />
+      </label>
+      <label className={styles.formRow}>
+        <span>Visibility</span>
+        <select className={styles.select} value={visibility} onChange={(e) => setVisibility(e.target.value)}>
+          <option value="private">Private</option>
+          <option value="team">Team</option>
+          <option value="org">Org</option>
+        </select>
+      </label>
+      <label className={styles.formRow}>
+        <span>Default entry title</span>
+        <input className={styles.input} value={title} onChange={(e) => setTitle(e.target.value)} placeholder="Primary shift" />
+      </label>
+      <label className={styles.formRow}>
+        <span>Offset (minutes)</span>
+        <input className={styles.input} type="number" value={startOffsetMinutes} onChange={(e) => setStartOffsetMinutes(e.target.value)} />
+      </label>
+      <label className={styles.formRow}>
+        <span>Duration (minutes)</span>
+        <input className={styles.input} type="number" min={1} value={durationMinutes} onChange={(e) => setDurationMinutes(e.target.value)} />
+      </label>
+      <label className={styles.formRow}>
+        <span>RRULE</span>
+        <input className={styles.input} value={rrule} onChange={(e) => setRrule(e.target.value)} />
+      </label>
+      <button className={styles.addFieldBtn} onClick={handleCreate} disabled={!onCreate}>Create template</button>
+
+      {templates.map((template) => (
+        <div key={template.id} className={styles.fieldRow}>
+          <div>
+            <strong>{template.name}</strong>
+            <div className={styles.sectionDesc}>
+              {template.visibility ?? 'org'} · {template.entries?.length ?? 0} entr{(template.entries?.length ?? 0) === 1 ? 'y' : 'ies'}
+            </div>
+          </div>
+          <button className={styles.removeBtn} onClick={() => onDelete?.(template.id)} disabled={!onDelete}>
+            <Trash2 size={13} />
+          </button>
+        </div>
+      ))}
     </div>
   );
 }


### PR DESCRIPTION
### Motivation
- Enable Phase 3 by adding backend-backed schedule template management and tenant-aware visibility so owners/admins can manage templates centrally.
- Surface templates in the existing Add Schedule flow while enforcing visibility rules and letting owners create/delete templates from the settings panel.

### Description
- Add an optional `scheduleTemplateAdapter` prop and adapter typing to load/create/delete remote templates and merge them with local `scheduleTemplates` (implement merging and dedupe via `mergedScheduleTemplates`).
- Introduce `canViewScheduleTemplate(template, viewer)` for visibility governance (`private|team|org`) and use `visibleScheduleTemplates` when previewing/instantiating templates in the Add Schedule dialog.
- Add owner-facing Templates tab in `ConfigPanel` with a small form to `create` simple templates and UI to delete templates, and surface adapter errors via `scheduleTemplateError`.
- Extend adapter contract (`CalendarAdapter`) and `RestAdapter` to support `updateScheduleTemplate` and `deleteScheduleTemplate` endpoints, and surface new types in `src/index.d.ts`.
- Tests: add unit tests for `canViewScheduleTemplate` and for the new `RestAdapter` template methods; update adapter interface test expectations.

### Testing
- Ran `npm test -- --run src/api/v1/__tests__/templates.test.ts src/api/v1/__tests__/adapters.test.ts` and all tests in those files passed (45 tests total across both files).
- Ran `npm test -- --run src/ui/__tests__/ScheduleTemplateDialog.test.jsx` which failed in this environment due to a missing runtime dependency (`@testing-library/dom`), unrelated to the new code changes.
- Validation: manual unit test additions exercise visibility rules and REST adapter `PATCH`/`DELETE` request shapes and passed in CI-local test runs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc6e886dbc832c8cc145ed0f9116ab)