### PR TITLE
Add generic CalendarExternalForm + Microsoft 365 example adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,3 +76,38 @@ import 'works-calendar/styles/ocean';   // optional theme
 Available themes: `light`, `dark`, `aviation`, `soft`, `minimal`, `corporate`, `forest`, `ocean`
 
 Owner password for config panel: `demo1234` (demo only — set your own via `ownerPassword` prop).
+
+## DataAdapter pattern (backend-agnostic)
+
+Use a submit adapter to keep form UX independent from storage/auth choices.
+
+```jsx
+import { CalendarExternalForm, createLocalStorageDataAdapter } from 'works-calendar';
+
+const adapter = createLocalStorageDataAdapter({ key: 'my-app:events' });
+
+<CalendarExternalForm adapter={adapter} />
+```
+
+Adapter contract:
+
+```ts
+{
+  submitEvent(payload, context): Promise<unknown>
+}
+```
+
+## External form workflows
+
+`CalendarExternalForm` is a standalone form that can be embedded outside the main calendar UI. It supports:
+
+- field-schema driven rendering
+- required-field + date-order validation
+- per-host transform/validate hooks
+- adapter-level error handling for network/backend failures
+
+## Microsoft 365 example
+
+A Microsoft Graph adapter example is included at `examples/microsoft-365/`.
+
+It is intentionally example-only to keep the core package free from required MSAL dependencies and enterprise auth opinions.

--- a/examples/microsoft-365/Microsoft365ExternalFormExample.jsx
+++ b/examples/microsoft-365/Microsoft365ExternalFormExample.jsx
@@ -1,0 +1,25 @@
+import { CalendarExternalForm } from '../../src/index.js';
+import { createMicrosoft365Adapter } from './microsoft365Adapter.js';
+
+const fields = [
+  { name: 'title', label: 'Title', type: 'text', required: true },
+  { name: 'start', label: 'Start', type: 'datetime-local', required: true },
+  { name: 'end', label: 'End', type: 'datetime-local', required: true },
+  { name: 'location', label: 'Location', type: 'text' },
+  { name: 'description', label: 'Description', type: 'textarea' },
+];
+
+export default function Microsoft365ExternalFormExample({ tokenProvider }) {
+  const adapter = createMicrosoft365Adapter({ tokenProvider });
+
+  return (
+    <CalendarExternalForm
+      fields={fields}
+      adapter={adapter}
+      submitLabel="Create in Microsoft 365"
+      onSuccess={(result) => {
+        console.log('Microsoft 365 event created', result?.id);
+      }}
+    />
+  );
+}

--- a/examples/microsoft-365/README.md
+++ b/examples/microsoft-365/README.md
@@ -1,0 +1,32 @@
+# Microsoft 365 external form example
+
+This example shows how to pair `CalendarExternalForm` with a Microsoft Graph adapter.
+
+## Why this lives here
+
+- Keeps MSAL / Graph auth choices out of the core `works-calendar` package.
+- Reuses the same backend-agnostic submit contract as any other adapter.
+
+## Adapter contract
+
+Your adapter only needs:
+
+```js
+{
+  async submitEvent(payload) => result
+}
+```
+
+## Token provider
+
+Pass a `tokenProvider` function that returns an access token. You can implement it with:
+
+- `@azure/msal-browser`
+- `@azure/msal-react`
+- your own backend token exchange
+
+Then render:
+
+```jsx
+<Microsoft365ExternalFormExample tokenProvider={getToken} />
+```

