### PR TITLE
Add touch swipe navigation for month and timeline views

### DIFF
--- a/src/WorksCalendar.jsx
+++ b/src/WorksCalendar.jsx
@@ -20,6 +20,7 @@ import { useSavedViews, deserializeFilters } from './hooks/useSavedViews.js';
 import { useRealtimeEvents }  from './hooks/useRealtimeEvents.js';
 import { usePermissions }     from './hooks/usePermissions.js';
 import { useEventOptions }    from './hooks/useEventOptions.js';
+import { useTouchSwipe }     from './hooks/useTouchSwipe.js';
 import { CalendarContext }    from './core/CalendarContext.js';
 import { normalizeEvents }    from './core/eventModel.js';
 import { CalendarEngine }     from './core/engine/CalendarEngine.ts';
@@ -842,6 +843,15 @@ export const WorksCalendar = forwardRef(function WorksCalendar(
     }
   }
 
+  const swipeAreaRef = useRef(null);
+  const swipeNavigationEnabled = cal.view === 'month' || cal.view === 'schedule';
+  useTouchSwipe({
+    targetRef: swipeAreaRef,
+    enabled: swipeNavigationEnabled,
+    onSwipeLeft: () => cal.navigate(1),
+    onSwipeRight: () => cal.navigate(-1),
+  });
+
   const hasAddButton = (showAddButton || ownerCfg.isOwner || devMode) && perms.canAddEvent;
   const hasScheduleTemplates = Array.isArray(visibleScheduleTemplates) && visibleScheduleTemplates.length > 0;
   const hasImport    = !!(onImport || ownerCfg.isOwner);
