### PR TITLE
Add WCAG contrast diagnostics to Theme Customizer

### DIFF
--- a/src/ui/ThemeCustomizer.jsx
+++ b/src/ui/ThemeCustomizer.jsx
@@ -73,6 +73,44 @@ function valueLabel(value, suffix) {
   return `${value}${suffix}`;
 }
 
+function hexToRgb(hex) {
+  const normalized = String(hex || '').trim().replace('#', '');
+  if (!/^[0-9a-f]{6}$/i.test(normalized)) return null;
+  const int = Number.parseInt(normalized, 16);
+  return {
+    r: (int >> 16) & 255,
+    g: (int >> 8) & 255,
+    b: int & 255,
+  };
+}
+
+function relativeLuminance(hex) {
+  const rgb = hexToRgb(hex);
+  if (!rgb) return null;
+  const map = [rgb.r, rgb.g, rgb.b].map((channel) => {
+    const c = channel / 255;
+    return c <= 0.03928 ? c / 12.92 : ((c + 0.055) / 1.055) ** 2.4;
+  });
+  return 0.2126 * map[0] + 0.7152 * map[1] + 0.0722 * map[2];
+}
+
+function contrastRatio(hexA, hexB) {
+  const lumA = relativeLuminance(hexA);
+  const lumB = relativeLuminance(hexB);
+  if (lumA === null || lumB === null) return null;
+  const lighter = Math.max(lumA, lumB);
+  const darker = Math.min(lumA, lumB);
+  return (lighter + 0.05) / (darker + 0.05);
+}
+
+function wcagRating(ratio) {
+  if (ratio === null) return { label: 'Invalid color', tone: 'bad' };
+  if (ratio >= 7) return { label: 'AAA', tone: 'good' };
+  if (ratio >= 4.5) return { label: 'AA', tone: 'good' };
+  if (ratio >= 3) return { label: 'Large text only', tone: 'warn' };
+  return { label: 'Fail', tone: 'bad' };
+}
+
 export default function ThemeCustomizer({ theme, onChange }) {
   const [draftImport, setDraftImport] = useState('');
   const [importError, setImportError] = useState('');
@@ -82,6 +120,20 @@ export default function ThemeCustomizer({ theme, onChange }) {
   const merged = normalizeCustomTheme(theme);
   const previewVars = customThemeToCssVars(merged);
   const exportJson = useMemo(() => JSON.stringify(merged, null, 2), [merged]);
+  const contrastChecks = useMemo(() => ([
+    { id: 'text-on-bg', label: 'Body text on background', fg: merged.colors.text, bg: merged.colors.bg },
+    { id: 'text-on-surface', label: 'Body text on surface', fg: merged.colors.text, bg: merged.colors.surface },
+    { id: 'accent-on-accent-dim', label: 'Accent on accent soft', fg: merged.colors.accent, bg: merged.colors.accentDim },
+    { id: 'muted-on-bg', label: 'Muted text on background', fg: merged.colors.textMuted, bg: merged.colors.bg },
+  ].map((item) => {
+    const ratio = contrastRatio(item.fg, item.bg);
+    const rating = wcagRating(ratio);
+    return {
+      ...item,
+      ratio,
+      rating,
+    };
+  })), [merged]);
 
   function update(path, value) {
     onChange((config) => {
@@ -208,6 +260,23 @@ export default function ThemeCustomizer({ theme, onChange }) {
 
       <div className={styles.actions}>
         <button className={styles.btn} onClick={() => onChange((c) => ({ ...c, customTheme: {} }))}>Reset to default</button>
+      </div>
+
+      <div className={styles.ioSection}>
+        <strong className={styles.blockLabel}>Contrast checks (WCAG)</strong>
+        <div className={styles.contrastList}>
+          {contrastChecks.map((check) => (
+            <div key={check.id} className={styles.contrastRow}>
+              <span>{check.label}</span>
+              <span className={styles.contrastMeta}>
+                <span>{check.ratio ? `${check.ratio.toFixed(2)}:1` : 'n/a'}</span>
+                <span className={[styles.rating, styles[`rating_${check.rating.tone}`]].join(' ')}>
+                  {check.rating.label}
+                </span>
+              </span>
+            </div>
+          ))}
+        </div>
       </div>
 
       <div className={styles.ioSection}>

--- a/src/ui/ThemeCustomizer.module.css
+++ b/src/ui/ThemeCustomizer.module.css
@@ -99,6 +99,47 @@
   flex-wrap: wrap;
   gap: 10px;
 }
+.contrastList {
+  border: 1px solid var(--wc-border);
+  border-radius: var(--wc-radius-sm);
+  overflow: hidden;
+}
+.contrastRow {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  padding: 8px 10px;
+  background: var(--wc-surface);
+  color: var(--wc-text);
+  font-size: 12px;
+}
+.contrastRow + .contrastRow {
+  border-top: 1px solid var(--wc-border);
+}
+.contrastMeta {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+}
+.rating {
+  border-radius: 999px;
+  padding: 2px 8px;
+  font-size: 11px;
+  font-weight: 600;
+}
+.rating_good {
+  background: #dcfce7;
+  color: #166534;
+}
+.rating_warn {
+  background: #fef9c3;
+  color: #854d0e;
+}
+.rating_bad {
+  background: #fee2e2;
+  color: #991b1b;
+}
 .radioLabel {
   display: inline-flex;
   align-items: center;

--- a/src/ui/__tests__/ThemeCustomizer.test.jsx
+++ b/src/ui/__tests__/ThemeCustomizer.test.jsx
@@ -114,4 +114,12 @@ describe('ThemeCustomizer', () => {
     expect(writeText).toHaveBeenCalled();
     expect(await screen.findByText('Copied JSON to clipboard.')).toBeInTheDocument();
   });
+
+  it('renders contrast checks and rating badges', () => {
+    renderWithConfig({});
+
+    expect(screen.getByText('Contrast checks (WCAG)')).toBeInTheDocument();
+    expect(screen.getByText('Body text on background')).toBeInTheDocument();
+    expect(screen.getAllByText(/AAA|AA|Large text only|Fail/).length).toBeGreaterThan(0);
+  });
 });


### PR DESCRIPTION
### Motivation
- Provide immediate accessibility feedback while editing custom themes by surfacing contrast ratios and WCAG ratings for common token pairs.
- Help designers and owners detect poor color combinations (e.g., accent on soft background) without leaving the customizer.

### Description
- Add color contrast utilities (`hexToRgb`, `relativeLuminance`, `contrastRatio`, `wcagRating`) inside `ThemeCustomizer` to compute ratios and ratings in real time.
- Introduce a `contrastChecks` `useMemo` that evaluates key token pairs (`text`/`bg`, `text`/`surface`, `accent`/`accentDim`, `textMuted`/`bg`) and maps them to rating badges (`AAA`, `AA`, `Large text only`, `Fail`) in the UI.
- Render a new “Contrast checks (WCAG)” section in `src/ui/ThemeCustomizer.jsx` that shows each check with a numeric ratio and a status pill.
- Add styling for the diagnostics list and rating pills in `src/ui/ThemeCustomizer.module.css` and extend tests in `src/ui/__tests__/ThemeCustomizer.test.jsx` to assert the diagnostics render.

### Testing
- Ran the component test file with `npm test -- src/ui/__tests__/ThemeCustomizer.test.jsx`, which initially failed due to an overly specific matcher but was updated accordingly.
- Re-ran `npm test -- src/ui/__tests__/ThemeCustomizer.test.jsx` after adjusting the test and observed all tests pass (`9 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd8cfd44d8832cac491001fa9c669d)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a "Contrast checks (WCAG)" section to the theme customizer that displays calculated contrast ratios and corresponding WCAG accessibility ratings for various color pairs including text, backgrounds, and accent colors.

* **Tests**
  * Added test coverage to verify the contrast checks UI renders correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->