--- a/examples/microsoft-365/microsoft365Adapter.js
+++ b/examples/microsoft-365/microsoft365Adapter.js
@@ -1,0 +1,50 @@
+/**
+ * Example Microsoft Graph adapter for CalendarExternalForm.
+ * Keep this in examples/ so the core package stays auth-provider neutral.
+ */
+
+export function createMicrosoft365Adapter({ tokenProvider, calendarId = 'primary' }) {
+  if (typeof tokenProvider !== 'function') {
+    throw new Error('tokenProvider is required for Microsoft 365 adapter.');
+  }
+
+  return {
+    async submitEvent(payload) {
+      const token = await tokenProvider();
+      const response = await fetch(`https://graph.microsoft.com/v1.0/me/calendars/${calendarId}/events`, {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${token}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(toGraphEvent(payload)),
+      });
+
+      if (!response.ok) {
+        const text = await response.text();
+        throw new Error(`Graph submit failed (${response.status}): ${text || 'unknown error'}`);
+      }
+
+      return response.json();
+    },
+  };
+}
+
+function toGraphEvent(payload) {
+  const timezone = Intl.DateTimeFormat().resolvedOptions().timeZone || 'UTC';
+  return {
+    subject: payload.title,
+    body: payload.description
+      ? { contentType: 'text', content: payload.description }
+      : undefined,
+    start: {
+      dateTime: new Date(payload.start).toISOString(),
+      timeZone: timezone,
+    },
+    end: {
+      dateTime: new Date(payload.end).toISOString(),
+      timeZone: timezone,
+    },
+    location: payload.location ? { displayName: payload.location } : undefined,
+  };
+}

--- a/src/external/localStorageDataAdapter.js
+++ b/src/external/localStorageDataAdapter.js
@@ -1,0 +1,29 @@
+/**
+ * localStorage adapter used by CalendarExternalForm examples and smoke tests.
+ */
+export function createLocalStorageDataAdapter({ key = 'works-calendar:external-events' } = {}) {
+  return {
+    async submitEvent(payload) {
+      const events = readEvents(key);
+      const record = {
+        id: `ext-${Date.now().toString(36)}`,
+        createdAt: new Date().toISOString(),
+        ...payload,
+      };
+      const next = [...events, record];
+      localStorage.setItem(key, JSON.stringify(next));
+      return record;
+    },
+  };
+}
+
+function readEvents(key) {
+  try {
+    const raw = localStorage.getItem(key);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed) ? parsed : [];
+  } catch {
+    return [];
+  }
+}

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -646,3 +646,46 @@ export declare const FIELD_TYPES: Array<{ value: FieldType; label: string }>;
 // Re-exports everything from the versioned public schema layer.
 // Consumers can also import directly from 'works-calendar/api/v1'.
 export * from './api/v1/index';
+
+// ─── External forms ───────────────────────────────────────────────────────────
+
+export interface CalendarExternalFormFieldOption {
+  label: string;
+  value: string;
+}
+
+export interface CalendarExternalFormField {
+  name: string;
+  label: string;
+  type?: 'text' | 'textarea' | 'datetime-local' | 'date' | 'checkbox' | 'select';
+  required?: boolean;
+  placeholder?: string;
+  options?: CalendarExternalFormFieldOption[];
+}
+
+export interface CalendarExternalFormAdapter {
+  submitEvent: (payload: Record<string, unknown>, context: {
+    values: Record<string, unknown>;
+    fields: CalendarExternalFormField[];
+  }) => Promise<unknown>;
+}
+
+export interface CalendarExternalFormProps {
+  adapter: CalendarExternalFormAdapter;
+  fields?: CalendarExternalFormField[];
+  initialValues?: Record<string, unknown>;
+  validate?: (
+    values: Record<string, unknown>,
+    fields: CalendarExternalFormField[],
+  ) => Record<string, string>;
+  transform?: (values: Record<string, unknown>) => Record<string, unknown>;
+  submitLabel?: string;
+  onSuccess?: (result: unknown, values: Record<string, unknown>) => void;
+  onError?: (error: unknown, values: Record<string, unknown>) => void;
+}
+
+export const CalendarExternalForm: React.ComponentType<CalendarExternalFormProps>;
+
+export declare function createLocalStorageDataAdapter(options?: {
+  key?: string;
+}): CalendarExternalFormAdapter;

