### PR TITLE
TypeScript the WorksCalendar public surface API

### DIFF
--- a/src/WorksCalendar.tsx
+++ b/src/WorksCalendar.tsx
@@ -101,6 +101,51 @@ function viewRange(view, date, weekStartDay = 0) {
   }
 }
 
+export type WorksCalendarProps = {
+  events?: unknown[];
+  fetchEvents?: (...args: any[]) => Promise<unknown[]>;
+  icalFeeds?: unknown[];
+  onImport?: (events: unknown[]) => void;
+  scheduleTemplates?: unknown[];
+  scheduleTemplateAdapter?: unknown;
+  scheduleInstantiationLimits?: { previewMax?: number; createMax?: number };
+  onScheduleTemplateAnalytics?: (...args: any[]) => void;
+  calendarId?: string;
+  ownerPassword?: string;
+  onConfigSave?: (...args: any[]) => void;
+  devMode?: boolean;
+  notes?: Record<string, unknown>;
+  onNoteSave?: (...args: any[]) => void;
+  onNoteDelete?: (...args: any[]) => void;
+  onEventClick?: (...args: any[]) => void;
+  onEventSave?: (...args: any[]) => void;
+  onEventMove?: (...args: any[]) => void;
+  onEventResize?: (...args: any[]) => void;
+  onEventDelete?: (...args: any[]) => void;
+  onDateSelect?: (...args: any[]) => void;
+  supabaseUrl?: string;
+  supabaseKey?: string;
+  supabaseTable?: string;
+  supabaseFilter?: string;
+  role?: 'admin' | 'user' | 'readonly';
+  employees?: unknown[];
+  onEmployeeAdd?: (...args: any[]) => void;
+  onEmployeeDelete?: (...args: any[]) => void;
+  blockedWindows?: unknown[];
+  theme?: string;
+  colorRules?: unknown[];
+  businessHours?: unknown;
+  renderEvent?: (...args: any[]) => unknown;
+  renderHoverCard?: (...args: any[]) => unknown;
+  renderToolbar?: (...args: any[]) => unknown;
+  renderFilterBar?: (...args: any[]) => unknown;
+  renderSavedViewsBar?: (...args: any[]) => unknown;
+  emptyState?: unknown;
+  filterSchema?: unknown[];
+  showAddButton?: boolean;
+  initialView?: 'month' | 'week' | 'day' | 'agenda' | 'schedule';
+};
+
 export const WorksCalendar = forwardRef(function WorksCalendar(
   {
     // ── Data ──
@@ -174,7 +219,7 @@ export const WorksCalendar = forwardRef(function WorksCalendar(
 
     // ── Initial view (overrides saved config on first render) ──
     initialView,
-  },
+  }: WorksCalendarProps,
   ref,
 ) {
   // SSR guard: avoid touching browser-only APIs during server rendering.

--- a/src/__tests__/WorksCalendar.scheduleTemplates.test.jsx
+++ b/src/__tests__/WorksCalendar.scheduleTemplates.test.jsx
@@ -3,7 +3,7 @@
 import { describe, it, expect, vi } from 'vitest';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import '@testing-library/jest-dom';
-import { WorksCalendar } from '../WorksCalendar.jsx';
+import { WorksCalendar } from '../WorksCalendar.tsx';
 
 const scheduleTemplates = [
   {

--- a/src/__tests__/WorksCalendar.ssr.test.jsx
+++ b/src/__tests__/WorksCalendar.ssr.test.jsx
@@ -3,7 +3,7 @@ import { describe, expect, it } from 'vitest';
 import React from 'react';
 import { renderToString } from 'react-dom/server';
 
-import { WorksCalendar } from '../WorksCalendar.jsx';
+import { WorksCalendar } from '../WorksCalendar.tsx';
 
 describe('WorksCalendar SSR safety', () => {
   it('returns null during SSR render', () => {

--- a/src/index.js
+++ b/src/index.js
@@ -5,7 +5,7 @@
 // ── Versioned public schema (engine types + serialization helpers) ───────────
 export * from './api/v1/index.js';
 
-export { WorksCalendar }                  from './WorksCalendar.jsx';
+export { WorksCalendar }                  from './WorksCalendar.tsx';
 export { default as TimelineView }        from './views/TimelineView.jsx';
 export { normalizeEvent, normalizeEvents } from './core/eventModel.js';
 export { loadConfig, saveConfig, DEFAULT_CONFIG, FIELD_TYPES } from './core/configSchema.js';


### PR DESCRIPTION
### Motivation
- Provide a TypeScript-first public surface so consumers can see the component prop types without reading implementation details.
- Keep runtime behavior unchanged while exposing a discoverable `WorksCalendarProps` contract for downstream TypeScript users.

### Description
- Renamed the public component file from `src/WorksCalendar.jsx` to `src/WorksCalendar.tsx` to make the surface module TypeScript-authored.
- Added and exported a `WorksCalendarProps` type in `src/WorksCalendar.tsx` and annotated the component signature as `}: WorksCalendarProps`.
- Updated references that imported the component to the new path, including `src/index.js` and the two test files under `src/__tests__`.
- No engine or internal API changes were made; this is a surface-layer typing change only.

### Testing
- Ran `npm run build`, which completed successfully.
- Ran `npm run test -- src/__tests__/WorksCalendar.ssr.test.jsx src/__tests__/WorksCalendar.scheduleTemplates.test.jsx`, where the tests themselves passed but Vitest reported an unhandled async `ReferenceError: window is not defined` (from `ScreenReaderAnnouncer` timer behavior under the test environment), causing a non-zero exit status.
- Committed the changes after validation (`git commit`) and verified imports compile via the build step.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd9c268114832c8a1043e9904fcfaf)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved component type safety and internal module organization for better code maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->