### PR TITLE
docs: overhaul README and add focused docs/examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,26 @@
 # WorksCalendar
 
-Drop-in embeddable React calendar with filter pills, hover cards, Excel export, and owner config panel.
+A modern, embeddable React calendar for teams that need fast scheduling, rich filtering, and flexible backend integration.
+
+
+> Drop-in UI, owner-managed setup, advanced smart views, recurring events, and external-form workflows.
+
+## ✨ Features
+
+- **Beautiful calendar UI** with month/week/day/schedule/agenda/timeline views
+- **Theme system** (`light`, `dark`, `aviation`, `soft`, `minimal`, `corporate`, `forest`, `ocean`)
+- **Advanced smart views** with saved filters and nested AND/OR builder via Setup Wizard
+- **First-time Setup Wizard** for owner onboarding, theme, team setup, and starter views
+- **Recurring events engine** with safe expansion and mutation flows
+- **Drag/drop + resize + undo/redo** editing workflow
+- **CSV import + Excel export** support
+- **DataAdapter pattern** for backend-agnostic form submission workflows
+- **CalendarExternalForm** for mobile-friendly, out-of-calendar event intake
+- **Owner config & permissions** controls for deployment customization
+- **Optional Supabase realtime** updates
+- **PWA-ready demo app**
+
+---
 
 ## Quick start
 
@@ -13,73 +33,89 @@ npm run examples     # examples at http://localhost:3001
 ## Build & preview
 
 ```bash
-npm run build        # library → dist/
-npm run build:demo   # demo app → dist-demo/
+npm run build        # library -> dist/
+npm run build:demo   # demo app -> dist-demo/
 npm run preview      # serve dist-demo/ locally
 ```
 
-## PWA (demo app)
-
-The demo is a full Progressive Web App. When you run `npm run build:demo`, `vite-plugin-pwa` emits:
-
-- `dist-demo/sw.js` — Workbox service worker (auto-updated via `registerType: 'autoUpdate'`)
-- `dist-demo/manifest.webmanifest` — Web App Manifest
-- Precached shell assets (JS, CSS, HTML, SVG)
-
-Runtime caching rules:
-- **Google Fonts** — `CacheFirst`, 1-year TTL
-- **Static shell** — precached via Workbox, updated on every deploy
-
-### Install prompt
-
-Browsers that support PWA install will show an install banner when the demo is served over HTTPS. After install the app opens in standalone mode (no browser chrome).
-
-### Update flow
-
-When a new version is deployed, the service worker detects the change and shows a toast: **"A new version is available."** Click **Update** to reload with the latest build. Dismissing the toast defers the update until the next navigation.
-
-### Regenerating icons
-
-Icons live in `demo/public/` as SVG files. To generate PNG variants (for broader compatibility):
-
-```bash
-# Requires sharp or any SVG-to-PNG tool, e.g.:
-npx sharp-cli -i demo/public/icon-512.svg -o demo/public/icon-512.png resize 512 512
-npx sharp-cli -i demo/public/icon-192.svg -o demo/public/icon-192.png resize 192 192
-```
-
-Then update `vite.demo.config.js` to reference the `.png` files and change `type` to `image/png` in the manifest icons array.
-
-### Known limitations
-
-- **Dynamic event data** is generated at runtime from `localStorage`. If the app is opened offline after a previous visit, the calendar shell loads but the event list reflects the last in-memory state from that session (no server sync in the demo).
-- **localStorage** is not cleared on SW update — user-saved events and profiles are preserved across deploys.
-- The maskable icon uses the same asset as the regular icon; for production use a version with extra padding/safe-area.
-
-## Library usage
+## Installation (library usage)
 
 ```jsx
 import { WorksCalendar } from 'works-calendar';
-import 'works-calendar/styles';         // base styles
-import 'works-calendar/styles/ocean';   // optional theme
+import 'works-calendar/styles';
+import 'works-calendar/styles/ocean'; // optional theme CSS
 
 <WorksCalendar
   events={events}
   employees={employees}
-  calendarId="my-calendar"
+  calendarId="ops-calendar"
   theme="ocean"
+  showAddButton
   onEventSave={handleSave}
   onEventDelete={handleDelete}
 />
 ```
 
