### PR TITLE
feat(qa): add visual QA pipeline with Qwen-VL screenshot review

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "test:browser": "playwright test",
+    "qa:visual": "playwright test visual-qa --config playwright.config.ts && node scripts/ai-qa-review.mjs",
     "qa:review": "node scripts/ai-qa-review.mjs",
     "ai:qa": "playwright test && node scripts/ai-qa-review.mjs",
     "dev": "vite --config vite.demo.config.js",

--- a/scripts/ai-qa-review.mjs
+++ b/scripts/ai-qa-review.mjs
@@ -1,38 +1,105 @@
+/**
+ * ai-qa-review.mjs
+ *
+ * Sends Playwright screenshots to a vision-capable LLM (Qwen2-VL via Ollama,
+ * or DashScope) and writes a structured QA report to qa-output/visual-review.md
+ *
+ * Configuration (env vars, all optional):
+ *
+ *   OLLAMA_BASE_URL   Ollama OpenAI-compatible endpoint  (default: http://localhost:11434/v1)
+ *   OLLAMA_MODEL      Vision model to use                (default: qwen2-vl:7b)
+ *
+ *   DASHSCOPE_API_KEY If set, routes to DashScope instead of Ollama
+ *   DASHSCOPE_MODEL   DashScope model ID                 (default: qwen-vl-max)
+ *
+ *   OPENAI_BASE_URL   Generic override (LM Studio, etc.) – overrides Ollama base
+ *   OPENAI_API_KEY    API key for generic override
+ *   LM_STUDIO_MODEL   Model name for generic override    (default: local-model)
+ *
+ * Usage:
+ *   node scripts/ai-qa-review.mjs
+ *   npm run qa:review
+ */
 import fs from 'fs';
+import path from 'path';
 import OpenAI from 'openai';
 
-const REPORT_PATH = 'qa-output/playwright-report.json';
-const OUTPUT_PATH = 'qa-output/ai-qa-notes.md';
+// ── Paths ────────────────────────────────────────────────────────────────────
 
-const client = new OpenAI({
-  baseURL: process.env.OPENAI_BASE_URL || process.env.LM_STUDIO_BASE_URL || 'http://127.0.0.1:1234/v1',
-  apiKey: process.env.OPENAI_API_KEY || process.env.LM_STUDIO_API_KEY || 'lm-studio',
-});
+const SHOTS_DIR    = 'qa-output/screenshots';
+const REPORT_PATH  = 'qa-output/playwright-report.json';
+const OUTPUT_PATH  = 'qa-output/visual-review.md';
+const BATCH_SIZE   = 5; // images per API request
 
