### PR TITLE
Expand Theme Customizer controls for Day 2 and add tests

### DIFF
--- a/src/ui/ThemeCustomizer.jsx
+++ b/src/ui/ThemeCustomizer.jsx
@@ -13,6 +13,21 @@ const COLOR_CONTROLS = [
   ['textMuted', 'Muted Text'],
 ];
 
+const TOKEN_SLIDERS = [
+  ['typography', 'baseSize', 'Base Font Size', 12, 20, 1, 'px'],
+  ['spacing', 'density', 'Density', 0.8, 1.2, 0.05, 'x'],
+  ['borders', 'radius', 'Radius', 0, 24, 1, 'px'],
+  ['borders', 'radiusSm', 'Small Radius', 0, 20, 1, 'px'],
+  ['borders', 'borderWidth', 'Border Width', 0, 4, 1, 'px'],
+  ['shadows', 'elevation', 'Shadow', 0, 32, 1, ''],
+];
+
+function valueLabel(value, suffix) {
+  if (suffix === 'x') return `${Number(value).toFixed(2)}x`;
+  if (!suffix) return String(value);
+  return `${value}${suffix}`;
+}
+
 export default function ThemeCustomizer({ theme, onChange }) {
   const merged = normalizeCustomTheme(theme);
   const previewVars = customThemeToCssVars(merged);
@@ -55,41 +70,19 @@ export default function ThemeCustomizer({ theme, onChange }) {
           />
         </label>
 
-        <label className={styles.control}>
-          <span>Base Font Size ({merged.typography.baseSize}px)</span>
-          <input
-            type="range"
-            min={12}
-            max={20}
-            step={1}
-            value={merged.typography.baseSize}
-            onChange={(e) => update(['typography', 'baseSize'], Number(e.target.value))}
-          />
-        </label>
-
-        <label className={styles.control}>
-          <span>Radius ({merged.borders.radius}px)</span>
-          <input
-            type="range"
-            min={0}
-            max={24}
-            step={1}
-            value={merged.borders.radius}
-            onChange={(e) => update(['borders', 'radius'], Number(e.target.value))}
-          />
-        </label>
-
-        <label className={styles.control}>
-          <span>Shadow ({merged.shadows.elevation})</span>
-          <input
-            type="range"
-            min={0}
-            max={32}
-            step={1}
-            value={merged.shadows.elevation}
-            onChange={(e) => update(['shadows', 'elevation'], Number(e.target.value))}
-          />
-        </label>
+        {TOKEN_SLIDERS.map(([group, key, label, min, max, step, suffix]) => (
+          <label key={`${group}.${key}`} className={styles.control}>
+            <span>{label} ({valueLabel(merged[group][key], suffix)})</span>
+            <input
+              type="range"
+              min={min}
+              max={max}
+              step={step}
+              value={merged[group][key]}
+              onChange={(e) => update([group, key], Number(e.target.value))}
+            />
+          </label>
+        ))}
       </div>
 
       <div className={styles.preview} style={previewVars}>

--- a/src/ui/__tests__/ThemeCustomizer.test.jsx
+++ b/src/ui/__tests__/ThemeCustomizer.test.jsx
@@ -1,0 +1,54 @@
+// @vitest-environment happy-dom
+
+import { describe, it, expect, vi } from 'vitest';
+import React from 'react';
+import { render, fireEvent, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import ThemeCustomizer from '../ThemeCustomizer.jsx';
+
+function renderWithConfig(customTheme = {}) {
+  const setConfig = vi.fn();
+
+  render(
+    <ThemeCustomizer
+      theme={customTheme}
+      onChange={(updater) => {
+        const next = updater({ customTheme });
+        setConfig(next);
+      }}
+    />,
+  );
+
+  return { setConfig };
+}
+
+describe('ThemeCustomizer', () => {
+  it('updates color controls in customTheme', () => {
+    const { setConfig } = renderWithConfig({});
+
+    const accent = screen.getByLabelText('Accent');
+    fireEvent.change(accent, { target: { value: '#111111' } });
+
+    const latest = setConfig.mock.calls.at(-1)[0];
+    expect(latest.customTheme.colors.accent).toBe('#111111');
+  });
+
+  it('updates density slider and stores as number', () => {
+    const { setConfig } = renderWithConfig({});
+
+    const density = screen.getByLabelText(/Density/);
+    fireEvent.change(density, { target: { value: '1.15' } });
+
+    const latest = setConfig.mock.calls.at(-1)[0];
+    expect(latest.customTheme.spacing.density).toBe(1.15);
+  });
+
+  it('resets customTheme to defaults payload', () => {
+    const { setConfig } = renderWithConfig({ colors: { accent: '#111111' } });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Reset to default' }));
+
+    const latest = setConfig.mock.calls.at(-1)[0];
+    expect(latest.customTheme).toEqual({});
+  });
+});


### PR DESCRIPTION
### Motivation
- Complete Day 2 of the Theme Customizer plan by exposing the full set of core design tokens (density, radii, border width, base font size, elevation) so owners can tune all runtime tokens from the UI. 
- Reduce repetitive JSX in the control panel by consolidating sliders into a shared configuration and keep the existing color/font controls and live preview behavior.

### Description
- Added a `TOKEN_SLIDERS` config and `valueLabel` helper and wired a mapped slider UI to `src/ui/ThemeCustomizer.jsx`, replacing several hand-written range controls. 
- Kept color pickers, font family input, live preview rendering, and the reset-to-default action while routing updates through the existing `update(path, value)` updater that writes into `ownerConfig.customTheme`.
- Added unit tests at `src/ui/__tests__/ThemeCustomizer.test.jsx` that cover color control updates, numeric density updates (stored as a number), and the reset-to-default payload.
- Changed files: `src/ui/ThemeCustomizer.jsx` and added `src/ui/__tests__/ThemeCustomizer.test.jsx`.

### Testing
- Ran `node -e "import('./src/core/themeSchema.js')..."` sanity check against `customThemeToCssVars` to validate density clamping and it succeeded. 
- Attempted `npm test -- src/ui/__tests__/ThemeCustomizer.test.jsx` which failed to run because `@testing-library/dom` could not be found in the environment, causing the Vitest import-stage failure. 
- Attempted `npm install` to restore deps but the environment blocked registry fetches (`403 Forbidden`), so the unit test suite could not be executed end-to-end in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd89a14ad8832cb7ee31c3c188d579)