### PR TITLE
Improve setup theme previews and add per-role font controls

### DIFF
--- a/src/WorksCalendar.module.css
+++ b/src/WorksCalendar.module.css
@@ -1,5 +1,7 @@
 .root {
   --wc-font:        'Inter', system-ui, -apple-system, sans-serif;
+  --wc-font-heading: var(--wc-font);
+  --wc-font-mono:    ui-monospace, 'Cascadia Code', 'SFMono-Regular', Menlo, monospace;
   --wc-accent:      #3b82f6;
   --wc-accent-dim:  #eff6ff;
   --wc-bg:          #ffffff;
@@ -29,6 +31,15 @@
   height: 100%;
   min-height: 400px;
   box-sizing: border-box;
+}
+
+
+.root :is(h1, h2, h3, h4, h5, h6) {
+  font-family: var(--wc-font-heading);
+}
+
+.root :is(code, pre, kbd, samp) {
+  font-family: var(--wc-font-mono);
 }
 
 /* Dark theme token overrides */

--- a/src/core/themeSchema.js
+++ b/src/core/themeSchema.js
@@ -12,6 +12,8 @@ export const DEFAULT_CUSTOM_THEME = {
   },
   typography: {
     fontFamily: "'Inter', system-ui, -apple-system, sans-serif",
+    headingFontFamily: "'Inter', system-ui, -apple-system, sans-serif",
+    monoFontFamily: "ui-monospace, 'Cascadia Code', 'SFMono-Regular', Menlo, monospace",
     baseSize: 14,
   },
   spacing: {
@@ -61,6 +63,8 @@ export function customThemeToCssVars(themeInput) {
     '--wc-text': theme.colors.text,
     '--wc-text-muted': theme.colors.textMuted,
     '--wc-font': theme.typography.fontFamily,
+    '--wc-font-heading': theme.typography.headingFontFamily || theme.typography.fontFamily,
+    '--wc-font-mono': theme.typography.monoFontFamily || "ui-monospace, 'Cascadia Code', 'SFMono-Regular', Menlo, monospace",
     '--wc-radius': `${theme.borders.radius}px`,
     '--wc-radius-sm': `${theme.borders.radiusSm}px`,
     '--wc-border-width': `${theme.borders.borderWidth}px`,

--- a/src/ui/ConfigPanel.jsx
+++ b/src/ui/ConfigPanel.jsx
@@ -120,11 +120,17 @@ function SetupTab({ config, onUpdate }) {
             title={theme.description}
             aria-pressed={selectedTheme === theme.id}
           >
-            <div className={styles.themeCardTop}>
-              <span className={styles.themeColorDot} style={{ background: theme.preview.accent }} />
-              <span>{theme.label}</span>
+            <div className={styles.themeCardPreview} style={{ background: theme.preview.bg, borderColor: theme.preview.border }}>
+              <div className={styles.themeCardAccent} style={{ background: theme.preview.accent }} />
+              <div className={styles.themeCardLines}>
+                <span style={{ background: theme.preview.text }} />
+                <span style={{ background: theme.preview.text, width: '65%' }} />
+              </div>
             </div>
-            {selectedTheme === theme.id && <Check size={12} />}
+            <div className={styles.themeCardTop}>
+              <span>{theme.label}</span>
+              {selectedTheme === theme.id && <Check size={12} />}
+            </div>
           </button>
         ))}
       </div>

--- a/src/ui/ConfigPanel.module.css
+++ b/src/ui/ConfigPanel.module.css
@@ -264,13 +264,14 @@
 
 .themeCard {
   display: flex;
-  align-items: center;
-  justify-content: space-between;
+  flex-direction: column;
+  align-items: stretch;
+  gap: 8px;
   border: 1px solid var(--wc-border);
   border-radius: var(--wc-radius-sm);
   background: var(--wc-surface);
   color: var(--wc-text);
-  padding: 8px 10px;
+  padding: 10px;
   cursor: pointer;
 }
 
@@ -278,16 +279,40 @@
   border-color: var(--wc-accent);
 }
 
