### PR TITLE
Start Phase 4 schedule operational hardening

### DIFF
--- a/docs/recurring-schedule-implementation-plan.md
+++ b/docs/recurring-schedule-implementation-plan.md
@@ -36,7 +36,13 @@ Deliver a complete "Add Schedule" workflow that uses reusable schedule templates
 2. Owner/admin template CRUD UI.
 3. Tenant-level visibility and governance (`private/team/org`).
 
-## Phase 4 — Operational hardening
-1. Analytics hooks (template usage and failures).
-2. Performance guardrails for large generated sets.
-3. Documentation/examples and migration notes.
+## Phase 4 — Operational hardening (started)
+1. ✅ Analytics hooks (template usage and failures).
+2. ✅ Performance guardrails for large generated sets.
+3. 🚧 Documentation/examples and migration notes.
+
+### Phase 4 kickoff notes (April 13, 2026)
+- Added `onScheduleTemplateAnalytics` callback support in `WorksCalendar` to emit lifecycle events for opening the dialog, preview generation success/failure, and instantiate success/failure.
+- Added schedule generation guardrails with default limits (`previewMax=200`, `createMax=200`) and a configurable `scheduleInstantiationLimits` prop.
+- Preview now fails fast with a user-visible error when template expansion exceeds the configured preview threshold.
+- Added migration guidance for adopters in `docs/schedule-phase4-migration-notes.md`.

--- a/docs/schedule-phase4-migration-notes.md
+++ b/docs/schedule-phase4-migration-notes.md
@@ -1,0 +1,42 @@
+# Schedule Templates Phase 4 — Migration Notes
+
+Phase 4 introduces optional operational hardening APIs for Add Schedule flows.
+
+## New props
+
+### `scheduleInstantiationLimits`
+Optional guardrails for large generated sets:
+
+- `previewMax` (default `200`): blocks preview expansion beyond this count.
+- `createMax` (default `200`): blocks instantiate requests beyond this count.
+
+```jsx
+<WorksCalendar
+  scheduleTemplates={templates}
+  scheduleInstantiationLimits={{ previewMax: 100, createMax: 100 }}
+/>
+```
+
+### `onScheduleTemplateAnalytics`
+Optional callback to observe Add Schedule usage and failure reasons.
+
+Emitted events:
+
+- `schedule_dialog_opened`
+- `schedule_preview_built`
+- `schedule_preview_failed`
+- `schedule_instantiate_succeeded`
+- `schedule_instantiate_failed`
+
+```jsx
+<WorksCalendar
+  onScheduleTemplateAnalytics={(evt) => {
+    analytics.track('calendar.schedule', evt);
+  }}
+/>
+```
+
+## Backward compatibility
+
+- Existing Add Schedule integrations continue to work without changes.
+- If new props are omitted, defaults are applied and no analytics are emitted.

--- a/src/WorksCalendar.jsx
+++ b/src/WorksCalendar.jsx
@@ -73,6 +73,11 @@ const VIEWS = [
   { id: 'schedule', label: 'Schedule' },
 ];
 
