### PR TITLE
Add CalendarErrorBoundary wrapper and SSR guard to WorksCalendar

### DIFF
--- a/src/WorksCalendar.jsx
+++ b/src/WorksCalendar.jsx
@@ -42,6 +42,7 @@ import ScheduleTemplateDialog from './ui/ScheduleTemplateDialog.jsx';
 import ValidationAlert          from './ui/ValidationAlert.jsx';
 import SetupWizardModal        from './ui/SetupWizardModal.jsx';
 import ScreenReaderAnnouncer   from './ui/ScreenReaderAnnouncer.jsx';
+import CalendarErrorBoundary   from './ui/CalendarErrorBoundary.jsx';
 import MonthView              from './views/MonthView.jsx';
 import WeekView               from './views/WeekView.jsx';
 import DayView                from './views/DayView.jsx';
@@ -168,6 +169,9 @@ export const WorksCalendar = forwardRef(function WorksCalendar(
   },
   ref,
 ) {
+  // SSR guard: avoid touching browser-only APIs during server rendering.
+  if (typeof window === 'undefined') return null;
+
   // ── View / date / filter state ───────────────────────────────────────────
   const schema   = filterSchema ?? DEFAULT_FILTER_SCHEMA;
   const cal      = useCalendar([], initialView ?? 'month', schema);
@@ -429,6 +433,7 @@ export const WorksCalendar = forwardRef(function WorksCalendar(
 
   // ── Keyboard shortcuts ───────────────────────────────────────────────────
   useEffect(() => {
+    if (typeof window === 'undefined') return undefined;
     const onKeyDown = (e) => {
       const meta = e.metaKey || e.ctrlKey;
       if (!meta) return;
@@ -862,8 +867,9 @@ export const WorksCalendar = forwardRef(function WorksCalendar(
   };
 
   return (
-    <CalendarContext.Provider value={ctxValue}>
-      <div className={styles.root} data-wc-theme={theme} data-testid="works-calendar" style={customThemeVars}>
+    <CalendarErrorBoundary>
+      <CalendarContext.Provider value={ctxValue}>
+        <div className={styles.root} data-wc-theme={theme} data-testid="works-calendar" style={customThemeVars}>
 
         {/* ── Toolbar ── */}
         {renderToolbar ? (
@@ -1135,7 +1141,8 @@ export const WorksCalendar = forwardRef(function WorksCalendar(
 
         {/* ── Screen reader live region ── */}
         <ScreenReaderAnnouncer ref={announcerRef} />
-      </div>
-    </CalendarContext.Provider>
+        </div>
+      </CalendarContext.Provider>
+    </CalendarErrorBoundary>
   );
 });

--- a/src/__tests__/WorksCalendar.ssr-and-error-boundary.test.jsx
+++ b/src/__tests__/WorksCalendar.ssr-and-error-boundary.test.jsx
@@ -1,0 +1,22 @@
+import { describe, expect, it, vi } from 'vitest';
+import { render } from '@testing-library/react';
+import React from 'react';
+
+import CalendarErrorBoundary from '../ui/CalendarErrorBoundary.jsx';
+
+describe('WorksCalendar SSR safety + CalendarErrorBoundary', () => {
+  it('renders fallback UI when a child throws', () => {
+    const Thrower = () => {
+      throw new Error('boom');
+    };
+
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const { getByRole } = render(
+      <CalendarErrorBoundary>
+        <Thrower />
+      </CalendarErrorBoundary>,
+    );
+    expect(getByRole('alert')).toHaveTextContent('Calendar failed to load');
+    spy.mockRestore();
+  });
+});

--- a/src/__tests__/WorksCalendar.ssr.test.jsx
+++ b/src/__tests__/WorksCalendar.ssr.test.jsx
@@ -1,0 +1,13 @@
+// @vitest-environment node
+import { describe, expect, it } from 'vitest';
+import React from 'react';
+import { renderToString } from 'react-dom/server';
+
+import { WorksCalendar } from '../WorksCalendar.jsx';
+
+describe('WorksCalendar SSR safety', () => {
+  it('returns null during SSR render', () => {
+    const html = renderToString(<WorksCalendar events={[]} />);
+    expect(html).toBe('');
+  });
+});

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -495,6 +495,14 @@ export declare const WorksCalendar: React.ForwardRefExoticComponent<
   WorksCalendarProps & React.RefAttributes<CalendarApi>
 >;
 
+export interface CalendarErrorBoundaryProps {
+  children?: React.ReactNode;
+  fallback?: React.ReactNode;
+  onError?: (error: Error, info: React.ErrorInfo) => void;
+}
+
+export declare const CalendarErrorBoundary: React.ComponentType<CalendarErrorBoundaryProps>;
+
 // ─── Hooks ─────────────────────────────────────────────────────────────────────
 
 export declare function useCalendar(

--- a/src/index.js
+++ b/src/index.js
@@ -25,6 +25,7 @@ export {
   default as CalendarExternalForm,
   SUPPORTED_EXTERNAL_FORM_FIELD_TYPES,
 } from './ui/CalendarExternalForm.jsx';
+export { default as CalendarErrorBoundary } from './ui/CalendarErrorBoundary.jsx';
 export { createLocalStorageDataAdapter } from './external/localStorageDataAdapter.js';
 export { parseICS, fetchAndParseICS }     from './core/icalParser.js';
 export { useOccurrences }                 from './hooks/useOccurrences.js';

--- a/src/ui/CalendarErrorBoundary.jsx
+++ b/src/ui/CalendarErrorBoundary.jsx
@@ -1,0 +1,31 @@
+import { Component } from 'react';
+
+/**
+ * Catches runtime render errors from the calendar subtree so host apps
+ * can keep running even if the calendar fails.
+ */
+export default class CalendarErrorBoundary extends Component {
+  constructor(props) {
+    super(props);
+    this.state = { hasError: false };
+  }
+
+  static getDerivedStateFromError() {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error, info) {
+    this.props.onError?.(error, info);
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return this.props.fallback ?? (
+        <div role="alert" aria-live="assertive">
+          Calendar failed to load
+        </div>
+      );
+    }
+    return this.props.children;
+  }
+}


### PR DESCRIPTION
### Motivation
- Prevent the host application from crashing when the calendar subtree throws by adding an error boundary around the calendar render tree. 
- Make `WorksCalendar` safe to import/require during server-side rendering (Next.js/Remix) by avoiding browser-only APIs during SSR. 

### Description
- Added a `CalendarErrorBoundary` component (`src/ui/CalendarErrorBoundary.jsx`) that calls an optional `onError` and renders a safe fallback (`Calendar failed to load`) or a custom `fallback` prop. 
- Wrapped the `WorksCalendar` render tree with `CalendarErrorBoundary` and exported it from the public entry (`src/index.js`). 
- Added an SSR guard to `WorksCalendar` (`if (typeof window === 'undefined') return null;`) and hardened the keyboard shortcut `useEffect` with the same browser check. 
- Added TypeScript declarations for the error boundary in `src/index.d.ts`. 
- Added unit tests: `src/__tests__/WorksCalendar.ssr.test.jsx` for SSR behavior and `src/__tests__/WorksCalendar.ssr-and-error-boundary.test.jsx` for error-boundary fallback.

### Testing
- Ran the new tests with `npm test -- src/__tests__/WorksCalendar.ssr.test.jsx src/__tests__/WorksCalendar.ssr-and-error-boundary.test.jsx` and both tests passed. 
- The test suite validated that `WorksCalendar` renders `null` during SSR and that `CalendarErrorBoundary` renders the fallback UI when a child throws.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd971a5684832cb88ac896799bb06c)