### PR TITLE
Harden CalendarExternalForm contract and export supported field types (Phase 1)

### DIFF
--- a/docs/generic-form-and-m365-roadmap.md
+++ b/docs/generic-form-and-m365-roadmap.md
@@ -16,6 +16,23 @@ This roadmap has clear product value and improves adoption:
 3. Expand docs/examples to frame Microsoft 365 as one integration among many.
 4. Harden with form-focused Playwright tests and explicit failure isolation paths.
 
+## Phase 1 (started): Generic `CalendarExternalForm` contract hardening
+
+### Completed in this kickoff
+
+- Adapter runtime contract now fails fast when `submitEvent(payload, context)` is missing.
+- Field-schema normalization now guarantees:
+  - unique field names,
+  - supported field types,
+  - default labels/required/options for consistent rendering.
+- Added tests for contract failures (missing adapter method + duplicate field names).
+- Exported supported field-type constant so host apps can validate/compose schemas before render.
+
+### Remaining in Phase 1
+
+- Add a Playwright external-form smoke suite in demo/examples.
+- Add one more non-Microsoft adapter example beyond localStorage (Supabase stub).
+
 ## Acceptance criteria for PR #2
 
 - Generic form can submit through a backend-agnostic adapter interface.

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -686,6 +686,8 @@ export interface CalendarExternalFormProps {
 
 export const CalendarExternalForm: React.ComponentType<CalendarExternalFormProps>;
 
+export const SUPPORTED_EXTERNAL_FORM_FIELD_TYPES: Array<NonNullable<CalendarExternalFormField['type']>>;
+
 export declare function createLocalStorageDataAdapter(options?: {
   key?: string;
 }): CalendarExternalFormAdapter;

--- a/src/index.js
+++ b/src/index.js
@@ -21,7 +21,10 @@ export {
 } from './filters/filterSchema.js';
 export { createInitialFilters, buildActiveFilterPills, isEmptyFilterValue } from './filters/filterState.js';
 export { THEMES, THEMES_BY_ID, THEME_IDS } from './styles/themes.js';
-export { default as CalendarExternalForm } from './ui/CalendarExternalForm.jsx';
+export {
+  default as CalendarExternalForm,
+  SUPPORTED_EXTERNAL_FORM_FIELD_TYPES,
+} from './ui/CalendarExternalForm.jsx';
 export { createLocalStorageDataAdapter } from './external/localStorageDataAdapter.js';
 export { parseICS, fetchAndParseICS }     from './core/icalParser.js';
 export { useOccurrences }                 from './hooks/useOccurrences.js';

--- a/src/ui/CalendarExternalForm.jsx
+++ b/src/ui/CalendarExternalForm.jsx
@@ -1,6 +1,8 @@
 import { useMemo, useState } from 'react';
 import styles from './CalendarExternalForm.module.css';
 
+const SUPPORTED_FIELD_TYPES = new Set(['text', 'textarea', 'datetime-local', 'date', 'checkbox', 'select']);
+
 const DEFAULT_FIELDS = [
   { name: 'title', label: 'Title', type: 'text', required: true },
   { name: 'start', label: 'Start', type: 'datetime-local', required: true },
@@ -10,6 +12,44 @@ const DEFAULT_FIELDS = [
   { name: 'resource', label: 'Resource', type: 'text', required: false },
   { name: 'description', label: 'Description', type: 'textarea', required: false },
 ];
+
+function normalizeFields(fields) {
+  if (!Array.isArray(fields) || fields.length === 0) {
+    throw new Error('CalendarExternalForm requires at least one field.');
+  }
+
+  const names = new Set();
+  return fields.map((field) => {
+    if (!field?.name || typeof field.name !== 'string') {
+      throw new Error('Each field requires a string `name`.');
+    }
+
+    if (names.has(field.name)) {
+      throw new Error(`Duplicate field name: ${field.name}`);
+    }
+    names.add(field.name);
+
+    const type = field.type || 'text';
+    if (!SUPPORTED_FIELD_TYPES.has(type)) {
+      throw new Error(`Unsupported field type: ${type}`);
+    }
+
+    return {
+      ...field,
+      type,
+      label: field.label ?? field.name,
+      required: Boolean(field.required),
+      options: field.options ?? [],
+    };
+  });
+}
+
+function ensureAdapter(adapter) {
+  if (!adapter || typeof adapter.submitEvent !== 'function') {
+    throw new Error('CalendarExternalForm adapter must define submitEvent(payload, context).');
+  }
+  return adapter;
+}
 
 function defaultValidate(values, fields) {
   const errors = {};
@@ -45,13 +85,16 @@ export default function CalendarExternalForm({
   onSuccess,
   onError,
 }) {
+  const safeAdapter = ensureAdapter(adapter);
+  const normalizedFields = useMemo(() => normalizeFields(fields), [fields]);
+
   const mergedInitialValues = useMemo(() => {
-    const fromFields = fields.reduce((acc, field) => {
+    const fromFields = normalizedFields.reduce((acc, field) => {
       acc[field.name] = field.type === 'checkbox' ? false : '';
       return acc;
     }, {});
     return { ...fromFields, ...initialValues };
-  }, [fields, initialValues]);
+  }, [normalizedFields, initialValues]);
 
   const [values, setValues] = useState(mergedInitialValues);
   const [errors, setErrors] = useState({});
@@ -66,7 +109,7 @@ export default function CalendarExternalForm({
 
   async function handleSubmit(event) {
     event.preventDefault();
-    const validationErrors = validate(values, fields);
+    const validationErrors = validate(values, normalizedFields);
     setErrors(validationErrors);
     if (Object.keys(validationErrors).length > 0) return;
 
@@ -75,7 +118,7 @@ export default function CalendarExternalForm({
 
     try {
       const payload = transform(values);
-      const result = await adapter.submitEvent(payload, { values, fields });
+      const result = await safeAdapter.submitEvent(payload, { values, fields: normalizedFields });
       onSuccess?.(result, values);
       setValues(mergedInitialValues);
     } catch (err) {
@@ -90,7 +133,7 @@ export default function CalendarExternalForm({
   return (
     <div className={styles.wrapper}>
       <form className={styles.form} onSubmit={handleSubmit} noValidate>
-        {fields.map((field) => {
+        {normalizedFields.map((field) => {
           const inputId = `external-${field.name}`;
           const value = values[field.name];
           return (
@@ -154,4 +197,4 @@ export default function CalendarExternalForm({
   );
 }
 
-export { DEFAULT_FIELDS };
+export { DEFAULT_FIELDS, SUPPORTED_FIELD_TYPES as SUPPORTED_EXTERNAL_FORM_FIELD_TYPES };

--- a/src/ui/__tests__/CalendarExternalForm.test.jsx
+++ b/src/ui/__tests__/CalendarExternalForm.test.jsx
@@ -48,4 +48,22 @@ describe('CalendarExternalForm', () => {
 
     expect(await screen.findByRole('alert')).toHaveTextContent('network failed');
   });
+
+  it('throws when adapter does not implement submitEvent', () => {
+    expect(() => render(<CalendarExternalForm adapter={{}} />)).toThrow(
+      'CalendarExternalForm adapter must define submitEvent(payload, context).',
+    );
+  });
+
+  it('throws on duplicate field names', () => {
+    expect(() => render(
+      <CalendarExternalForm
+        adapter={{ submitEvent: vi.fn(async () => ({})) }}
+        fields={[
+          { name: 'title', label: 'Title' },
+          { name: 'title', label: 'Title duplicate' },
+        ]}
+      />, 
+    )).toThrow('Duplicate field name: title');
+  });
 });


### PR DESCRIPTION
### Motivation

- Start Phase 1 of the generic external form + Microsoft 365 roadmap by hardening the external form contract to make integrations safer and host-side schema composition easier.
- Fail fast on misconfigured adapters and provide a normalized, deterministic field schema so host apps and adapters can rely on a single contract for validation and rendering.

### Description

- Add runtime field normalization via `normalizeFields` that enforces a string `name`, unique field names, supported types, default `label`/`required`/`options`, and rejects unsupported `type` values.
- Add adapter validation via `ensureAdapter` that throws when the adapter does not implement `submitEvent(payload, context)` and use the validated adapter (`safeAdapter`) for submission.
- Use the normalized fields consistently during initial value merging, validation, rendering, and submission (`normalizedFields`), and keep the existing `DEFAULT_FIELDS` fallback.
- Export the supported field-types constant as `SUPPORTED_EXTERNAL_FORM_FIELD_TYPES` from the public API (`src/index.js`) and add the matching declaration to `src/index.d.ts`, and update the roadmap doc with a Phase 1 kickoff summary.
- Add unit tests covering successful submit, validation errors, adapter/network failures, plus new tests that assert throwing behavior for a missing `submitEvent` and for duplicate field names (`src/ui/__tests__/CalendarExternalForm.test.jsx`).

### Testing

- Ran the unit test file with `npm run test -- src/ui/__tests__/CalendarExternalForm.test.jsx` which attempted to execute the updated test suite but failed due to a missing test dependency (`Error: Cannot find module '@testing-library/dom'`).
- The added tests exercise adapter submission, `onSuccess` callback behavior, validation error messages, adapter/network error surfacing, missing-adapter method throwing, and duplicate-field-name throwing, but could not be executed in this environment because of the missing dependency.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc7e8d0af0832cbdc87f8fbc697b43)