### PR TITLE
Add built-in event templates and integrate into EventForm with template metadata

### DIFF
--- a/src/core/engine/recurrence/templates.ts
+++ b/src/core/engine/recurrence/templates.ts
@@ -1,0 +1,157 @@
+export interface EventTemplateDefaults {
+  readonly title?: string;
+  readonly durationMinutes?: number;
+  readonly allDay?: boolean;
+  readonly category?: string;
+  readonly resource?: string;
+  readonly recurrencePreset?: 'none' | 'daily' | 'weekdays' | 'weekly' | 'monthlyDate' | 'custom';
+  readonly rrule?: string;
+  readonly color?: string;
+  readonly notes?: string;
+}
+
+export interface EventTemplate {
+  readonly id: string;
+  readonly version: number;
+  readonly label: string;
+  readonly description?: string;
+  readonly defaults: EventTemplateDefaults | null;
+}
+
+export const BUILT_IN_EVENT_TEMPLATES: readonly EventTemplate[] = [
+  { id: 'none', version: 1, label: 'Blank event', defaults: null },
+  {
+    id: 'dailyStandup',
+    version: 1,
+    label: 'Daily standup',
+    description: '15-minute weekday sync.',
+    defaults: {
+      title: 'Daily standup',
+      durationMinutes: 15,
+      recurrencePreset: 'weekdays',
+      category: 'Meetings',
+    },
+  },
+  {
+    id: 'weekly1on1',
+    version: 1,
+    label: 'Weekly 1:1',
+    defaults: {
+      title: 'Weekly 1:1',
+      durationMinutes: 30,
+      recurrencePreset: 'weekly',
+      category: 'Meetings',
+    },
+  },
+  {
+    id: 'onCallPrimary',
+    version: 1,
+    label: 'On-call (Primary)',
+    defaults: {
+      title: 'Primary on-call',
+      durationMinutes: 60,
+      recurrencePreset: 'daily',
+      category: 'On-call',
+      color: '#ef4444',
+    },
+  },
+  {
+    id: 'sprintPlanning',
+    version: 1,
+    label: 'Sprint planning',
+    defaults: {
+      title: 'Sprint planning',
+      durationMinutes: 90,
+      recurrencePreset: 'weekly',
+      category: 'Planning',
+      color: '#2563eb',
+    },
+  },
+  {
+    id: 'retrospective',
+    version: 1,
+    label: 'Team retrospective',
+    defaults: {
+      title: 'Retrospective',
+      durationMinutes: 60,
+      recurrencePreset: 'weekly',
+      category: 'Planning',
+      color: '#7c3aed',
+    },
+  },
+  {
+    id: 'monthlyReview',
+    version: 1,
+    label: 'Monthly review',
+    defaults: {
+      title: 'Monthly review',
+      durationMinutes: 60,
+      recurrencePreset: 'monthlyDate',
+      category: 'Operations',
+    },
+  },
+  {
+    id: 'incidentDrill',
+    version: 1,
+    label: 'Incident drill',
+    defaults: {
+      title: 'Incident response drill',
+      durationMinutes: 45,
+      recurrencePreset: 'monthlyDate',
+      category: 'Operations',
+      color: '#dc2626',
+    },
+  },
+  {
+    id: 'officeHours',
+    version: 1,
+    label: 'Office hours',
+    defaults: {
+      title: 'Office hours',
+      durationMinutes: 60,
+      recurrencePreset: 'weekly',
+      category: 'Support',
+      color: '#059669',
+    },
+  },
+  {
+    id: 'demoDay',
+    version: 1,
+    label: 'Demo day',
+    defaults: {
+      title: 'Demo day',
+      durationMinutes: 60,
+      recurrencePreset: 'weekly',
+      category: 'Engineering',
+      color: '#0ea5e9',
+    },
+  },
+  {
+    id: 'customerFollowup',
+    version: 1,
+    label: 'Customer follow-up',
+    defaults: {
+      title: 'Customer follow-up',
+      durationMinutes: 30,
+      recurrencePreset: 'weekly',
+      category: 'Customer Success',
+      color: '#f59e0b',
+    },
+  },
+  {
+    id: 'releaseWindow',
+    version: 1,
+    label: 'Release window',
+    defaults: {
+      title: 'Release window',
+      durationMinutes: 120,
+      recurrencePreset: 'weekly',
+      category: 'Engineering',
+      color: '#111827',
+    },
+  },
+];
+
+export function getEventTemplateById(id: string): EventTemplate | null {
+  return BUILT_IN_EVENT_TEMPLATES.find((template) => template.id === id) ?? null;
+}

--- a/src/ui/EventForm.jsx
+++ b/src/ui/EventForm.jsx
@@ -6,6 +6,7 @@ import { useState, useEffect, useRef } from 'react';
 import { format, parseISO, isValid } from 'date-fns';
 import { X, Plus } from 'lucide-react';
 import { useFocusTrap } from '../hooks/useFocusTrap.js';
+import { BUILT_IN_EVENT_TEMPLATES, getEventTemplateById } from '../core/engine/recurrence/templates.ts';
 import styles from './EventForm.module.css';
 
 const BUILT_IN_CATEGORIES = [];
