### PR TITLE
TypeScript the WorksCalendar public API surface

### DIFF
--- a/src/WorksCalendar.tsx
+++ b/src/WorksCalendar.tsx
@@ -5,7 +5,7 @@ import {
   useState, useCallback, useEffect, useRef, useReducer,
   useImperativeHandle, forwardRef, useMemo,
 } from 'react';
-import type { ReactNode } from 'react';
+import type { ForwardedRef, ReactNode } from 'react';
 import {
   format, startOfMonth, endOfMonth,
   startOfWeek, endOfWeek, addDays,
@@ -56,52 +56,72 @@ import { canViewScheduleTemplate, instantiateScheduleTemplate } from './api/v1/t
 import styles from './WorksCalendar.module.css';
 import { customThemeToCssVars } from './core/themeSchema.js';
 
+export type WorksCalendarEvent = Record<string, unknown>;
+export type CalendarView = 'month' | 'week' | 'day' | 'agenda' | 'schedule';
+export type CalendarRole = 'admin' | 'user' | 'readonly';
+
+export type ScheduleInstantiationLimits = {
+  previewMax?: number;
+  createMax?: number;
+};
+
+export type CalendarApi = {
+  navigateTo: (date: Date) => void;
+  setView: (view: CalendarView) => void;
+  goToToday: () => void;
+  openEvent: (id: string) => void;
+  getVisibleEvents: () => WorksCalendarEvent[];
+  clearFilters: () => void;
+  addEvent: (defaults?: Partial<WorksCalendarEvent>) => void;
+  undo: () => boolean;
+  redo: () => boolean;
+  readonly canUndo: boolean;
+  readonly canRedo: boolean;
+};
+
 export type WorksCalendarProps = {
-  events?: any[];
-  fetchEvents?: (...args: any[]) => Promise<any[]>;
-  icalFeeds?: any[];
-  onImport?: (events: any[]) => void;
-  scheduleTemplates?: any[];
-  scheduleTemplateAdapter?: any;
-  scheduleInstantiationLimits?: {
-    previewMax?: number;
-    createMax?: number;
-  };
-  onScheduleTemplateAnalytics?: (payload: Record<string, any>) => void;
+  events?: WorksCalendarEvent[];
+  fetchEvents?: (...args: unknown[]) => Promise<WorksCalendarEvent[]>;
+  icalFeeds?: Array<Record<string, unknown>>;
+  onImport?: (events: WorksCalendarEvent[]) => void;
+  scheduleTemplates?: Array<Record<string, unknown>>;
+  scheduleTemplateAdapter?: Record<string, unknown>;
+  scheduleInstantiationLimits?: ScheduleInstantiationLimits;
+  onScheduleTemplateAnalytics?: (payload: Record<string, unknown>) => void;
   calendarId?: string;
   ownerPassword?: string;
-  onConfigSave?: (config: any) => void;
+  onConfigSave?: (config: Record<string, unknown>) => void;
   devMode?: boolean;
-  notes?: Record<string, any>;
-  onNoteSave?: (note: any) => void;
+  notes?: Record<string, unknown>;
+  onNoteSave?: (note: Record<string, unknown>) => void;
   onNoteDelete?: (noteId: string) => void;
-  onEventClick?: (event: any) => void;
-  onEventSave?: (event: any) => void;
-  onEventMove?: (event: any, newStart: Date, newEnd: Date) => void;
-  onEventResize?: (event: any, newStart: Date, newEnd: Date) => void;
+  onEventClick?: (event: WorksCalendarEvent) => void;
+  onEventSave?: (event: WorksCalendarEvent) => void;
+  onEventMove?: (event: WorksCalendarEvent, newStart: Date, newEnd: Date) => void;
+  onEventResize?: (event: WorksCalendarEvent, newStart: Date, newEnd: Date) => void;
   onEventDelete?: (eventId: string) => void;
   onDateSelect?: (start: Date, end: Date) => void;
   supabaseUrl?: string;
   supabaseKey?: string;
   supabaseTable?: string;
   supabaseFilter?: string;
-  role?: 'admin' | 'user' | 'readonly';
-  employees?: any[];
-  onEmployeeAdd?: (...args: any[]) => void;
-  onEmployeeDelete?: (...args: any[]) => void;
-  blockedWindows?: any[];
+  role?: CalendarRole;
+  employees?: Array<Record<string, unknown>>;
+  onEmployeeAdd?: (...args: unknown[]) => void;
+  onEmployeeDelete?: (...args: unknown[]) => void;
+  blockedWindows?: Array<Record<string, unknown>>;
   theme?: string;
-  colorRules?: any[];
-  businessHours?: any;
-  renderEvent?: (...args: any[]) => ReactNode;
-  renderHoverCard?: (...args: any[]) => ReactNode;
-  renderToolbar?: (...args: any[]) => ReactNode;
-  renderFilterBar?: (...args: any[]) => ReactNode;
-  renderSavedViewsBar?: (...args: any[]) => ReactNode;
+  colorRules?: Array<Record<string, unknown>>;
+  businessHours?: Record<string, unknown>;
+  renderEvent?: (...args: unknown[]) => ReactNode;
+  renderHoverCard?: (...args: unknown[]) => ReactNode;
+  renderToolbar?: (api: CalendarApi) => ReactNode;
+  renderFilterBar?: (...args: unknown[]) => ReactNode;
+  renderSavedViewsBar?: (...args: unknown[]) => ReactNode;
   emptyState?: ReactNode;
-  filterSchema?: any[];
+  filterSchema?: Array<Record<string, unknown>>;
   showAddButton?: boolean;
-  initialView?: string;
+  initialView?: CalendarView;
 };
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
@@ -143,7 +163,7 @@ function viewRange(view, date, weekStartDay = 0) {
   }
 }
 
