### PR TITLE
Sprint 2: align schedule forms with user intent

### DIFF
--- a/src/__tests__/WorksCalendar.scheduleWorkflow.test.jsx
+++ b/src/__tests__/WorksCalendar.scheduleWorkflow.test.jsx
@@ -16,7 +16,7 @@ describe('WorksCalendar schedule workflow entry points', () => {
     fireEvent.click(await screen.findByRole('button', { name: 'Actions for Alex Rivera' }));
 
     expect(await screen.findByRole('menu', { name: 'Actions for Alex Rivera' })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'Edit Schedule' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Add Schedule' })).toBeInTheDocument();
   });
 
   it('routes empty schedule-cell click to ScheduleEditorForm instead of EventForm', async () => {
@@ -25,7 +25,43 @@ describe('WorksCalendar schedule workflow entry points', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Schedule' }));
     fireEvent.click(await screen.findByRole('gridcell', { name: /^Alex Rivera, April 1, empty/ }));
 
-    expect(await screen.findByRole('dialog', { name: 'Edit schedule for Alex Rivera' })).toBeInTheDocument();
+    expect(await screen.findByRole('dialog', { name: 'Add schedule for Alex Rivera' })).toBeInTheDocument();
     expect(screen.queryByRole('dialog', { name: 'Add event' })).not.toBeInTheDocument();
+  });
+
+  it('opens PTO-focused form when Request PTO is selected', async () => {
+    render(<WorksCalendar events={[]} employees={employees} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Schedule' }));
+    fireEvent.click(await screen.findByRole('button', { name: 'Actions for Alex Rivera' }));
+    fireEvent.click(await screen.findByRole('button', { name: 'Request PTO' }));
+
+    expect(await screen.findByRole('dialog', { name: 'Request PTO for Alex Rivera' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Save PTO Request' })).toBeInTheDocument();
+    expect(screen.queryByRole('combobox', { name: 'Type' })).not.toBeInTheDocument();
+  });
+
+  it('opens unavailable-focused form when Mark Unavailable is selected', async () => {
+    render(<WorksCalendar events={[]} employees={employees} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Schedule' }));
+    fireEvent.click(await screen.findByRole('button', { name: 'Actions for Alex Rivera' }));
+    fireEvent.click(await screen.findByRole('button', { name: 'Mark Unavailable' }));
+
+    expect(await screen.findByRole('dialog', { name: 'Mark Unavailable for Alex Rivera' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Save Unavailable Time' })).toBeInTheDocument();
+    expect(screen.queryByRole('combobox', { name: 'Type' })).not.toBeInTheDocument();
+  });
+
+  it('opens availability-focused form when Edit Availability is selected', async () => {
+    render(<WorksCalendar events={[]} employees={employees} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Schedule' }));
+    fireEvent.click(await screen.findByRole('button', { name: 'Actions for Alex Rivera' }));
+    fireEvent.click(await screen.findByRole('button', { name: 'Edit Availability' }));
+
+    expect(await screen.findByRole('dialog', { name: 'Edit Availability for Alex Rivera' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Save Availability' })).toBeInTheDocument();
+    expect(screen.queryByRole('combobox', { name: 'Type' })).not.toBeInTheDocument();
   });
 });

--- a/src/ui/AvailabilityForm.jsx
+++ b/src/ui/AvailabilityForm.jsx
@@ -30,6 +30,21 @@ const KIND_META = {
   },
 };
 
+const INTENT_META = {
+  pto: {
+    heading: 'Request PTO',
+    submitLabel: 'Save PTO Request',
+  },
+  unavailable: {
+    heading: 'Mark Unavailable',
+    submitLabel: 'Save Unavailable Time',
+  },
+  availability: {
+    heading: 'Edit Availability',
+    submitLabel: 'Save Availability',
+  },
+};
+
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
 function toDateInput(date, allDay) {
@@ -63,8 +78,9 @@ function fromInput(str, allDay) {
 export default function AvailabilityForm({ emp, kind: initialKind, initialStart, onSave, onClose }) {
   const trapRef = useFocusTrap(onClose);
 
-  const [kind, setKind] = useState(initialKind ?? 'pto');
+  const kind = initialKind ?? 'pto';
   const meta = KIND_META[kind] ?? KIND_META.pto;
+  const intentMeta = INTENT_META[kind] ?? INTENT_META.pto;
 
   const startDefault = initialStart ?? new Date();
   const endDefault   = new Date(startDefault.getTime() + (meta.allDayDefault ? 24 * 60 * 60 * 1000 : 60 * 60 * 1000));
@@ -75,22 +91,6 @@ export default function AvailabilityForm({ emp, kind: initialKind, initialStart,
   const [end,    setEnd]    = useState(toDateInput(endDefault,   allDay));
   const [notes,  setNotes]  = useState('');
   const [errors, setErrors] = useState({});
-
-  // When kind changes, update default title + allDay if user hasn't touched them.
-  // Also reformat start/end strings to match the new allDay format so inputs stay valid.
-  function handleKindChange(nextKind) {
-    const nextMeta = KIND_META[nextKind] ?? KIND_META.pto;
-    setKind(nextKind);
-    if (title === meta.defaultTitle) setTitle(nextMeta.defaultTitle);
-    if (allDay === meta.allDayDefault) {
-      const nextAllDay  = nextMeta.allDayDefault;
-      const parsedStart = fromInput(start, allDay);
-      const parsedEnd   = fromInput(end, allDay);
-      setAllDay(nextAllDay);
-      if (parsedStart) setStart(toDateInput(parsedStart, nextAllDay));
-      if (parsedEnd)   setEnd(toDateInput(parsedEnd,   nextAllDay));
-    }
-  }
 
   function validate() {
     const errs = {};
@@ -135,12 +135,12 @@ export default function AvailabilityForm({ emp, kind: initialKind, initialStart,
         className={styles.modal}
         role="dialog"
         aria-modal="true"
-        aria-label={`${kindLabel} for ${emp.name}`}
+        aria-label={`${intentMeta.heading} for ${emp.name}`}
       >
         {/* Header */}
         <div className={styles.header}>
           <div className={styles.headerInfo}>
-            <h2 className={styles.title}>{kindLabel}</h2>
+            <h2 className={styles.title}>{intentMeta.heading}</h2>
             <span className={styles.empName}>{emp.name}{emp.role ? ` · ${emp.role}` : ''}</span>
           </div>
           <button className={styles.closeBtn} onClick={onClose} aria-label="Close">
@@ -149,21 +149,6 @@ export default function AvailabilityForm({ emp, kind: initialKind, initialStart,
         </div>
 
         <form className={styles.form} onSubmit={handleSubmit} noValidate>
-          {/* Kind selector */}
-          <div className={styles.field}>
-            <label className={styles.label} htmlFor="af-kind">Type</label>
-            <select
-              id="af-kind"
-              className={styles.select}
-              value={kind}
-              onChange={e => handleKindChange(e.target.value)}
-            >
-              <option value="pto">PTO / Time Off</option>
-              <option value="unavailable">Unavailable</option>
-              <option value="availability">Availability</option>
-            </select>
-          </div>
-
           {/* Title */}
           <div className={styles.field}>
             <label className={styles.label} htmlFor="af-title">
@@ -256,7 +241,7 @@ export default function AvailabilityForm({ emp, kind: initialKind, initialStart,
           {/* Actions */}
           <div className={styles.actions}>
             <button type="button" className={styles.btnCancel} onClick={onClose}>Cancel</button>
-            <button type="submit" className={styles.btnSave}>Save</button>
+            <button type="submit" className={styles.btnSave}>{intentMeta.submitLabel}</button>
           </div>
         </form>
       </div>

--- a/src/ui/EmployeeActionCard.jsx
+++ b/src/ui/EmployeeActionCard.jsx
@@ -84,7 +84,7 @@ export default function EmployeeActionCard({ emp, anchorRect, onAction, onClose 
           className={styles.actionBtn}
           onClick={() => handleAction('schedule')}
         >
-          Edit Schedule
+          Add Schedule
         </button>
         <button
           className={styles.actionBtn}

--- a/src/ui/ScheduleEditorForm.jsx
+++ b/src/ui/ScheduleEditorForm.jsx
@@ -191,12 +191,12 @@ export default function ScheduleEditorForm({
         className={styles.modal}
         role="dialog"
         aria-modal="true"
-        aria-label={`Edit schedule for ${emp.name}`}
+        aria-label={`Add schedule for ${emp.name}`}
       >
         {/* Header */}
         <div className={styles.header}>
           <div className={styles.headerInfo}>
-            <h2 className={styles.title}>Edit Schedule</h2>
+            <h2 className={styles.title}>Add Schedule</h2>
             <span className={styles.empName}>{emp.name}{emp.role ? ` · ${emp.role}` : ''}</span>
           </div>
           <button className={styles.closeBtn} onClick={onClose} aria-label="Close">


### PR DESCRIPTION
### Motivation

- Clarify the schedule entry UX so schedule creation is explicitly add-only and availability/PTO flows present the right intent to users.
- Remove ambiguous "Edit" language and the in-form kind switcher so each employee action opens a focused, predictable modal.

### Description

- Renamed the employee action CTA from `Edit Schedule` to `Add Schedule` in `src/ui/EmployeeActionCard.jsx` so the row action clearly initiates schedule creation.
- Updated `ScheduleEditorForm` title and dialog aria label to `Add Schedule` / `Add schedule for {employee}` in `src/ui/ScheduleEditorForm.jsx` to remove edit/create ambiguity.
- Simplified `AvailabilityForm` in `src/ui/AvailabilityForm.jsx` by removing the in-modal kind selector, deriving intent from the opener, and adding `INTENT_META` for intent-specific headings and submit labels (`Request PTO`, `Mark Unavailable`, `Edit Availability` with matching CTAs).
- Expanded the schedule-workflow tests in `src/__tests__/WorksCalendar.scheduleWorkflow.test.jsx` to assert the new labels and to verify each employee action (`Request PTO`, `Mark Unavailable`, `Edit Availability`) opens the focused form with the expected CTA and without the old `Type` selector.

### Testing

- Ran `npm test -- src/__tests__/WorksCalendar.scheduleWorkflow.test.jsx` and the suite passed: 1 test file, 5 tests passed, exit 0.
- The changes are covered by the updated unit tests included in `src/__tests__/WorksCalendar.scheduleWorkflow.test.jsx` which validate the new entry points and modal intent.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de098a8e14832cb25b4b52d4f35106)