+.themeCardPreview {
+  height: 42px;
+  border-radius: 7px;
+  border: 1px solid var(--wc-border);
+  display: flex;
+  align-items: stretch;
+  overflow: hidden;
+}
+
+.themeCardAccent {
+  width: 8px;
+  flex-shrink: 0;
+}
+
+.themeCardLines {
+  padding: 8px;
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  gap: 6px;
+}
+
+.themeCardLines span {
+  height: 4px;
+  border-radius: 999px;
+  opacity: 0.8;
+}
+
 .themeCardTop {
   display: flex;
   align-items: center;
+  justify-content: space-between;
   gap: 8px;
-}
-
-.themeColorDot {
-  width: 10px;
-  height: 10px;
-  border-radius: 50%;
 }
 
 .memberRow {

--- a/src/ui/ThemeCustomizer.jsx
+++ b/src/ui/ThemeCustomizer.jsx
@@ -67,7 +67,7 @@ const PRESET_THEMES = [
   },
 ];
 
-const FONT_FAMILY_OPTIONS = [
+const FONT_STACK_OPTIONS = [
   { label: 'Inter (Default)', value: "'Inter', system-ui, -apple-system, sans-serif" },
   { label: 'System UI', value: "system-ui, -apple-system, 'Segoe UI', sans-serif" },
   { label: 'Segoe UI', value: "'Segoe UI', Tahoma, Geneva, Verdana, sans-serif" },
@@ -77,6 +77,24 @@ const FONT_FAMILY_OPTIONS = [
   { label: 'Nunito', value: "'Nunito', 'Segoe UI', system-ui, sans-serif" },
   { label: 'IBM Plex Sans', value: "'IBM Plex Sans', 'Segoe UI', system-ui, sans-serif" },
   { label: 'JetBrains Mono', value: "'JetBrains Mono', 'Roboto Mono', 'Courier New', monospace" },
+];
+
+const FONT_ROLE_CONTROLS = [
+  {
+    key: 'fontFamily',
+    label: 'Body Font',
+    customPlaceholder: "Enter body font stack",
+  },
+  {
+    key: 'headingFontFamily',
+    label: 'Heading Font',
+    customPlaceholder: "Enter heading font stack",
+  },
+  {
+    key: 'monoFontFamily',
+    label: 'Monospace Font',
+    customPlaceholder: "Enter monospace font stack",
+  },
 ];
 
 function valueLabel(value, suffix) {
@@ -130,8 +148,13 @@ export default function ThemeCustomizer({ theme, onChange }) {
   const [importSuccess, setImportSuccess] = useState('');
   const [copyState, setCopyState] = useState('');
   const merged = normalizeCustomTheme(theme);
-  const hasNamedFontOption = FONT_FAMILY_OPTIONS.some((option) => option.value === merged.typography.fontFamily);
-  const selectedFontOption = hasNamedFontOption ? merged.typography.fontFamily : '__custom__';
+  const selectedFontOptionByRole = useMemo(() => Object.fromEntries(
+    FONT_ROLE_CONTROLS.map(({ key }) => {
+      const rawValue = merged.typography[key] ?? merged.typography.fontFamily;
+      const hasNamedFontOption = FONT_STACK_OPTIONS.some((option) => option.value === rawValue);
+      return [key, hasNamedFontOption ? rawValue : '__custom__'];
+    }),
+  ), [merged]);
   const previewVars = customThemeToCssVars(merged);
   const previewStyle = {
     ...previewVars,
@@ -227,28 +250,36 @@ export default function ThemeCustomizer({ theme, onChange }) {
           </label>
         ))}
 
-        <label className={styles.control}>
-          <span>Font Family</span>
-          <select
-            value={selectedFontOption}
-            onChange={(e) => {
-              if (e.target.value !== '__custom__') update(['typography', 'fontFamily'], e.target.value);
-            }}
-          >
-            {FONT_FAMILY_OPTIONS.map((option) => (
-              <option key={option.label} value={option.value}>{option.label}</option>
-            ))}
-            <option value="__custom__">Custom…</option>
-          </select>
-          {selectedFontOption === '__custom__' && (
-            <input
-              type="text"
-              value={merged.typography.fontFamily}
-              onChange={(e) => update(['typography', 'fontFamily'], e.target.value)}
-              placeholder="Enter custom font stack"
-            />
-          )}
-        </label>
+        {FONT_ROLE_CONTROLS.map((role) => {
+          const roleValue = merged.typography[role.key] ?? merged.typography.fontFamily;
+          const selectedFontOption = selectedFontOptionByRole[role.key];
+          return (
+            <label className={styles.control} key={role.key}>
+              <span>{role.label}</span>
+              <select
+                value={selectedFontOption}
+                onChange={(e) => {
+                  if (e.target.value !== '__custom__') update(['typography', role.key], e.target.value);
+                }}
+              >
+                {FONT_STACK_OPTIONS.map((option) => (
+                  <option key={option.label} value={option.value} style={{ fontFamily: option.value }}>
+                    {option.label}
+                  </option>
+                ))}
+                <option value="__custom__">Custom…</option>
+              </select>
+              {selectedFontOption === '__custom__' && (
+                <input
+                  type="text"
+                  value={roleValue}
+                  onChange={(e) => update(['typography', role.key], e.target.value)}
+                  placeholder={role.customPlaceholder}
+                />
+              )}
+            </label>
+          );
+        })}
 
         {TOKEN_SLIDERS.map(([group, key, label, min, max, step, suffix]) => (
           <label key={`${group}.${key}`} className={styles.control}>

--- a/src/ui/__tests__/ThemeCustomizer.test.jsx
+++ b/src/ui/__tests__/ThemeCustomizer.test.jsx
@@ -2,7 +2,7 @@
 
 import { describe, it, expect, vi } from 'vitest';
 import React from 'react';
-import { render, fireEvent, screen } from '@testing-library/react';
+import { render, fireEvent, screen, cleanup } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import ThemeCustomizer from '../ThemeCustomizer.jsx';
 
@@ -43,15 +43,37 @@ describe('ThemeCustomizer', () => {
     expect(latest.customTheme.spacing.density).toBe(1.15);
   });
 
-  it('updates font family from dropdown selection', () => {
+  it('updates body font from dropdown selection', () => {
     const { setConfig } = renderWithConfig({});
 
-    fireEvent.change(screen.getByLabelText('Font Family'), {
+    fireEvent.change(screen.getByLabelText('Body Font'), {
       target: { value: "'Roboto', 'Helvetica Neue', Arial, sans-serif" },
     });
 
     const latest = setConfig.mock.calls.at(-1)[0];
     expect(latest.customTheme.typography.fontFamily).toBe("'Roboto', 'Helvetica Neue', Arial, sans-serif");
+  });
+
+
+  it('updates heading and monospace fonts independently', () => {
+    const heading = renderWithConfig({});
+
+    fireEvent.change(screen.getByLabelText('Heading Font'), {
+      target: { value: "Georgia, 'Times New Roman', serif" },
+    });
+
+    const headingLatest = heading.setConfig.mock.calls.at(-1)[0];
+    expect(headingLatest.customTheme.typography.headingFontFamily).toBe("Georgia, 'Times New Roman', serif");
+
+    cleanup();
+
+    const mono = renderWithConfig({});
+    fireEvent.change(screen.getAllByLabelText('Monospace Font')[1], {
+      target: { value: "'JetBrains Mono', 'Roboto Mono', 'Courier New', monospace" },
+    });
+
+    const monoLatest = mono.setConfig.mock.calls.at(-1)[0];
+    expect(monoLatest.customTheme.typography.monoFontFamily).toBe("'JetBrains Mono', 'Roboto Mono', 'Courier New', monospace");
   });
 
   it('resets customTheme to defaults payload', () => {


### PR DESCRIPTION
### Motivation
- Make theme selection more informative by showing compact previews instead of small color dots. 
- Allow choosing different fonts for different roles (body, headings, monospace) instead of a single global font dropdown. 
- Improve the font dropdown UX so each option’s label is rendered in its own font stack for easier visual selection.

### Description
- Replace the simple color-dot theme cards in the Setup tab with mini previews (background, border, accent rail, and text lines) and related styles (`src/ui/ConfigPanel.jsx`, `src/ui/ConfigPanel.module.css`).
- Split typography controls into per-role selectors (`Body Font`, `Heading Font`, `Monospace Font`) and render option labels using their font stacks; introduce `FONT_STACK_OPTIONS` and `FONT_ROLE_CONTROLS` in `src/ui/ThemeCustomizer.jsx` and update the UI to persist per-role values.
- Extend the custom theme schema and CSS var output to include `headingFontFamily` and `monoFontFamily`, and expose `--wc-font-heading` and `--wc-font-mono` variables via `src/core/themeSchema.js` and `src/WorksCalendar.module.css` so headings and code elements can use dedicated fonts.
- Update unit tests to cover the renamed body font control and the new heading/monospace controls (`src/ui/__tests__/ThemeCustomizer.test.jsx`).

### Testing
- Ran `npm test -- --run src/ui/__tests__/ThemeCustomizer.test.jsx` and all tests in that file passed (11 tests passed). 
- The Theme customizer unit tests exercise color controls, token sliders, per-role font selection, presets, import/export, and contrast checks and succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ddafc98e3c832c8372f9144db2109a)