### PR TITLE
Fix e2e navigation labels and month matrix week start

### DIFF
--- a/demo/pill-span-matrix-fixture.jsx
+++ b/demo/pill-span-matrix-fixture.jsx
@@ -83,6 +83,7 @@ function App() {
             theme="light"
             showAddButton={false}
             initialView="month"
+            weekStartDay={1}
           />
         </div>
       </div>

--- a/src/WorksCalendar.tsx
+++ b/src/WorksCalendar.tsx
@@ -939,11 +939,21 @@ export const WorksCalendar = forwardRef(function WorksCalendar(
         ) : (
           <div className={styles.toolbar} role="toolbar" aria-label="Calendar navigation">
             <div className={styles.navGroup}>
-              <button className={styles.navBtn} onClick={() => cal.navigate(-1)} aria-label={`Previous ${cal.view}`}>
+              <button
+                className={styles.navBtn}
+                onClick={() => cal.navigate(-1)}
+                aria-label="Previous"
+                title={`Previous ${cal.view}`}
+              >
                 <ChevronLeft size={18} aria-hidden="true" />
               </button>
               <button className={styles.todayBtn} onClick={cal.goToToday}>Today</button>
-              <button className={styles.navBtn} onClick={() => cal.navigate(1)} aria-label={`Next ${cal.view}`}>
+              <button
+                className={styles.navBtn}
+                onClick={() => cal.navigate(1)}
+                aria-label="Next"
+                title={`Next ${cal.view}`}
+              >
                 <ChevronRight size={18} aria-hidden="true" />
               </button>
               <span className={styles.dateLabel} aria-live="polite" aria-atomic="true">{getDateLabel()}</span>


### PR DESCRIPTION
### Motivation
- E2E selectors and month-span visual assertions were brittle because the toolbar navigation buttons exposed view-specific `aria-label` strings and the pill-span fixture used a different week start than tests expected.

### Description
- Changed the calendar toolbar navigation icon buttons to use stable accessible names `aria-label="Previous"` and `aria-label="Next"` and moved the view-specific context into the `title` attribute in `src/WorksCalendar.tsx`.
- Updated the month pill-span demo fixture to force Monday-based weeks by adding `weekStartDay={1}` in `demo/pill-span-matrix-fixture.jsx` so cross-week span expectations align with the test cases.

### Testing
- Ran the unit/integration suite with `npm test` which executed the Vitest run; most tests passed but Vitest reported one unhandled error (`ReferenceError: window is not defined`) originating from `ScreenReaderAnnouncer` teardown. 
- Attempted targeted Playwright runs for the failing E2E specs, but Playwright could not launch browsers because `npx playwright install chromium` failed due to CDN HTTP 403 responses, so E2E verification could not complete in this environment. 
- Attempt to run `npm test -- --runInBand` was skipped because the `--runInBand` flag is not supported by this project's Vitest CLI.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd9e74bdcc832c9ffa0fffc24437ac)