### PR TITLE
Move setup flow into gear settings tabs

### DIFF
--- a/src/WorksCalendar.tsx
+++ b/src/WorksCalendar.tsx
@@ -9,7 +9,7 @@ import {
   format, startOfMonth, endOfMonth,
   startOfWeek, endOfWeek, addDays,
 } from 'date-fns';
-import { ChevronLeft, ChevronRight, Download, Plus, Upload, Wand2 } from 'lucide-react';
+import { ChevronLeft, ChevronRight, Download, Plus, Upload } from 'lucide-react';
 
 import { useCalendar }        from './hooks/useCalendar.js';
 import { useOwnerConfig }     from './hooks/useOwnerConfig.js';
@@ -41,7 +41,6 @@ import EventForm              from './ui/EventForm.jsx';
 import ImportZone             from './ui/ImportZone.jsx';
 import ScheduleTemplateDialog from './ui/ScheduleTemplateDialog.jsx';
 import ValidationAlert          from './ui/ValidationAlert.jsx';
-import SetupWizardModal        from './ui/SetupWizardModal.jsx';
 import ScreenReaderAnnouncer   from './ui/ScreenReaderAnnouncer.jsx';
 import CalendarErrorBoundary   from './ui/CalendarErrorBoundary.jsx';
 import MonthView              from './views/MonthView.jsx';
