### PR TITLE
Add Playwright E2E happy-path tests for core calendar flows

### DIFF
--- a/tests-e2e/calendar.happy-paths.spec.ts
+++ b/tests-e2e/calendar.happy-paths.spec.ts
@@ -1,0 +1,108 @@
+import { expect, test } from '@playwright/test';
+
+function toDatetimeLocalInput(date: Date): string {
+  const d = new Date(date);
+  d.setSeconds(0, 0);
+  const year = d.getFullYear();
+  const month = String(d.getMonth() + 1).padStart(2, '0');
+  const day = String(d.getDate()).padStart(2, '0');
+  const hours = String(d.getHours()).padStart(2, '0');
+  const minutes = String(d.getMinutes()).padStart(2, '0');
+  return `${year}-${month}-${day}T${hours}:${minutes}`;
+}
+
+function dateKey(offsetDays = 0): string {
+  const d = new Date();
+  d.setHours(0, 0, 0, 0);
+  d.setDate(d.getDate() + offsetDays);
+  const yyyy = d.getFullYear();
+  const mm = String(d.getMonth() + 1).padStart(2, '0');
+  const dd = String(d.getDate()).padStart(2, '0');
+  return `${yyyy}-${mm}-${dd}`;
+}
+
+test.describe('WorksCalendar happy paths', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.setViewportSize({ width: 1280, height: 900 });
+    await page.goto('/');
+    await expect(page.getByTestId('works-calendar')).toBeVisible();
+  });
+
+  test('month view navigation moves forward and back', async ({ page }) => {
+    const monthButton = page.getByRole('button', { name: /^Month$/i });
+    await monthButton.click();
+    await expect(monthButton).toHaveAttribute('aria-pressed', 'true');
+
+    const dateLabel = page.locator('[aria-live="polite"]').first();
+    const originalLabel = (await dateLabel.textContent())?.trim();
+    expect(originalLabel).toBeTruthy();
+
+    await page.getByRole('button', { name: /^Next$/i }).first().click();
+    await expect(dateLabel).not.toHaveText(originalLabel ?? '');
+
+    await page.getByRole('button', { name: /^Previous$/i }).first().click();
+    await expect(dateLabel).toHaveText(originalLabel ?? '');
+  });
+
+  test('can drag an event in month view without crashing', async ({ page }) => {
+    const event = page.getByRole('button', { name: /On Call, on-call/i }).first();
+    await expect(event).toBeVisible();
+
+    const sourceBox = await event.boundingBox();
+    const targetCell = page.locator(`[data-date="${dateKey(1)}"]`).first();
+    await expect(targetCell).toBeVisible();
+    const targetBox = await targetCell.boundingBox();
+
+    expect(sourceBox).not.toBeNull();
+    expect(targetBox).not.toBeNull();
+
+    if (!sourceBox || !targetBox) {
+      throw new Error('Unable to resolve drag coordinates for month event move.');
+    }
+
+    await page.mouse.move(sourceBox.x + sourceBox.width / 2, sourceBox.y + sourceBox.height / 2);
+    await page.mouse.down();
+    await page.mouse.move(targetBox.x + targetBox.width / 2, targetBox.y + targetBox.height / 2, { steps: 14 });
+    await page.mouse.up();
+
+    await expect(page.getByTestId('works-calendar')).toBeVisible();
+    await expect(page.getByRole('button', { name: /On Call, on-call/i }).first()).toBeVisible();
+  });
+
+  test('can create a recurring event from the add-event modal', async ({ page }) => {
+    await page.getByRole('button', { name: /Add New Event/i }).click();
+    await expect(page.getByRole('dialog', { name: /Add event/i })).toBeVisible();
+
+    const now = new Date();
+    const start = new Date(now);
+    start.setHours(10, 0, 0, 0);
+    const end = new Date(now);
+    end.setHours(11, 0, 0, 0);
+
+    await page.getByLabel(/^Title/i).fill('Happy Path Recurring Event');
+    await page.getByLabel(/^Start/i).fill(toDatetimeLocalInput(start));
+    await page.getByLabel(/^End/i).fill(toDatetimeLocalInput(end));
+    await page.getByLabel(/^Repeat$/i).selectOption('daily');
+
+    await page.getByRole('button', { name: /Add Event/i }).click();
+
+    await expect(page.getByRole('button', { name: /Happy Path Recurring Event/i }).first()).toBeVisible();
+  });
+
+  test('can switch theme from demo theme picker', async ({ page }) => {
+    await page.getByTitle('Change theme').click();
+    await page.getByRole('button', { name: /Ocean/i }).click();
+
+    await expect(page.getByTestId('works-calendar')).toHaveAttribute('data-wc-theme', 'ocean');
+  });
+
+  test('can export visible events to spreadsheet download', async ({ page }) => {
+    const [download] = await Promise.all([
+      page.waitForEvent('download'),
+      page.getByRole('button', { name: /Export to Excel/i }).click(),
+    ]);
+
+    const suggested = download.suggestedFilename();
+    expect(suggested).toMatch(/^calendar-events\.(xlsx|csv)$/i);
+  });
+});


### PR DESCRIPTION
### Motivation
- Increase browser E2E coverage for core happy-paths over a short (2 day) sprint focusing on common user flows in the month/demo UI.

### Description
- Add a new Playwright suite `tests-e2e/calendar.happy-paths.spec.ts` that covers month navigation, month drag-and-drop, creating a recurring event via the add-event modal, switching themes via the demo theme picker, and exporting visible events to a spreadsheet.
- Include deterministic helpers `toDatetimeLocalInput` and `dateKey` to stabilize `datetime-local` inputs and date-cell selectors across runs and timezones.
- Tests interact with the demo app via existing Playwright config (uses `baseURL`/demo server) and assert UI visibility, state changes, downloads, and non-crashing drag interactions.
- No production/runtime code changes were made; this PR only adds the E2E test file and helpers.

### Testing
- Ran `npx playwright test --list tests-e2e/calendar.happy-paths.spec.ts` to enumerate the new tests, which succeeded.
- Attempted to run `npm run test:browser -- tests-e2e/calendar.happy-paths.spec.ts`, but the test run failed in this environment because Playwright browser binaries were not present, resulting in 5 test failures due to `browserType.launch` errors.
- Attempted `npx playwright install chromium` to fetch browsers, but the download failed with CDN `403 Forbidden`, preventing local test execution; these are environment-level failures and the tests are expected to pass when Playwright browsers are available in CI.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd99cfc220832cbd303a67569f052f)