--- a/src/index.js
+++ b/src/index.js
@@ -21,6 +21,8 @@ export {
 } from './filters/filterSchema.js';
 export { createInitialFilters, buildActiveFilterPills, isEmptyFilterValue } from './filters/filterState.js';
 export { THEMES, THEMES_BY_ID, THEME_IDS } from './styles/themes.js';
+export { default as CalendarExternalForm } from './ui/CalendarExternalForm.jsx';
+export { createLocalStorageDataAdapter } from './external/localStorageDataAdapter.js';
 export { parseICS, fetchAndParseICS }     from './core/icalParser.js';
 export { useOccurrences }                 from './hooks/useOccurrences.js';
 export { useDrag }                        from './hooks/useDrag.js';

--- a/src/ui/CalendarExternalForm.jsx
+++ b/src/ui/CalendarExternalForm.jsx
@@ -1,0 +1,157 @@
+import { useMemo, useState } from 'react';
+import styles from './CalendarExternalForm.module.css';
+
+const DEFAULT_FIELDS = [
+  { name: 'title', label: 'Title', type: 'text', required: true },
+  { name: 'start', label: 'Start', type: 'datetime-local', required: true },
+  { name: 'end', label: 'End', type: 'datetime-local', required: true },
+  { name: 'allDay', label: 'All day', type: 'checkbox', required: false },
+  { name: 'category', label: 'Category', type: 'text', required: false },
+  { name: 'resource', label: 'Resource', type: 'text', required: false },
+  { name: 'description', label: 'Description', type: 'textarea', required: false },
+];
+
+function defaultValidate(values, fields) {
+  const errors = {};
+  fields.forEach((field) => {
+    if (!field.required) return;
+    if (field.type === 'checkbox') return;
+    const value = values[field.name];
+    if (value === '' || value === null || value === undefined) {
+      errors[field.name] = `${field.label ?? field.name} is required.`;
+    }
+  });
+
+  if (values.start && values.end && new Date(values.start) > new Date(values.end)) {
+    errors.end = 'End must be after start.';
+  }
+
+  return errors;
+}
+
+/**
+ * Backend-agnostic external event form.
+ *
+ * Adapter contract:
+ *   await adapter.submitEvent(payload, { values, fields })
+ */
+export default function CalendarExternalForm({
+  adapter,
+  fields = DEFAULT_FIELDS,
+  initialValues = {},
+  validate = defaultValidate,
+  transform = (values) => values,
+  submitLabel = 'Submit event',
+  onSuccess,
+  onError,
+}) {
+  const mergedInitialValues = useMemo(() => {
+    const fromFields = fields.reduce((acc, field) => {
+      acc[field.name] = field.type === 'checkbox' ? false : '';
+      return acc;
+    }, {});
+    return { ...fromFields, ...initialValues };
+  }, [fields, initialValues]);
+
+  const [values, setValues] = useState(mergedInitialValues);
+  const [errors, setErrors] = useState({});
+  const [submitError, setSubmitError] = useState('');
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  function setValue(name, value) {
+    setValues((prev) => ({ ...prev, [name]: value }));
+    setErrors((prev) => ({ ...prev, [name]: undefined }));
+    setSubmitError('');
+  }
+
+  async function handleSubmit(event) {
+    event.preventDefault();
+    const validationErrors = validate(values, fields);
+    setErrors(validationErrors);
+    if (Object.keys(validationErrors).length > 0) return;
+
+    setIsSubmitting(true);
+    setSubmitError('');
+
+    try {
+      const payload = transform(values);
+      const result = await adapter.submitEvent(payload, { values, fields });
+      onSuccess?.(result, values);
+      setValues(mergedInitialValues);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Unable to submit event.';
+      setSubmitError(message);
+      onError?.(err, values);
+    } finally {
+      setIsSubmitting(false);
+    }
+  }
+
+  return (
+    <div className={styles.wrapper}>
+      <form className={styles.form} onSubmit={handleSubmit} noValidate>
+        {fields.map((field) => {
+          const inputId = `external-${field.name}`;
+          const value = values[field.name];
+          return (
+            <div className={styles.row} key={field.name}>
+              <label className={styles.label} htmlFor={inputId}>{field.label}</label>
+              {field.type === 'textarea' && (
+                <textarea
+                  id={inputId}
+                  className={styles.textarea}
+                  value={value}
+                  placeholder={field.placeholder}
+                  onChange={(e) => setValue(field.name, e.target.value)}
+                  rows={3}
+                />
+              )}
+              {field.type === 'select' && (
+                <select
+                  id={inputId}
+                  className={styles.select}
+                  value={value}
+                  onChange={(e) => setValue(field.name, e.target.value)}
+                >
+                  <option value="">Select…</option>
+                  {(field.options ?? []).map((option) => (
+                    <option key={option.value} value={option.value}>{option.label}</option>
+                  ))}
+                </select>
+              )}
+              {field.type === 'checkbox' && (
+                <input
+                  id={inputId}
+                  type="checkbox"
+                  checked={Boolean(value)}
+                  onChange={(e) => setValue(field.name, e.target.checked)}
+                />
+              )}
+              {!['textarea', 'select', 'checkbox'].includes(field.type) && (
+                <input
+                  id={inputId}
+                  className={styles.input}
+                  type={field.type || 'text'}
+                  value={value}
+                  placeholder={field.placeholder}
+                  onChange={(e) => setValue(field.name, e.target.value)}
+                />
+              )}
+              {errors[field.name] && <span className={styles.error}>{errors[field.name]}</span>}
+            </div>
+          );
+        })}
+
+        {submitError && <div className={styles.globalError} role="alert">{submitError}</div>}
+
+        <div className={styles.actions}>
+          <button className={styles.button} type="submit" disabled={isSubmitting}>
+            {isSubmitting ? 'Submitting…' : submitLabel}
+          </button>
+        </div>
+      </form>
+    </div>
+  );
+}
+
+export { DEFAULT_FIELDS };

