### PR TITLE
Start Phase 2: preview & safety for schedule templates

### DIFF
--- a/docs/recurring-schedule-implementation-plan.md
+++ b/docs/recurring-schedule-implementation-plan.md
@@ -48,10 +48,15 @@ Deliver a complete "Add Schedule" workflow that uses reusable schedule templates
 - Locked deterministic occurrence ID behavior across repeated expansion calls for the same query window.
 - Added explicit regression coverage for `EXDATE` filtering and `maxPerSeries` generation caps.
 
-## Phase 2 — Preview + safety
+## Phase 2 — Preview + safety (started)
 1. Add pre-submit preview list of generated masters.
 2. Highlight obvious conflicts using existing validation pipeline.
 3. Add validation for malformed anchors/template payloads and user-facing errors.
+
+### Phase 2 kickoff notes (April 13, 2026)
+- Added per-entry conflict details in `ScheduleTemplateDialog` preview rows so users can see validation messages before creation.
+- Hardened `instantiateScheduleTemplate` with explicit validation for invalid anchors and malformed schedule template entries.
+- Added regression tests for preview conflict rendering and template/anchor validation failures.
 
 ## Phase 3 — Template management and backend integration
 1. Optional adapter-backed template fetching/creation flows.

--- a/src/WorksCalendar.jsx
+++ b/src/WorksCalendar.jsx
@@ -612,7 +612,16 @@ export const WorksCalendar = forwardRef(function WorksCalendar(
       });
       return;
     }
