### PR TITLE
docs: expand README API reference and feature examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,34 +58,67 @@ import 'works-calendar/styles/ocean'; // optional theme CSS
 
 ---
 
-## WorksCalendar props (core)
+## WorksCalendar props reference
+
+### Data & loading
 
 | Prop | Type | Description |
 |---|---|---|
 | `events` | `WorksCalendarEvent[]` | Static event array source. |
-| `fetchEvents` | `(params) => Promise<WorksCalendarEvent[]>` | Async range-based loading; merged with `events`. |
-| `calendarId` | `string` | Namespaces local state (owner config, saved views, sources). |
-| `ownerPassword` | `string` | Password for owner config access. |
-| `theme` | `ThemeId` | Visual theme id (`light`, `dark`, etc.). |
-| `showAddButton` | `boolean` | Enables add-event CTA (owner mode always can add). |
-| `filterSchema` | `FilterField[]` | Extend/replace default filters with custom dimensions. |
-| `employees` | `Employee[]` | Resources used in schedule/timeline modes. |
-| `blockedWindows` | `BlockedWindow[]` | Hard-block time ranges for validation. |
-| `supabaseUrl` / `supabaseKey` | `string` | Enables realtime subscriptions. |
+| `fetchEvents` | `(params: FetchEventsParams) => Promise<WorksCalendarEvent[]>` | Async range-based loading when view window changes. |
+| `icalFeeds` | `ICalFeed[]` | Subscribe to one or more `.ics` feeds and merge into visible events. |
+| `scheduleTemplates` | `ScheduleTemplate[]` | Inline templates exposed in **Add Schedule** flow. |
+| `scheduleTemplateAdapter` | `ScheduleTemplateAdapter` | Backend adapter for listing/creating/deleting templates. |
+| `scheduleInstantiationLimits` | `ScheduleInstantiationLimits` | Guardrails for preview/create expansion volume. |
+| `onScheduleTemplateAnalytics` | `(event: ScheduleTemplateAnalyticsEvent) => void` | Optional analytics sink for schedule-template lifecycle telemetry. |
+
+### Identity, owner config, and notes
+
+| Prop | Type | Description |
+|---|---|---|
+| `calendarId` | `string` | Namespaces local state (`default` when omitted). |
+| `ownerPassword` | `string` | Password for owner configuration access. |
+| `onConfigSave` | `(config: CalendarConfig) => void` | Called when owner config is changed/saved. |
+| `notes` | `Record<string, Note>` | External notes state keyed by note id. |
+| `onNoteSave` | `(note: Partial<Note>) => void` | Persist note create/update from hover card/editor flows. |
+| `onNoteDelete` | `(noteId: string) => void` | Delete note callback. |
+
+### Event interaction callbacks
+
+| Prop | Type | Description |
+|---|---|---|
+| `onEventClick` | `(event: NormalizedEvent) => void` | Fired when user clicks an event. |
+| `onEventSave` | `(event: WorksCalendarEvent) => void` | Create/edit persistence callback. |
+| `onEventMove` | `(event, newStart, newEnd) => void` | Drag/move callback; falls back to `onEventSave` if omitted. |
+| `onEventResize` | `(event, newStart, newEnd) => void` | Resize callback; falls back to `onEventSave` if omitted. |
+| `onEventDelete` | `(eventId: string) => void` | Delete callback. |
+| `onDateSelect` | `(start: Date, end: Date) => void` | Empty-range selection callback. |
+| `onImport` | `(events: WorksCalendarEvent[]) => void` | Called after drag/drop/feed import actions. |
+
+### Realtime + validation + appearance
+
+| Prop | Type | Description |
+|---|---|---|
+| `supabaseUrl` / `supabaseKey` | `string` | Enables realtime event subscriptions. |
 | `supabaseTable` / `supabaseFilter` | `string` | Controls realtime source table and row filter. |
-| `renderToolbar` | `(api) => ReactNode` | Custom toolbar render hook. |
-| `renderFilterBar` | `(ctx) => ReactNode` | Replace default filter bar UI. |
-| `renderSavedViewsBar` | `(ctx) => ReactNode` | Replace default saved-views bar UI. |
+| `blockedWindows` | `BlockedWindow[]` | Hard-block windows used by built-in validation. |
+| `theme` | `ThemeId` | Visual theme id (`light`, `dark`, `aviation`, `soft`, `minimal`, `corporate`, `forest`, `ocean`). |
+| `colorRules` | `ColorRule[]` | Conditional color overrides (predicate or field/value rules). |
+| `businessHours` | `BusinessHours` | Defines business-day shading and validation context. |
+
+### Rendering, composition, and UI toggles
+
+| Prop | Type | Description |
+|---|---|---|
 | `renderEvent` | `(event, context) => ReactNode` | Custom event content renderer. |
-| `renderHoverCard` | `(event, onClose) => ReactNode` | Custom hover card renderer. |
-| `onEventSave` | `(event) => void` | Create/edit persistence callback. |
-| `onEventMove` | `(event, newStart, newEnd) => void` | Drag move callback. |
-| `onEventResize` | `(event, newStart, newEnd) => void` | Resize callback. |
-| `onEventDelete` | `(eventId) => void` | Delete callback. |
-| `onDateSelect` | `(start, end) => void` | Empty-range select callback. |
-| `onImport` | `(events) => void` | Receives imported event payloads. |
+| `renderHoverCard` | `(event, onClose) => ReactNode` | Replace default hover card. |
+| `renderToolbar` | `(api: CalendarApi) => ReactNode` | Replace full toolbar with custom controls. |
+| `emptyState` | `ReactNode` | Custom empty state when filtered result set is empty. |
+| `showAddButton` | `boolean` | Enables add-event CTA in non-owner mode. |
+| `ref` | `React.Ref<CalendarApi>` | Imperative API handle (`navigateTo`, `setView`, `addEvent`, etc.). |
 
 For full typings, see `src/index.d.ts`.