-Available themes: `light`, `dark`, `aviation`, `soft`, `minimal`, `corporate`, `forest`, `ocean`
+---
 
-Owner password for config panel: `demo1234` (demo only — set your own via `ownerPassword` prop).
+## WorksCalendar props (core)
 
-## DataAdapter pattern (backend-agnostic)
+| Prop | Type | Description |
+|---|---|---|
+| `events` | `WorksCalendarEvent[]` | Static event array source. |
+| `fetchEvents` | `(params) => Promise<WorksCalendarEvent[]>` | Async range-based loading; merged with `events`. |
+| `calendarId` | `string` | Namespaces local state (owner config, saved views, sources). |
+| `ownerPassword` | `string` | Password for owner config access. |
+| `theme` | `ThemeId` | Visual theme id (`light`, `dark`, etc.). |
+| `showAddButton` | `boolean` | Enables add-event CTA (owner mode always can add). |
+| `filterSchema` | `FilterField[]` | Extend/replace default filters with custom dimensions. |
+| `employees` | `Employee[]` | Resources used in schedule/timeline modes. |
+| `blockedWindows` | `BlockedWindow[]` | Hard-block time ranges for validation. |
+| `supabaseUrl` / `supabaseKey` | `string` | Enables realtime subscriptions. |
+| `supabaseTable` / `supabaseFilter` | `string` | Controls realtime source table and row filter. |
+| `renderToolbar` | `(api) => ReactNode` | Custom toolbar render hook. |
+| `renderFilterBar` | `(ctx) => ReactNode` | Replace default filter bar UI. |
+| `renderSavedViewsBar` | `(ctx) => ReactNode` | Replace default saved-views bar UI. |
+| `renderEvent` | `(event, context) => ReactNode` | Custom event content renderer. |
+| `renderHoverCard` | `(event, onClose) => ReactNode` | Custom hover card renderer. |
+| `onEventSave` | `(event) => void` | Create/edit persistence callback. |
+| `onEventMove` | `(event, newStart, newEnd) => void` | Drag move callback. |
+| `onEventResize` | `(event, newStart, newEnd) => void` | Resize callback. |
+| `onEventDelete` | `(eventId) => void` | Delete callback. |
+| `onDateSelect` | `(start, end) => void` | Empty-range select callback. |
+| `onImport` | `(events) => void` | Receives imported event payloads. |
 
-Use a submit adapter to keep form UX independent from storage/auth choices.
+For full typings, see `src/index.d.ts`.
+
+---
+
+## First-Time Setup Wizard
+
+The Setup Wizard auto-opens for authenticated owners when setup has not been completed yet (`setupCompleted !== true` in owner config).
+
+What it helps with:
+- choose theme
+- add team members and avatars
+- define categories
+- build starter smart views with advanced filter logic
+
+Owners can reopen it from the toolbar using the wand icon.
+
+See detailed guide: [`docs/SetupWizard.md`](./docs/SetupWizard.md)
+
+## Advanced Smart Views / Filter Builder
+
+WorksCalendar includes:
+- schema-driven filters
+- active filter pills
+- saved views
+- advanced AND/OR grouping in wizard workflows
+
+See: [`docs/AdvancedFilters.md`](./docs/AdvancedFilters.md)
+
+## DataAdapter pattern
+
+Keep UI decoupled from storage/auth providers.
 
 ```jsx
 import { CalendarExternalForm, createLocalStorageDataAdapter } from 'works-calendar';
@@ -97,17 +133,81 @@ Adapter contract:
 }
 ```
 
