### PR TITLE
Improve theme editor font picker and live preview for style tokens

### DIFF
--- a/src/ui/ThemeCustomizer.jsx
+++ b/src/ui/ThemeCustomizer.jsx
@@ -67,6 +67,18 @@ const PRESET_THEMES = [
   },
 ];
 
+const FONT_FAMILY_OPTIONS = [
+  { label: 'Inter (Default)', value: "'Inter', system-ui, -apple-system, sans-serif" },
+  { label: 'System UI', value: "system-ui, -apple-system, 'Segoe UI', sans-serif" },
+  { label: 'Segoe UI', value: "'Segoe UI', Tahoma, Geneva, Verdana, sans-serif" },
+  { label: 'Roboto', value: "'Roboto', 'Helvetica Neue', Arial, sans-serif" },
+  { label: 'Arial', value: "Arial, 'Helvetica Neue', sans-serif" },
+  { label: 'Georgia', value: "Georgia, 'Times New Roman', serif" },
+  { label: 'Nunito', value: "'Nunito', 'Segoe UI', system-ui, sans-serif" },
+  { label: 'IBM Plex Sans', value: "'IBM Plex Sans', 'Segoe UI', system-ui, sans-serif" },
+  { label: 'JetBrains Mono', value: "'JetBrains Mono', 'Roboto Mono', 'Courier New', monospace" },
+];
+
 function valueLabel(value, suffix) {
   if (suffix === 'x') return `${Number(value).toFixed(2)}x`;
   if (!suffix) return String(value);
@@ -118,7 +130,13 @@ export default function ThemeCustomizer({ theme, onChange }) {
   const [importSuccess, setImportSuccess] = useState('');
   const [copyState, setCopyState] = useState('');
   const merged = normalizeCustomTheme(theme);
+  const hasNamedFontOption = FONT_FAMILY_OPTIONS.some((option) => option.value === merged.typography.fontFamily);
+  const selectedFontOption = hasNamedFontOption ? merged.typography.fontFamily : '__custom__';
   const previewVars = customThemeToCssVars(merged);
+  const previewStyle = {
+    ...previewVars,
+    '--tc-density': merged.spacing.density,
+  };
   const exportJson = useMemo(() => JSON.stringify(merged, null, 2), [merged]);
   const contrastChecks = useMemo(() => ([
     { id: 'text-on-bg', label: 'Body text on background', fg: merged.colors.text, bg: merged.colors.bg },
@@ -211,11 +229,25 @@ export default function ThemeCustomizer({ theme, onChange }) {
 
         <label className={styles.control}>
           <span>Font Family</span>
-          <input
-            type="text"
-            value={merged.typography.fontFamily}
-            onChange={(e) => update(['typography', 'fontFamily'], e.target.value)}
-          />
+          <select
+            value={selectedFontOption}
+            onChange={(e) => {
+              if (e.target.value !== '__custom__') update(['typography', 'fontFamily'], e.target.value);
+            }}
+          >
+            {FONT_FAMILY_OPTIONS.map((option) => (
+              <option key={option.label} value={option.value}>{option.label}</option>
+            ))}
+            <option value="__custom__">Custom…</option>
+          </select>
+          {selectedFontOption === '__custom__' && (
+            <input
+              type="text"
+              value={merged.typography.fontFamily}
+              onChange={(e) => update(['typography', 'fontFamily'], e.target.value)}
+              placeholder="Enter custom font stack"
+            />
+          )}
         </label>
 
         {TOKEN_SLIDERS.map(([group, key, label, min, max, step, suffix]) => (
@@ -244,12 +276,15 @@ export default function ThemeCustomizer({ theme, onChange }) {
         </div>
       </div>
 
-      <div className={styles.preview} style={previewVars}>
+      <div className={styles.preview} style={previewStyle}>
         <div className={styles.previewHeader}>
           <strong>Live Preview</strong>
           <span className={styles.badge}>Mini Calendar</span>
         </div>
         <div className={styles.previewBody}>
+          <div className={styles.previewLegend}>
+            Aa Text preview • Border {merged.borders.borderWidth}px • Density {merged.spacing.density.toFixed(2)}x
+          </div>
           {Array.from({ length: 14 }).map((_, i) => (
             <div key={i} className={styles.day}>
               {(i === 2 || i === 8) && <div className={styles.event} />}

--- a/src/ui/ThemeCustomizer.module.css
+++ b/src/ui/ThemeCustomizer.module.css
@@ -15,7 +15,8 @@
 }
 .control input[type="text"],
 .control input[type="number"],
-.control input[type="range"] {
+.control input[type="range"],
+.control select {
   width: 100%;
 }
 .control input[type="color"] {
@@ -26,44 +27,51 @@
   background: transparent;
 }
 .preview {
-  border: 1px solid var(--wc-border);
+  font-family: var(--wc-font);
+  font-size: var(--wc-base-font-size);
+  border: var(--wc-border-width) solid var(--wc-border);
   border-radius: var(--wc-radius);
   background: var(--wc-bg);
-  box-shadow: var(--wc-shadow-sm);
+  box-shadow: var(--wc-shadow);
   overflow: hidden;
 }
 .previewHeader {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: 10px;
-  border-bottom: 1px solid var(--wc-border);
+  padding: calc(8px * var(--tc-density)) calc(10px * var(--tc-density));
+  border-bottom: var(--wc-border-width) solid var(--wc-border);
   background: var(--wc-surface);
   color: var(--wc-text);
 }
 .badge {
-  font-size: 11px;
+  font-size: calc(var(--wc-base-font-size) * 0.8);
   background: var(--wc-accent-dim);
   color: var(--wc-accent);
   border-radius: 999px;
-  padding: 3px 8px;
+  padding: calc(3px * var(--tc-density)) calc(8px * var(--tc-density));
 }
 .previewBody {
   display: grid;
   grid-template-columns: repeat(7, 1fr);
-  gap: 6px;
-  padding: 10px;
+  gap: calc(6px * var(--tc-density));
+  padding: calc(10px * var(--tc-density));
   background: var(--wc-bg);
 }
+.previewLegend {
+  grid-column: 1 / -1;
+  font-size: calc(var(--wc-base-font-size) * 0.9);
+  color: var(--wc-text-muted);
+}
 .day {
-  min-height: 34px;
-  border: 1px solid var(--wc-border);
+  min-height: calc(34px * var(--tc-density));
+  border: var(--wc-border-width) solid var(--wc-border);
   border-radius: var(--wc-radius-sm);
   background: var(--wc-surface-2);
 }
 .event {
-  margin: 2px;
-  height: 8px;
+  margin: calc(2px * var(--tc-density));
+  height: calc(8px * var(--tc-density));
   border-radius: 999px;
   background: var(--wc-accent);
 }

--- a/src/ui/__tests__/ThemeCustomizer.test.jsx
+++ b/src/ui/__tests__/ThemeCustomizer.test.jsx
@@ -43,6 +43,17 @@ describe('ThemeCustomizer', () => {
     expect(latest.customTheme.spacing.density).toBe(1.15);
   });
 
+  it('updates font family from dropdown selection', () => {
+    const { setConfig } = renderWithConfig({});
+
+    fireEvent.change(screen.getByLabelText('Font Family'), {
+      target: { value: "'Roboto', 'Helvetica Neue', Arial, sans-serif" },
+    });
+
+    const latest = setConfig.mock.calls.at(-1)[0];
+    expect(latest.customTheme.typography.fontFamily).toBe("'Roboto', 'Helvetica Neue', Arial, sans-serif");
+  });
+
   it('resets customTheme to defaults payload', () => {
     const { setConfig } = renderWithConfig({ colors: { accent: '#111111' } });
 


### PR DESCRIPTION
### Motivation
- The theme editor required entering raw font-family strings and the preview did not visibly reflect several token controls, making configuration error-prone and confusing.
- Provide a Word-like font dropdown and make sliders (density, base size, borders, shadows) meaningfully affect the live preview so users can see changes immediately.

### Description
- Added a curated `FONT_FAMILY_OPTIONS` list and replaced the free-text `Font Family` input with a `<select>` plus a `Custom…` text fallback so common stacks are one-click choices (`src/ui/ThemeCustomizer.jsx`).
- Applied preview token bindings by producing a `previewStyle` (spreading `customThemeToCssVars(merged)` and adding `--tc-density`) and using it on the preview container so typography, density, border width, radius, and shadow change the preview (`src/ui/ThemeCustomizer.jsx`, `src/core/themeSchema.js` unchanged except vars already provided).
- Updated preview CSS to consume the CSS variables (`--wc-base-font-size`, `--wc-border-width`, `--wc-shadow`, and the new `--tc-density`) and scale paddings, gaps, day sizes, event sizes, and badge/font sizes accordingly (`src/ui/ThemeCustomizer.module.css`).
- Added a compact preview legend that surfaces current `density` and `borderWidth`, and extended tests to assert dropdown font selection updates `customTheme.typography.fontFamily` (`src/ui/__tests__/ThemeCustomizer.test.jsx`).

### Testing
- Ran `npm test -- src/ui/__tests__/ThemeCustomizer.test.jsx` and the suite passed: all tests in the file succeeded (10 tests passed).
- The updated test verifies selecting a font from the dropdown updates the theme payload.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dda8a3450c832c822b3fad29e38b1b)