@@ -417,21 +416,7 @@ export const WorksCalendar = forwardRef(function WorksCalendar(
   // ── Local UI state ───────────────────────────────────────────────────────
   const [selectedEvent,  setSelectedEvent]  = useState(null);
   const [formEvent,      setFormEvent]      = useState(null);
-  const [wizardOpen,     setWizardOpen]     = useState(false);
   const [importOpen,     setImportOpen]     = useState(false);
-
-  // Auto-open setup wizard once for owners who haven't completed setup
-  const wizardAutoOpened = useRef(false);
-  useEffect(() => {
-    if (
-      ownerCfg.isOwner &&
-      !ownerCfg.config?.setupCompleted &&
-      !wizardAutoOpened.current
-    ) {
-      wizardAutoOpened.current = true;
-      setWizardOpen(true);
-    }
-  }, [ownerCfg.isOwner, ownerCfg.config?.setupCompleted]);
   const [scheduleOpen,   setScheduleOpen]   = useState(false);
   const [pillHoverTitle, setPillHoverTitle] = useState(false);
   const [remoteTemplates, setRemoteTemplates] = useState([]);
@@ -1002,16 +987,6 @@ export const WorksCalendar = forwardRef(function WorksCalendar(
               <button className={styles.exportBtn} onClick={() => exportVisibleEvents(visibleEvents)} aria-label="Export to Excel">
                 <Download size={15} aria-hidden="true" />
               </button>
-              {ownerCfg.isOwner && (
-                <button
-                  className={styles.exportBtn}
-                  onClick={() => setWizardOpen(true)}
-                  aria-label="Open setup wizard"
-                  title="Setup Wizard"
-                >
-                  <Wand2 size={15} aria-hidden="true" />
-                </button>
-              )}
               {ownerPassword && (
                 <OwnerLock
                   isOwner={ownerCfg.isOwner}
@@ -1179,25 +1154,15 @@ export const WorksCalendar = forwardRef(function WorksCalendar(
           />
         )}
 
-        {/* ── Setup wizard ── */}
-        {wizardOpen && ownerCfg.isOwner && (
-          <SetupWizardModal
-            isOpen={wizardOpen}
-            onClose={() => setWizardOpen(false)}
-            updateConfig={ownerCfg.updateConfig}
-            categories={categories}
-            resources={resources}
-            onSaveView={(name, filters, opts) => savedViews.saveView(name, filters, opts)}
-          />
-        )}
-
         {/* ── Owner config panel ── */}
         {ownerCfg.configOpen && (
           <ConfigPanel
             config={ownerCfg.config}
             categories={categories}
+            resources={resources}
             onUpdate={ownerCfg.updateConfig}
             onClose={ownerCfg.closeConfig}
+            onSaveView={(name, filters, opts) => savedViews.saveView(name, filters, opts)}
             sources={sourceStore.sources}
             feedErrors={feedErrors}
             onAddSource={sourceStore.addSource}

--- a/src/ui/ConfigPanel.jsx
+++ b/src/ui/ConfigPanel.jsx
@@ -1,28 +1,33 @@
 import { useState } from 'react';
-import { X, Plus, Trash2 } from 'lucide-react';
+import { X, Plus, Trash2, Check, Camera } from 'lucide-react';
 import { FIELD_TYPES } from '../core/configSchema.js';
 import { useFocusTrap } from '../hooks/useFocusTrap.js';
+import { THEMES } from '../styles/themes.js';
 import SourcePanel from './SourcePanel.jsx';
 import ThemeCustomizer from './ThemeCustomizer.jsx';
+import AdvancedFilterBuilder from './AdvancedFilterBuilder.jsx';
 import styles from './ConfigPanel.module.css';
 
 const TABS = [
+  { id: 'setup',       label: 'Setup' },
   { id: 'hoverCard',   label: 'Hover Card' },
   { id: 'eventFields', label: 'Event Fields' },
   { id: 'display',     label: 'Display' },
   { id: 'theme',       label: 'Theme' },
   { id: 'feeds',       label: 'Feeds' },
   { id: 'templates',   label: 'Templates' },
+  { id: 'smartViews',  label: 'Smart Views' },
+  { id: 'team',        label: 'Employees' },
   { id: 'access',      label: 'Access' },
 ];
 
 export default function ConfigPanel({
-  config, categories, onUpdate, onClose,
+  config, categories, resources, onUpdate, onClose, onSaveView,
   // Source store props (optional — omitted when owner has no source store)
   sources, feedErrors, onAddSource, onRemoveSource, onToggleSource, onUpdateSource,
   scheduleTemplates, onCreateScheduleTemplate, onDeleteScheduleTemplate, scheduleTemplateError,
 }) {
-  const [tab, setTab] = useState('hoverCard');
+  const [tab, setTab] = useState('setup');
   const trapRef = useFocusTrap(onClose);
 
   return (
@@ -46,6 +51,7 @@ export default function ConfigPanel({
         </div>
 
         <div className={styles.body}>
+          {tab === 'setup'       && <SetupTab config={config} onUpdate={onUpdate} />}
           {tab === 'hoverCard'   && <HoverCardTab   config={config} onUpdate={onUpdate} />}
           {tab === 'eventFields' && <EventFieldsTab config={config} categories={categories} onUpdate={onUpdate} />}
           {tab === 'display'     && <DisplayTab     config={config} onUpdate={onUpdate} />}
@@ -68,9 +74,133 @@ export default function ConfigPanel({
               error={scheduleTemplateError}
             />
           )}
+          {tab === 'smartViews'  && <SmartViewsTab categories={categories} resources={resources} onSaveView={onSaveView} />}
+          {tab === 'team'        && <TeamTab config={config} onUpdate={onUpdate} />}
           {tab === 'access'      && <AccessTab      config={config} onUpdate={onUpdate} />}
         </div>
       </div>
+    </div>
+  );
+}
+
+function SetupTab({ config, onUpdate }) {
+  const selectedTheme = config.wizardData?.preferredTheme ?? 'corporate';
+  const calendarName = config.wizardData?.calendarName ?? 'My WorksCalendar';
+
+  const setCalendarName = (name) => onUpdate(c => ({
+    ...c,
+    wizardData: { ...(c.wizardData ?? {}), calendarName: name },
+  }));
+
+  const setPreferredTheme = (themeId) => onUpdate(c => ({
+    ...c,
+    wizardData: { ...(c.wizardData ?? {}), preferredTheme: themeId },
+    setupCompleted: true,
+  }));
+
+  return (
+    <div className={styles.section}>
+      <p className={styles.sectionDesc}>Start setup by naming your calendar and selecting a theme.</p>
+      <label className={styles.formRow}>
+        <span>Calendar name</span>
+        <input
+          className={styles.input}
+          value={calendarName}
+          onChange={(e) => setCalendarName(e.target.value)}
+          maxLength={64}
+          placeholder="My WorksCalendar"
+        />
+      </label>
+      <div className={styles.themeGrid}>
+        {THEMES.map((theme) => (
+          <button
+            key={theme.id}
+            className={[styles.themeCard, selectedTheme === theme.id && styles.themeCardSelected].filter(Boolean).join(' ')}
+            onClick={() => setPreferredTheme(theme.id)}
+            title={theme.description}
+            aria-pressed={selectedTheme === theme.id}
+          >
+            <div className={styles.themeCardTop}>
+              <span className={styles.themeColorDot} style={{ background: theme.preview.accent }} />
+              <span>{theme.label}</span>
+            </div>
+            {selectedTheme === theme.id && <Check size={12} />}
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function SmartViewsTab({ categories, resources, onSaveView }) {
+  return (
+    <div className={styles.section}>
+      <p className={styles.sectionDesc}>Create Smart Views once categories and people are configured.</p>
+      <AdvancedFilterBuilder categories={categories ?? []} resources={resources ?? []} onSave={onSaveView} />
+    </div>
+  );
+}
+
+function TeamTab({ config, onUpdate }) {
+  const teamMembers = config.wizardData?.teamMembers ?? [];
+
+  const updateMembers = (nextMembers) => onUpdate(c => ({
+    ...c,
+    wizardData: { ...(c.wizardData ?? {}), teamMembers: nextMembers },
+    setupCompleted: true,
+  }));
+
+  const addMember = () => {
+    const nextId = Math.max(0, ...teamMembers.map((member) => Number(member.id) || 0)) + 1;
+    updateMembers([...teamMembers, { id: nextId, name: '', color: '#8b5cf6', avatar: null }]);
+  };
+
+  const updateMember = (id, patch) => {
+    updateMembers(teamMembers.map((member) => (member.id === id ? { ...member, ...patch } : member)));
+  };
+
+  const removeMember = (id) => updateMembers(teamMembers.filter((member) => member.id !== id));
+
+  const handleProfileUpload = (memberId, e) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    const reader = new FileReader();
+    reader.onload = (ev) => {
+      updateMember(memberId, { avatar: ev.target.result });
+    };
+    reader.readAsDataURL(file);
+  };
+
+  return (
+    <div className={styles.section}>
+      <p className={styles.sectionDesc}>Add employee photos after your categories and Smart Views are in place.</p>
+      {teamMembers.map((member) => (
+        <div key={member.id} className={styles.memberRow}>
+          <label className={styles.avatarPicker}>
+            <div className={styles.avatarFrame}>
+              {member.avatar ? (
+                <img src={member.avatar} alt={`${member.name || 'Employee'} avatar`} className={styles.avatarImg} />
+              ) : (
+                <div className={styles.avatarFallback} style={{ backgroundColor: member.color }}>
+                  {(member.name?.trim()?.[0] ?? '?').toUpperCase()}
+                </div>
+              )}
+            </div>
+            <input type="file" accept="image/*" className={styles.fileInput} onChange={(e) => handleProfileUpload(member.id, e)} />
+            <span className={styles.avatarBadge}><Camera size={11} /> Photo</span>
+          </label>
+          <input
+            className={styles.input}
+            value={member.name ?? ''}
+            onChange={(e) => updateMember(member.id, { name: e.target.value })}
+            placeholder="Employee name"
+          />
+          <button className={styles.removeBtn} onClick={() => removeMember(member.id)} aria-label={`Remove ${member.name || 'employee'}`}>
+            <Trash2 size={13} />
+          </button>
+        </div>
+      ))}
+      <button className={styles.addFieldBtn} onClick={addMember}><Plus size={13} /> Add employee</button>
     </div>
   );
 }

--- a/src/ui/ConfigPanel.module.css
+++ b/src/ui/ConfigPanel.module.css
@@ -256,6 +256,100 @@
   color: var(--wc-accent);
 }
 
+.themeGrid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 8px;
+}
+
+.themeCard {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  border: 1px solid var(--wc-border);
+  border-radius: var(--wc-radius-sm);
+  background: var(--wc-surface);
+  color: var(--wc-text);
+  padding: 8px 10px;
+  cursor: pointer;
+}
+
+.themeCardSelected {
+  border-color: var(--wc-accent);
+}
+
+.themeCardTop {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.themeColorDot {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+}
+
+.memberRow {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px;
+  background: var(--wc-surface);
+  border-radius: var(--wc-radius-sm);
+  border: 1px solid var(--wc-border);
+}
+
+.avatarPicker {
+  position: relative;
+  display: inline-flex;
+}
+
+.avatarFrame {
+  width: 34px;
+  height: 34px;
+  border-radius: 50%;
+  overflow: hidden;
+  border: 1px solid var(--wc-border);
+}
+
+.avatarImg {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.avatarFallback {
+  width: 100%;
+  height: 100%;
+  display: grid;
+  place-items: center;
+  color: #fff;
+  font-size: 12px;
+  font-weight: 700;
+}
+
+.fileInput {
+  position: absolute;
+  inset: 0;
+  opacity: 0;
+  cursor: pointer;
+}
+
+.avatarBadge {
+  position: absolute;
+  right: -4px;
+  bottom: -4px;
+  border-radius: 999px;
+  padding: 2px 5px;
+  font-size: 10px;
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  color: #fff;
+  background: var(--wc-accent);
+}
+
 /* ─── Responsive: bottom sheet on mobile ────────────────────── */
 @media (max-width: 480px) {
   .overlay {
@@ -290,5 +384,13 @@
 
   .fieldRow {
     flex-direction: column;
+  }
+
+  .themeGrid {
+    grid-template-columns: 1fr;
+  }
+
+  .memberRow {
+    flex-wrap: wrap;
   }
 }


### PR DESCRIPTION
### Motivation
- Prevent the first-time setup wizard from interrupting initial calendar configuration and keep setup actions inside the settings/gear panel. 
- Provide a reliable place for naming the calendar and choosing a theme before creating smart views or uploading employee photos. 

### Description
- Removed the automatic and toolbar-triggered setup wizard from `WorksCalendar` and stopped auto-opening the modal; `SetupWizardModal` is no longer launched from the main toolbar. 
- Routed `resources` and `onSaveView` into the `ConfigPanel` by passing `resources={resources}` and `onSaveView={(name, filters, opts) => savedViews.saveView(name, filters, opts)}` from `WorksCalendar`. 
- Added a new default `Setup` tab to `ConfigPanel` to let owners set the calendar name and select a theme (`src/ui/ConfigPanel.jsx`). 
- Added `Smart Views` and `Employees` tabs to `ConfigPanel` to create saved filter views via `AdvancedFilterBuilder` and to manage employee names/photos, respectively, and implemented UI and styles for theme cards and avatar controls (`src/ui/ConfigPanel.jsx`, `src/ui/ConfigPanel.module.css`). 

### Testing
- Ran `npm run test -- src/ui/__tests__/ThemeCustomizer.test.jsx` and all tests passed. 
- Ran `npm run build` which completed successfully and produced the production bundles.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ddaa897688832c87e3d1c3dac9808d)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Integrated setup wizard functionality into the configuration panel with new dedicated tabs.
  * Added visual theme selector for calendar personalization.
  * Introduced team member management with photo upload capabilities.

* **Improvements**
  * Reorganized configuration interface with tabbed layout for streamlined navigation between setup, views, and team settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->