-## External form workflows
+See: [`docs/DataAdapter.md`](./docs/DataAdapter.md)
 
-`CalendarExternalForm` is a standalone form that can be embedded outside the main calendar UI. It supports:
+## External Form (CalendarExternalForm)
 
-- field-schema driven rendering
-- required-field + date-order validation
-- per-host transform/validate hooks
-- adapter-level error handling for network/backend failures
+`CalendarExternalForm` is a standalone intake form component you can place outside the main calendar UI.
 
-## Microsoft 365 example
+Use cases:
+- public scheduling requests
+- mobile intake screens
+- role-separated submission workflows
 
-A Microsoft Graph adapter example is included at `examples/microsoft-365/`.
+Examples:
+- [`examples/external-form.jsx`](./examples/external-form.jsx)
+- [`examples/microsoft-365/Microsoft365ExternalFormExample.jsx`](./examples/microsoft-365/Microsoft365ExternalFormExample.jsx)
 
-It is intentionally example-only to keep the core package free from required MSAL dependencies and enterprise auth opinions.
+## Theming
+
+Theme css bundles:
+
+```jsx
+import 'works-calendar/styles';
+import 'works-calendar/styles/forest';
+```
+
+Available theme ids:
+`light`, `dark`, `aviation`, `soft`, `minimal`, `corporate`, `forest`, `ocean`
+
+You can also combine theme selection with owner config defaults.
+
+## Owner Config & Security Notes
+
+- Protect owner actions with a strong `ownerPassword` (never ship demo defaults).
+- Use least-privilege role settings for non-owners.
+- Validate server-side on all persistence APIs.
+- Audit imported feeds and external form payloads.
+
+See: [`docs/HIPAA-Security.md`](./docs/HIPAA-Security.md)
+
+## Examples
+
+See [`examples/README.md`](./examples/README.md) and run:
+
+```bash
+npm run examples
+```
+
+Includes:
+- basic usage
+- setup wizard flow
+- advanced filters
+- data adapter (local + Microsoft 365)
+- external form workflows
+
+## PWA (demo app)
+
+When running `npm run build:demo`, `vite-plugin-pwa` emits:
+- `dist-demo/sw.js`
+- `dist-demo/manifest.webmanifest`
+- precached shell assets
+
+Runtime caching:
+- Google Fonts: `CacheFirst` (1 year)
+- static shell: Workbox precache
+
+## License / Commercial Use
+
+This repository currently does not declare a standalone `LICENSE` file. Add one before production/commercial distribution.
+
+## Roadmap
+
+- More official adapters (Supabase, Microsoft 365 hardening, generic REST)
+- Expanded docs for recurrence exceptions and template governance
+- More examples for multi-tenant deployments
+- Optional hosted starter backend packages
+
+## Contributing
+
+See [`docs/Contributing.md`](./docs/Contributing.md).

--- a/docs/AdvancedFilters.md
+++ b/docs/AdvancedFilters.md
@@ -1,0 +1,52 @@
+# Advanced Filters & Smart Views
+
+WorksCalendar filtering is schema-driven, so host apps can extend filter dimensions without rewriting filter UI.
+
+## Built-in capabilities
+
+- Multi-select filters (`categories`, `resources`, `sources`)
+- Search text filter
+- Active filter pills
+- Clear-all and per-pill clearing
+- Saved views with optional pinned view mode
+
+## Smart Views
+
+Saved views capture:
+- filter state
+- optional preferred calendar view
+- optional color/tag metadata
+
+These views are ideal for team-specific presets like:
+- "On-call this week"
+- "Incidents only"
+- "Operations timeline"
+
+## Advanced Builder (Wizard)
+
+The Setup Wizard includes a visual builder for nested logic groups:
+- `AND` groups
+- `OR` groups
+- Live filter previews before save
+
+Use this to create robust starter presets during onboarding.
+
+## Custom schema example
+
+```jsx
+import {
+  priorityField,
+  ownerField,
+  tagsField,
+  DEFAULT_FILTER_SCHEMA,
+} from 'works-calendar';
+
+const schema = [
+  ...DEFAULT_FILTER_SCHEMA,
+  priorityField(),
+  ownerField(),
+  tagsField(),
+];
+
+<WorksCalendar filterSchema={schema} events={events} />
+```

