### PR TITLE
Lazy-load Excel export path and document bundle-size audit

### DIFF
--- a/docs/bundle-size-audit.md
+++ b/docs/bundle-size-audit.md
@@ -1,0 +1,33 @@
+# Bundle size audit (2026-04-14)
+
+## What was checked
+
+- Ran a production build (`npm run build`) to inspect emitted chunk sizes.
+- Verified the Excel export path is fully lazy: base UI click handler lazy-loads export code, and public API export uses a lazy wrapper.
+- Attempted to run `vite-bundle-visualizer`, but npm registry access is blocked in this environment (`403 Forbidden`).
+
+## Current build output snapshot
+
+From `npm run build` after this change:
+
+- `dist/index-DxbOqCiJ.js`: **493.90 kB** (gzip **117.14 kB**)
+- `dist/excelExport-DUhHt3G1.js`: **1.17 kB** (gzip **0.66 kB**)
+- `dist/works-calendar.es.js` bootstrap: **3.65 kB** (gzip **1.56 kB**)
+
+## Audit conclusion
+
+- `xlsx` is no longer reachable via any static import path from the main entrypoint.
+- Excel export is loaded on demand via dynamic import, so optional export code is excluded from the base runtime path and fetched only when needed.
+
+## Follow-up when network-restricted policy is lifted
+
+Run the visualizer for a full treemap breakdown:
+
+```bash
+npx vite-bundle-visualizer
+```
+
+Then confirm:
+
+1. `lucide-react` contribution is tree-shaken to only used icons.
+2. No `xlsx` code appears in the initial app/library chunk(s).

--- a/src/WorksCalendar.jsx
+++ b/src/WorksCalendar.jsx
@@ -49,7 +49,6 @@ import WeekView               from './views/WeekView.jsx';
 import DayView                from './views/DayView.jsx';
 import AgendaView             from './views/AgendaView.jsx';
 import TimelineView           from './views/TimelineView.jsx';
-import { exportToExcel }      from './export/excelExport.js';
 import { canViewScheduleTemplate, instantiateScheduleTemplate } from './api/v1/templates.ts';
 
 import styles from './WorksCalendar.module.css';
@@ -81,6 +80,14 @@ const DEFAULT_SCHEDULE_INSTANTIATION_LIMITS = {
   previewMax: 200,
   createMax: 200,
 };
+let exportToExcelFn = null;
+
+async function exportVisibleEvents(events) {
+  if (!exportToExcelFn) {
+    ({ exportToExcel: exportToExcelFn } = await import('./export/excelExport.js'));
+  }
+  return exportToExcelFn(events);
+}
 
 /** Compute the visible [start, end] range for a given view + date. */
 function viewRange(view, date, weekStartDay = 0) {
@@ -937,7 +944,7 @@ export const WorksCalendar = forwardRef(function WorksCalendar(
                   <Upload size={15} aria-hidden="true" />
                 </button>
               )}
-              <button className={styles.exportBtn} onClick={() => exportToExcel(visibleEvents)} aria-label="Export to Excel">
+              <button className={styles.exportBtn} onClick={() => exportVisibleEvents(visibleEvents)} aria-label="Export to Excel">
                 <Download size={15} aria-hidden="true" />
               </button>
               {ownerCfg.isOwner && (

--- a/src/export/exportToExcelLazy.js
+++ b/src/export/exportToExcelLazy.js
@@ -1,0 +1,7 @@
+/**
+ * Public export wrapper that lazy-loads the heavy Excel implementation.
+ */
+export async function exportToExcel(events, filename = 'calendar-events') {
+  const { exportToExcel: exportImpl } = await import('./excelExport.js');
+  return exportImpl(events, filename);
+}

--- a/src/index.js
+++ b/src/index.js
@@ -10,7 +10,7 @@ export { default as TimelineView }        from './views/TimelineView.jsx';
 export { normalizeEvent, normalizeEvents } from './core/eventModel.js';
 export { loadConfig, saveConfig, DEFAULT_CONFIG, FIELD_TYPES } from './core/configSchema.js';
 export { applyFilters, getCategories, getResources } from './filters/filterEngine.js';
-export { exportToExcel }                  from './export/excelExport.js';
+export { exportToExcel }                  from './export/exportToExcelLazy.js';
 export { useCalendar }                    from './hooks/useCalendar.js';
 export { useOwnerConfig }                 from './hooks/useOwnerConfig.js';
 export { useRealtimeEvents }              from './hooks/useRealtimeEvents.js';


### PR DESCRIPTION
### Motivation

- Reduce base bundle size by ensuring the optional `xlsx`/SheetJS export implementation is not statically included in the main library runtime.
- Make the Excel export load on demand so consumers who never use export do not pay the optional dependency cost.
- Capture a quick bundle-size audit and next steps to validate `lucide-react` tree-shaking once visualizer tooling is available.

### Description

- Change the UI export button to call a lazy loader (`exportVisibleEvents`) that dynamically imports the heavy export implementation from `src/export/excelExport.js` on first use in `WorksCalendar` (`src/WorksCalendar.jsx`).
- Add a public lazy wrapper `src/export/exportToExcelLazy.js` and update `src/index.js` to export that wrapper so the package entrypoint no longer statically imports `excelExport.js`.
- Add `docs/bundle-size-audit.md` recording build snapshots and reasoning, and commit the changes.

### Testing

- Ran `npm run build`, which succeeded and emitted a separate export chunk (example snapshot: `dist/excelExport-*.js` ~1.17 kB, `dist/index-*.js` ~493.9 kB, `dist/works-calendar.es.js` small bootstrap), demonstrating the export code is split out of the main runtime.
- Ran `npm test` (Vitest): the test suite reported tests passing but the run exited with an unhandled exception (`ReferenceError: window is not defined`) originating from a `ScreenReaderAnnouncer` timeout during teardown, causing a non-zero test runner exit.
- Attempted to run `npx vite-bundle-visualizer` to produce a treemap, but registry access is blocked in this environment (`403 Forbidden`); the audit notes this and recommends running the visualizer when network policy allows.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd9906e514832cb3258b284301b7bf)