### PR TITLE
Make AvailabilityForm edit-aware and wire Edit Availability flow (Sprint 2)

### DIFF
--- a/src/WorksCalendar.tsx
+++ b/src/WorksCalendar.tsx
@@ -460,7 +460,7 @@ export const WorksCalendar = forwardRef<CalendarApi, WorksCalendarProps>(functio
   const [formEvent,        setFormEvent]        = useState(null);
   const [importOpen,       setImportOpen]       = useState(false);
   const [scheduleOpen,     setScheduleOpen]     = useState(false);
-  // { emp: { id, name, role? }, kind: 'pto' | 'unavailable' | 'availability', start?: Date }
+  // { emp: { id, name, role? }, kind: 'pto' | 'unavailable' | 'availability', start?: Date, initialEvent?: object | null }
   const [availabilityState, setAvailabilityState] = useState(null);
   // { emp: { id, name, role? }, start?: Date }
   const [scheduleEditorState, setScheduleEditorState] = useState(null);
@@ -643,22 +643,56 @@ export const WorksCalendar = forwardRef<CalendarApi, WorksCalendarProps>(functio
     const emp = employees.find(e => String(e.id) === String(empId)) ?? { id: empId, name: empId };
     const AVAILABILITY_ACTIONS = new Set(['pto', 'unavailable', 'availability']);
     if (AVAILABILITY_ACTIONS.has(action)) {
-      setAvailabilityState({ emp, kind: action, start: new Date() });
+      const initialEvent = action === 'availability'
+        ? expandedEvents
+          .filter((ev) => {
+            const evKind = String(ev?.kind ?? ev?.meta?.kind ?? '').toLowerCase();
+            const evCat  = String(ev?.category ?? '').toLowerCase();
+            const resourceId = String(ev?.resource ?? ev?.resourceId ?? ev?.employeeId ?? '');
+            return resourceId === String(empId) && (evKind === 'availability' || evCat === 'availability');
+          })
+          .sort((a, b) => {
+            const aStart = a?.start ? new Date(a.start).getTime() : 0;
+            const bStart = b?.start ? new Date(b.start).getTime() : 0;
+            return bStart - aStart;
+          })
+          .map((ev) => ({ ...ev, id: ev?._eventId ?? ev?.id }))[0] ?? null
+        : null;
+      setAvailabilityState({ emp, kind: action, start: new Date(), initialEvent });
     } else if (action === 'schedule') {
       setScheduleEditorState({ emp, start: new Date() });
     }
     onEmployeeAction?.(empId, action);
-  }, [employees, onEmployeeAction]);
+  }, [employees, expandedEvents, onEmployeeAction]);
 
   /** Save an availability/PTO event through the engine then notify the host.
    *  Also runs overlap detection: any uncovered shift that overlaps the PTO/
    *  unavailable window automatically gets an open-shift event created. */
   const handleAvailabilitySave = useCallback((availEv) => {
-    // 1. Create the availability event itself
-    applyEngineOp(
-      { type: 'create', event: { ...availEv, id: availEv.id ?? `avail-${Date.now()}` }, source: 'api' },
-      () => onAvailabilitySave?.(availEv),
+    const existingAvailability = expandedEvents.find(
+      (ev) => String(ev._eventId ?? ev.id) === String(availEv.id),
     );
+    const saveOp = existingAvailability
+      ? {
+        type: 'update',
+        id: String(existingAvailability._eventId ?? existingAvailability.id),
+        patch: {
+          title: availEv.title,
+          start: availEv.start,
+          end: availEv.end,
+          allDay: availEv.allDay,
+          category: availEv.category,
+          color: availEv.color,
+          resource: availEv.resource,
+          resourceId: availEv.resource,
+          meta: availEv.meta,
+        },
+        source: 'api',
+      }
+      : { type: 'create', event: { ...availEv, id: availEv.id ?? `avail-${Date.now()}` }, source: 'api' };
+
+    // 1. Create or update the availability event itself
+    applyEngineOp(saveOp, () => onAvailabilitySave?.(availEv));
 
     // 2. Detect overlapping shifts and auto-create open-shift records
     const isLeave = availEv.kind === 'pto' || availEv.kind === 'unavailable';
@@ -1302,6 +1336,7 @@ export const WorksCalendar = forwardRef<CalendarApi, WorksCalendarProps>(functio
             emp={availabilityState.emp}
             kind={availabilityState.kind}
             initialStart={availabilityState.start}
+            initialEvent={availabilityState.initialEvent}
             onSave={handleAvailabilitySave}
             onClose={() => setAvailabilityState(null)}
           />

--- a/src/__tests__/WorksCalendar.scheduleWorkflow.test.jsx
+++ b/src/__tests__/WorksCalendar.scheduleWorkflow.test.jsx
@@ -53,15 +53,31 @@ describe('WorksCalendar schedule workflow entry points', () => {
     expect(screen.queryByRole('combobox', { name: 'Type' })).not.toBeInTheDocument();
   });
 
-  it('opens availability-focused form when Edit Availability is selected', async () => {
-    render(<WorksCalendar events={[]} employees={employees} />);
+  it('opens availability-focused edit form when Edit Availability is selected', async () => {
+    render(
+      <WorksCalendar
+        employees={employees}
+        events={[
+          {
+            id: 'avail-1',
+            title: 'Clinic Hours',
+            category: 'availability',
+            resource: 'emp-1',
+            start: new Date('2026-04-01T09:00:00.000Z'),
+            end: new Date('2026-04-01T17:00:00.000Z'),
+            meta: { kind: 'availability' },
+          },
+        ]}
+      />,
+    );
 
     fireEvent.click(screen.getByRole('button', { name: 'Schedule' }));
     fireEvent.click(await screen.findByRole('button', { name: 'Actions for Alex Rivera' }));
     fireEvent.click(await screen.findByRole('button', { name: 'Edit Availability' }));
 
     expect(await screen.findByRole('dialog', { name: 'Edit Availability for Alex Rivera' })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'Save Availability' })).toBeInTheDocument();
+    expect(screen.getByDisplayValue('Clinic Hours')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Save Availability Changes' })).toBeInTheDocument();
     expect(screen.queryByRole('combobox', { name: 'Type' })).not.toBeInTheDocument();
   });
 });

--- a/src/ui/AvailabilityForm.jsx
+++ b/src/ui/AvailabilityForm.jsx
@@ -66,30 +66,33 @@ function fromInput(str, allDay) {
 // ─── Component ───────────────────────────────────────────────────────────────
 
 /**
- * AvailabilityForm — modal for creating PTO / Unavailable / Availability events.
+ * AvailabilityForm — modal for creating PTO/Unavailable and creating or editing Availability events.
  *
  * Props:
  *   emp        { id, name, role? }       — the employee this record is for
  *   kind       'pto' | 'unavailable' | 'availability'  — pre-selected kind
  *   initialStart  Date | null            — pre-filled start (e.g. from timeline click)
+ *   initialEvent  event | null           — optional event to edit (used by Edit Availability)
  *   onSave     (availabilityEvent) => void
  *   onClose    () => void
  */
-export default function AvailabilityForm({ emp, kind: initialKind, initialStart, onSave, onClose }) {
+export default function AvailabilityForm({ emp, kind: initialKind, initialStart, initialEvent = null, onSave, onClose }) {
   const trapRef = useFocusTrap(onClose);
 
   const kind = initialKind ?? 'pto';
   const meta = KIND_META[kind] ?? KIND_META.pto;
+  const isEdit = Boolean(initialEvent?.id);
   const intentMeta = INTENT_META[kind] ?? INTENT_META.pto;
 
-  const startDefault = initialStart ?? new Date();
-  const endDefault   = new Date(startDefault.getTime() + (meta.allDayDefault ? 24 * 60 * 60 * 1000 : 60 * 60 * 1000));
+  const eventStart = initialEvent?.start ?? initialStart;
+  const startDefault = eventStart ?? new Date();
+  const endDefault   = initialEvent?.end ?? new Date(startDefault.getTime() + (meta.allDayDefault ? 24 * 60 * 60 * 1000 : 60 * 60 * 1000));
 
-  const [allDay, setAllDay] = useState(meta.allDayDefault);
-  const [title,  setTitle]  = useState(meta.defaultTitle);
-  const [start,  setStart]  = useState(toDateInput(startDefault, allDay));
-  const [end,    setEnd]    = useState(toDateInput(endDefault,   allDay));
-  const [notes,  setNotes]  = useState('');
+  const [allDay, setAllDay] = useState(initialEvent?.allDay ?? meta.allDayDefault);
+  const [title,  setTitle]  = useState(initialEvent?.title ?? meta.defaultTitle);
+  const [start,  setStart]  = useState(toDateInput(startDefault, initialEvent?.allDay ?? meta.allDayDefault));
+  const [end,    setEnd]    = useState(toDateInput(endDefault,   initialEvent?.allDay ?? meta.allDayDefault));
+  const [notes,  setNotes]  = useState(initialEvent?.meta?.notes ?? '');
   const [errors, setErrors] = useState({});
 
   function validate() {
@@ -112,7 +115,7 @@ export default function AvailabilityForm({ emp, kind: initialKind, initialStart,
     const en = fromInput(end, allDay);
 
     onSave({
-      id:         `avail-${Date.now()}-${Math.random().toString(36).slice(2, 7)}`,
+      id:         initialEvent?.id ?? `avail-${Date.now()}-${Math.random().toString(36).slice(2, 7)}`,
       employeeId: emp.id,
       kind,
       title:      title.trim(),
@@ -122,7 +125,7 @@ export default function AvailabilityForm({ emp, kind: initialKind, initialStart,
       color:      meta.color,
       category:   meta.category,
       resource:   emp.id,
-      meta:       { kind, ...(notes.trim() ? { notes: notes.trim() } : {}) },
+      meta:       { ...(initialEvent?.meta ?? {}), kind, ...(notes.trim() ? { notes: notes.trim() } : {}) },
     });
   }
 
@@ -234,14 +237,14 @@ export default function AvailabilityForm({ emp, kind: initialKind, initialStart,
               aria-hidden="true"
             />
             <span className={styles.colorLabel}>
-              Event will be shown in {kindLabel.toLowerCase()} color
+              {isEdit ? 'Changes will keep this event in' : 'Event will be shown in'} {kindLabel.toLowerCase()} color
             </span>
           </div>
 
           {/* Actions */}
           <div className={styles.actions}>
             <button type="button" className={styles.btnCancel} onClick={onClose}>Cancel</button>
-            <button type="submit" className={styles.btnSave}>{intentMeta.submitLabel}</button>
+            <button type="submit" className={styles.btnSave}>{isEdit && kind === 'availability' ? 'Save Availability Changes' : intentMeta.submitLabel}</button>
           </div>
         </form>
       </div>


### PR DESCRIPTION
### Motivation
- Forms should match user intent: `Edit Availability` must open an edit-aware availability form while PTO/unavailable actions remain create-only. 
- The schedule workflow should surface the most-recent availability for an employee so edits feel direct and predictable. 

### Description
- Added `initialEvent` support to `AvailabilityForm` and made it pre-fill `title`, `start`, `end`, `allDay`, and `notes`, preserve the original `id`/`meta`, and adjust the CTA to `Save Availability Changes` for availability edits. 
- Updated `WorksCalendar` `handleEmployeeAction` to locate the most recent availability event for the clicked employee and pass it as `initialEvent` when the action is `availability`. 
- Changed availability save behavior in `WorksCalendar` so existing availability events are updated through an `update` engine op (patching relevant fields) while new PTO/unavailable/availability entries continue to be created. 
- Wired `availabilityState.initialEvent` into the modal render path and extended the schedule-workflow test to assert the edit path shows prior values and edit-specific submit copy. 

### Testing
- Ran the schedule-workflow test file with `npm test -- --run src/__tests__/WorksCalendar.scheduleWorkflow.test.jsx` and the test file passed: 1 test file, 5 tests passed. 
- The updated test verifies that `Edit Availability` opens with existing availability data and that the submit button shows `Save Availability Changes`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de0d7fdc88832c829f78659d17d128)