--- a/docs/Contributing.md
+++ b/docs/Contributing.md
@@ -1,0 +1,33 @@
+# Contributing
+
+Thanks for contributing to WorksCalendar.
+
+## Local development
+
+```bash
+npm install
+npm run dev
+npm run examples
+npm test
+```
+
+## Recommended workflow
+
+1. Create a feature branch.
+2. Add/update tests for behavior changes.
+3. Run lint/tests before submitting.
+4. Update docs/examples for user-facing changes.
+
+## Documentation expectations
+
+When adding new user-facing features, include:
+- README updates (feature + usage)
+- at least one runnable example in `examples/`
+- any focused deep-dive in `docs/`
+
+## PR quality checklist
+
+- [ ] Behavior verified locally
+- [ ] Tests added/updated
+- [ ] No sensitive credentials in code
+- [ ] Docs and examples updated

--- a/docs/DataAdapter.md
+++ b/docs/DataAdapter.md
@@ -1,0 +1,40 @@
+# DataAdapter Pattern
+
+The DataAdapter pattern decouples form UX from backend/storage providers.
+
+## Contract
+
+A calendar external form adapter must expose:
+
+```ts
+{
+  submitEvent(payload, context): Promise<unknown>
+}
+```
+
+## Why use it
+
+- Swap persistence targets without rewriting UI
+- Keep auth/token logic out of presentation code
+- Standardize submit and error handling across providers
+
+## Local storage adapter
+
+```jsx
+import { CalendarExternalForm, createLocalStorageDataAdapter } from 'works-calendar';
+
+const adapter = createLocalStorageDataAdapter({ key: 'my-calendar:events' });
+
+<CalendarExternalForm adapter={adapter} />
+```
+
+## Microsoft 365 adapter
+
+See `examples/microsoft-365/` for an adapter implementation that demonstrates Graph API submission patterns.
+
+## Recommended production additions
+
+- request idempotency keys
+- structured error mapping
+- retry/backoff for transient failures
+- audit logging for compliance workflows

--- a/docs/HIPAA-Security.md
+++ b/docs/HIPAA-Security.md
@@ -1,0 +1,29 @@
+# HIPAA / Security Notes (Planning Doc)
+
+> This is a practical hardening checklist and not legal advice.
+
+## Baseline controls
+
+- Enforce authentication and authorization at your API boundary.
+- Validate all event payloads server-side.
+- Use HTTPS everywhere (including embedded form endpoints).
+- Encrypt data at rest and in transit.
+- Apply least-privilege roles for schedule editing.
+
+## Calendar-specific concerns
+
+- Avoid exposing PHI in feed URLs or query strings.
+- Redact sensitive fields in client logs and analytics events.
+- Restrict external form fields to minimum necessary data.
+- Implement immutable audit trails for create/update/delete operations.
+
+## Operational controls
+
+- Rotate keys/tokens regularly.
+- Configure data retention and deletion policies.
+- Add incident response runbooks for data-access anomalies.
+- Define backup/restore and disaster recovery procedures.
+
+## Product usage guidance
+
+WorksCalendar is UI infrastructure. HIPAA compliance depends on your full stack (identity, backend, storage, monitoring, policies, contracts).