@@ -1012,7 +1022,7 @@ export const WorksCalendar = forwardRef(function WorksCalendar(
         }
 
         {/* ── View area ── */}
-        <div className={styles.viewArea}>
+        <div ref={swipeAreaRef} className={styles.viewArea}>
           {isEmpty && emptyState ? (
             <div className={styles.emptyStateWrap}>{emptyState}</div>
           ) : (

--- a/src/hooks/__tests__/useTouchSwipe.test.jsx
+++ b/src/hooks/__tests__/useTouchSwipe.test.jsx
@@ -1,0 +1,64 @@
+import { render } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { useRef } from 'react';
+import { useTouchSwipe } from '../useTouchSwipe.js';
+
+function Harness({ enabled = true, onSwipeLeft, onSwipeRight }) {
+  const ref = useRef(null);
+  useTouchSwipe({ targetRef: ref, enabled, onSwipeLeft, onSwipeRight, minDistance: 40 });
+  return <div ref={ref} data-testid="swipe-target">Swipe target</div>;
+}
+
+function dispatchSwipe(el, { startX, startY, endX, endY }) {
+  const touchstart = new Event('touchstart', { bubbles: true, cancelable: true });
+  Object.defineProperty(touchstart, 'touches', {
+    value: [{ clientX: startX, clientY: startY, target: el }],
+  });
+  el.dispatchEvent(touchstart);
+
+  const touchend = new Event('touchend', { bubbles: true, cancelable: true });
+  Object.defineProperty(touchend, 'changedTouches', {
+    value: [{ clientX: endX, clientY: endY, target: el }],
+  });
+  el.dispatchEvent(touchend);
+}
+
+describe('useTouchSwipe', () => {
+  it('calls onSwipeLeft for a horizontal left swipe', () => {
+    const onSwipeLeft = vi.fn();
+    const { getByTestId } = render(<Harness onSwipeLeft={onSwipeLeft} onSwipeRight={vi.fn()} />);
+    const target = getByTestId('swipe-target');
+
+    dispatchSwipe(target, { startX: 220, startY: 90, endX: 140, endY: 96 });
+    expect(onSwipeLeft).toHaveBeenCalledOnce();
+  });
+
+  it('calls onSwipeRight for a horizontal right swipe', () => {
+    const onSwipeRight = vi.fn();
+    const { getByTestId } = render(<Harness onSwipeLeft={vi.fn()} onSwipeRight={onSwipeRight} />);
+    const target = getByTestId('swipe-target');
+
+    dispatchSwipe(target, { startX: 90, startY: 150, endX: 160, endY: 146 });
+    expect(onSwipeRight).toHaveBeenCalledOnce();
+  });
+
+  it('ignores mostly-vertical gestures', () => {
+    const onSwipeLeft = vi.fn();
+    const onSwipeRight = vi.fn();
+    const { getByTestId } = render(<Harness onSwipeLeft={onSwipeLeft} onSwipeRight={onSwipeRight} />);
+    const target = getByTestId('swipe-target');
+
+    dispatchSwipe(target, { startX: 140, startY: 40, endX: 150, endY: 170 });
+    expect(onSwipeLeft).not.toHaveBeenCalled();
+    expect(onSwipeRight).not.toHaveBeenCalled();
+  });
+
+  it('does nothing when disabled', () => {
+    const onSwipeLeft = vi.fn();
+    const { getByTestId } = render(<Harness enabled={false} onSwipeLeft={onSwipeLeft} onSwipeRight={vi.fn()} />);
+    const target = getByTestId('swipe-target');
+
+    dispatchSwipe(target, { startX: 200, startY: 100, endX: 100, endY: 100 });
+    expect(onSwipeLeft).not.toHaveBeenCalled();
+  });
+});

--- a/src/hooks/useTouchSwipe.js
+++ b/src/hooks/useTouchSwipe.js
@@ -1,0 +1,83 @@
+import { useEffect, useRef } from 'react';
+
+const INTERACTIVE_TAGS = new Set(['INPUT', 'TEXTAREA', 'SELECT', 'BUTTON', 'A']);
+
+function isInteractiveElement(node) {
+  if (!(node instanceof Element)) return false;
+  if (INTERACTIVE_TAGS.has(node.tagName)) return true;
+  return node.closest('[contenteditable="true"], [data-no-swipe="true"]') != null;
+}
+
+/**
+ * useTouchSwipe — lightweight horizontal swipe detection for touch devices.
+ *
+ * Designed for calendar navigation: swipe left => next range, swipe right => previous.
+ * The hook intentionally avoids calling preventDefault so vertical page/view scrolling
+ * remains natural on mobile.
+ */
+export function useTouchSwipe({
+  targetRef,
+  enabled = true,
+  onSwipeLeft,
+  onSwipeRight,
+  minDistance = 48,
+  maxOffAxis = 72,
+  maxDurationMs = 700,
+}) {
+  const gestureRef = useRef(null);
+
+  useEffect(() => {
+    const el = targetRef?.current;
+    if (!enabled || !el) return undefined;
+
+    const handleTouchStart = (e) => {
+      if (e.touches.length !== 1) {
+        gestureRef.current = null;
+        return;
+      }
+      if (isInteractiveElement(e.target)) {
+        gestureRef.current = null;
+        return;
+      }
+      const touch = e.touches[0];
+      gestureRef.current = {
+        x: touch.clientX,
+        y: touch.clientY,
+        ts: Date.now(),
+      };
+    };
+
+    const handleTouchEnd = (e) => {
+      const start = gestureRef.current;
+      gestureRef.current = null;
+      if (!start || e.changedTouches.length === 0) return;
+
+      const touch = e.changedTouches[0];
+      const dx = touch.clientX - start.x;
+      const dy = touch.clientY - start.y;
+      const dt = Date.now() - start.ts;
+
+      if (dt > maxDurationMs) return;
+      if (Math.abs(dy) > maxOffAxis) return;
+      if (Math.abs(dx) < minDistance) return;
+      if (Math.abs(dx) <= Math.abs(dy)) return;
+
+      if (dx < 0) onSwipeLeft?.();
+      else onSwipeRight?.();
+    };
+
+    const clearGesture = () => {
+      gestureRef.current = null;
+    };
+
+    el.addEventListener('touchstart', handleTouchStart, { passive: true });
+    el.addEventListener('touchend', handleTouchEnd, { passive: true });
+    el.addEventListener('touchcancel', clearGesture, { passive: true });
+
+    return () => {
+      el.removeEventListener('touchstart', handleTouchStart);
+      el.removeEventListener('touchend', handleTouchEnd);
+      el.removeEventListener('touchcancel', clearGesture);
+    };
+  }, [enabled, maxDurationMs, maxOffAxis, minDistance, onSwipeLeft, onSwipeRight, targetRef]);
+}


### PR DESCRIPTION
### Motivation
- Improve mobile UX by enabling horizontal swipe navigation on calendar views so users can move between date ranges without desktop-only controls.
- Provide a small, reusable hook that detects intentional horizontal swipes while allowing natural vertical scrolling and ignoring interactive controls.

### Description
- Add a new hook `useTouchSwipe` (`src/hooks/useTouchSwipe.js`) that detects single-finger horizontal swipes with configurable thresholds and rejects off-axis/slow gestures and touches on interactive elements.
- Wire the hook into the main calendar container in `WorksCalendar.jsx` by importing `useTouchSwipe`, creating `swipeAreaRef`, and calling `useTouchSwipe({ targetRef: swipeAreaRef, enabled: cal.view === 'month' || cal.view === 'schedule', onSwipeLeft: () => cal.navigate(1), onSwipeRight: () => cal.navigate(-1) })` so swipes advance/retreat the current range via `cal.navigate`.
- Attach the `swipeAreaRef` to the view area container so the gesture applies across month and timeline surfaces (`<div ref={swipeAreaRef} className={styles.viewArea}>`).
- Add focused unit tests (`src/hooks/__tests__/useTouchSwipe.test.jsx`) covering left/right swipes, vertical-gesture rejection, and disabled mode.

### Testing
- Ran `npm test -- --run src/hooks/__tests__/useTouchSwipe.test.jsx` and the new tests passed (4 tests).
- Ran `npm test -- --run src/__tests__/WorksCalendar.ssr.test.jsx` and the existing SSR test passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd9837b694832cac0d27d32c21097d)