-export const WorksCalendar = forwardRef(function WorksCalendar(
+export const WorksCalendar = forwardRef<CalendarApi, WorksCalendarProps>(function WorksCalendar(
   {
     // ── Data ──
     events:     rawEvents   = [],
@@ -217,7 +237,7 @@ export const WorksCalendar = forwardRef(function WorksCalendar(
     // ── Initial view (overrides saved config on first render) ──
     initialView,
   }: WorksCalendarProps,
-  ref,
+  ref: ForwardedRef<CalendarApi>,
 ) {
   // SSR guard: avoid touching browser-only APIs during server rendering.
   if (typeof window === 'undefined') return null;

--- a/src/WorksCalendar.tsx
+++ b/src/WorksCalendar.tsx
@@ -5,6 +5,7 @@ import {
   useState, useCallback, useEffect, useRef, useReducer,
   useImperativeHandle, forwardRef, useMemo,
 } from 'react';
+import type { ReactNode } from 'react';
 import {
   format, startOfMonth, endOfMonth,
   startOfWeek, endOfWeek, addDays,
@@ -54,6 +55,54 @@ import { canViewScheduleTemplate, instantiateScheduleTemplate } from './api/v1/t
 
 import styles from './WorksCalendar.module.css';
 import { customThemeToCssVars } from './core/themeSchema.js';
+
+export type WorksCalendarProps = {
+  events?: any[];
+  fetchEvents?: (...args: any[]) => Promise<any[]>;
+  icalFeeds?: any[];
+  onImport?: (events: any[]) => void;
+  scheduleTemplates?: any[];
+  scheduleTemplateAdapter?: any;
+  scheduleInstantiationLimits?: {
+    previewMax?: number;
+    createMax?: number;
+  };
+  onScheduleTemplateAnalytics?: (payload: Record<string, any>) => void;
+  calendarId?: string;
+  ownerPassword?: string;
+  onConfigSave?: (config: any) => void;
+  devMode?: boolean;
+  notes?: Record<string, any>;
+  onNoteSave?: (note: any) => void;
+  onNoteDelete?: (noteId: string) => void;
+  onEventClick?: (event: any) => void;
+  onEventSave?: (event: any) => void;
+  onEventMove?: (event: any, newStart: Date, newEnd: Date) => void;
+  onEventResize?: (event: any, newStart: Date, newEnd: Date) => void;
+  onEventDelete?: (eventId: string) => void;
+  onDateSelect?: (start: Date, end: Date) => void;
+  supabaseUrl?: string;
+  supabaseKey?: string;
+  supabaseTable?: string;
+  supabaseFilter?: string;
+  role?: 'admin' | 'user' | 'readonly';
+  employees?: any[];
+  onEmployeeAdd?: (...args: any[]) => void;
+  onEmployeeDelete?: (...args: any[]) => void;
+  blockedWindows?: any[];
+  theme?: string;
+  colorRules?: any[];
+  businessHours?: any;
+  renderEvent?: (...args: any[]) => ReactNode;
+  renderHoverCard?: (...args: any[]) => ReactNode;
+  renderToolbar?: (...args: any[]) => ReactNode;
+  renderFilterBar?: (...args: any[]) => ReactNode;
+  renderSavedViewsBar?: (...args: any[]) => ReactNode;
+  emptyState?: ReactNode;
+  filterSchema?: any[];
+  showAddButton?: boolean;
+  initialView?: string;
+};
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
@@ -167,7 +216,7 @@ export const WorksCalendar = forwardRef(function WorksCalendar(
 
     // ── Initial view (overrides saved config on first render) ──
     initialView,
-  },
+  }: WorksCalendarProps,
   ref,
 ) {
   // SSR guard: avoid touching browser-only APIs during server rendering.

--- a/src/__tests__/WorksCalendar.scheduleTemplates.test.jsx
+++ b/src/__tests__/WorksCalendar.scheduleTemplates.test.jsx
@@ -3,7 +3,7 @@
 import { describe, it, expect, vi } from 'vitest';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import '@testing-library/jest-dom';
-import { WorksCalendar } from '../WorksCalendar.jsx';
+import { WorksCalendar } from '../WorksCalendar.tsx';
 
 const scheduleTemplates = [
   {

--- a/src/__tests__/WorksCalendar.ssr.test.jsx
+++ b/src/__tests__/WorksCalendar.ssr.test.jsx
@@ -3,7 +3,7 @@ import { describe, expect, it } from 'vitest';
 import React from 'react';
 import { renderToString } from 'react-dom/server';
 
-import { WorksCalendar } from '../WorksCalendar.jsx';
+import { WorksCalendar } from '../WorksCalendar.tsx';
 
 describe('WorksCalendar SSR safety', () => {
   it('returns null during SSR render', () => {

--- a/src/index.js
+++ b/src/index.js
@@ -5,7 +5,7 @@
 // ── Versioned public schema (engine types + serialization helpers) ───────────
 export * from './api/v1/index.js';
 
-export { WorksCalendar }                  from './WorksCalendar.jsx';
+export { WorksCalendar }                  from './WorksCalendar.tsx';
 export { default as TimelineView }        from './views/TimelineView.jsx';
 export { normalizeEvent, normalizeEvents } from './core/eventModel.js';
 export { loadConfig, saveConfig, DEFAULT_CONFIG, FIELD_TYPES } from './core/configSchema.js';


### PR DESCRIPTION
### Motivation
- Provide a typed, discoverable public API for consumers by surfacing the component props in TypeScript.
- Keep the internal engine/types untouched while making the top-level component easier to consume from TS projects.

### Description
- Renamed and converted the public component file to `src/WorksCalendar.tsx` preserving the implementation.
- Added and exported a `WorksCalendarProps` type that documents the component's public props and annotated the component to use it. 
- Updated public exports and tests to import from `WorksCalendar.tsx` instead of `WorksCalendar.jsx`.

### Testing
- Ran `npm run build` successfully and the production bundle was produced. 
- Ran `npm test -- src/__tests__/WorksCalendar.ssr.test.jsx src/__tests__/WorksCalendar.scheduleTemplates.test.jsx` where the tests passed, but Vitest exited non-zero due to an existing unhandled `window is not defined` teardown exception originating from `ScreenReaderAnnouncer`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd99ba0f50832c922455f1b7e202b0)