--- a/src/ui/CalendarExternalForm.module.css
+++ b/src/ui/CalendarExternalForm.module.css
@@ -1,0 +1,69 @@
+.wrapper {
+  border: 1px solid var(--wc-border, #d0d7de);
+  border-radius: 12px;
+  padding: 16px;
+  background: var(--wc-surface, #fff);
+}
+
+.form {
+  display: grid;
+  gap: 12px;
+}
+
+.row {
+  display: grid;
+  gap: 6px;
+}
+
+.label {
+  font-size: 0.9rem;
+  font-weight: 600;
+}
+
+.input,
+.select,
+.textarea {
+  width: 100%;
+  border: 1px solid var(--wc-border, #d0d7de);
+  border-radius: 8px;
+  padding: 8px 10px;
+  font-size: 0.95rem;
+}
+
+.textarea {
+  resize: vertical;
+}
+
+.error {
+  color: #b42318;
+  font-size: 0.82rem;
+}
+
+.globalError {
+  border: 1px solid #fecaca;
+  background: #fef2f2;
+  color: #991b1b;
+  border-radius: 8px;
+  padding: 8px 10px;
+  font-size: 0.85rem;
+}
+
+.actions {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.button {
+  border: none;
+  border-radius: 8px;
+  background: #2563eb;
+  color: #fff;
+  font-weight: 600;
+  padding: 8px 12px;
+  cursor: pointer;
+}
+
+.button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}

--- a/src/ui/__tests__/CalendarExternalForm.test.jsx
+++ b/src/ui/__tests__/CalendarExternalForm.test.jsx
@@ -1,0 +1,51 @@
+// @vitest-environment happy-dom
+
+import { describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import CalendarExternalForm from '../CalendarExternalForm.jsx';
+
+describe('CalendarExternalForm', () => {
+  it('submits through adapter and calls onSuccess', async () => {
+    const submitEvent = vi.fn(async () => ({ id: 'graph-1' }));
+    const onSuccess = vi.fn();
+
+    render(<CalendarExternalForm adapter={{ submitEvent }} onSuccess={onSuccess} />);
+
+    fireEvent.change(screen.getByLabelText('Title'), { target: { value: 'Planning' } });
+    fireEvent.change(screen.getByLabelText('Start'), { target: { value: '2026-04-13T09:00' } });
+    fireEvent.change(screen.getByLabelText('End'), { target: { value: '2026-04-13T10:00' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Submit event' }));
+
+    await waitFor(() => expect(submitEvent).toHaveBeenCalledTimes(1));
+    expect(onSuccess).toHaveBeenCalledWith({ id: 'graph-1' }, expect.any(Object));
+  });
+
+  it('shows validation errors for required fields and date ordering', async () => {
+    const submitEvent = vi.fn();
+
+    render(<CalendarExternalForm adapter={{ submitEvent }} />);
+    fireEvent.change(screen.getByLabelText('Start'), { target: { value: '2026-04-13T10:00' } });
+    fireEvent.change(screen.getByLabelText('End'), { target: { value: '2026-04-13T09:00' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Submit event' }));
+
+    expect(await screen.findByText('Title is required.')).toBeInTheDocument();
+    expect(await screen.findByText('End must be after start.')).toBeInTheDocument();
+    expect(submitEvent).not.toHaveBeenCalled();
+  });
+
+  it('surfaces adapter/network failures', async () => {
+    const submitEvent = vi.fn(async () => {
+      throw new Error('network failed');
+    });
+
+    render(<CalendarExternalForm adapter={{ submitEvent }} />);
+
+    fireEvent.change(screen.getByLabelText('Title'), { target: { value: 'Planning' } });
+    fireEvent.change(screen.getByLabelText('Start'), { target: { value: '2026-04-13T09:00' } });
+    fireEvent.change(screen.getByLabelText('End'), { target: { value: '2026-04-13T10:00' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Submit event' }));
+
+    expect(await screen.findByRole('alert')).toHaveTextContent('network failed');
+  });
+});


### PR DESCRIPTION
### Motivation
- Provide a reusable, backend-agnostic external event submission form so hosts can embed a submission UX without coupling the core library to an auth/storage choice. 
- Define a simple DataAdapter contract so adapters (Graph, REST, localStorage, etc.) can be plugged in uniformly. 
- Ship a Microsoft 365 example as a self-contained example (adapter + wiring) while keeping MSAL/Graph dependencies out of the core package.

### Description
- Add `CalendarExternalForm` component with field-schema driven rendering, default validation (required fields + start/end ordering), transform hook, and adapter submission/error handling (`src/ui/CalendarExternalForm.jsx` and styles in `src/ui/CalendarExternalForm.module.css`).
- Add a simple local persistence adapter `createLocalStorageDataAdapter` for examples/tests (`src/external/localStorageDataAdapter.js`).
- Add an example Microsoft Graph adapter `createMicrosoft365Adapter` and example usage component under `examples/microsoft-365/` plus an example README demonstrating the `tokenProvider` pattern. 
- Export the form and adapter from the public entrypoint and add TypeScript declarations for the external form API (`src/index.js`, `src/index.d.ts`).
- Update top-level `README.md` with a `DataAdapter` section, `External form workflows` notes, and a link to the Microsoft 365 example. 
- Add Playwright/Jest-like unit tests for the external form (`src/ui/__tests__/CalendarExternalForm.test.jsx`) that cover successful submit, validation errors, and adapter/network failures.

### Testing
- `npm run build` completed successfully and produced library artifacts. ✅
- `npm run test -- src/api/v1/__tests__/templates.test.ts` ran and passed. ✅
- `npm run test -- src/ui/__tests__/CalendarExternalForm.test.jsx` could not run to completion in this environment due to a missing test dependency (`@testing-library/dom`) required by `@testing-library/react`, so the form test suite failed to execute here. ⚠️

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc7d427ba4832cba850290bf19f47c)