### PR TITLE
Theme customizer: add presets and JSON import/export (Day 3)

### DIFF
--- a/src/ui/ThemeCustomizer.jsx
+++ b/src/ui/ThemeCustomizer.jsx
@@ -1,5 +1,6 @@
 import { normalizeCustomTheme, customThemeToCssVars } from '../core/themeSchema.js';
 import styles from './ThemeCustomizer.module.css';
+import { useMemo, useState } from 'react';
 
 const COLOR_CONTROLS = [
   ['accent', 'Accent'],
@@ -22,6 +23,50 @@ const TOKEN_SLIDERS = [
   ['shadows', 'elevation', 'Shadow', 0, 32, 1, ''],
 ];
 
+const PRESET_THEMES = [
+  {
+    id: 'default',
+    label: 'Default',
+    customTheme: {},
+  },
+  {
+    id: 'midnight',
+    label: 'Midnight',
+    customTheme: {
+      colors: {
+        accent: '#8b5cf6',
+        accentDim: '#2e1065',
+        bg: '#0b1020',
+        surface: '#121a31',
+        surface2: '#1c2744',
+        border: '#30406a',
+        borderDark: '#3f5487',
+        text: '#eff4ff',
+        textMuted: '#a4b2d8',
+      },
+      shadows: { elevation: 18 },
+    },
+  },
+  {
+    id: 'warm',
+    label: 'Warm',
+    customTheme: {
+      colors: {
+        accent: '#ea580c',
+        accentDim: '#fff7ed',
+        bg: '#fffaf5',
+        surface: '#fff1df',
+        surface2: '#ffe7cf',
+        border: '#fed7aa',
+        borderDark: '#fdba74',
+        text: '#4a2a12',
+        textMuted: '#9a6a43',
+      },
+      borders: { radius: 12, radiusSm: 8 },
+    },
+  },
+];
+
 function valueLabel(value, suffix) {
   if (suffix === 'x') return `${Number(value).toFixed(2)}x`;
   if (!suffix) return String(value);
@@ -29,8 +74,11 @@ function valueLabel(value, suffix) {
 }
 
 export default function ThemeCustomizer({ theme, onChange }) {
+  const [draftImport, setDraftImport] = useState('');
+  const [importError, setImportError] = useState('');
   const merged = normalizeCustomTheme(theme);
   const previewVars = customThemeToCssVars(merged);
+  const exportJson = useMemo(() => JSON.stringify(merged, null, 2), [merged]);
 
   function update(path, value) {
     onChange((config) => {
@@ -47,6 +95,24 @@ export default function ThemeCustomizer({ theme, onChange }) {
         },
       };
     });
+  }
+
+  function applyPreset(preset) {
+    onChange((config) => ({ ...config, customTheme: preset.customTheme }));
+  }
+
+  function applyImport() {
+    try {
+      const parsed = JSON.parse(draftImport);
+      if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+        setImportError('Theme JSON must be an object.');
+        return;
+      }
+      setImportError('');
+      onChange((config) => ({ ...config, customTheme: parsed }));
+    } catch {
+      setImportError('Could not parse JSON. Check formatting and try again.');
+    }
   }
 
   return (
@@ -85,6 +151,17 @@ export default function ThemeCustomizer({ theme, onChange }) {
         ))}
       </div>
 
+      <div className={styles.presets}>
+        <strong className={styles.blockLabel}>Quick presets</strong>
+        <div className={styles.presetRow}>
+          {PRESET_THEMES.map((preset) => (
+            <button key={preset.id} className={styles.btn} onClick={() => applyPreset(preset)}>
+              {preset.label}
+            </button>
+          ))}
+        </div>
+      </div>
+
       <div className={styles.preview} style={previewVars}>
         <div className={styles.previewHeader}>
           <strong>Live Preview</strong>
@@ -101,6 +178,24 @@ export default function ThemeCustomizer({ theme, onChange }) {
 
       <div className={styles.actions}>
         <button className={styles.btn} onClick={() => onChange((c) => ({ ...c, customTheme: {} }))}>Reset to default</button>
+      </div>
+
+      <div className={styles.ioSection}>
+        <strong className={styles.blockLabel}>Export theme JSON</strong>
+        <textarea className={styles.textarea} value={exportJson} readOnly aria-label="Export theme JSON" />
+      </div>
+
+      <div className={styles.ioSection}>
+        <strong className={styles.blockLabel}>Import theme JSON</strong>
+        <textarea
+          className={styles.textarea}
+          value={draftImport}
+          onChange={(e) => setDraftImport(e.target.value)}
+          aria-label="Import theme JSON"
+          placeholder='{"colors":{"accent":"#00bcd4"}}'
+        />
+        {importError && <div className={styles.importError} role="alert">{importError}</div>}
+        <button className={styles.btn} onClick={applyImport}>Apply imported JSON</button>
       </div>
     </div>
   );