-    const result = instantiateScheduleTemplate(template, request);
+    let result;
+    try {
+      result = instantiateScheduleTemplate(template, request);
+    } catch {
+      trackScheduleTemplateAnalytics('schedule_instantiate_failed', {
+        reason: 'instantiate-throw',
+        templateId: template.id,
+      });
+      return;
+    }
     if (result.generated.length > resolvedScheduleLimits.createMax) {
       trackScheduleTemplateAnalytics('schedule_instantiate_failed', {
         reason: 'create-limit-exceeded',

--- a/src/api/v1/__tests__/templates.test.ts
+++ b/src/api/v1/__tests__/templates.test.ts
@@ -35,6 +35,27 @@ describe('instantiateScheduleTemplate', () => {
       generatedBy: 'wizard',
     });
   });
+
+  it('throws on malformed anchor and malformed template entries', () => {
+    expect(() => instantiateScheduleTemplate(template, { anchor: 'bad-anchor' })).toThrow(
+      'Schedule anchor must be a valid date.',
+    );
+
+    const malformedTemplate: ScheduleTemplateV1 = {
+      ...template,
+      entries: [
+        {
+          title: '',
+          startOffsetMinutes: Number.NaN,
+          durationMinutes: Number.NaN,
+        },
+      ],
+    };
+
+    expect(() => instantiateScheduleTemplate(malformedTemplate, { anchor: new Date('2026-04-20T08:00:00.000Z') })).toThrow(
+      'Schedule template entry 1 is missing a valid title.',
+    );
+  });
 });
 
 describe('canViewScheduleTemplate', () => {

--- a/src/api/v1/templates.ts
+++ b/src/api/v1/templates.ts
@@ -79,6 +79,24 @@ function asDate(input: Date | string | number): Date {
   return input instanceof Date ? input : new Date(input);
 }
 
+function ensureValidTemplate(template: ScheduleTemplateV1): void {
+  if (!template || !Array.isArray(template.entries) || template.entries.length === 0) {
+    throw new Error('Schedule template must include at least one entry.');
+  }
+
+  template.entries.forEach((entry, idx) => {
+    if (!entry || typeof entry.title !== 'string' || !entry.title.trim()) {
+      throw new Error(`Schedule template entry ${idx + 1} is missing a valid title.`);
+    }
+    if (!Number.isFinite(entry.startOffsetMinutes)) {
+      throw new Error(`Schedule template entry ${idx + 1} has an invalid start offset.`);
+    }
+    if (!Number.isFinite(entry.durationMinutes)) {
+      throw new Error(`Schedule template entry ${idx + 1} has an invalid duration.`);
+    }
+  });
+}
+
 /**
  * Build master events from a schedule template and user-selected anchor.
  * This is pure client-side scaffolding for "Add Schedule" flows.
@@ -87,7 +105,11 @@ export function instantiateScheduleTemplate(
   template: ScheduleTemplateV1,
   request: ScheduleInstantiationRequestV1,
 ): ScheduleInstantiationResultV1 {
+  ensureValidTemplate(template);
   const anchor = asDate(request.anchor);
+  if (Number.isNaN(anchor.getTime())) {
+    throw new Error('Schedule anchor must be a valid date.');
+  }
 
   const generated = template.entries.map((entry, idx) => {
     const start = addMinutes(anchor, entry.startOffsetMinutes);

--- a/src/ui/ScheduleTemplateDialog.jsx
+++ b/src/ui/ScheduleTemplateDialog.jsx
@@ -64,6 +64,14 @@ export default function ScheduleTemplateDialog({
   }, [anchorError, onPreview, request, selectedTemplate, templateError]);
 
   const submitDisabled = !!(templateError || anchorError || preview.error);
+  const conflictsByIndex = useMemo(() => {
+    const map = new Map();
+    (preview.conflicts ?? []).forEach((conflict) => {
+      if (typeof conflict?.index !== 'number') return;
+      map.set(conflict.index, conflict);
+    });
+    return map;
+  }, [preview.conflicts]);
 
   function handleSubmit(e) {
     e.preventDefault();
@@ -137,9 +145,23 @@ export default function ScheduleTemplateDialog({
                 </div>
                 <ul className={styles.previewList}>
                   {preview.generated.map((ev, idx) => (
-                    <li key={`${ev.title}-${idx}`} className={styles.previewItem}>
-                      <span>{ev.title ?? '(untitled)'}</span>
-                      <span>{toDatetimeLocal(ev.start)}</span>
+                    <li
+                      key={`${ev.title}-${idx}`}
+                      className={`${styles.previewItem} ${conflictsByIndex.has(idx) ? styles.previewItemConflict : ''}`}
+                    >
+                      <div className={styles.previewSummary}>
+                        <span>{ev.title ?? '(untitled)'}</span>
+                        <span>{toDatetimeLocal(ev.start)}</span>
+                      </div>
+                      {conflictsByIndex.has(idx) && (
+                        <ul className={styles.conflictList}>
+                          {conflictsByIndex.get(idx).violations?.map((violation, vIdx) => (
+                            <li key={`${violation.rule}-${vIdx}`} className={styles.conflictItem}>
+                              {violation.message}
+                            </li>
+                          ))}
+                        </ul>
+                      )}
                     </li>
                   ))}
                 </ul>

--- a/src/ui/ScheduleTemplateDialog.module.css
+++ b/src/ui/ScheduleTemplateDialog.module.css
@@ -123,8 +123,28 @@
 }
 
 .previewItem {
+  display: grid;
+  gap: 4px;
+  padding: 4px 0;
+}
+
+.previewSummary {
   display: flex;
   justify-content: space-between;
   gap: 8px;
-  padding: 2px 0;
+}
+
+.previewItemConflict {
+  border-left: 3px solid #f59e0b;
+  padding-left: 8px;
+}
+
+.conflictList {
+  margin: 0;
+  padding-left: 18px;
+  color: #92400e;
+}
+
+.conflictItem {
+  font-size: 0.78rem;
 }

--- a/src/ui/__tests__/ScheduleTemplateDialog.test.jsx
+++ b/src/ui/__tests__/ScheduleTemplateDialog.test.jsx
@@ -80,4 +80,29 @@ describe('ScheduleTemplateDialog', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Create schedule' }));
     expect(onInstantiate).not.toHaveBeenCalled();
   });
+
+  it('renders conflict details from preview results', () => {
+    render(
+      <ScheduleTemplateDialog
+        templates={templates}
+        onPreview={() => ({
+          generated: templates[0].entries,
+          conflicts: [
+            {
+              index: 0,
+              violations: [
+                { rule: 'overlap', message: 'Overlaps an existing event.' },
+              ],
+            },
+          ],
+          error: '',
+        })}
+        onInstantiate={() => {}}
+        onClose={() => {}}
+      />,
+    );
+
+    expect(screen.getByText('1 conflict')).toBeInTheDocument();
+    expect(screen.getByText('Overlaps an existing event.')).toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
### Motivation
- Begin Phase 2 of the recurring schedule templates plan to add preview and safety features for Add Schedule flows.
- Improve UX by surfacing per-entry validation/conflict information before instantiation so users can inspect problems prior to creation.
- Harden client-side instantiation to fail fast on malformed anchors or template entries and surface analytics for instantiation failures.

### Description
- Mark Phase 2 as started and add kickoff notes in `docs/recurring-schedule-implementation-plan.md` documenting preview conflict work and validation hardening.
- Add `ensureValidTemplate` and anchor validation in `instantiateScheduleTemplate` (in `src/api/v1/templates.ts`) to throw clear errors for malformed templates or invalid anchors.
- Guard `WorksCalendar` schedule instantiation (`handleScheduleInstantiate` in `src/WorksCalendar.jsx`) with a `try/catch` around `instantiateScheduleTemplate` and emit `schedule_instantiate_failed` analytics on error instead of allowing runtime crashes.
- Enhance `ScheduleTemplateDialog` preview UI (`src/ui/ScheduleTemplateDialog.jsx` + CSS) to build a `conflictsByIndex` map, highlight preview rows with conflicts, and render per-entry violation messages inline.
- Add/adjust unit tests: extend `src/api/v1/__tests__/templates.test.ts` with cases for malformed anchors and entries, and add a UI test in `src/ui/__tests__/ScheduleTemplateDialog.test.jsx` to assert conflict detail rendering.

### Testing
- Ran the test command: `npm test -- src/ui/__tests__/ScheduleTemplateDialog.test.jsx src/api/v1/__tests__/templates.test.ts src/__tests__/WorksCalendar.scheduleTemplates.test.jsx`.
- API-level tests for `instantiateScheduleTemplate` passed and the new validation assertions succeeded (template tests passed).
- UI test suites failed to run in this environment due to a missing dev dependency (`@testing-library/dom`), so browser/DOM tests reported module resolution errors and did not complete here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc821645e8832cb284a129f3d28cea)