### PR TITLE
Stabilize E2E fixture data for month-span and regression flows

### DIFF
--- a/demo/pill-span-matrix-fixture.jsx
+++ b/demo/pill-span-matrix-fixture.jsx
@@ -13,10 +13,6 @@ const base = new Date();
 base.setHours(0, 0, 0, 0);
 const monday = firstMondayInMonth(base);
 
-function iso(day) {
-  return day.toISOString();
-}
-
 const matrixCases = [
   {
     id: 'case-sameweek-oncall',
@@ -59,8 +55,8 @@ const matrixCases = [
 const events = matrixCases.map((item) => ({
   id: item.id,
   title: item.title,
-  start: iso(item.start),
-  end: iso(item.endExclusive),
+  start: item.start,
+  end: item.endExclusive,
   category: item.category,
   color: item.color,
   resource: 'emp-alpha',

--- a/demo/regression-bugs.jsx
+++ b/demo/regression-bugs.jsx
@@ -11,6 +11,16 @@ function at(base, dayOffset, hour, minute = 0) {
   return d;
 }
 
+if (typeof window !== 'undefined') {
+  const configKey = `wc-config-${CALENDAR_ID}`;
+  try {
+    const existing = JSON.parse(window.localStorage.getItem(configKey) ?? '{}');
+    window.localStorage.setItem(configKey, JSON.stringify({ ...existing, setupCompleted: true }));
+  } catch {
+    window.localStorage.setItem(configKey, JSON.stringify({ setupCompleted: true }));
+  }
+}
+
 function App() {
   const today = useMemo(() => {
     const d = new Date();

--- a/demo/source-single-stack-fixture.jsx
+++ b/demo/source-single-stack-fixture.jsx
@@ -14,8 +14,8 @@ base.setHours(0, 0, 0, 0);
 const monday = firstMondayInMonth(base);
 
 const events = [
-  { id: 'source-a-single', title: 'Source A Single', start: monday.toISOString(), end: addDays(monday, 0).toISOString(), category: 'Project', color: '#2563eb' },
-  { id: 'source-b-single', title: 'Source B Single', start: monday.toISOString(), end: addDays(monday, 0).toISOString(), category: 'Project', color: '#dc2626' },
+  { id: 'source-a-single', title: 'Source A Single', start: monday, end: addDays(monday, 1), allDay: true, category: 'Project', color: '#2563eb' },
+  { id: 'source-b-single', title: 'Source B Single', start: monday, end: addDays(monday, 1), allDay: true, category: 'Project', color: '#dc2626' },
 ];
 
 function App() {


### PR DESCRIPTION
### Motivation
- Fix flaky Playwright E2E failures caused by timezone drift and UI overlays in demo fixtures that make visual/span assertions and interaction tests brittle.
- Ensure demo fixtures model events in the same shape the app expects for month/all-day rendering and avoid setup-wizard blocking of test clicks.

### Description
- Pass `Date` objects directly for `start`/`end` in `demo/pill-span-matrix-fixture.jsx` instead of `toISOString()` strings to avoid timezone/UTC drift altering span boundaries.
- Change `demo/source-single-stack-fixture.jsx` to represent single-day source events as true all-day events (`allDay: true` with exclusive `end` on the next day) so month-view pills render and stack as expected.
- Pre-seed `setupCompleted: true` into `localStorage` for the regression fixture calendar in `demo/regression-bugs.jsx` so the setup wizard overlay does not obstruct click interactions during tests.

### Testing
- Attempted browser E2E: ran `npx playwright install chromium` and Playwright-based test runs, but browser download/install failed with CDN 403 so Playwright browser tests could not be executed in this environment.
- Ran unit tests via `npm test` (Vitest): unit test suites completed and assertions passed, but the run surfaced a pre-existing teardown error (`ReferenceError: window is not defined`) from `ScreenReaderAnnouncer` which should be investigated separately.
- Verified files were updated and committed locally as part of the change (`demo/pill-span-matrix-fixture.jsx`, `demo/source-single-stack-fixture.jsx`, `demo/regression-bugs.jsx`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd9bced274832c9c9cb9fdacd6c496)