+
 
 ---
 
@@ -148,19 +181,48 @@ Examples:
 - [`examples/external-form.jsx`](./examples/external-form.jsx)
 - [`examples/microsoft-365/Microsoft365ExternalFormExample.jsx`](./examples/microsoft-365/Microsoft365ExternalFormExample.jsx)
 
+## Feature demos (copy/paste)
+
+Run all demos:
+
+```bash
+npm run examples
+```
+
+Focused examples:
+
+| Feature | Example file |
+|---|---|
+| Setup Wizard onboarding flow | [`examples/setup-wizard.jsx`](./examples/setup-wizard.jsx) |
+| Advanced smart views / nested filters | [`examples/advanced-filters.jsx`](./examples/advanced-filters.jsx) |
+| DataAdapter with local persistence | [`examples/data-adapter-local.jsx`](./examples/data-adapter-local.jsx) |
+| DataAdapter with Microsoft 365 | [`examples/data-adapter-microsoft365.jsx`](./examples/data-adapter-microsoft365.jsx) |
+| Standalone CalendarExternalForm | [`examples/external-form.jsx`](./examples/external-form.jsx) |
+
 ## Theming
 
-Theme css bundles:
+1. Import base styles once:
 
 ```jsx
 import 'works-calendar/styles';
-import 'works-calendar/styles/forest';
+```
+
+2. Optionally import a preset bundle:
+
+```jsx
+import 'works-calendar/styles/ocean';
+```
+
+3. Pass the matching `theme` prop:
+
+```jsx
+<WorksCalendar theme="ocean" />
 ```
 
 Available theme ids:
 `light`, `dark`, `aviation`, `soft`, `minimal`, `corporate`, `forest`, `ocean`
 
-You can also combine theme selection with owner config defaults.
+You can combine theme selection with owner config defaults from the Setup Wizard.
 
 ## Owner Config & Security Notes
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -8,19 +8,19 @@ npm run examples
 
 ## Core examples
 
-- `01-GettingStarted.jsx`
-- `02-BasicCalendar.jsx`
-- `03-WithFilters.jsx`
-- `04-TimelineScheduler.jsx`
-- `05-CustomFilters.jsx`
-- `06-TeamCalendar.jsx`
-- `07-MultiSource.jsx`
+- `01-GettingStarted.jsx` — minimum setup
+- `02-BasicCalendar.jsx` — standard calendar configuration
+- `03-WithFilters.jsx` — baseline filter bar usage
+- `04-TimelineScheduler.jsx` — resource timeline/scheduler layout
+- `05-CustomFilters.jsx` — custom filter schema fields
+- `06-TeamCalendar.jsx` — multi-resource team scheduling
+- `07-MultiSource.jsx` — merging multiple event sources
 
-## New focused examples
+## Focused examples for new features
 
-- `basic-usage.jsx`
-- `setup-wizard.jsx`
-- `advanced-filters.jsx`
-- `data-adapter-local.jsx`
-- `data-adapter-microsoft365.jsx`
-- `external-form.jsx`
+- `setup-wizard.jsx` — owner onboarding wizard flow
+- `advanced-filters.jsx` — nested AND/OR smart-view filter builder
+- `data-adapter-local.jsx` — `DataAdapter` with local storage persistence
+- `data-adapter-microsoft365.jsx` — `DataAdapter` with Microsoft 365 integration
+- `external-form.jsx` — standalone `CalendarExternalForm` intake workflow
+- `basic-usage.jsx` — compact integration template for docs/tutorials


### PR DESCRIPTION
### Motivation

- Improve documentation depth by providing a clearer, grouped `WorksCalendar` props reference to address missing usage details and prop explanations. 
- Surface recently added features (Setup Wizard, Advanced Filter Builder, DataAdapter pattern, `CalendarExternalForm`) with direct example links so users can quickly find runnable demos. 
- Make theming and onboarding guidance explicit for first-time integrators to reduce friction during evaluation and onboarding.

### Description

- Expanded `README.md` with a structured `WorksCalendar` props reference grouped by domain (`Data & loading`, `Identity/owner config`, `Event callbacks`, `Realtime/validation`, `Rendering/UI toggles`).
- Added a `Feature demos (copy/paste)` section in `README.md` mapping new capabilities to example files (e.g. `examples/setup-wizard.jsx`, `examples/advanced-filters.jsx`, `examples/data-adapter-local.jsx`, `examples/external-form.jsx`).
- Reworked theming instructions in `README.md` into a clear 3-step flow (import base styles, optionally import a preset bundle, pass the matching `theme` prop).
- Updated `examples/README.md` with concise, purpose-driven descriptions for core examples and focused examples for new features.

### Testing

- Ran `npm run build` which completed successfully (`vite build` passed). 
- Ran `npm test` where Vitest encountered multiple failures in this environment due to a missing test dependency (`@testing-library/dom`) and repeated `ECONNREFUSED` errors when tests attempted to contact `localhost:3000`, causing the test run to fail. 
- Attempted `npm test -- --runInBand` which failed because Vitest does not accept the `--runInBand` option (invalid flag).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dcda3c5df8832c9d2710776337730b)