@@ -18,32 +19,6 @@ const RECURRENCE_PRESETS = [
   { id: 'monthlyDate', label: 'Monthly on start date' },
   { id: 'custom', label: 'Custom RRULE' },
 ];
-const EVENT_TEMPLATES = [
-  {
-    id: 'none',
-    label: 'Blank event',
-    defaults: null,
-  },
-  {
-    id: 'dailyStandup',
-    label: 'Daily standup',
-    defaults: {
-      title:           'Daily standup',
-      durationMinutes: 15,
-      recurrencePreset:'weekdays',
-    },
-  },
-  {
-    id: 'weekly1on1',
-    label: 'Weekly 1:1',
-    defaults: {
-      title:           'Weekly 1:1',
-      durationMinutes: 30,
-      recurrencePreset:'weekly',
-    },
-  },
-];
-
 function toDatetimeLocal(date) {
   if (!date) return '';
   try {
@@ -132,14 +107,22 @@ export default function EventForm({ event, config, categories, onSave, onDelete,
 
   function applyTemplate(nextTemplateId) {
     setTemplateId(nextTemplateId);
-    const template = EVENT_TEMPLATES.find(t => t.id === nextTemplateId);
+    const template = getEventTemplateById(nextTemplateId);
     if (!template?.defaults) return;
     setValues((v) => {
       const startDate = fromDatetimeLocal(v.start);
-      const next = { ...v };
+      const next = {
+        ...v,
+        meta: {
+          ...(v.meta ?? {}),
+          templateId: template.id,
+          templateVersion: template.version,
+        },
+      };
       if (template.defaults.title) next.title = template.defaults.title;
       if (template.defaults.category) next.category = template.defaults.category;
       if (template.defaults.resource) next.resource = template.defaults.resource;
+      if (template.defaults.color) next.color = template.defaults.color;
       if (typeof template.defaults.allDay === 'boolean') next.allDay = template.defaults.allDay;
       if (startDate && Number.isFinite(template.defaults.durationMinutes)) {
         const nextEnd = new Date(startDate.getTime() + template.defaults.durationMinutes * 60 * 1000);
@@ -211,7 +194,7 @@ export default function EventForm({ event, config, categories, onSave, onDelete,
           <div className={styles.field}>
             <label className={styles.label}>Template</label>
             <select className={styles.select} value={templateId} onChange={e => applyTemplate(e.target.value)}>
-              {EVENT_TEMPLATES.map(t => <option key={t.id} value={t.id}>{t.label}</option>)}
+              {BUILT_IN_EVENT_TEMPLATES.map(t => <option key={t.id} value={t.id}>{t.label}</option>)}
             </select>
           </div>
 

--- a/src/ui/__tests__/EventForm.recurrence.test.jsx
+++ b/src/ui/__tests__/EventForm.recurrence.test.jsx
@@ -42,7 +42,7 @@ describe('EventForm recurrence controls', () => {
   });
 
   it('applies the Daily standup template defaults', () => {
-    renderForm({
+    const { onSave } = renderForm({
       event: {
         title: '',
       },
@@ -56,5 +56,12 @@ describe('EventForm recurrence controls', () => {
 
     expect(screen.getByPlaceholderText('Event title')).toHaveValue('Daily standup');
     expect(recurrenceSelect).toHaveValue('weekdays');
+
+    fireEvent.click(screen.getByRole('button', { name: 'Add Event' }));
+    expect(onSave).toHaveBeenCalledTimes(1);
+    expect(onSave.mock.calls[0][0].meta).toMatchObject({
+      templateId: 'dailyStandup',
+      templateVersion: 1,
+    });
   });
 });


### PR DESCRIPTION
### Motivation
- Centralize built-in event templates into a single source so UI and other code can reuse consistent template defaults and metadata.
- Persist template identity and version on created events so consumers can detect which template (and version) produced an event.

### Description
- Added `src/core/engine/recurrence/templates.ts` which exports `EventTemplate` types, `BUILT_IN_EVENT_TEMPLATES`, and `getEventTemplateById` for programmatic access to templates.
- Updated `src/ui/EventForm.jsx` to import the shared templates, remove the local `EVENT_TEMPLATES`, populate the template selector from `BUILT_IN_EVENT_TEMPLATES`, and use `getEventTemplateById` in `applyTemplate`.
- `applyTemplate` now writes `meta.templateId` and `meta.templateVersion` and applies additional defaults such as `color` and `category`, and preserves existing `meta` values.
- Updated the recurrence-related test to verify template defaults are applied and that template metadata (`templateId` and `templateVersion`) is saved with the event.

### Testing
- Ran the updated unit test `src/ui/__tests__/EventForm.recurrence.test.jsx` which verifies recurrence RRULE generation and that the Daily standup template applies defaults and metadata, and the test passed.
- Verified the template-application behavior in the modified test by asserting `meta` contains `templateId: 'dailyStandup'` and `templateVersion: 1`, and the assertion succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc75964238832c8e69200373069fef)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced event templates catalog with multiple predefined templates for common meeting types including daily standups, weekly 1:1s, planning sessions, and operations/support meetings.
  * Templates now automatically apply associated colors and other settings when selected for creating events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->