### PR TITLE
Add owner edit mode with inline event customization

### DIFF
--- a/src/WorksCalendar.module.css
+++ b/src/WorksCalendar.module.css
@@ -364,6 +364,65 @@
   color: var(--wc-text);
 }
 
+/* Wand / edit-mode toggle button */
+.wandBtn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  border-radius: var(--wc-radius-sm);
+  background: transparent;
+  border: 1px solid var(--wc-border);
+  cursor: pointer;
+  color: var(--wc-text-muted);
+  transition: all 0.15s;
+}
+.wandBtn:hover {
+  background: var(--wc-surface);
+  border-color: var(--wc-border-dark);
+  color: var(--wc-text);
+}
+.wandBtnActive {
+  background: var(--wc-accent-dim);
+  border-color: var(--wc-accent);
+  color: var(--wc-accent);
+}
+
+/* Edit mode: glow ring on the calendar root */
+.root[data-wc-edit-mode] {
+  box-shadow: 0 0 0 2px var(--wc-accent);
+}
+
+/* Edit mode banner */
+.editModeBanner {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  padding: 6px 12px;
+  background: var(--wc-accent-dim);
+  color: var(--wc-accent);
+  font-size: 12px;
+  font-weight: 500;
+  border-bottom: 1px solid var(--wc-accent);
+  flex-shrink: 0;
+}
+
+.editModeExit {
+  margin-left: auto;
+  background: var(--wc-accent);
+  color: #fff;
+  border: none;
+  border-radius: var(--wc-radius-sm);
+  padding: 3px 10px;
+  font-size: 11px;
+  font-weight: 600;
+  cursor: pointer;
+  font-family: inherit;
+  transition: opacity 0.15s;
+}
+.editModeExit:hover { opacity: 0.85; }
+
 /* View area */
 .viewArea {
   flex: 1;

--- a/src/WorksCalendar.tsx
+++ b/src/WorksCalendar.tsx
@@ -10,7 +10,7 @@ import {
   format, startOfMonth, endOfMonth,
   startOfWeek, endOfWeek, addDays,
 } from 'date-fns';
-import { ChevronLeft, ChevronRight, Download, Plus, Upload } from 'lucide-react';
+import { ChevronLeft, ChevronRight, Download, Plus, Sparkles, Upload } from 'lucide-react';
 
 import { useCalendar }        from './hooks/useCalendar.js';
 import { useOwnerConfig }     from './hooks/useOwnerConfig.js';
@@ -45,6 +45,7 @@ import AvailabilityForm        from './ui/AvailabilityForm.jsx';
 import ScheduleEditorForm      from './ui/ScheduleEditorForm.jsx';
 import { detectShiftConflicts, buildOpenShiftEvent } from './core/scheduleOverlap.js';
 import ValidationAlert          from './ui/ValidationAlert.jsx';
+import InlineEventEditor        from './ui/InlineEventEditor.jsx';
 import ScreenReaderAnnouncer   from './ui/ScreenReaderAnnouncer.jsx';
 import CalendarErrorBoundary   from './ui/CalendarErrorBoundary.jsx';
 import MonthView              from './views/MonthView.jsx';
@@ -465,6 +466,13 @@ export const WorksCalendar = forwardRef<CalendarApi, WorksCalendarProps>(functio
   // { emp: { id, name, role? }, start?: Date }
   const [scheduleEditorState, setScheduleEditorState] = useState(null);
   const [pillHoverTitle, setPillHoverTitle] = useState(false);
+  const [editMode,         setEditMode]         = useState(false);
+  // { event, x, y } — set when an event is clicked in edit mode
+  const [inlineEditTarget, setInlineEditTarget] = useState(null);
+  // Capture last click coords so InlineEventEditor can position near the pill
+  const lastClickCoordsRef = useRef({ x: 0, y: 0 });
+  const editModeRef = useRef(false);
+  editModeRef.current = editMode;
   const [remoteTemplates, setRemoteTemplates] = useState([]);
   const [templateError, setTemplateError] = useState('');
 
@@ -563,6 +571,15 @@ export const WorksCalendar = forwardRef<CalendarApi, WorksCalendarProps>(functio
 
   // ── Callbacks ────────────────────────────────────────────────────────────
   const handleEventClick = useCallback((ev) => {
+    if (editModeRef.current) {
+      setSelectedEvent(null);
+      setInlineEditTarget({
+        event: ev,
+        x: lastClickCoordsRef.current.x,
+        y: lastClickCoordsRef.current.y,
+      });
+      return;
+    }
     setSelectedEvent(ev);
     onEventClickProp?.(ev);
   }, [onEventClickProp]);
@@ -1019,11 +1036,28 @@ export const WorksCalendar = forwardRef<CalendarApi, WorksCalendarProps>(functio
     setFormEvent(ev._raw ?? ev);
   }, []);
 
+  /** Save quick display customizations from InlineEventEditor. */
+  const handleInlineSave = useCallback((patch) => {
+    const ev = inlineEditTarget?.event;
+    if (!ev) return;
+    const eventId = ev._eventId ?? String(ev.id);
+    applyEngineOp({
+      type:   'update',
+      id:     eventId,
+      patch:  { title: patch.title, color: patch.color, meta: patch.meta },
+      source: 'inline-edit',
+    }, () => {
+      onEventSave?.({ ...ev, ...patch });
+      setInlineEditTarget(null);
+    });
+  }, [inlineEditTarget, applyEngineOp, onEventSave]);
+
   // ── Context value ────────────────────────────────────────────────────────
   const ctxValue = useMemo(() => ({
     renderEvent, renderHoverCard, colorRules, businessHours, emptyState,
     permissions: perms,
-  }), [renderEvent, renderHoverCard, colorRules, businessHours, emptyState, perms]);
+    editMode,
+  }), [renderEvent, renderHoverCard, colorRules, businessHours, emptyState, perms, editMode]);
 
   // ── Toolbar date label ───────────────────────────────────────────────────
   function getDateLabel() {
@@ -1095,7 +1129,7 @@ export const WorksCalendar = forwardRef<CalendarApi, WorksCalendarProps>(functio
   return (
     <CalendarErrorBoundary>
       <CalendarContext.Provider value={ctxValue}>
-        <div className={styles.root} data-wc-theme={theme} data-testid="works-calendar" style={customThemeVars}>
+        <div className={styles.root} data-wc-theme={theme} data-testid="works-calendar" data-wc-edit-mode={editMode ? '' : undefined} style={customThemeVars}>
 
         {/* ── Toolbar ── */}
         {renderToolbar ? (
@@ -1139,6 +1173,16 @@ export const WorksCalendar = forwardRef<CalendarApi, WorksCalendarProps>(functio
 
             <div className={styles.actions}>
               {devMode && <span className={styles.devBadge}>Dev</span>}
+              {(ownerCfg.isOwner || devMode) && (
+                <button
+                  className={[styles.wandBtn, editMode && styles.wandBtnActive].filter(Boolean).join(' ')}
+                  onClick={() => { setEditMode(v => !v); setInlineEditTarget(null); }}
+                  aria-label={editMode ? 'Exit edit mode' : 'Enter edit mode — click events to customize them'}
+                  title={editMode ? 'Exit edit mode' : 'Customize events'}
+                >
+                  <Sparkles size={15} aria-hidden="true" />
+                </button>
+              )}
               {hasAddButton && (
                 <button className={styles.addBtn} onClick={() => setFormEvent({})} aria-label="Add new event">
                   <Plus size={14} aria-hidden="true" /><span className={styles.addBtnLabel}> Add Event</span>
@@ -1176,6 +1220,21 @@ export const WorksCalendar = forwardRef<CalendarApi, WorksCalendarProps>(functio
                 />
               )}
             </div>
+          </div>
+        )}
+
+        {/* ── Edit mode banner ── */}
+        {editMode && (
+          <div className={styles.editModeBanner} role="status" aria-live="polite">
+            <Sparkles size={13} aria-hidden="true" />
+            <span>Edit mode — click any event to customize it</span>
+            <button
+              className={styles.editModeExit}
+              onClick={() => { setEditMode(false); setInlineEditTarget(null); }}
+              aria-label="Exit edit mode"
+            >
+              Done
+            </button>
           </div>
         )}
 
@@ -1238,7 +1297,13 @@ export const WorksCalendar = forwardRef<CalendarApi, WorksCalendarProps>(functio
         }
 
         {/* ── View area ── */}
-        <div ref={swipeAreaRef} className={styles.viewArea}>
+        <div
+          ref={swipeAreaRef}
+          className={styles.viewArea}
+          onClickCapture={editMode ? (e) => {
+            lastClickCoordsRef.current = { x: e.clientX, y: e.clientY };
+          } : undefined}
+        >
           {isEmpty && emptyState ? (
             <div className={styles.emptyStateWrap}>{emptyState}</div>
           ) : (
@@ -1381,6 +1446,17 @@ export const WorksCalendar = forwardRef<CalendarApi, WorksCalendarProps>(functio
         {/* ── Screen reader live region ── */}
         <ScreenReaderAnnouncer ref={announcerRef} />
         </div>
+
+        {/* ── Inline event editor (edit mode) ── */}
+        {inlineEditTarget && (
+          <InlineEventEditor
+            event={inlineEditTarget.event}
+            x={inlineEditTarget.x}
+            y={inlineEditTarget.y}
+            onSave={handleInlineSave}
+            onClose={() => setInlineEditTarget(null)}
+          />
+        )}
       </CalendarContext.Provider>
     </CalendarErrorBoundary>
   );

--- a/src/ui/InlineEventEditor.jsx
+++ b/src/ui/InlineEventEditor.jsx
@@ -1,0 +1,135 @@
+/**
+ * InlineEventEditor — lightweight event customization popover.
+ *
+ * Activated when the owner clicks an event in Edit Mode.
+ * Lets owners tweak title, color, bold, and size without opening the full form.
+ */
+import { useState, useRef, useEffect } from 'react';
+import { X } from 'lucide-react';
+import styles from './InlineEventEditor.module.css';
+
+const PRESET_COLORS = [
+  '#3b82f6', '#ef4444', '#f59e0b', '#10b981',
+  '#8b5cf6', '#ec4899', '#06b6d4', '#64748b',
+];
+
+export default function InlineEventEditor({ event, x, y, onSave, onClose }) {
+  const [title, setTitle] = useState(event.title ?? '');
+  const [color, setColor] = useState(event.color ?? PRESET_COLORS[0]);
+  const [bold,  setBold]  = useState(!!(event.meta?._display?.bold));
+  const [large, setLarge] = useState(!!(event.meta?._display?.large));
+  const panelRef = useRef(null);
+  const inputRef = useRef(null);
+
+  useEffect(() => {
+    inputRef.current?.focus();
+    inputRef.current?.select();
+  }, []);
+
+  // Close on outside click
+  useEffect(() => {
+    function handler(e) {
+      if (panelRef.current && !panelRef.current.contains(e.target)) onClose();
+    }
+    document.addEventListener('mousedown', handler);
+    return () => document.removeEventListener('mousedown', handler);
+  }, [onClose]);
+
+  function handleKeyDown(e) {
+    if (e.key === 'Escape') { e.stopPropagation(); onClose(); }
+    if (e.key === 'Enter' && !e.shiftKey) { e.preventDefault(); handleSave(); }
+  }
+
+  function handleSave() {
+    onSave({
+      title: title.trim() || '(untitled)',
+      color,
+      meta: {
+        ...(event.meta ?? {}),
+        _display: { bold, large },
+      },
+    });
+  }
+
+  // Clamp position to stay within viewport
+  const CARD_W = 252;
+  const CARD_H = 260;
+  const vw = typeof window !== 'undefined' ? window.innerWidth  : 1024;
+  const vh = typeof window !== 'undefined' ? window.innerHeight : 768;
+  const px = Math.min(x + 8, vw - CARD_W - 12);
+  const py = y + 16 + CARD_H > vh ? Math.max(8, y - CARD_H - 8) : y + 16;
+
+  const styleLabel = bold && large ? 'Bold + Priority'
+    : bold  ? 'Bold text'
+    : large ? 'Priority size'
+    : 'Normal';
+
+  return (
+    <div
+      ref={panelRef}
+      className={styles.panel}
+      style={{ left: px, top: py }}
+      role="dialog"
+      aria-label="Edit event appearance"
+      onKeyDown={handleKeyDown}
+    >
+      <div className={styles.header}>
+        <span className={styles.headerLabel}>Customize Event</span>
+        <button className={styles.closeBtn} onClick={onClose} aria-label="Close">
+          <X size={14} />
+        </button>
+      </div>
+
+      {/* Title */}
+      <input
+        ref={inputRef}
+        className={styles.titleInput}
+        value={title}
+        onChange={e => setTitle(e.target.value)}
+        placeholder="Event title…"
+        aria-label="Event title"
+      />
+
+      {/* Color swatches */}
+      <div className={styles.colorRow} role="group" aria-label="Event color">
+        {PRESET_COLORS.map(c => (
+          <button
+            key={c}
+            className={[styles.colorSwatch, color === c && styles.colorActive].filter(Boolean).join(' ')}
+            style={{ background: c }}
+            onClick={() => setColor(c)}
+            aria-label={`Color ${c}`}
+            aria-pressed={color === c}
+          />
+        ))}
+      </div>
+
+      {/* Style toggles */}
+      <div className={styles.styleRow}>
+        <button
+          className={[styles.styleBtn, bold && styles.styleBtnActive].filter(Boolean).join(' ')}
+          onClick={() => setBold(v => !v)}
+          aria-pressed={bold}
+          title="Bold text"
+        >
+          <strong>B</strong>
+        </button>
+        <button
+          className={[styles.styleBtn, large && styles.styleBtnActive].filter(Boolean).join(' ')}
+          onClick={() => setLarge(v => !v)}
+          aria-pressed={large}
+          title="Priority size — makes this event stand out"
+        >
+          <span aria-hidden="true">★</span>
+        </button>
+        <span className={styles.styleHint}>{styleLabel}</span>
+      </div>
+
+      {/* Actions */}
+      <div className={styles.actions}>
+        <button className={styles.saveBtn} onClick={handleSave}>Save</button>
+        <button className={styles.cancelBtn} onClick={onClose}>Cancel</button>
+      </div>
+    </div>
+  );
+}

--- a/src/ui/InlineEventEditor.module.css
+++ b/src/ui/InlineEventEditor.module.css
@@ -1,0 +1,162 @@
+.panel {
+  position: fixed;
+  z-index: 2000;
+  background: var(--wc-bg);
+  border: 1.5px solid var(--wc-border-dark);
+  border-radius: var(--wc-radius);
+  box-shadow: var(--wc-shadow);
+  padding: 12px;
+  width: 252px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  box-sizing: border-box;
+}
+
+/* ── Header ── */
+.header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.headerLabel {
+  font-size: 11px;
+  font-weight: 700;
+  color: var(--wc-text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.07em;
+}
+
+.closeBtn {
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: var(--wc-text-muted);
+  padding: 2px;
+  display: flex;
+  align-items: center;
+  border-radius: var(--wc-radius-sm);
+  line-height: 1;
+}
+.closeBtn:hover {
+  background: var(--wc-surface-2);
+  color: var(--wc-text);
+}
+
+/* ── Title input ── */
+.titleInput {
+  width: 100%;
+  padding: 7px 9px;
+  border: 1px solid var(--wc-border);
+  border-radius: var(--wc-radius-sm);
+  background: var(--wc-surface);
+  color: var(--wc-text);
+  font-size: 13px;
+  font-family: var(--wc-font);
+  box-sizing: border-box;
+  outline: none;
+  transition: border-color 0.15s, box-shadow 0.15s;
+}
+.titleInput:focus {
+  border-color: var(--wc-accent);
+  box-shadow: 0 0 0 2px var(--wc-accent-dim);
+}
+
+/* ── Color row ── */
+.colorRow {
+  display: flex;
+  gap: 6px;
+  flex-wrap: wrap;
+}
+
+.colorSwatch {
+  width: 22px;
+  height: 22px;
+  border-radius: 50%;
+  border: 2.5px solid transparent;
+  cursor: pointer;
+  padding: 0;
+  outline: none;
+  transition: transform 0.1s, border-color 0.1s;
+  flex-shrink: 0;
+}
+.colorSwatch:hover {
+  transform: scale(1.18);
+}
+.colorActive {
+  border-color: var(--wc-text);
+  transform: scale(1.15);
+}
+
+/* ── Style toggles ── */
+.styleRow {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.styleBtn {
+  width: 28px;
+  height: 28px;
+  border: 1px solid var(--wc-border);
+  border-radius: var(--wc-radius-sm);
+  background: var(--wc-surface);
+  color: var(--wc-text);
+  font-size: 13px;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  transition: background 0.1s, border-color 0.1s, color 0.1s;
+  font-family: inherit;
+}
+.styleBtn:hover {
+  background: var(--wc-surface-2);
+}
+.styleBtnActive {
+  background: var(--wc-accent-dim);
+  border-color: var(--wc-accent);
+  color: var(--wc-accent);
+}
+
+.styleHint {
+  font-size: 11px;
+  color: var(--wc-text-faint);
+}
+
+/* ── Actions ── */
+.actions {
+  display: flex;
+  gap: 8px;
+}
+
+.saveBtn {
+  flex: 1;
+  padding: 7px;
+  background: var(--wc-accent);
+  color: #fff;
+  border: none;
+  border-radius: var(--wc-radius-sm);
+  cursor: pointer;
+  font-size: 12px;
+  font-weight: 600;
+  font-family: inherit;
+  transition: opacity 0.15s;
+}
+.saveBtn:hover { opacity: 0.88; }
+
+.cancelBtn {
+  flex: 1;
+  padding: 7px;
+  background: var(--wc-surface-2);
+  color: var(--wc-text-muted);
+  border: 1px solid var(--wc-border);
+  border-radius: var(--wc-radius-sm);
+  cursor: pointer;
+  font-size: 12px;
+  font-family: inherit;
+  transition: background 0.15s;
+}
+.cancelBtn:hover { background: var(--wc-border); }

--- a/src/views/MonthView.jsx
+++ b/src/views/MonthView.jsx
@@ -211,6 +211,7 @@ export default function MonthView({
     const isDimmed    = dragRef.current?.ev?.id === ev.id && dragTarget !== null;
     const statusClass = ev.status === 'cancelled' ? styles.cancelled
       : ev.status === 'tentative' ? styles.tentative : '';
+    const display     = ev.meta?._display ?? {};
 
     function handlePillMouseEnter(e) {
       if (enlargeMonthRowOnHover && weekIdx != null) setHoveredWeekIdx(weekIdx);
@@ -251,8 +252,19 @@ export default function MonthView({
 
     return (
       <button key={ev.id}
-        className={[styles.eventPill, statusClass, isDimmed && styles.dragging].filter(Boolean).join(' ')}
-        style={{ '--ev-color': color }}
+        className={[
+          styles.eventPill,
+          statusClass,
+          isDimmed && styles.dragging,
+          ctx?.editMode && styles.editModePill,
+        ].filter(Boolean).join(' ')}
+        style={{
+          '--ev-color': color,
+          fontWeight: display.bold  ? '700' : undefined,
+          fontSize:   display.large ? '12px' : undefined,
+          minHeight:  display.large ? '26px' : undefined,
+          height:     display.large ? '26px' : undefined,
+        }}
         onClick={e => { e.stopPropagation(); onClick(); }}
         onPointerDown={e => startPillDrag(ev, e)}
         onMouseEnter={handlePillMouseEnter}

--- a/src/views/MonthView.module.css
+++ b/src/views/MonthView.module.css
@@ -202,6 +202,8 @@
   transition: opacity 0.1s;
 }
 .eventPill:hover { opacity: 0.85; }
+/* In edit mode: subtle dashed outline signals every pill is editable */
+.editModePill { outline: 1.5px dashed rgba(255,255,255,0.55); outline-offset: -2px; cursor: cell; }
 .eventPill.tentative { opacity: 0.65; background-image: repeating-linear-gradient(45deg, transparent, transparent 3px, rgba(255,255,255,.25) 3px, rgba(255,255,255,.25) 6px); }
 .eventPill.cancelled { opacity: 0.5; text-decoration: line-through; }
 .eventPill.dragging { opacity: 0.3; pointer-events: none; cursor: grabbing; }

--- a/src/views/WeekView.jsx
+++ b/src/views/WeekView.jsx
@@ -271,6 +271,7 @@ export default function WeekView({
     const statusClass = ev.status === 'cancelled' ? styles.cancelled
       : ev.status === 'tentative' ? styles.tentative : '';
     const ariaLabel = `${ev.title}, ${format(ev.start, 'h:mm a')} to ${format(ev.end, 'h:mm a')}${ev.category ? `, ${ev.category}` : ''}${ev.status && ev.status !== 'confirmed' ? `, ${ev.status}` : ''}`;
+    const display   = ev.meta?._display ?? {};
 
     const inner = ctx?.renderEvent
       ? ctx.renderEvent(ev, { view: 'week', isCompact: false, onClick, color })
@@ -278,8 +279,16 @@ export default function WeekView({
 
     return (
       <div key={ev.id} data-event="1"
-        className={[styles.event, statusClass, isDimmed && styles.dragging].filter(Boolean).join(' ')}
-        style={{ top, height, '--ev-color': color, left: `${pctLeft}%`, width: `${pctWidth}%` }}
+        className={[
+          styles.event, statusClass,
+          isDimmed && styles.dragging,
+          ctx?.editMode && styles.editModeEvent,
+        ].filter(Boolean).join(' ')}
+        style={{
+          top, height, '--ev-color': color,
+          left: `${pctLeft}%`, width: `${pctWidth}%`,
+          fontSize: display.large ? '12px' : undefined,
+        }}
         role="button" tabIndex={0}
         aria-label={ariaLabel}
         onClick={onClick}
@@ -291,7 +300,7 @@ export default function WeekView({
           aria-hidden="true" />
         {inner ?? (
           <>
-            <span className={styles.evTitle}>{ev.title}</span>
+            <span className={styles.evTitle} style={{ fontWeight: display.bold ? '700' : undefined }}>{ev.title}</span>
             <span className={styles.evTime}>{format(ev.start, 'h:mm a')}</span>
           </>
         )}

--- a/src/views/WeekView.module.css
+++ b/src/views/WeekView.module.css
@@ -289,6 +289,8 @@
 }
 .event:hover { filter: brightness(1.1); }
 .event:active { cursor: grabbing; }
+/* In edit mode: dashed outline signals the event is editable */
+.editModeEvent { outline: 1.5px dashed rgba(255,255,255,0.55); outline-offset: -3px; cursor: cell; }
 .event.dragging { opacity: 0.35; pointer-events: none; }
 .event.tentative {
   opacity: 0.65;


### PR DESCRIPTION
When logged in as dev/owner, a wand (Sparkles) button appears in the toolbar. Clicking it enters Edit Mode, signaled by a glowing accent border on the calendar and a banner reading "Edit mode — click any event to customize it." All event pills get a dashed outline cursor to reinforce editability.

Clicking any event in edit mode opens a lightweight InlineEventEditor popover (positioned near the click) instead of the HoverCard. The editor lets owners change the event title, pick from 8 preset colors, toggle bold text, and toggle a priority/"large" size flag — all saving instantly through the engine. Bold and large flags are stored in event.meta._display and applied at render time in MonthView and WeekView without touching the full EventForm flow.

https://claude.ai/code/session_01Qe61nrbs3DFX4awRXqzy8q

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added inline event editing—toggle edit mode to click and customize event titles, colors, and styling directly in the calendar.
  * Events display visual indicators when editable.
  * Edit mode banner appears when active with a completion button.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->