### PR TITLE
Add owner Theme Customizer with live preview and CSS variable injection

### DIFF
--- a/src/WorksCalendar.jsx
+++ b/src/WorksCalendar.jsx
@@ -51,6 +51,7 @@ import { exportToExcel }      from './export/excelExport.js';
 import { canViewScheduleTemplate, instantiateScheduleTemplate } from './api/v1/templates.ts';
 
 import styles from './WorksCalendar.module.css';
+import { customThemeToCssVars } from './core/themeSchema.js';
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
@@ -172,6 +173,7 @@ export const WorksCalendar = forwardRef(function WorksCalendar(
   const cal      = useCalendar([], initialView ?? 'month', schema);
   const ownerCfg = useOwnerConfig({ calendarId, ownerPassword, onConfigSave, devMode });
   const weekStartDay = ownerCfg.config?.display?.weekStartDay ?? 0;
+  const customThemeVars = useMemo(() => customThemeToCssVars(ownerCfg.config?.customTheme), [ownerCfg.config?.customTheme]);
 
   // Honor defaultView from owner config (applied once after config loads)
   const defaultViewApplied = useRef(false);
@@ -861,7 +863,7 @@ export const WorksCalendar = forwardRef(function WorksCalendar(
 
   return (
     <CalendarContext.Provider value={ctxValue}>
-      <div className={styles.root} data-wc-theme={theme} data-testid="works-calendar">
+      <div className={styles.root} data-wc-theme={theme} data-testid="works-calendar" style={customThemeVars}>
 
         {/* ── Toolbar ── */}
         {renderToolbar ? (

--- a/src/core/configSchema.js
+++ b/src/core/configSchema.js
@@ -36,6 +36,11 @@ export const DEFAULT_CONFIG = {
     },
   },
 
+
+
+  // Full custom theme object applied via CSS variable injection.
+  customTheme: {},
+
   // Access control
   access: {
     viewerPassword: '',   // empty = no viewer lock

--- a/src/core/themeSchema.js
+++ b/src/core/themeSchema.js
@@ -1,0 +1,72 @@
+export const DEFAULT_CUSTOM_THEME = {
+  colors: {
+    accent: '#3b82f6',
+    accentDim: '#eff6ff',
+    bg: '#ffffff',
+    surface: '#f8fafc',
+    surface2: '#f1f5f9',
+    border: '#e2e8f0',
+    borderDark: '#cbd5e1',
+    text: '#0f172a',
+    textMuted: '#64748b',
+  },
+  typography: {
+    fontFamily: "'Inter', system-ui, -apple-system, sans-serif",
+    baseSize: 14,
+  },
+  spacing: {
+    density: 1,
+  },
+  borders: {
+    radius: 10,
+    radiusSm: 6,
+    borderWidth: 1,
+  },
+  shadows: {
+    elevation: 10,
+  },
+};
+
+export function mergeTheme(base, patch) {
+  const next = { ...base };
+  for (const key of Object.keys(patch || {})) {
+    const value = patch[key];
+    if (value && typeof value === 'object' && !Array.isArray(value)) {
+      next[key] = mergeTheme(base[key] ?? {}, value);
+    } else if (value !== undefined) {
+      next[key] = value;
+    }
+  }
+  return next;
+}
+
+export function normalizeCustomTheme(theme) {
+  return mergeTheme(DEFAULT_CUSTOM_THEME, theme || {});
+}
+
+export function customThemeToCssVars(themeInput) {
+  if (!themeInput || (typeof themeInput === 'object' && Object.keys(themeInput).length === 0)) return undefined;
+  const theme = normalizeCustomTheme(themeInput);
+  const e = Math.max(0, Number(theme.shadows.elevation) || 0);
+  const density = Math.max(0.8, Math.min(1.2, Number(theme.spacing.density) || 1));
+
+  return {
+    '--wc-accent': theme.colors.accent,
+    '--wc-accent-dim': theme.colors.accentDim,
+    '--wc-bg': theme.colors.bg,
+    '--wc-surface': theme.colors.surface,
+    '--wc-surface-2': theme.colors.surface2,
+    '--wc-border': theme.colors.border,
+    '--wc-border-dark': theme.colors.borderDark,
+    '--wc-text': theme.colors.text,
+    '--wc-text-muted': theme.colors.textMuted,
+    '--wc-font': theme.typography.fontFamily,
+    '--wc-radius': `${theme.borders.radius}px`,
+    '--wc-radius-sm': `${theme.borders.radiusSm}px`,
+    '--wc-border-width': `${theme.borders.borderWidth}px`,
+    '--wc-shadow': `0 4px ${12 + Math.round(e)}px rgba(0,0,0,${(0.08 + e / 200).toFixed(2)})`,
+    '--wc-shadow-sm': `0 1px ${3 + Math.round(e / 3)}px rgba(0,0,0,${(0.05 + e / 250).toFixed(2)})`,
+    '--wc-base-font-size': `${theme.typography.baseSize}px`,
+    '--wc-density': density,
+  };
+}

--- a/src/ui/ConfigPanel.jsx
+++ b/src/ui/ConfigPanel.jsx
@@ -3,12 +3,14 @@ import { X, Plus, Trash2 } from 'lucide-react';
 import { FIELD_TYPES } from '../core/configSchema.js';
 import { useFocusTrap } from '../hooks/useFocusTrap.js';
 import SourcePanel from './SourcePanel.jsx';
+import ThemeCustomizer from './ThemeCustomizer.jsx';
 import styles from './ConfigPanel.module.css';
 
 const TABS = [
   { id: 'hoverCard',   label: 'Hover Card' },
   { id: 'eventFields', label: 'Event Fields' },
   { id: 'display',     label: 'Display' },
+  { id: 'theme',       label: 'Theme' },
   { id: 'feeds',       label: 'Feeds' },
   { id: 'templates',   label: 'Templates' },
   { id: 'access',      label: 'Access' },
@@ -47,6 +49,7 @@ export default function ConfigPanel({
           {tab === 'hoverCard'   && <HoverCardTab   config={config} onUpdate={onUpdate} />}
           {tab === 'eventFields' && <EventFieldsTab config={config} categories={categories} onUpdate={onUpdate} />}
           {tab === 'display'     && <DisplayTab     config={config} onUpdate={onUpdate} />}
+          {tab === 'theme'       && <ThemeCustomizer theme={config.customTheme} onChange={onUpdate} />}
           {tab === 'feeds'       && (
             <SourcePanel
               sources={sources ?? []}

--- a/src/ui/ThemeCustomizer.jsx
+++ b/src/ui/ThemeCustomizer.jsx
@@ -1,0 +1,114 @@
+import { normalizeCustomTheme, customThemeToCssVars } from '../core/themeSchema.js';
+import styles from './ThemeCustomizer.module.css';
+
+const COLOR_CONTROLS = [
+  ['accent', 'Accent'],
+  ['accentDim', 'Accent Soft'],
+  ['bg', 'Background'],
+  ['surface', 'Surface'],
+  ['surface2', 'Surface 2'],
+  ['border', 'Border'],
+  ['borderDark', 'Strong Border'],
+  ['text', 'Text'],
+  ['textMuted', 'Muted Text'],
+];
+
+export default function ThemeCustomizer({ theme, onChange }) {
+  const merged = normalizeCustomTheme(theme);
+  const previewVars = customThemeToCssVars(merged);
+
+  function update(path, value) {
+    onChange((config) => {
+      const current = normalizeCustomTheme(config.customTheme);
+      const [group, key] = path;
+      return {
+        ...config,
+        customTheme: {
+          ...current,
+          [group]: {
+            ...current[group],
+            [key]: value,
+          },
+        },
+      };
+    });
+  }
+
+  return (
+    <div className={styles.section}>
+      <p>Tune colors and core style tokens. Changes are saved to <code>ownerConfig.customTheme</code>.</p>
+
+      <div className={styles.grid}>
+        {COLOR_CONTROLS.map(([key, label]) => (
+          <label key={key} className={styles.control}>
+            <span>{label}</span>
+            <input type="color" value={merged.colors[key]} onChange={(e) => update(['colors', key], e.target.value)} />
+          </label>
+        ))}
+
+        <label className={styles.control}>
+          <span>Font Family</span>
+          <input
+            type="text"
+            value={merged.typography.fontFamily}
+            onChange={(e) => update(['typography', 'fontFamily'], e.target.value)}
+          />
+        </label>
+
+        <label className={styles.control}>
+          <span>Base Font Size ({merged.typography.baseSize}px)</span>
+          <input
+            type="range"
+            min={12}
+            max={20}
+            step={1}
+            value={merged.typography.baseSize}
+            onChange={(e) => update(['typography', 'baseSize'], Number(e.target.value))}
+          />
+        </label>
+
+        <label className={styles.control}>
+          <span>Radius ({merged.borders.radius}px)</span>
+          <input
+            type="range"
+            min={0}
+            max={24}
+            step={1}
+            value={merged.borders.radius}
+            onChange={(e) => update(['borders', 'radius'], Number(e.target.value))}
+          />
+        </label>
+
+        <label className={styles.control}>
+          <span>Shadow ({merged.shadows.elevation})</span>
+          <input
+            type="range"
+            min={0}
+            max={32}
+            step={1}
+            value={merged.shadows.elevation}
+            onChange={(e) => update(['shadows', 'elevation'], Number(e.target.value))}
+          />
+        </label>
+      </div>
+
+      <div className={styles.preview} style={previewVars}>
+        <div className={styles.previewHeader}>
+          <strong>Live Preview</strong>
+          <span className={styles.badge}>Mini Calendar</span>
+        </div>
+        <div className={styles.previewBody}>
+          {Array.from({ length: 14 }).map((_, i) => (
+            <div key={i} className={styles.day}>
+              {(i === 2 || i === 8) && <div className={styles.event} />}
+            </div>
+          ))}
+        </div>
+      </div>
+
+      <div className={styles.actions}>
+        <button className={styles.btn} onClick={() => onChange((c) => ({ ...c, customTheme: {} }))}>Reset to default</button>
+      </div>
+    </div>
+  );
+}

--- a/src/ui/ThemeCustomizer.module.css
+++ b/src/ui/ThemeCustomizer.module.css
@@ -1,0 +1,81 @@
+.section {
+  display: grid;
+  gap: 14px;
+}
+.grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 10px;
+}
+.control {
+  display: grid;
+  gap: 6px;
+  font-size: 12px;
+  color: var(--wc-text-muted);
+}
+.control input[type="text"],
+.control input[type="number"],
+.control input[type="range"] {
+  width: 100%;
+}
+.control input[type="color"] {
+  width: 100%;
+  height: 34px;
+  border: 1px solid var(--wc-border);
+  border-radius: 8px;
+  background: transparent;
+}
+.preview {
+  border: 1px solid var(--wc-border);
+  border-radius: var(--wc-radius);
+  background: var(--wc-bg);
+  box-shadow: var(--wc-shadow-sm);
+  overflow: hidden;
+}
+.previewHeader {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 10px;
+  border-bottom: 1px solid var(--wc-border);
+  background: var(--wc-surface);
+  color: var(--wc-text);
+}
+.badge {
+  font-size: 11px;
+  background: var(--wc-accent-dim);
+  color: var(--wc-accent);
+  border-radius: 999px;
+  padding: 3px 8px;
+}
+.previewBody {
+  display: grid;
+  grid-template-columns: repeat(7, 1fr);
+  gap: 6px;
+  padding: 10px;
+  background: var(--wc-bg);
+}
+.day {
+  min-height: 34px;
+  border: 1px solid var(--wc-border);
+  border-radius: var(--wc-radius-sm);
+  background: var(--wc-surface-2);
+}
+.event {
+  margin: 2px;
+  height: 8px;
+  border-radius: 999px;
+  background: var(--wc-accent);
+}
+.actions {
+  display: flex;
+  gap: 8px;
+}
+.btn {
+  border: 1px solid var(--wc-border);
+  background: var(--wc-surface);
+  color: var(--wc-text);
+  border-radius: var(--wc-radius-sm);
+  padding: 6px 10px;
+  cursor: pointer;
+}


### PR DESCRIPTION
### Motivation
- Provide an owner-facing Theme Customizer so calendar owners can tune colors, typography, spacing and shadows and persist those choices to `ownerConfig.customTheme`.
- Apply themes at runtime using CSS variables so changes can be previewed live without rebuilding the app.
- Deliver the Day 1 foundation for a full customizer: core token controls, live mini-calendar preview, and reset/import-ready storage.

### Description
- Add `src/core/themeSchema.js` which defines `DEFAULT_CUSTOM_THEME`, a deep-merge normalizer, and `customThemeToCssVars` to map theme objects to CSS variables for runtime injection.
- Add `src/ui/ThemeCustomizer.jsx` and `src/ui/ThemeCustomizer.module.css` implementing color pickers, typography and token sliders, a live mini-calendar preview, and a reset action wired to owner config.
- Persist `customTheme` in the owner defaults by extending `DEFAULT_CONFIG` in `src/core/configSchema.js` and expose editing via a new `Theme` tab in `src/ui/ConfigPanel.jsx`.
- Wire CSS-variable injection into the calendar root by computing `customThemeToCssVars(ownerCfg.config?.customTheme)` and applying it to the `style` of the root element in `src/WorksCalendar.jsx` so saved owner themes apply automatically.

### Testing
- Ran `npm run build`, which completed successfully and produced the production bundles under `dist/`.
- Ran `npm test`, which failed in this environment due to a missing test dependency (`@testing-library/dom`) causing unrelated test-suite failures.
- The build verifies bundling and integration of the new files, while failing tests are due to the environment, not the theme customizer changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd83a1e568832c9ed0d0e901df3983)