### PR TITLE
Normalize schedule event kinds and add integration tests for schedule integrity

### DIFF
--- a/src/WorksCalendar.tsx
+++ b/src/WorksCalendar.tsx
@@ -44,6 +44,12 @@ import ScheduleTemplateDialog from './ui/ScheduleTemplateDialog.jsx';
 import AvailabilityForm        from './ui/AvailabilityForm.jsx';
 import ScheduleEditorForm      from './ui/ScheduleEditorForm.jsx';
 import { detectShiftConflicts, buildOpenShiftEvent } from './core/scheduleOverlap.js';
+import {
+  isCoveringEvent,
+  isOpenShiftEvent,
+  normalizeScheduleKind,
+  SCHEDULE_KINDS,
+} from './core/scheduleModel.js';
 import ValidationAlert          from './ui/ValidationAlert.jsx';
 import ScreenReaderAnnouncer   from './ui/ScreenReaderAnnouncer.jsx';
 import CalendarErrorBoundary   from './ui/CalendarErrorBoundary.jsx';
@@ -588,7 +594,7 @@ export const WorksCalendar = forwardRef<CalendarApi, WorksCalendarProps>(functio
       const linkedOpenShifts = expandedEvents.filter((candidate) => {
         const candidateId = String(candidate._eventId ?? candidate.id ?? '');
         const linkedById = openShiftId && candidateId === String(openShiftId);
-        const linkedBySource = candidate.meta?.kind === 'open-shift'
+        const linkedBySource = isOpenShiftEvent(candidate)
           && String(candidate.meta?.sourceShiftId ?? '') === String(eventId);
         return linkedById || linkedBySource;
       });
@@ -599,7 +605,7 @@ export const WorksCalendar = forwardRef<CalendarApi, WorksCalendarProps>(functio
       });
 
       const mirroredCoverage = expandedEvents.filter(
-        (candidate) => candidate.meta?.kind === 'covering-shift'
+        (candidate) => isCoveringEvent(candidate)
           && String(candidate.meta?.sourceShiftId ?? '') === String(eventId),
       );
       mirroredCoverage.forEach((coverEv) => {
@@ -640,7 +646,7 @@ export const WorksCalendar = forwardRef<CalendarApi, WorksCalendarProps>(functio
     }
 
     const mirroredCoverage = expandedEvents.filter(
-      (candidate) => candidate.meta?.kind === 'covering-shift'
+      (candidate) => isCoveringEvent(candidate)
         && String(candidate.meta?.sourceShiftId ?? '') === String(eventId),
     );
     mirroredCoverage.slice(1).forEach((duplicateEv) => {
@@ -658,7 +664,7 @@ export const WorksCalendar = forwardRef<CalendarApi, WorksCalendarProps>(functio
       category: onCallCat,
       resource: coveringEmployeeId,
       meta: {
-        kind:              'covering-shift',
+        kind:              SCHEDULE_KINDS.COVERING,
         sourceShiftId:     eventId,
         coveredEmployeeId: String(ev.resource ?? ev.employeeId ?? ''),
       },
@@ -690,7 +696,7 @@ export const WorksCalendar = forwardRef<CalendarApi, WorksCalendarProps>(functio
       const initialEvent = action === 'availability'
         ? expandedEvents
           .filter((ev) => {
-            const evKind = String(ev?.kind ?? ev?.meta?.kind ?? '').toLowerCase();
+            const evKind = normalizeScheduleKind(ev?.kind ?? ev?.meta?.kind);
             const evCat  = String(ev?.category ?? '').toLowerCase();
             const resourceId = String(ev?.resource ?? ev?.resourceId ?? ev?.employeeId ?? '');
             return resourceId === String(empId) && (evKind === 'availability' || evCat === 'availability');
@@ -753,7 +759,7 @@ export const WorksCalendar = forwardRef<CalendarApi, WorksCalendarProps>(functio
         const shiftId = shiftEv._eventId ?? String(shiftEv.id ?? '');
         if (!shiftId) return;
         const existingOpenShifts = expandedEvents.filter(
-          (candidate) => candidate.meta?.kind === 'open-shift'
+          (candidate) => isOpenShiftEvent(candidate)
             && String(candidate.meta?.sourceShiftId ?? '') === String(shiftId),
         );
         existingOpenShifts.slice(1).forEach((duplicateOpenShift) => {
@@ -769,7 +775,7 @@ export const WorksCalendar = forwardRef<CalendarApi, WorksCalendarProps>(functio
           resource: null,
           meta: {
             ...(existingOpenShifts[0]?.meta ?? {}),
-            kind:               'open-shift',
+            kind:               SCHEDULE_KINDS.OPEN_SHIFT,
             sourceShiftId:      String(shiftId),
             originalEmployeeId: String(shiftEv.resource ?? shiftEv.employeeId ?? ''),
             reason:             availEv.kind,

--- a/src/__tests__/WorksCalendar.scheduleModel.integration.test.jsx
+++ b/src/__tests__/WorksCalendar.scheduleModel.integration.test.jsx
@@ -1,0 +1,106 @@
+import { describe, expect, it } from 'vitest';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import React, { createRef } from 'react';
+
+import { WorksCalendar } from '../WorksCalendar.tsx';
+
+function getKinds(events) {
+  return events.map((ev) => String(ev?.meta?.kind ?? ev?.kind ?? '').toLowerCase());
+}
+
+describe('WorksCalendar schedule model integration', () => {
+  const employees = [
+    { id: 'emp-1', name: 'Alex Rivera', role: 'RN' },
+    { id: 'emp-2', name: 'Bailey Chen', role: 'RN' },
+    { id: 'emp-3', name: 'Casey Patel', role: 'RN' },
+  ];
+
+  const baseShift = {
+    id: 'shift-1',
+    title: 'Night Shift',
+    category: 'on-call',
+    resource: 'emp-1',
+    start: new Date('2026-04-01T00:00:00.000Z'),
+    end: new Date('2026-04-01T08:00:00.000Z'),
+    meta: { kind: 'shift', employeeId: 'emp-1' },
+  };
+
+  async function requestPtoForAlex() {
+    fireEvent.click(await screen.findByRole('button', { name: 'Actions for Alex Rivera' }));
+    fireEvent.click(await screen.findByRole('button', { name: 'Request PTO' }));
+    fireEvent.change(screen.getByLabelText('Start *'), { target: { value: '2026-04-01' } });
+    fireEvent.change(screen.getByLabelText('End *'), { target: { value: '2026-04-02' } });
+    fireEvent.click(await screen.findByRole('button', { name: 'Save PTO Request' }));
+  }
+
+  it('creates an open-shift record when PTO overlaps a shift', async () => {
+    const apiRef = createRef();
+    render(<WorksCalendar ref={apiRef} employees={employees} events={[baseShift]} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Schedule' }));
+    await requestPtoForAlex();
+
+    await waitFor(() => {
+      const visible = apiRef.current.getVisibleEvents();
+      const kinds = getKinds(visible);
+      expect(kinds).toContain('open-shift');
+    });
+  });
+
+  it('clears linked schedule metadata and open/covering events when status is cleared', async () => {
+    const apiRef = createRef();
+    render(<WorksCalendar ref={apiRef} employees={employees} events={[baseShift]} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Schedule' }));
+    await requestPtoForAlex();
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Shift not covered — click to assign coverage' }));
+    fireEvent.click(await screen.findByRole('button', { name: /^Bailey Chen — RN$/ }));
+
+    fireEvent.click(screen.getByRole('button', { name: 'Set shift availability' }));
+    fireEvent.click(screen.getByRole('button', { name: /Clear Status/ }));
+
+    await waitFor(() => {
+      const visible = apiRef.current.getVisibleEvents();
+      const kinds = getKinds(visible);
+      expect(kinds).not.toContain('open-shift');
+      expect(kinds).not.toContain('covering');
+      expect(kinds).not.toContain('covering-shift');
+
+      const shift = visible.find((ev) => String(ev.id) === 'shift-1');
+      expect(shift.meta?.shiftStatus).toBeUndefined();
+      expect(shift.meta?.coveredBy).toBeUndefined();
+      expect(shift.meta?.openShiftId).toBeUndefined();
+    });
+  });
+
+  it('keeps exactly one covering record when coverage is reassigned', async () => {
+    const apiRef = createRef();
+    render(<WorksCalendar ref={apiRef} employees={employees} events={[baseShift]} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Schedule' }));
+    await requestPtoForAlex();
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Shift not covered — click to assign coverage' }));
+    fireEvent.click(await screen.findByRole('button', { name: /^Bailey Chen — RN$/ }));
+
+    fireEvent.click(screen.getByRole('button', { name: 'Set shift availability' }));
+    fireEvent.click(screen.getByRole('button', { name: /Clear Status/ }));
+    await requestPtoForAlex();
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Shift not covered — click to assign coverage' }));
+    fireEvent.click(await screen.findByRole('button', { name: /^Casey Patel — RN$/ }));
+
+    await waitFor(() => {
+      const visible = apiRef.current.getVisibleEvents();
+      const coveringEvents = visible.filter((ev) => {
+        const kind = String(ev?.meta?.kind ?? '').toLowerCase();
+        return kind === 'covering' || kind === 'covering-shift';
+      });
+      expect(coveringEvents).toHaveLength(1);
+
+      const shift = visible.find((ev) => String(ev.id) === 'shift-1');
+      expect(String(shift.meta?.coveredBy ?? '')).toBe('emp-3');
+    });
+  }, 15000);
+});

--- a/src/core/scheduleModel.js
+++ b/src/core/scheduleModel.js
@@ -1,0 +1,56 @@
+/**
+ * Canonical schedule model helpers.
+ *
+ * Normalized kinds:
+ * - shift
+ * - on-call
+ * - open-shift
+ * - covering
+ */
+
+export const SCHEDULE_KINDS = Object.freeze({
+  SHIFT: 'shift',
+  ON_CALL: 'on-call',
+  OPEN_SHIFT: 'open-shift',
+  COVERING: 'covering',
+});
+
+const KIND_ALIASES = Object.freeze({
+  oncall: SCHEDULE_KINDS.ON_CALL,
+  'on_call': SCHEDULE_KINDS.ON_CALL,
+  openshift: SCHEDULE_KINDS.OPEN_SHIFT,
+  'open_shift': SCHEDULE_KINDS.OPEN_SHIFT,
+  'covering-shift': SCHEDULE_KINDS.COVERING,
+});
+
+export function normalizeScheduleKind(rawKind) {
+  const normalized = String(rawKind ?? '').trim().toLowerCase();
+  if (!normalized) return '';
+  return KIND_ALIASES[normalized] ?? normalized;
+}
+
+export function isOpenShiftEvent(ev) {
+  const kind = normalizeScheduleKind(ev?.meta?.kind ?? ev?.kind);
+  const category = String(ev?.category ?? '').toLowerCase();
+  return kind === SCHEDULE_KINDS.OPEN_SHIFT || category === SCHEDULE_KINDS.OPEN_SHIFT;
+}
+
+export function isCoveringEvent(ev) {
+  const kind = normalizeScheduleKind(ev?.meta?.kind ?? ev?.kind);
+  return kind === SCHEDULE_KINDS.COVERING;
+}
+
+export function isShiftOrOnCallEvent(ev, onCallCategory = 'on-call') {
+  const kind = normalizeScheduleKind(ev?.meta?.kind ?? ev?.kind);
+  const category = String(ev?.category ?? '').toLowerCase();
+  return kind === SCHEDULE_KINDS.SHIFT
+    || kind === SCHEDULE_KINDS.ON_CALL
+    || ev?.meta?.onCall === true
+    || category === String(onCallCategory).toLowerCase();
+}
+
+export function isCoveredShift(ev) {
+  return !!ev?.meta?.coveredBy
+    || ev?.meta?.status === 'covered'
+    || ev?.meta?.shiftStatus === 'covered';
+}

--- a/src/core/scheduleOverlap.js
+++ b/src/core/scheduleOverlap.js
@@ -1,3 +1,11 @@
+import {
+  isCoveringEvent,
+  isCoveredShift,
+  isOpenShiftEvent,
+  isShiftOrOnCallEvent,
+  SCHEDULE_KINDS,
+} from './scheduleModel.js';
+
 /**
  * scheduleOverlap.js — utilities for detecting shift / on-call conflicts
  * when an employee submits a PTO or Unavailable request.
@@ -52,15 +60,13 @@ export function detectShiftConflicts({
     // Must belong to this employee
     if (String(ev.resource ?? ev.employeeId ?? '') !== empId) return false;
 
-    // Must be a shift or on-call event (not another PTO/unavailable)
-    const isShiftKind = ev.meta?.kind === 'shift'
-      || ev.meta?.onCall === true
-      || ev.category === onCallCategory;
-    if (!isShiftKind) return false;
+    // Must be a real shift/on-call event, not an open-shift or mirror event.
+    if (!isShiftOrOnCallEvent(ev, onCallCategory)) return false;
+    if (isOpenShiftEvent(ev) || isCoveringEvent(ev)) return false;
 
-    // Must already have a shiftStatus that is NOT already covered
-    // (We want to flag uncovered shifts, not already-covered ones)
-    if (ev.meta?.shiftStatus === 'covered') return false;
+    // Conflict generation should be idempotent: already-covered shifts
+    // should not keep regenerating open-shift work.
+    if (isCoveredShift(ev)) return false;
 
     const evStart = ev.start instanceof Date ? ev.start : new Date(ev.start);
     const evEnd   = ev.end   instanceof Date ? ev.end   : new Date(ev.end);
@@ -97,7 +103,7 @@ export function buildOpenShiftEvent({ shiftEvent, reason, openShiftCategory = 'o
     resource: null,    // unassigned — no covering employee yet
     color:    '#f59e0b', // amber — visually distinct "needs coverage" colour
     meta: {
-      kind:               'open-shift',
+      kind:               SCHEDULE_KINDS.OPEN_SHIFT,
       sourceShiftId:      String(shiftEvent._eventId ?? shiftEvent.id ?? ''),
       originalEmployeeId: String(shiftEvent.resource ?? shiftEvent.employeeId ?? ''),
       reason,


### PR DESCRIPTION
### Motivation

- Create a single canonical model for schedule event kinds so different code paths and legacy aliases agree on what an event is (shift, on-call, open-shift, covering).  
- Prevent duplicate open-shifts and mirrored coverage artifacts by making conflict detection and cleanup use normalized predicates.  
- Provide automated coverage for sprint-4 goals around PTO → open-shift, clearing status cleanup, and assign/reassign idempotency.

### Description

- Add `src/core/scheduleModel.js` which exports `SCHEDULE_KINDS`, `normalizeScheduleKind`, and predicates `isOpenShiftEvent`, `isCoveringEvent`, `isShiftOrOnCallEvent`, and `isCoveredShift`.  
- Update `src/core/scheduleOverlap.js` to use the canonical model and ignore open-shift / covering mirror records when detecting conflicts and building open-shift events.  
- Update `src/WorksCalendar.tsx` to normalize kinds end-to-end (`normalizeScheduleKind`, `isOpenShiftEvent`, `isCoveringEvent`) and to create/update mirrored coverage events using `SCHEDULE_KINDS.COVERING`, and to reliably delete linked open/covering records when status is cleared.  
- Add integration tests `src/__tests__/WorksCalendar.scheduleModel.integration.test.jsx` that exercise PTO → open-shift creation, clearing PTO/unavailable → cleanup, and assign/reassign coverage idempotency.

### Testing

- Ran the focused test set with `npm test -- src/core/__tests__/scheduleOverlap.test.js src/__tests__/WorksCalendar.scheduleModel.integration.test.jsx`.  
- Both test files passed (`Test Files 2 passed`, `Tests 23 passed`) confirming conflict detection, open-shift creation, cleanup, and coverage reassignment behavior are working as expected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de13968f98832c9cd16d276c02753f)