### PR TITLE
ThemeCustomizer: add import modes and copy/export workflow (day 4)

### DIFF
--- a/src/ui/ThemeCustomizer.jsx
+++ b/src/ui/ThemeCustomizer.jsx
@@ -76,6 +76,9 @@ function valueLabel(value, suffix) {
 export default function ThemeCustomizer({ theme, onChange }) {
   const [draftImport, setDraftImport] = useState('');
   const [importError, setImportError] = useState('');
+  const [importMode, setImportMode] = useState('merge');
+  const [importSuccess, setImportSuccess] = useState('');
+  const [copyState, setCopyState] = useState('');
   const merged = normalizeCustomTheme(theme);
   const previewVars = customThemeToCssVars(merged);
   const exportJson = useMemo(() => JSON.stringify(merged, null, 2), [merged]);
@@ -106,12 +109,39 @@ export default function ThemeCustomizer({ theme, onChange }) {
       const parsed = JSON.parse(draftImport);
       if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
         setImportError('Theme JSON must be an object.');
+        setImportSuccess('');
         return;
       }
       setImportError('');
-      onChange((config) => ({ ...config, customTheme: parsed }));
+      setImportSuccess(importMode === 'merge' ? 'Imported and merged into current theme.' : 'Imported and replaced current theme.');
+      onChange((config) => {
+        const current = normalizeCustomTheme(config.customTheme);
+        const nextCustomTheme = importMode === 'replace'
+          ? parsed
+          : {
+            ...current,
+            ...parsed,
+            colors: { ...current.colors, ...(parsed.colors || {}) },
+            typography: { ...current.typography, ...(parsed.typography || {}) },
+            spacing: { ...current.spacing, ...(parsed.spacing || {}) },
+            borders: { ...current.borders, ...(parsed.borders || {}) },
+            shadows: { ...current.shadows, ...(parsed.shadows || {}) },
+          };
+        return { ...config, customTheme: nextCustomTheme };
+      });
     } catch {
       setImportError('Could not parse JSON. Check formatting and try again.');
+      setImportSuccess('');
+    }
+  }
+
+  async function copyExportJson() {
+    try {
+      if (!navigator?.clipboard?.writeText) throw new Error('Clipboard API unavailable');
+      await navigator.clipboard.writeText(exportJson);
+      setCopyState('Copied JSON to clipboard.');
+    } catch {
+      setCopyState('Clipboard unavailable. Copy manually from the export box.');
     }
   }
 