--- a/src/ui/ThemeCustomizer.module.css
+++ b/src/ui/ThemeCustomizer.module.css
@@ -71,6 +71,35 @@
   display: flex;
   gap: 8px;
 }
+.presets,
+.ioSection {
+  display: grid;
+  gap: 8px;
+}
+.blockLabel {
+  font-size: 12px;
+  color: var(--wc-text-muted);
+}
+.presetRow {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+.textarea {
+  width: 100%;
+  min-height: 120px;
+  border: 1px solid var(--wc-border);
+  border-radius: var(--wc-radius-sm);
+  background: var(--wc-surface);
+  color: var(--wc-text);
+  font: 12px/1.35 ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', monospace;
+  padding: 8px;
+  resize: vertical;
+}
+.importError {
+  color: #b91c1c;
+  font-size: 12px;
+}
 .btn {
   border: 1px solid var(--wc-border);
   background: var(--wc-surface);

--- a/src/ui/__tests__/ThemeCustomizer.test.jsx
+++ b/src/ui/__tests__/ThemeCustomizer.test.jsx
@@ -51,4 +51,38 @@ describe('ThemeCustomizer', () => {
     const latest = setConfig.mock.calls.at(-1)[0];
     expect(latest.customTheme).toEqual({});
   });
+
+  it('applies quick preset payload', () => {
+    const { setConfig } = renderWithConfig({});
+
+    fireEvent.click(screen.getByRole('button', { name: 'Midnight' }));
+
+    const latest = setConfig.mock.calls.at(-1)[0];
+    expect(latest.customTheme.colors.bg).toBe('#0b1020');
+    expect(latest.customTheme.colors.accent).toBe('#8b5cf6');
+  });
+
+  it('imports valid JSON theme patch', () => {
+    const { setConfig } = renderWithConfig({});
+
+    fireEvent.change(screen.getByLabelText('Import theme JSON'), {
+      target: { value: '{"colors":{"accent":"#0ea5e9"}}' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Apply imported JSON' }));
+
+    const latest = setConfig.mock.calls.at(-1)[0];
+    expect(latest.customTheme.colors.accent).toBe('#0ea5e9');
+  });
+
+  it('shows error for invalid JSON import', () => {
+    const { setConfig } = renderWithConfig({});
+
+    fireEvent.change(screen.getByLabelText('Import theme JSON'), {
+      target: { value: '{bad json' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Apply imported JSON' }));
+
+    expect(screen.getByRole('alert')).toHaveTextContent('Could not parse JSON.');
+    expect(setConfig).not.toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
### Motivation
- Provide faster owner theming workflows by offering one-click presets and enable easy sharing/backup via JSON export/import.
- Give owners a safe import path with validation and clear error messaging to avoid applying malformed payloads.
- Surface the effective normalized theme JSON so owners and integrators can inspect or copy the exact CSS-variable payload.

### Description
- Add preset themes (`Default`, `Midnight`, `Warm`) and an `applyPreset` handler to `ThemeCustomizer` so owners can apply full theme payloads quickly (`src/ui/ThemeCustomizer.jsx`).
- Add JSON export (`exportJson` read-only textarea) and import (`draftImport`, `applyImport`) UI with validation and inline parse errors, and wire updates through the existing `onChange` callback (`src/ui/ThemeCustomizer.jsx`).
- Add styles for the new UI blocks (`.presets`, `.ioSection`, `.blockLabel`, `.presetRow`, `.textarea`, `.importError`) to `src/ui/ThemeCustomizer.module.css`.
- Extend unit tests in `src/ui/__tests__/ThemeCustomizer.test.jsx` to cover preset application, valid JSON import, and invalid JSON handling.

### Testing
- Ran `npm test -- src/ui/__tests__/ThemeCustomizer.test.jsx` and the test run failed to start because `@testing-library/dom` was missing from `node_modules`, causing Vitest to error during import; no assertions were executed in this environment.
- New/updated test cases were added to `src/ui/__tests__/ThemeCustomizer.test.jsx` exercising presets and import/export logic, intended to pass when the test environment has `@testing-library/dom` available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd8a850eac832c8a6c452c7886a02d)