### PR TITLE
Start phase 1 recurring schedule template integration coverage

### DIFF
--- a/docs/recurring-schedule-implementation-plan.md
+++ b/docs/recurring-schedule-implementation-plan.md
@@ -39,6 +39,10 @@ Deliver a complete "Add Schedule" workflow that uses reusable schedule templates
 - Core callbacks (`onEventSave`) fire for generated events.
 - Tests cover template selection and instantiate callback payload.
 
+### Phase 1 kickoff notes (April 13, 2026)
+- Added `WorksCalendar` integration coverage ensuring the `Add Schedule` action only appears when visible schedule templates exist.
+- Added a focused flow test that opens the schedule dialog, submits template generation, and verifies `onEventSave` receives generated master payloads.
+
 ### Phase 0 kickoff notes (April 13, 2026)
 - Added a dedicated recurring expansion baseline test suite at `src/core/engine/__tests__/recurringPhase0Baseline.test.ts`.
 - Locked deterministic occurrence ID behavior across repeated expansion calls for the same query window.

--- a/src/__tests__/WorksCalendar.scheduleTemplates.test.jsx
+++ b/src/__tests__/WorksCalendar.scheduleTemplates.test.jsx
@@ -1,0 +1,70 @@
+// @vitest-environment happy-dom
+
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { WorksCalendar } from '../WorksCalendar.jsx';
+
+const scheduleTemplates = [
+  {
+    id: 'sched-ops',
+    name: 'Ops Coverage',
+    visibility: 'org',
+    entries: [
+      {
+        title: 'Morning coverage',
+        startOffsetMinutes: 0,
+        durationMinutes: 120,
+        rrule: 'FREQ=DAILY;COUNT=2',
+      },
+    ],
+  },
+];
+
+describe('WorksCalendar schedule template flow', () => {
+  it('shows Add Schedule button only when templates are available', () => {
+    const { rerender } = render(
+      <WorksCalendar
+        events={[]}
+        showAddButton
+        scheduleTemplates={[]}
+      />,
+    );
+
+    expect(screen.queryByRole('button', { name: 'Add schedule from template' })).not.toBeInTheDocument();
+
+    rerender(
+      <WorksCalendar
+        events={[]}
+        showAddButton
+        scheduleTemplates={scheduleTemplates}
+      />,
+    );
+
+    expect(screen.getByRole('button', { name: 'Add schedule from template' })).toBeInTheDocument();
+  });
+
+  it('instantiates a schedule and fires onEventSave for generated masters', async () => {
+    const onEventSave = vi.fn();
+
+    render(
+      <WorksCalendar
+        events={[]}
+        showAddButton
+        scheduleTemplates={scheduleTemplates}
+        onEventSave={onEventSave}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Add schedule from template' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Create schedule' }));
+
+    await waitFor(() => expect(onEventSave).toHaveBeenCalledTimes(1));
+    expect(onEventSave).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: 'Morning coverage',
+        rrule: 'FREQ=DAILY;COUNT=2',
+      }),
+    );
+  });
+});


### PR DESCRIPTION
### Motivation
- Begin Phase 1 of the recurring schedules plan by adding integration-level coverage for the new Add Schedule flow so UI behavior and instantiation callbacks are exercised. 
- Ensure the `WorksCalendar` shows the Add Schedule action only when templates are available and that generated masters trigger the expected callbacks.

### Description
- Added an integration test `src/__tests__/WorksCalendar.scheduleTemplates.test.jsx` that verifies Add Schedule visibility and that instantiating a template fires `onEventSave` with generated master payloads. 
- Updated `docs/recurring-schedule-implementation-plan.md` to include Phase 1 kickoff notes documenting the new integration coverage and callback verification. 
- Tests rely on existing `ScheduleTemplateDialog` test coverage and the client-side `instantiateScheduleTemplate` flow used by `WorksCalendar`.

### Testing
- Ran the focused test command: `npm test -- src/__tests__/WorksCalendar.scheduleTemplates.test.jsx src/ui/__tests__/ScheduleTemplateDialog.test.jsx` which attempted to execute the new integration spec alongside the dialog unit tests. 
- Test run failed to complete due to a missing test dependency (`Cannot find module '@testing-library/dom'`), causing the suites to error before assertions could run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc81256d38832c9d1d077b3c37dcab)