--- a/docs/SetupWizard.md
+++ b/docs/SetupWizard.md
@@ -1,0 +1,37 @@
+# Setup Wizard
+
+The Setup Wizard is a first-time onboarding modal for calendar owners.
+
+## Behavior
+
+- Opens automatically once for owners when `setupCompleted` is missing/false.
+- Can be reopened manually from the toolbar (magic-wand button).
+- Persists setup state through owner config.
+
+## What it configures
+
+1. **Theme selection**
+2. **Team setup** (members/profile metadata)
+3. **Categories** for event taxonomy
+4. **Starter smart views** using advanced filter logic
+
+## Typical flow
+
+1. Render `WorksCalendar` with a stable `calendarId`.
+2. Provide an `ownerPassword` so owner mode can authenticate.
+3. Complete wizard once; config persists under that `calendarId`.
+
+```jsx
+<WorksCalendar
+  calendarId="team-alpha"
+  ownerPassword={process.env.REACT_APP_OWNER_PASSWORD}
+  events={events}
+  onEventSave={saveEvent}
+/>
+```
+
+## Tips
+
+- Seed a few categories/resources before onboarding demos.
+- Pair wizard onboarding with saved-view defaults for new teams.
+- Never use demo passwords in production.

--- a/examples/App.jsx
+++ b/examples/App.jsx
@@ -16,6 +16,11 @@ import { TimelineScheduler } from './04-TimelineScheduler.jsx';
 import { CustomFilters }     from './05-CustomFilters.jsx';
 import { TeamCalendar }      from './06-TeamCalendar.jsx';
 import { MultiSource }       from './07-MultiSource.jsx';