+const DEFAULT_SCHEDULE_INSTANTIATION_LIMITS = {
+  previewMax: 200,
+  createMax: 200,
+};
+
 /** Compute the visible [start, end] range for a given view + date. */
 function viewRange(view, date, weekStartDay = 0) {
   switch (view) {
@@ -94,6 +99,8 @@ export const WorksCalendar = forwardRef(function WorksCalendar(
     onImport,
     scheduleTemplates = [],
     scheduleTemplateAdapter,
+    scheduleInstantiationLimits = DEFAULT_SCHEDULE_INSTANTIATION_LIMITS,
+    onScheduleTemplateAnalytics,
 
     // ── Identity ──
     calendarId              = 'default',
@@ -356,6 +363,24 @@ export const WorksCalendar = forwardRef(function WorksCalendar(
   const [remoteTemplates, setRemoteTemplates] = useState([]);
   const [templateError, setTemplateError] = useState('');
 
+  const resolvedScheduleLimits = useMemo(() => {
+    const previewMax = Number.isFinite(scheduleInstantiationLimits?.previewMax)
+      ? Math.max(1, Number(scheduleInstantiationLimits.previewMax))
+      : DEFAULT_SCHEDULE_INSTANTIATION_LIMITS.previewMax;
+    const createMax = Number.isFinite(scheduleInstantiationLimits?.createMax)
+      ? Math.max(1, Number(scheduleInstantiationLimits.createMax))
+      : DEFAULT_SCHEDULE_INSTANTIATION_LIMITS.createMax;
+    return { previewMax, createMax };
+  }, [scheduleInstantiationLimits]);
+
+  const trackScheduleTemplateAnalytics = useCallback((event, payload = {}) => {
+    onScheduleTemplateAnalytics?.({
+      event,
+      at: new Date().toISOString(),
+      ...payload,
+    });
+  }, [onScheduleTemplateAnalytics]);
+
   const reloadRemoteTemplates = useCallback(async () => {
     if (!scheduleTemplateAdapter?.listScheduleTemplates) return;
     try {
@@ -570,11 +595,33 @@ export const WorksCalendar = forwardRef(function WorksCalendar(
   }, [onImport, sourceStore]);
 
   const handleScheduleInstantiate = useCallback((request) => {
+    const startedAt = Date.now();
     const template = visibleScheduleTemplates.find(t => t.id === request.templateId);
-    if (!template || !Array.isArray(template.entries) || template.entries.length === 0) return;
+    if (!template || !Array.isArray(template.entries) || template.entries.length === 0) {
+      trackScheduleTemplateAnalytics('schedule_instantiate_failed', {
+        reason: 'template-missing-or-invalid',
+        templateId: request?.templateId ?? null,
+      });
+      return;
+    }
     const anchor = request?.anchor instanceof Date ? request.anchor : new Date(request?.anchor);
-    if (Number.isNaN(anchor.getTime())) return;
+    if (Number.isNaN(anchor.getTime())) {
+      trackScheduleTemplateAnalytics('schedule_instantiate_failed', {
+        reason: 'invalid-anchor',
+        templateId: template.id,
+      });
+      return;
+    }
     const result = instantiateScheduleTemplate(template, request);
+    if (result.generated.length > resolvedScheduleLimits.createMax) {
+      trackScheduleTemplateAnalytics('schedule_instantiate_failed', {
+        reason: 'create-limit-exceeded',
+        templateId: template.id,
+        generatedCount: result.generated.length,
+        createMax: resolvedScheduleLimits.createMax,
+      });
+      return;
+    }
 
     result.generated.forEach((ev) => {
       const start = ev.start instanceof Date ? ev.start : new Date(ev.start);
@@ -597,10 +644,16 @@ export const WorksCalendar = forwardRef(function WorksCalendar(
         source: 'template',
       }, () => onEventSave?.(ev));
     });
+    trackScheduleTemplateAnalytics('schedule_instantiate_succeeded', {
+      templateId: template.id,
+      generatedCount: result.generated.length,
+      elapsedMs: Date.now() - startedAt,
+    });
     setScheduleOpen(false);
-  }, [applyEngineOp, onEventSave, visibleScheduleTemplates]);
+  }, [applyEngineOp, onEventSave, resolvedScheduleLimits.createMax, trackScheduleTemplateAnalytics, visibleScheduleTemplates]);
 
   const buildSchedulePreview = useCallback((request) => {
+    const startedAt = Date.now();
     const template = visibleScheduleTemplates.find(t => t.id === request.templateId);
     if (!template) return { generated: [], conflicts: [], error: 'Selected template was not found.' };
     if (!Array.isArray(template.entries) || template.entries.length === 0) {
@@ -616,7 +669,25 @@ export const WorksCalendar = forwardRef(function WorksCalendar(
     try {
       generated = instantiateScheduleTemplate(template, { ...request, anchor }).generated;
     } catch {
+      trackScheduleTemplateAnalytics('schedule_preview_failed', {
+        reason: 'instantiate-throw',
+        templateId: template.id,
+      });
       return { generated: [], conflicts: [], error: 'Unable to build schedule preview.' };
+    }
+
+    if (generated.length > resolvedScheduleLimits.previewMax) {
+      trackScheduleTemplateAnalytics('schedule_preview_failed', {
+        reason: 'preview-limit-exceeded',
+        templateId: template.id,
+        generatedCount: generated.length,
+        previewMax: resolvedScheduleLimits.previewMax,
+      });
+      return {
+        generated: [],
+        conflicts: [],
+        error: `This template would generate ${generated.length} events, which exceeds the preview limit of ${resolvedScheduleLimits.previewMax}.`,
+      };
     }
 
     const ctx = opCtxRef.current;
@@ -652,8 +723,14 @@ export const WorksCalendar = forwardRef(function WorksCalendar(
       seededEvents.push(previewEvent);
     });
 
+    trackScheduleTemplateAnalytics('schedule_preview_built', {
+      templateId: template.id,
+      generatedCount: generated.length,
+      conflictCount: conflicts.length,
+      elapsedMs: Date.now() - startedAt,
+    });
     return { generated, conflicts, error: '' };
-  }, [visibleScheduleTemplates]);
+  }, [resolvedScheduleLimits.previewMax, trackScheduleTemplateAnalytics, visibleScheduleTemplates]);
 
   const handleCreateScheduleTemplate = useCallback(async (template) => {
     if (!scheduleTemplateAdapter?.createScheduleTemplate) return;
@@ -774,7 +851,16 @@ export const WorksCalendar = forwardRef(function WorksCalendar(
                 </button>
               )}
               {hasAddButton && hasScheduleTemplates && (
-                <button className={styles.addBtn} onClick={() => setScheduleOpen(true)} aria-label="Add schedule from template">
+                <button
+                  className={styles.addBtn}
+                  onClick={() => {
+                    setScheduleOpen(true);
+                    trackScheduleTemplateAnalytics('schedule_dialog_opened', {
+                      templateCount: visibleScheduleTemplates.length,
+                    });
+                  }}
+                  aria-label="Add schedule from template"
+                >
                   <Plus size={14} aria-hidden="true" /><span className={styles.addBtnLabel}> Add Schedule</span>
                 </button>
               )}

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -315,6 +315,31 @@ export interface ScheduleTemplateAdapter {
   deleteScheduleTemplate?: (id: string) => Promise<void>;
 }
 
+export interface ScheduleInstantiationLimits {
+  /** Maximum number of generated events allowed when building a preview. Default: 200. */
+  previewMax?: number;
+  /** Maximum number of generated events allowed when creating schedule masters. Default: 200. */
+  createMax?: number;
+}
+
+export interface ScheduleTemplateAnalyticsEvent {
+  event:
+    | 'schedule_dialog_opened'
+    | 'schedule_preview_built'
+    | 'schedule_preview_failed'
+    | 'schedule_instantiate_succeeded'
+    | 'schedule_instantiate_failed';
+  at: string;
+  templateId?: string | null;
+  templateCount?: number;
+  generatedCount?: number;
+  conflictCount?: number;
+  previewMax?: number;
+  createMax?: number;
+  elapsedMs?: number;
+  reason?: string;
+}
+
 // ─── Imperative API ────────────────────────────────────────────────────────────
 
 export interface CalendarApi {
@@ -363,6 +388,10 @@ export interface WorksCalendarProps {
   scheduleTemplates?: ScheduleTemplate[];
   /** Optional backend adapter for template management and tenant-governed template loading. */
   scheduleTemplateAdapter?: ScheduleTemplateAdapter;
+  /** Operational guardrails for schedule template preview/create flows. */
+  scheduleInstantiationLimits?: ScheduleInstantiationLimits;
+  /** Optional analytics hook fired for Add Schedule workflow lifecycle events. */
+  onScheduleTemplateAnalytics?: (event: ScheduleTemplateAnalyticsEvent) => void;
 
   // ── Identity ──
   /** Namespaces localStorage (config, profiles). Default: 'default'. */

--- a/src/ui/__tests__/ScheduleTemplateDialog.test.jsx
+++ b/src/ui/__tests__/ScheduleTemplateDialog.test.jsx
@@ -62,4 +62,22 @@ describe('ScheduleTemplateDialog', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Create schedule' }));
     expect(onInstantiate).not.toHaveBeenCalled();
   });
+
+  it('shows preview errors and blocks submit', () => {
+    const onInstantiate = vi.fn();
+
+    render(
+      <ScheduleTemplateDialog
+        templates={templates}
+        onPreview={() => ({ generated: [], conflicts: [], error: 'Preview limit exceeded.' })}
+        onInstantiate={onInstantiate}
+        onClose={() => {}}
+      />,
+    );
+
+    expect(screen.getByRole('alert')).toHaveTextContent('Preview limit exceeded.');
+    expect(screen.getByRole('button', { name: 'Create schedule' })).toBeDisabled();
+    fireEvent.click(screen.getByRole('button', { name: 'Create schedule' }));
+    expect(onInstantiate).not.toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
### Motivation
- Harden the Add Schedule flow against large template expansions and surface telemetry for operational monitoring. 
- Prevent user-facing performance and UX issues by adding preview/create guardrails and clear errors when templates would produce too many events.

### Description
- Added two new optional props on `WorksCalendar`: `scheduleInstantiationLimits` (defaults: `previewMax=200`, `createMax=200`) and `onScheduleTemplateAnalytics` to emit lifecycle telemetry events. 
- Implemented limit resolution and enforcement (`resolvedScheduleLimits`) and short-circuit fail paths for preview/instantiate when thresholds are exceeded or inputs are invalid, returning a user-visible preview error and blocking creation. 
- Instrumented analytics events for dialog open, preview built/failed, and instantiate succeeded/failed via `trackScheduleTemplateAnalytics`, and emitted payloads with `templateId`, counts and timing. 
- Updated TypeScript declarations (`ScheduleInstantiationLimits`, `ScheduleTemplateAnalyticsEvent`, and `WorksCalendarProps`), updated docs (`docs/recurring-schedule-implementation-plan.md`) to mark Phase 4 started, and added migration notes in `docs/schedule-phase4-migration-notes.md`. 
- Added a UI test case ensuring preview errors block submit in `src/ui/__tests__/ScheduleTemplateDialog.test.jsx`.

### Testing
- Ran `npm test -- src/api/v1/__tests__/templates.test.ts` and it passed (all tests succeeded). 
- Ran `npm test -- src/ui/__tests__/ScheduleTemplateDialog.test.jsx` which failed in this environment due to a missing test dependency (`@testing-library/dom`), but the added test asserts that preview errors are shown and submission is disabled (the failure is environmental, not due to the new logic).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc6fedcb38832ca903c34c1996d7fa)