### PR TITLE
Fix schedule linkage integrity for open-shifts and mirrored coverage

### DIFF
--- a/src/WorksCalendar.tsx
+++ b/src/WorksCalendar.tsx
@@ -576,12 +576,39 @@ export const WorksCalendar = forwardRef<CalendarApi, WorksCalendarProps>(functio
     } else {
       delete newMeta.shiftStatus;
       delete newMeta.coveredBy;
+      delete newMeta.openShiftId;
     }
     applyEngineOp(
       { type: 'update', id: eventId, patch: { meta: newMeta }, source: 'api' },
       () => onEventSave?.(ev),
     );
-  }, [applyEngineOp, onEventSave]);
+
+    if (!status) {
+      const openShiftId = ev.meta?.openShiftId;
+      const linkedOpenShifts = expandedEvents.filter((candidate) => {
+        const candidateId = String(candidate._eventId ?? candidate.id ?? '');
+        const linkedById = openShiftId && candidateId === String(openShiftId);
+        const linkedBySource = candidate.meta?.kind === 'open-shift'
+          && String(candidate.meta?.sourceShiftId ?? '') === String(eventId);
+        return linkedById || linkedBySource;
+      });
+      linkedOpenShifts.forEach((openEv) => {
+        const openId = openEv._eventId ?? String(openEv.id ?? '');
+        if (!openId) return;
+        applyEngineOp({ type: 'delete', id: openId, source: 'api' }, () => {});
+      });
+
+      const mirroredCoverage = expandedEvents.filter(
+        (candidate) => candidate.meta?.kind === 'covering-shift'
+          && String(candidate.meta?.sourceShiftId ?? '') === String(eventId),
+      );
+      mirroredCoverage.forEach((coverEv) => {
+        const coverId = coverEv._eventId ?? String(coverEv.id ?? '');
+        if (!coverId) return;
+        applyEngineOp({ type: 'delete', id: coverId, source: 'api' }, () => {});
+      });
+    }
+  }, [applyEngineOp, expandedEvents, onEventSave]);
 
   const handleCoverageAssign = useCallback((ev, coveringEmployeeId) => {
     const eventId = ev._eventId ?? String(ev.id);
@@ -612,25 +639,42 @@ export const WorksCalendar = forwardRef<CalendarApi, WorksCalendarProps>(functio
       }
     }
 
-    // 3. Create a mirrored on-call event on the covering employee's row
+    const mirroredCoverage = expandedEvents.filter(
+      (candidate) => candidate.meta?.kind === 'covering-shift'
+        && String(candidate.meta?.sourceShiftId ?? '') === String(eventId),
+    );
+    mirroredCoverage.slice(1).forEach((duplicateEv) => {
+      const duplicateId = duplicateEv._eventId ?? String(duplicateEv.id ?? '');
+      if (!duplicateId) return;
+      applyEngineOp({ type: 'delete', id: duplicateId, source: 'api' }, () => {});
+    });
+
+    // 3. Create or update the mirrored on-call event on the covering employee's row
     const onCallCat = ownerCfg.config?.onCallCategory ?? 'on-call';
-    const mirroredEvent = {
-      id:       `cover-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`,
+    const mirroredPatch = {
       title:    `Covering: ${ev.title ?? 'Shift'}`,
       start:    ev.start instanceof Date ? ev.start : new Date(ev.start),
       end:      ev.end   instanceof Date ? ev.end   : new Date(ev.end),
       category: onCallCat,
       resource: coveringEmployeeId,
       meta: {
-        kind:            'covering-shift',
-        sourceShiftId:   eventId,
+        kind:              'covering-shift',
+        sourceShiftId:     eventId,
         coveredEmployeeId: String(ev.resource ?? ev.employeeId ?? ''),
       },
     };
-    applyEngineOp(
-      { type: 'create', event: mirroredEvent, source: 'api' },
-      () => {},
-    );
+    const existingMirror = mirroredCoverage[0];
+    if (existingMirror) {
+      const mirrorId = existingMirror._eventId ?? String(existingMirror.id ?? '');
+      if (mirrorId) {
+        applyEngineOp({ type: 'update', id: mirrorId, patch: mirroredPatch, source: 'api' }, () => {});
+      }
+    } else {
+      applyEngineOp(
+        { type: 'create', event: { ...mirroredPatch, id: `cover-${eventId}` }, source: 'api' },
+        () => {},
+      );
+    }
   }, [applyEngineOp, onEventSave, expandedEvents, ownerCfg.config?.onCallCategory]);
 
   /**
@@ -706,28 +750,55 @@ export const WorksCalendar = forwardRef<CalendarApi, WorksCalendarProps>(functio
         onCallCategory: onCallCat,
       });
       conflictingEvents.forEach(shiftEv => {
-        const openShift = buildOpenShiftEvent({ shiftEvent: shiftEv, reason: availEv.kind });
-
-        // Create the open-shift record
-        applyEngineOp(
-          { type: 'create', event: openShift, source: 'api' },
-          () => {},
+        const shiftId = shiftEv._eventId ?? String(shiftEv.id ?? '');
+        if (!shiftId) return;
+        const existingOpenShifts = expandedEvents.filter(
+          (candidate) => candidate.meta?.kind === 'open-shift'
+            && String(candidate.meta?.sourceShiftId ?? '') === String(shiftId),
         );
+        existingOpenShifts.slice(1).forEach((duplicateOpenShift) => {
+          const duplicateId = duplicateOpenShift._eventId ?? String(duplicateOpenShift.id ?? '');
+          if (!duplicateId) return;
+          applyEngineOp({ type: 'delete', id: duplicateId, source: 'api' }, () => {});
+        });
+
+        const openShiftPatch = {
+          title: `Open: ${shiftEv.title ?? 'Shift'}`,
+          start: shiftEv.start instanceof Date ? shiftEv.start : new Date(shiftEv.start),
+          end: shiftEv.end instanceof Date ? shiftEv.end : new Date(shiftEv.end),
+          resource: null,
+          meta: {
+            ...(existingOpenShifts[0]?.meta ?? {}),
+            kind:               'open-shift',
+            sourceShiftId:      String(shiftId),
+            originalEmployeeId: String(shiftEv.resource ?? shiftEv.employeeId ?? ''),
+            reason:             availEv.kind,
+            coveredBy:          null,
+            status:             'open',
+          },
+        };
+        const openShift = existingOpenShifts[0]
+          ? { ...existingOpenShifts[0], ...openShiftPatch }
+          : buildOpenShiftEvent({ shiftEvent: shiftEv, reason: availEv.kind });
+
+        if (existingOpenShifts[0]) {
+          const openId = existingOpenShifts[0]._eventId ?? String(existingOpenShifts[0].id ?? '');
+          if (openId) applyEngineOp({ type: 'update', id: openId, patch: openShiftPatch, source: 'api' }, () => {});
+        } else {
+          applyEngineOp({ type: 'create', event: openShift, source: 'api' }, () => {});
+        }
 
         // Mark the original shift as needing coverage
-        const shiftId = shiftEv._eventId ?? String(shiftEv.id ?? '');
-        if (shiftId) {
-          const updatedMeta = {
-            ...(shiftEv.meta ?? {}),
-            shiftStatus: availEv.kind,   // 'pto' | 'unavailable'
-            openShiftId: openShift.id,
-            coveredBy:   null,
-          };
-          applyEngineOp(
-            { type: 'update', id: shiftId, patch: { meta: updatedMeta }, source: 'api' },
-            () => {},
-          );
-        }
+        const updatedMeta = {
+          ...(shiftEv.meta ?? {}),
+          shiftStatus: availEv.kind,   // 'pto' | 'unavailable'
+          openShiftId: openShift.id,
+          coveredBy:   null,
+        };
+        applyEngineOp(
+          { type: 'update', id: shiftId, patch: { meta: updatedMeta }, source: 'api' },
+          () => {},
+        );
       });
     }
 


### PR DESCRIPTION
### Motivation
- Prevent stale or duplicate linked schedule records when clearing shift status, assigning coverage, or saving PTO/unavailable so repeated actions are idempotent and the model stays consistent.

### Description
- When clearing a shift status, also remove `openShiftId` from the shift meta and delete any linked `open-shift` and `covering-shift` events found in `expandedEvents` so stale records are cleaned up (`src/WorksCalendar.tsx`).
- Make coverage assignment idempotent by deduplicating existing `covering-shift` mirrors, deleting duplicates, and performing create-or-update logic to avoid producing multiple mirrored coverage events on repeated assignments (`src/WorksCalendar.tsx`).
- Harden PTO/unavailable save flow to dedupe open-shift records per source shift, update an existing linked open-shift when present, and consistently set `openShiftId` on the source shift metadata instead of always creating new open-shift records (`src/WorksCalendar.tsx`).

### Testing
- Ran the focused unit/interaction tests with `npm test -- src/__tests__/WorksCalendar.scheduleWorkflow.test.jsx src/core/__tests__/scheduleOverlap.test.js` and all tests passed (2 files, 25 tests, 25 passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de1128a6f4832c83fc890829b6acca)