+import { BasicUsageExample }    from './basic-usage.jsx';
+import { SetupWizardExample }  from './setup-wizard.jsx';
+import { AdvancedFiltersExample } from './advanced-filters.jsx';
+import { LocalDataAdapterExample } from './data-adapter-local.jsx';
+import { ExternalFormExample } from './external-form.jsx';
 
 // ── Nav config ────────────────────────────────────────────────────────────────
 const EXAMPLES = [
@@ -60,6 +65,41 @@ const EXAMPLES = [
     tag:   'Multi-source',
     desc:  'Three team calendars merged into one. Tag events with _sourceId and source filter pills appear automatically.',
     component: TeamCalendar,
+  },
+  {
+    id:    'basic-usage-modern',
+    label: 'Basic Usage (New)',
+    tag:   'Docs refresh',
+    desc:  'Minimal modern example used by README/docs updates.',
+    component: BasicUsageExample,
+  },
+  {
+    id:    'setup-wizard',
+    label: 'Setup Wizard',
+    tag:   'Owner onboarding',
+    desc:  'Demonstrates owner-first setup flow and persisted onboarding state.',
+    component: SetupWizardExample,
+  },
+  {
+    id:    'advanced-filters-new',
+    label: 'Advanced Filters',
+    tag:   'Smart views',
+    desc:  'Schema extensions with priority/owner/tags fields.',
+    component: AdvancedFiltersExample,
+  },
+  {
+    id:    'data-adapter-local',
+    label: 'Data Adapter (Local)',
+    tag:   'External form',
+    desc:  'CalendarExternalForm with localStorage adapter.',
+    component: LocalDataAdapterExample,
+  },
+  {
+    id:    'external-form',
+    label: 'External Form',
+    tag:   'Standalone intake',
+    desc:  'Standalone external event request form with async adapter.',
+    component: ExternalFormExample,
   },
   {
     id:    'multi-source',
@@ -152,6 +192,11 @@ function SourceHint({ id }) {
     'custom-filters':  '05-CustomFilters.jsx',
     'team-calendar':   '06-TeamCalendar.jsx',
     'multi-source':    '07-MultiSource.jsx',
+    'basic-usage-modern': 'basic-usage.jsx',
+    'setup-wizard':    'setup-wizard.jsx',
+    'advanced-filters-new': 'advanced-filters.jsx',
+    'data-adapter-local': 'data-adapter-local.jsx',
+    'external-form':   'external-form.jsx',
   }[id];
 
   return (

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,26 @@
+# Examples
+
+Run all examples:
+
+```bash
+npm run examples
+```
+
+## Core examples
+
+- `01-GettingStarted.jsx`
+- `02-BasicCalendar.jsx`
+- `03-WithFilters.jsx`
+- `04-TimelineScheduler.jsx`
+- `05-CustomFilters.jsx`
+- `06-TeamCalendar.jsx`
+- `07-MultiSource.jsx`
+
+## New focused examples
+
+- `basic-usage.jsx`
+- `setup-wizard.jsx`
+- `advanced-filters.jsx`
+- `data-adapter-local.jsx`
+- `data-adapter-microsoft365.jsx`
+- `external-form.jsx`

--- a/examples/advanced-filters.jsx
+++ b/examples/advanced-filters.jsx
@@ -1,0 +1,39 @@
+import { useState } from 'react';
+import {
+  WorksCalendar,
+  DEFAULT_FILTER_SCHEMA,
+  priorityField,
+  ownerField,
+  tagsField,
+} from '../src/index.js';
+
+const schema = [...DEFAULT_FILTER_SCHEMA, priorityField(), ownerField(), tagsField()];
+
+const seed = [
+  {
+    id: 'af-1',
+    title: 'Incident: API timeout',
+    start: new Date(),
+    end: new Date(Date.now() + 3600000),
+    category: 'Incident',
+    resource: 'Alice',
+    priority: 'high',
+    owner: 'alice@company.com',
+    tags: ['sev2', 'backend'],
+  },
+];
+
+export function AdvancedFiltersExample() {
+  const [events, setEvents] = useState(seed);
+
+  return (
+    <div style={{ height: '100%' }}>
+      <WorksCalendar
+        calendarId="advanced-filters-example"
+        events={events}
+        filterSchema={schema}
+        onEventSave={(ev) => setEvents(prev => [...prev.filter(e => e.id !== ev.id), ev])}
+      />
+    </div>
+  );
+}

--- a/examples/basic-usage.jsx
+++ b/examples/basic-usage.jsx
@@ -1,0 +1,27 @@
+import { useState } from 'react';
+import { WorksCalendar } from '../src/index.js';
+
+const now = new Date();
+const addHours = (h) => new Date(now.getTime() + (h * 60 * 60 * 1000));
+
+const INITIAL = [
+  { id: 'basic-1', title: 'Kickoff', start: addHours(2), end: addHours(3), category: 'Meeting' },
+  { id: 'basic-2', title: 'QA Sync', start: addHours(26), end: addHours(27), category: 'Ops' },
+];
+
+export function BasicUsageExample() {
+  const [events, setEvents] = useState(INITIAL);
+
+  return (
+    <div style={{ height: '100%' }}>
+      <WorksCalendar
+        calendarId="basic-usage-example"
+        theme="soft"
+        showAddButton
+        events={events}
+        onEventSave={(ev) => setEvents(prev => [...prev.filter(e => e.id !== ev.id), ev])}
+        onEventDelete={(id) => setEvents(prev => prev.filter(e => e.id !== id))}
+      />
+    </div>
+  );
+}

--- a/examples/data-adapter-local.jsx
+++ b/examples/data-adapter-local.jsx
@@ -1,0 +1,14 @@
+import { CalendarExternalForm, createLocalStorageDataAdapter } from '../src/index.js';
+
+const fields = [
+  { name: 'title', label: 'Title', type: 'text', required: true },
+  { name: 'start', label: 'Start', type: 'datetime-local', required: true },
+  { name: 'end', label: 'End', type: 'datetime-local', required: true },
+  { name: 'category', label: 'Category', type: 'text' },
+];
+
+const adapter = createLocalStorageDataAdapter({ key: 'works-calendar:example:external-form' });
+
+export function LocalDataAdapterExample() {
+  return <CalendarExternalForm fields={fields} adapter={adapter} submitLabel="Save Event" />;
+}

--- a/examples/data-adapter-microsoft365.jsx
+++ b/examples/data-adapter-microsoft365.jsx
@@ -1,0 +1,1 @@
+export { default as Microsoft365ExternalFormExample } from './microsoft-365/Microsoft365ExternalFormExample.jsx';

--- a/examples/external-form.jsx
+++ b/examples/external-form.jsx
@@ -1,0 +1,26 @@
+import { CalendarExternalForm } from '../src/index.js';
+
+const fields = [
+  { name: 'title', label: 'Title', type: 'text', required: true },
+  { name: 'start', label: 'Start', type: 'datetime-local', required: true },
+  { name: 'end', label: 'End', type: 'datetime-local', required: true },
+  { name: 'description', label: 'Description', type: 'textarea' },
+];
+
+const adapter = {
+  async submitEvent(payload) {
+    await new Promise(resolve => setTimeout(resolve, 250));
+    return { id: `ext-${Date.now()}`, payload };
+  },
+};
+
+export function ExternalFormExample() {
+  return (
+    <CalendarExternalForm
+      fields={fields}
+      adapter={adapter}
+      submitLabel="Submit Request"
+      onSuccess={(result) => console.log('external-form success', result)}
+    />
+  );
+}

--- a/examples/setup-wizard.jsx
+++ b/examples/setup-wizard.jsx
@@ -1,0 +1,22 @@
+import { useState } from 'react';
+import { WorksCalendar } from '../src/index.js';
+
+const EVENTS = [
+  { id: 'wiz-1', title: 'Owner Onboarding', start: new Date(), end: new Date(Date.now() + 3600000), category: 'Onboarding' },
+];
+
+export function SetupWizardExample() {
+  const [events, setEvents] = useState(EVENTS);
+
+  return (
+    <div style={{ height: '100%' }}>
+      <WorksCalendar
+        calendarId="setup-wizard-example"
+        ownerPassword="change-me-in-real-apps"
+        events={events}
+        showAddButton
+        onEventSave={(ev) => setEvents(prev => [...prev.filter(e => e.id !== ev.id), ev])}
+      />
+    </div>
+  );
+}


### PR DESCRIPTION
### Motivation

- Make the project ready for consumers by replacing the thin README with a full product-facing guide highlighting features, usage, and architecture patterns.
- Surface high-priority features that previously lacked public docs (Setup Wizard, Advanced Filters, DataAdapter, External Form, Owner Config).
- Provide runnable, focused examples so maintainers and users can quickly exercise onboarding, filter builder, adapters, and external form flows.

### Description

- Rewrote `README.md` into a fuller guide with feature list, quick start, core props table, Setup Wizard and Advanced Filters sections, DataAdapter guidance, theming, security notes, roadmap, and contributing pointers.
- Added dedicated docs pages: `docs/SetupWizard.md`, `docs/AdvancedFilters.md`, `docs/DataAdapter.md`, `docs/HIPAA-Security.md`, and `docs/Contributing.md` for deeper coverage of key areas.
- Added example index and six focused examples under `examples/`: `basic-usage.jsx`, `setup-wizard.jsx`, `advanced-filters.jsx`, `data-adapter-local.jsx`, `data-adapter-microsoft365.jsx`, and `external-form.jsx` to demonstrate common workflows and adapter patterns.
- Updated the examples showcase (`examples/App.jsx`) and `examples/README.md` to register and surface the new examples in the live examples runner.

### Testing

- Ran `npm run build:examples` which completed successfully and produced the examples build. ✅
- Ran `npm test` which failed in this environment due to tests attempting to contact a local app server and hitting `ECONNREFUSED` (localhost:3000). ⚠️
- No further automated changes to application code; please re-run the test suite in an environment where the dev/demo server is available or mock the external server dependency to validate tests fully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dcd70294ec832c85ad53812e876136)