@@ -183,10 +213,34 @@ export default function ThemeCustomizer({ theme, onChange }) {
       <div className={styles.ioSection}>
         <strong className={styles.blockLabel}>Export theme JSON</strong>
         <textarea className={styles.textarea} value={exportJson} readOnly aria-label="Export theme JSON" />
+        <div className={styles.inlineActions}>
+          <button className={styles.btn} onClick={copyExportJson}>Copy JSON</button>
+          {copyState && <span className={styles.helperText}>{copyState}</span>}
+        </div>
       </div>
 
       <div className={styles.ioSection}>
         <strong className={styles.blockLabel}>Import theme JSON</strong>
+        <div className={styles.importMode}>
+          <label className={styles.radioLabel}>
+            <input
+              type="radio"
+              name="theme-import-mode"
+              checked={importMode === 'merge'}
+              onChange={() => setImportMode('merge')}
+            />
+            Merge into current theme
+          </label>
+          <label className={styles.radioLabel}>
+            <input
+              type="radio"
+              name="theme-import-mode"
+              checked={importMode === 'replace'}
+              onChange={() => setImportMode('replace')}
+            />
+            Replace current theme
+          </label>
+        </div>
         <textarea
           className={styles.textarea}
           value={draftImport}
@@ -195,6 +249,7 @@ export default function ThemeCustomizer({ theme, onChange }) {
           placeholder='{"colors":{"accent":"#00bcd4"}}'
         />
         {importError && <div className={styles.importError} role="alert">{importError}</div>}
+        {importSuccess && <div className={styles.importSuccess} role="status">{importSuccess}</div>}
         <button className={styles.btn} onClick={applyImport}>Apply imported JSON</button>
       </div>
     </div>

--- a/src/ui/ThemeCustomizer.module.css
+++ b/src/ui/ThemeCustomizer.module.css
@@ -76,7 +76,16 @@
   display: grid;
   gap: 8px;
 }
+.inlineActions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
 .blockLabel {
+  font-size: 12px;
+  color: var(--wc-text-muted);
+}
+.helperText {
   font-size: 12px;
   color: var(--wc-text-muted);
 }
@@ -84,6 +93,18 @@
   display: flex;
   flex-wrap: wrap;
   gap: 8px;
+}
+.importMode {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+.radioLabel {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 12px;
+  color: var(--wc-text-muted);
 }
 .textarea {
   width: 100%;
@@ -98,6 +119,10 @@
 }
 .importError {
   color: #b91c1c;
+  font-size: 12px;
+}
+.importSuccess {
+  color: #166534;
   font-size: 12px;
 }
 .btn {

--- a/src/ui/__tests__/ThemeCustomizer.test.jsx
+++ b/src/ui/__tests__/ThemeCustomizer.test.jsx
@@ -72,6 +72,21 @@ describe('ThemeCustomizer', () => {
 
     const latest = setConfig.mock.calls.at(-1)[0];
     expect(latest.customTheme.colors.accent).toBe('#0ea5e9');
+    expect(screen.getByRole('status')).toHaveTextContent('Imported and merged');
+  });
+
+  it('replaces the theme when replace import mode is selected', () => {
+    const { setConfig } = renderWithConfig({ colors: { accent: '#111111' }, borders: { radius: 14 } });
+
+    fireEvent.click(screen.getByLabelText('Replace current theme'));
+    fireEvent.change(screen.getByLabelText('Import theme JSON'), {
+      target: { value: '{"colors":{"accent":"#0ea5e9"}}' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Apply imported JSON' }));
+
+    const latest = setConfig.mock.calls.at(-1)[0];
+    expect(latest.customTheme).toEqual({ colors: { accent: '#0ea5e9' } });
+    expect(screen.getByRole('status')).toHaveTextContent('Imported and replaced');
   });
 
   it('shows error for invalid JSON import', () => {
@@ -84,5 +99,19 @@ describe('ThemeCustomizer', () => {
 
     expect(screen.getByRole('alert')).toHaveTextContent('Could not parse JSON.');
     expect(setConfig).not.toHaveBeenCalled();
+  });
+
+  it('copies exported JSON to clipboard', async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, 'clipboard', {
+      value: { writeText },
+      configurable: true,
+    });
+    renderWithConfig({});
+
+    fireEvent.click(screen.getByRole('button', { name: 'Copy JSON' }));
+
+    expect(writeText).toHaveBeenCalled();
+    expect(await screen.findByText('Copied JSON to clipboard.')).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
### Motivation
- Finish day 4 of the theme customizer plan by letting owners import JSON either merged into the current theme or as a full replacement. 
- Provide explicit success feedback for imports and a convenient `Copy JSON` action for the exported theme payload. 
- Keep the UI consistent with the existing panel and make the new flows testable.

### Description
- Added import UI and state: `importMode`, `importSuccess`, and `copyState`, plus radio controls to choose `merge` or `replace` import strategies in `ThemeCustomizer`.
- Implemented `applyImport` merge-vs-replace logic that preserves nested token groups when merging and sets a success message; invalid JSON still shows the existing error path.
- Added `copyExportJson` which uses `navigator.clipboard.writeText` with a graceful fallback message, and added a `Copy JSON` button and inline helper text in the export section.
- Added CSS rules for `.inlineActions`, `.importMode`, `.radioLabel`, `.helperText`, and `.importSuccess` to style the new controls and feedback.
- Expanded tests in `src/ui/__tests__/ThemeCustomizer.test.jsx` to cover merge-mode success messaging, replace-mode behavior, and the clipboard-copy interaction.

### Testing
- Ran `npm test -- src/ui/__tests__/ThemeCustomizer.test.jsx` which executed the ThemeCustomizer suite and completed successfully. 
- Test summary: `1` test file, `8` tests passed, all assertions green.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd8b8a9c5c832c83f9ecc96013686e)