### PR TITLE
Refocus schedule tab entry points on employee actions

### DIFF
--- a/src/WorksCalendar.tsx
+++ b/src/WorksCalendar.tsx
@@ -1066,6 +1066,20 @@ export const WorksCalendar = forwardRef<CalendarApi, WorksCalendarProps>(functio
     setFormEvent({ start, end });
   }, [hasAddButton, onDateSelect]);
 
+  // Schedule cell select → route to schedule-specific editor, not generic EventForm.
+  const handleScheduleDateSelect = useCallback((start, end, resourceId) => {
+    if (!hasAddButton) return;
+    onDateSelect?.(start, end, resourceId);
+
+    const emp = employees.find(e => String(e.id) === String(resourceId));
+    if (!emp) return;
+
+    setScheduleEditorState({
+      emp,
+      start: start instanceof Date ? start : new Date(start),
+    });
+  }, [employees, hasAddButton, onDateSelect]);
+
   const sharedViewProps = {
     currentDate:   cal.currentDate,
     events:        visibleEvents,
@@ -1238,7 +1252,7 @@ export const WorksCalendar = forwardRef<CalendarApi, WorksCalendarProps>(functio
                   currentDate={cal.currentDate}
                   events={visibleEvents}
                   onEventClick={handleEventClick}
-                  onDateSelect={handleDateSelect}
+                  onDateSelect={handleScheduleDateSelect}
                   employees={employees}
                   onEmployeeAdd={perms.canManagePeople ? onEmployeeAdd : undefined}
                   onEmployeeDelete={perms.canManagePeople ? onEmployeeDelete : undefined}

--- a/src/__tests__/WorksCalendar.scheduleWorkflow.test.jsx
+++ b/src/__tests__/WorksCalendar.scheduleWorkflow.test.jsx
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+import React from 'react';
+
+import { WorksCalendar } from '../WorksCalendar.tsx';
+
+describe('WorksCalendar schedule workflow entry points', () => {
+  const employees = [
+    { id: 'emp-1', name: 'Alex Rivera', role: 'RN' },
+  ];
+
+  it('opens employee action card when employee name is clicked', async () => {
+    render(<WorksCalendar events={[]} employees={employees} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Schedule' }));
+    fireEvent.click(await screen.findByRole('button', { name: 'Actions for Alex Rivera' }));
+
+    expect(await screen.findByRole('menu', { name: 'Actions for Alex Rivera' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Edit Schedule' })).toBeInTheDocument();
+  });
+
+  it('routes empty schedule-cell click to ScheduleEditorForm instead of EventForm', async () => {
+    render(<WorksCalendar events={[]} employees={employees} showAddButton />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Schedule' }));
+    fireEvent.click(await screen.findByRole('gridcell', { name: /^Alex Rivera, April 1, empty/ }));
+
+    expect(await screen.findByRole('dialog', { name: 'Edit schedule for Alex Rivera' })).toBeInTheDocument();
+    expect(screen.queryByRole('dialog', { name: 'Add event' })).not.toBeInTheDocument();
+  });
+});

--- a/src/views/TimelineView.jsx
+++ b/src/views/TimelineView.jsx
@@ -189,22 +189,6 @@ export default function TimelineView({
     setAddFormOpen(false);
   }, [addName, addRole, onEmployeeAdd]);
 
-  const openShiftEditorForRow = useCallback((rowEvents, anchorEl) => {
-    if (!onShiftStatusChange || !anchorEl) return;
-    const onCallEvents = rowEvents
-      .filter(ev => ev.category === onCallCategory || ev.meta?.onCall === true)
-      .sort((a, b) => a.start - b.start);
-    if (onCallEvents.length === 0) return;
-
-    const today = startOfDay(currentDate);
-    const preferred = onCallEvents.find(ev => (
-      startOfDay(ev.start) <= today && startOfDay(ev.end) >= today
-    )) ?? onCallEvents[0];
-    const rect = anchorEl.getBoundingClientRect();
-    setCoverMenu(null);
-    setShiftMenu({ ev: preferred, rect });
-  }, [currentDate, onCallCategory, onShiftStatusChange]);
-
   // ── Row source: employees list OR derive from event resources ──────────────
 
   const useEmployees = employees && employees.length > 0;
@@ -500,18 +484,6 @@ export default function TimelineView({
                   style={{ width: NAME_W, minWidth: NAME_W, height: rowH }}
                   role="rowheader"
                   aria-label={label}
-                  onClick={(e) => {
-                    if (!emp) return;
-                    openShiftEditorForRow(rowEvents, e.currentTarget);
-                  }}
-                  onKeyDown={(e) => {
-                    if (!emp) return;
-                    if (e.key === 'Enter' || e.key === ' ') {
-                      e.preventDefault();
-                      openShiftEditorForRow(rowEvents, e.currentTarget);
-                    }
-                  }}
-                  tabIndex={emp ? 0 : undefined}
                 >
                   {emp ? (
                     /* Employee display: avatar + name + role */


### PR DESCRIPTION
### Motivation

- Make the schedule tab UX obvious by funneling schedule creation and employee actions through the employee-focused controls rather than the generic event flow.
- Remove the confusing row-header behavior that opened shift-status controls and made the entry points ambiguous.

### Description

- Added a schedule-specific date-select handler `handleScheduleDateSelect` in `src/WorksCalendar.tsx` that routes schedule cell clicks to `ScheduleEditorForm` instead of the generic `EventForm`.
- Wired `TimelineView` in schedule mode to use `handleScheduleDateSelect` by replacing its `onDateSelect` prop wiring.
- Removed the row-header click/keyboard handlers in `src/views/TimelineView.jsx` that previously opened shift-status controls, leaving the `EmployeeActionCard` button as the primary employee action entry point.
- Added `src/__tests__/WorksCalendar.scheduleWorkflow.test.jsx` to cover the new workflow: clicking an employee name opens the `EmployeeActionCard`, and clicking an empty schedule cell opens `ScheduleEditorForm` (and does not open `EventForm`).

### Testing

- Ran `npm test -- src/__tests__/WorksCalendar.scheduleWorkflow.test.jsx` and the new workflow tests passed.
- Ran `npm test -- src/ui/__tests__/a11y.test.jsx` and the existing accessibility suite passed (all tests green).
- The changes were validated by the test runs described above which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de085745f8832c9575f9cc42067ebc)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced schedule editing workflow to open a dedicated schedule editor form when selecting dates in schedule view mode.

* **Tests**
  * Added test suite validating schedule workflow entry points and interactions.

* **Changes**
  * Removed click and keyboard interactions from employee row headers in timeline view.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->