-function readJson(file) {
-  return JSON.parse(fs.readFileSync(file, 'utf8'));
+// ── Client setup ─────────────────────────────────────────────────────────────
+
+function buildClient() {
+  // DashScope (Alibaba Cloud) — native Qwen-VL in the cloud
+  if (process.env.DASHSCOPE_API_KEY) {
+    return {
+      client: new OpenAI({
+        baseURL: 'https://dashscope.aliyuncs.com/compatible-mode/v1',
+        apiKey: process.env.DASHSCOPE_API_KEY,
+      }),
+      model: process.env.DASHSCOPE_MODEL || 'qwen-vl-max',
+    };
+  }
+
+  // Generic override (LM Studio, hosted OpenAI-compatible)
+  if (process.env.OPENAI_BASE_URL || process.env.LM_STUDIO_BASE_URL) {
+    return {
+      client: new OpenAI({
+        baseURL: process.env.OPENAI_BASE_URL || process.env.LM_STUDIO_BASE_URL,
+        apiKey: process.env.OPENAI_API_KEY || process.env.LM_STUDIO_API_KEY || 'lm-studio',
+      }),
+      model: process.env.LM_STUDIO_MODEL || 'local-model',
+    };
+  }
+
+  // Default: Ollama local (qwen2-vl:7b)
+  return {
+    client: new OpenAI({
+      baseURL: process.env.OLLAMA_BASE_URL || 'http://localhost:11434/v1',
+      apiKey: 'ollama', // Ollama doesn't validate the key, but the header is required
+    }),
+    model: process.env.OLLAMA_MODEL || 'qwen2-vl:7b',
+  };
 }
 
-function flattenReport(report) {
-  const out = [];
+// ── Image helpers ─────────────────────────────────────────────────────────────
 
-  function walkSuite(suite, prefix = '') {
-    const suiteTitle = [prefix, suite.title].filter(Boolean).join(' > ');
+function imageToDataUrl(filePath) {
+  const bytes = fs.readFileSync(filePath);
+  return `data:image/png;base64,${bytes.toString('base64')}`;
+}
 
-    if (suite.specs) {
-      for (const spec of suite.specs) {
+function buildImageContentPart(filePath) {
+  return {
+    type: 'image_url',
+    image_url: { url: imageToDataUrl(filePath) },
+  };
+}
+
+// ── Playwright report helpers ─────────────────────────────────────────────────
+
+function loadTestResults() {
+  if (!fs.existsSync(REPORT_PATH)) return [];
+  try {
+    const report = JSON.parse(fs.readFileSync(REPORT_PATH, 'utf8'));
+    const out = [];
+
+    function walkSuite(suite, prefix = '') {
+      const suiteTitle = [prefix, suite.title].filter(Boolean).join(' > ');
+      for (const spec of suite.specs || []) {
         const specTitle = [suiteTitle, spec.title].filter(Boolean).join(' > ');
-
         for (const t of spec.tests || []) {
-          const results = t.results || [];
+          const results  = t.results || [];
           const statuses = results.map((r) => r.status).filter(Boolean);
-          const errors = results.flatMap((r) =>
+          const errors   = results.flatMap((r) =>
             (r.errors || []).map((e) => e.message || JSON.stringify(e)),
           );
-
           out.push({
             title: specTitle,
-            projectName: t.projectName || '',
             status: statuses.includes('failed')
               ? 'failed'
               : statuses.includes('timedOut')
@@ -44,79 +111,184 @@ function flattenReport(report) {
           });
         }
       }
+      for (const child of suite.suites || []) walkSuite(child, suiteTitle);
     }
 
-    for (const child of suite.suites || []) {
-      walkSuite(child, suiteTitle);
-    }
+    for (const suite of report.suites || []) walkSuite(suite);
+    return out;
+  } catch {
+    return [];
   }
-
-  for (const suite of report.suites || []) {
-    walkSuite(suite);
-  }
-
-  return out;
 }
 
-async function main() {
-  const report = readJson(REPORT_PATH);
-  const tests = flattenReport(report);
+// ── Prompt builders ───────────────────────────────────────────────────────────
 
-  const screenshots = fs.existsSync('qa-output')
-    ? fs.readdirSync('qa-output').filter((f) => f.endsWith('.png'))
-    : [];
+const SYSTEM_PROMPT = `You are a senior frontend QA engineer specialising in calendar UIs.
+You review screenshots of WorksCalendar — a Vite/React embeddable calendar component.
+Be specific: describe exactly what you see, where it is on screen, and how severe it is.
+Use the severity labels: [CRITICAL], [MAJOR], [MINOR], [COSMETIC].`;
 
-  const prompt = `
-You are a senior frontend QA reviewer.
+function batchPrompt(shotNames, testResultsJson) {
+  return `You are reviewing ${shotNames.length} screenshot(s) of WorksCalendar:
+${shotNames.map((n, i) => `  Image ${i + 1}: ${n}`).join('\n')}
 
-You are reviewing Playwright results for WorksCalendar, a Vite/React embeddable calendar demo.
+For each screenshot look for:
+• Layout: overflow, clipping, misalignment, broken grid
+• Pills/events: wrong width, missing, overlapping incorrectly, cross-week clip errors
+• Toolbar/navigation: buttons invisible, misaligned, wrong active state
+• Modals/popovers: off-screen, z-index bleed, missing close button
+• Typography: truncation, overflow, illegible text
+• Responsive: elements too small, touch targets under 44px, horizontal scroll on mobile
+• Accessibility: missing focus rings, low contrast
 
-Return markdown with exactly these sections:
+${testResultsJson ? `Playwright test results (for cross-reference):\n${testResultsJson}\n` : ''}
+Return a markdown list. Each item: severity label, screenshot name, short location, and clear description.
+Example:
+- [MAJOR] 02-week-desktop — toolbar overlaps time-gutter by ~8 px on the left edge`;
+}
 
-# AI QA Notes
+function summaryPrompt(allFindings) {
+  return `You have reviewed all WorksCalendar screenshots. Here are all per-batch findings:
+
+${allFindings}
+
+Now write the final QA report with exactly these sections:
+
+# WorksCalendar Visual QA Report
+
 ## Overall Status
+(one sentence: Ready / Needs work / Broken)
+
 ## Critical Issues
-## Important Issues
-## Cosmetic / Lower Priority
+(show-stoppers — list or "None")
+
+## Major Issues
+(significant but not blocking — list or "None")
+
+## Minor / Cosmetic Issues
+(polish items — list or "None")
+
 ## Likely Root Causes
+(engineering diagnosis — CSS, state, layout engine, etc.)
+
 ## Recommended Next Fixes
+(ordered by impact, actionable, reference file names where possible)
+
 ## Suggested Additional Tests
+(gaps in the current screenshot set)
 
-Be practical and specific.
-Focus on:
-- viewport/layout issues
-- toolbar/nav failures
-- view switching bugs
-- add-event modal issues
-- accessibility or focus issues
-- console/runtime errors
-- likely CSS overflow or state bugs
+Be concise and practical.`;
+}
 
-Test results:
-${JSON.stringify(tests, null, 2)}
+// ── Core logic ────────────────────────────────────────────────────────────────
 
-Screenshots captured:
-${JSON.stringify(screenshots, null, 2)}
-`;
+async function reviewBatch(client, model, shots, testResultsJson) {
+  // Build the content array: [text prompt, image1, image2, ...]
+  const shotNames = shots.map((s) => path.basename(s));
+  const content   = [
+    { type: 'text', text: batchPrompt(shotNames, testResultsJson) },
+    ...shots.map(buildImageContentPart),
+  ];
 
   const response = await client.chat.completions.create({
-    model: process.env.LM_STUDIO_MODEL || 'local-model',
+    model,
     temperature: 0.2,
+    max_tokens: 1024,
     messages: [
-      {
-        role: 'system',
-        content: 'You are an expert QA engineer and frontend debugger.',
-      },
-      {
-        role: 'user',
-        content: prompt,
-      },
+      { role: 'system', content: SYSTEM_PROMPT },
+      { role: 'user',   content },
     ],
   });
 
-  const text = response.choices?.[0]?.message?.content || 'No response returned.';
-  fs.writeFileSync(OUTPUT_PATH, text, 'utf8');
-  console.log(text);
+  return response.choices?.[0]?.message?.content || '(no response)';
+}
+
+async function buildSummary(client, model, allFindings) {
+  const response = await client.chat.completions.create({
+    model,
+    temperature: 0.2,
+    max_tokens: 2048,
+    messages: [
+      { role: 'system', content: SYSTEM_PROMPT },
+      { role: 'user',   content: summaryPrompt(allFindings) },
+    ],
+  });
+  return response.choices?.[0]?.message?.content || '(no response)';
+}
+
+// ── Main ──────────────────────────────────────────────────────────────────────
+
+async function main() {
+  const { client, model } = buildClient();
+
+  // Gather screenshots
+  if (!fs.existsSync(SHOTS_DIR)) {
+    console.error(`Screenshots directory not found: ${SHOTS_DIR}`);
+    console.error('Run "npx playwright test visual-qa" first.');
+    process.exit(1);
+  }
+
+  const shots = fs
+    .readdirSync(SHOTS_DIR)
+    .filter((f) => f.endsWith('.png'))
+    .sort()
+    .map((f) => path.join(SHOTS_DIR, f));
+
+  if (shots.length === 0) {
+    console.error(`No PNG screenshots found in ${SHOTS_DIR}`);
+    process.exit(1);
+  }
+
+  console.log(`Found ${shots.length} screenshot(s). Using model: ${model}`);
+
+  // Load Playwright results for context (optional — won't fail if missing)
+  const testResults    = loadTestResults();
+  const testResultsJson = testResults.length
+    ? JSON.stringify(testResults, null, 2)
+    : null;
+
+  // Process in batches
+  const batches    = [];
+  for (let i = 0; i < shots.length; i += BATCH_SIZE) {
+    batches.push(shots.slice(i, i + BATCH_SIZE));
+  }
+
+  const batchResults = [];
+  for (let i = 0; i < batches.length; i++) {
+    const batch     = batches[i];
+    const batchNums = batch.map((s) => path.basename(s)).join(', ');
+    console.log(`\nBatch ${i + 1}/${batches.length}: ${batchNums}`);
+    try {
+      const result = await reviewBatch(
+        client, model, batch,
+        // Only include test results in the first batch to save tokens
+        i === 0 ? testResultsJson : null,
+      );
+      batchResults.push(`## Batch ${i + 1}: ${batchNums}\n\n${result}`);
+      console.log(result);
+    } catch (err) {
+      const msg = `Error in batch ${i + 1}: ${err.message}`;
+      batchResults.push(`## Batch ${i + 1}: ${batchNums}\n\n_${msg}_`);
+      console.error(msg);
+    }
+  }
+
+  // Build summary from all batch findings
+  console.log('\nBuilding summary report...');
+  let summary;
+  try {
+    summary = await buildSummary(client, model, batchResults.join('\n\n'));
+  } catch (err) {
+    summary = `# WorksCalendar Visual QA Report\n\n_Summary generation failed: ${err.message}_\n\n${batchResults.join('\n\n')}`;
+  }
+
+  // Write output
+  fs.mkdirSync('qa-output', { recursive: true });
+  const timestamp = new Date().toISOString();
+  const output    = `<!-- Generated: ${timestamp} | Model: ${model} -->\n\n${summary}\n\n---\n\n# Raw Batch Findings\n\n${batchResults.join('\n\n')}`;
+  fs.writeFileSync(OUTPUT_PATH, output, 'utf8');
+
+  console.log(`\nReport written to ${OUTPUT_PATH}`);
 }
 
 main().catch((err) => {

--- a/tests-e2e/visual-qa.spec.ts
+++ b/tests-e2e/visual-qa.spec.ts
@@ -1,0 +1,222 @@
+/**
+ * visual-qa.spec.ts
+ *
+ * Screenshot capture for AI visual QA review.
+ * No assertions that can fail — this is a data-collection step.
+ * All screenshots land in qa-output/screenshots/ for ai-qa-review.mjs.
+ *
+ * Run standalone:  npx playwright test visual-qa --config playwright.config.ts
+ * Run full suite:  npm run qa:visual  (capture + AI review)
+ */
+import { test, expect } from '@playwright/test';
+import fs from 'fs';
+import path from 'path';
+
+const SHOTS_DIR = 'qa-output/screenshots';
+
+// Create output dir before any test runs
+test.beforeAll(() => {
+  fs.mkdirSync(SHOTS_DIR, { recursive: true });
+});
+
+async function snap(page, name: string) {
+  await page.screenshot({
+    path: path.join(SHOTS_DIR, `${name}.png`),
+    fullPage: false,
+  });
+}
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+async function waitForCalendar(page) {
+  await expect(page.locator('[role="grid"], [role="table"], .wc-agenda')).toBeVisible({ timeout: 10_000 });
+  // Short settle for animations / async font loads
+  await page.waitForTimeout(400);
+}
+
+async function switchView(page, viewLabel: string) {
+  const btn = page.getByRole('button', { name: new RegExp(viewLabel, 'i') }).first();
+  if (await btn.isVisible()) {
+    await btn.click();
+    await page.waitForTimeout(300);
+  }
+}
+
+// ── Desktop viewport captures ─────────────────────────────────────────────
+
+test.describe('Desktop (1280×900)', () => {
+  test.use({ viewport: { width: 1280, height: 900 } });
+
+  test('month view', async ({ page }) => {
+    await page.goto('/');
+    await waitForCalendar(page);
+    await switchView(page, 'month');
+    await snap(page, '01-month-desktop');
+  });
+
+  test('week view', async ({ page }) => {
+    await page.goto('/');
+    await waitForCalendar(page);
+    await switchView(page, 'week');
+    await snap(page, '02-week-desktop');
+  });
+
+  test('day view', async ({ page }) => {
+    await page.goto('/');
+    await waitForCalendar(page);
+    await switchView(page, 'day');
+    await snap(page, '03-day-desktop');
+  });
+
+  test('agenda view', async ({ page }) => {
+    await page.goto('/');
+    await waitForCalendar(page);
+    await switchView(page, 'agenda');
+    await snap(page, '04-agenda-desktop');
+  });
+
+  test('schedule / timeline view', async ({ page }) => {
+    await page.goto('/');
+    await waitForCalendar(page);
+    await switchView(page, 'schedule');
+    await snap(page, '05-schedule-desktop');
+  });
+
+  test('add-event modal open', async ({ page }) => {
+    await page.goto('/');
+    await waitForCalendar(page);
+    await switchView(page, 'month');
+    // Click the + button or a day cell to open the modal
+    const addBtn = page.getByRole('button', { name: /add event|new event|\+/i }).first();
+    if (await addBtn.isVisible()) {
+      await addBtn.click();
+    } else {
+      // Click a day cell as fallback
+      const cell = page.locator('[data-date]').first();
+      await cell.dblclick().catch(() => cell.click());
+    }
+    await page.waitForTimeout(400);
+    await snap(page, '06-add-event-modal');
+    // Close it
+    await page.keyboard.press('Escape');
+  });
+
+  test('hover card on event', async ({ page }) => {
+    await page.goto('/');
+    await waitForCalendar(page);
+    await switchView(page, 'month');
+    // Hover the first visible event pill
+    const pill = page.locator('[role="button"][class*="eventPill"], [role="button"][class*="spanBar"]').first();
+    if (await pill.isVisible()) {
+      await pill.hover();
+      await page.waitForTimeout(500);
+    }
+    await snap(page, '07-hover-card-desktop');
+  });
+
+  test('filter bar with active filter', async ({ page }) => {
+    await page.goto('/');
+    await waitForCalendar(page);
+    // Click the first filter pill if present
+    const filterPill = page.locator('[class*="filterPill"], [class*="FilterPill"]').first();
+    if (await filterPill.isVisible()) {
+      await filterPill.click();
+      await page.waitForTimeout(300);
+    }
+    await snap(page, '08-filter-active-desktop');
+  });
+
+  test('month view — navigate forward one month', async ({ page }) => {
+    await page.goto('/');
+    await waitForCalendar(page);
+    await switchView(page, 'month');
+    const nextBtn = page.getByRole('button', { name: /next|›|chevron.*right/i }).first();
+    if (await nextBtn.isVisible()) {
+      await nextBtn.click();
+      await page.waitForTimeout(300);
+    }
+    await snap(page, '09-month-next-desktop');
+  });
+
+  test('week view — time grid with events', async ({ page }) => {
+    await page.goto('/');
+    await waitForCalendar(page);
+    await switchView(page, 'week');
+    // Navigate to a week that likely has events
+    const nextBtn = page.getByRole('button', { name: /next|›/i }).first();
+    if (await nextBtn.isVisible()) await nextBtn.click();
+    await page.waitForTimeout(300);
+    await snap(page, '10-week-events-desktop');
+  });
+});
+
+// ── Mobile viewport captures ──────────────────────────────────────────────
+
+test.describe('Mobile (375×812)', () => {
+  test.use({ viewport: { width: 375, height: 812 } });
+
+  test('month view mobile', async ({ page }) => {
+    await page.goto('/');
+    await waitForCalendar(page);
+    await switchView(page, 'month');
+    await snap(page, '11-month-mobile');
+  });
+
+  test('agenda view mobile', async ({ page }) => {
+    await page.goto('/');
+    await waitForCalendar(page);
+    await switchView(page, 'agenda');
+    await snap(page, '12-agenda-mobile');
+  });
+
+  test('week view mobile', async ({ page }) => {
+    await page.goto('/');
+    await waitForCalendar(page);
+    await switchView(page, 'week');
+    await snap(page, '13-week-mobile');
+  });
+});
+
+// ── Tablet viewport captures ──────────────────────────────────────────────
+
+test.describe('Tablet (768×1024)', () => {
+  test.use({ viewport: { width: 768, height: 1024 } });
+
+  test('month view tablet', async ({ page }) => {
+    await page.goto('/');
+    await waitForCalendar(page);
+    await switchView(page, 'month');
+    await snap(page, '14-month-tablet');
+  });
+
+  test('schedule view tablet', async ({ page }) => {
+    await page.goto('/');
+    await waitForCalendar(page);
+    await switchView(page, 'schedule');
+    await snap(page, '15-schedule-tablet');
+  });
+});
+
+// ── Specialised fixture captures ──────────────────────────────────────────
+
+test.describe('Fixtures', () => {
+  test.use({ viewport: { width: 1280, height: 900 } });
+
+  test('pill span matrix', async ({ page }) => {
+    await page.goto('/pill-span-matrix-fixture.html');
+    await waitForCalendar(page);
+    await snap(page, '16-pill-span-matrix');
+  });
+
+  test('regression bugs fixture', async ({ page }) => {
+    await page.goto('/regression-bugs.html');
+    await page.waitForTimeout(600);
+    await snap(page, '17-regression-bugs');
+  });
+
+  test('on-call span fixture', async ({ page }) => {
+    await page.goto('/oncall-span-fixture.html');
+    await waitForCalendar(page);
+    await snap(page, '18-oncall-span');
+  });
+});


### PR DESCRIPTION
- Add tests-e2e/visual-qa.spec.ts: 18 screenshot captures across desktop, mobile, and tablet viewports for all calendar views, modals, hover cards, filter states, and fixture pages — no failing assertions (data-collection only)
- Rewrite scripts/ai-qa-review.mjs: base64-encodes screenshots and sends them to a vision-capable LLM (Qwen2-VL via Ollama default, DashScope via DASHSCOPE_API_KEY, or generic OpenAI-compatible endpoint) in batches of 5, then generates a structured severity-labelled report at qa-output/visual-review.md
- Add qa:visual npm script to run the visual-qa spec then the AI review in sequence

https://claude.ai/code/session_01E3nEyCMUbkVBZmwzuSGtK4