### PR TITLE
Return engine-authoritative event payloads to save callbacks

### DIFF
--- a/src/WorksCalendar.tsx
+++ b/src/WorksCalendar.tsx
@@ -27,7 +27,7 @@ import { normalizeEvents }    from './core/eventModel.js';
 import { CalendarEngine }     from './core/engine/CalendarEngine.ts';
 import { UndoRedoManager }   from './core/engine/UndoRedoManager.ts';
 import { fromLegacyEvents }   from './core/engine/adapters/fromLegacyEvents.ts';
-import { occurrenceToLegacy } from './core/engine/adapters/toLegacyEvents.ts';
+import { occurrenceToLegacy, toLegacyEvent } from './core/engine/adapters/toLegacyEvents.ts';
 import { validateOperation } from './core/engine/validation/validateOperation.ts';
 import RecurringScopeDialog   from './ui/RecurringScopeDialog.jsx';
 import { applyFilters, getCategories, getResources } from './filters/filterEngine.js';
@@ -590,6 +590,16 @@ export const WorksCalendar = forwardRef<CalendarApi, WorksCalendarProps>(functio
     onEventClickProp?.(ev);
   }, [onEventClickProp]);
 
+  const getSavedEventPayload = useCallback((eventId, fallbackEvent = null, fallbackPatch = null) => {
+    const normalizedId = eventId == null ? '' : String(eventId);
+    if (normalizedId) {
+      const saved = engineRef.current.state.events.get(normalizedId);
+      if (saved) return toLegacyEvent(saved);
+    }
+    if (!fallbackEvent) return null;
+    return fallbackPatch ? { ...fallbackEvent, ...fallbackPatch } : fallbackEvent;
+  }, []);
+
   const handleShiftStatusChange = useCallback((ev, status) => {
     const eventId = ev._eventId ?? String(ev.id);
     if (!eventId) return;
@@ -603,7 +613,10 @@ export const WorksCalendar = forwardRef<CalendarApi, WorksCalendarProps>(functio
     }
     applyEngineOp(
       { type: 'update', id: eventId, patch: { meta: newMeta }, source: 'api' },
-      () => onEventSave?.(ev),
+      () => {
+        const savedPayload = getSavedEventPayload(eventId, ev, { meta: newMeta });
+        if (savedPayload) onEventSave?.(savedPayload);
+      },
     );
 
     if (!status) {
@@ -631,7 +644,7 @@ export const WorksCalendar = forwardRef<CalendarApi, WorksCalendarProps>(functio
         applyEngineOp({ type: 'delete', id: coverId, source: 'api' }, () => {});
       });
     }
-  }, [applyEngineOp, expandedEvents, onEventSave]);
+  }, [applyEngineOp, expandedEvents, getSavedEventPayload, onEventSave]);
 
   const handleCoverageAssign = useCallback((ev, coveringEmployeeId) => {
     const eventId = ev._eventId ?? String(ev.id);
@@ -641,7 +654,10 @@ export const WorksCalendar = forwardRef<CalendarApi, WorksCalendarProps>(functio
     const newMeta = { ...(ev.meta ?? {}), coveredBy: coveringEmployeeId };
     applyEngineOp(
       { type: 'update', id: eventId, patch: { meta: newMeta }, source: 'api' },
-      () => onEventSave?.(ev),
+      () => {
+        const savedPayload = getSavedEventPayload(eventId, ev, { meta: newMeta });
+        if (savedPayload) onEventSave?.(savedPayload);
+      },
     );
 
     // 2. If there is a linked open-shift record, mark it as covered too
@@ -698,7 +714,7 @@ export const WorksCalendar = forwardRef<CalendarApi, WorksCalendarProps>(functio
         () => {},
       );
     }
-  }, [applyEngineOp, onEventSave, expandedEvents, ownerCfg.config?.onCallCategory]);
+  }, [applyEngineOp, getSavedEventPayload, onEventSave, expandedEvents, ownerCfg.config?.onCallCategory]);
 
   /**
    * Handle employee action card clicks.
@@ -739,10 +755,13 @@ export const WorksCalendar = forwardRef<CalendarApi, WorksCalendarProps>(functio
     const existingAvailability = expandedEvents.find(
       (ev) => String(ev._eventId ?? ev.id) === String(availEv.id),
     );
+    const availabilityId = existingAvailability
+      ? String(existingAvailability._eventId ?? existingAvailability.id)
+      : String(availEv.id ?? `avail-${Date.now()}`);
     const saveOp = existingAvailability
       ? {
         type: 'update',
-        id: String(existingAvailability._eventId ?? existingAvailability.id),
+        id: availabilityId,
         patch: {
           title: availEv.title,
           start: availEv.start,
@@ -756,10 +775,13 @@ export const WorksCalendar = forwardRef<CalendarApi, WorksCalendarProps>(functio
         },
         source: 'api',
       }
-      : { type: 'create', event: { ...availEv, id: availEv.id ?? `avail-${Date.now()}` }, source: 'api' };
+      : { type: 'create', event: { ...availEv, id: availabilityId }, source: 'api' };
 
     // 1. Create or update the availability event itself
-    applyEngineOp(saveOp, () => onAvailabilitySave?.(availEv));
+    applyEngineOp(saveOp, () => {
+      const savedPayload = getSavedEventPayload(availabilityId, availEv, { id: availabilityId });
+      if (savedPayload) onAvailabilitySave?.(savedPayload);
+    });
 
     // 2. Detect overlapping shifts and auto-create open-shift records
     const isLeave = availEv.kind === 'pto' || availEv.kind === 'unavailable';
@@ -826,19 +848,23 @@ export const WorksCalendar = forwardRef<CalendarApi, WorksCalendarProps>(functio
     }
 
     setAvailabilityState(null);
-  }, [applyEngineOp, onAvailabilitySave, expandedEvents, ownerCfg.config?.onCallCategory]);
+  }, [applyEngineOp, getSavedEventPayload, onAvailabilitySave, expandedEvents, ownerCfg.config?.onCallCategory]);
 
   /** Save one or more shift events (from ScheduleEditorForm) through the engine. */
   const handleScheduleEditorSave = useCallback((shiftEvOrArr) => {
     const events = Array.isArray(shiftEvOrArr) ? shiftEvOrArr : [shiftEvOrArr];
-    events.forEach(ev => {
+    events.forEach((ev, index) => {
+      const scheduleId = String(ev.id ?? `shift-${Date.now()}-${index}`);
       applyEngineOp(
-        { type: 'create', event: { ...ev, id: ev.id ?? `shift-${Date.now()}` }, source: 'api' },
-        () => onScheduleSave?.(ev),
+        { type: 'create', event: { ...ev, id: scheduleId }, source: 'api' },
+        () => {
+          const savedPayload = getSavedEventPayload(scheduleId, ev, { id: scheduleId });
+          if (savedPayload) onScheduleSave?.(savedPayload);
+        },
       );
     });
     setScheduleEditorState(null);
-  }, [applyEngineOp, onScheduleSave]);
+  }, [applyEngineOp, getSavedEventPayload, onScheduleSave]);
 
   // All handlers run through applyEngineOp before touching host state.
 
@@ -876,9 +902,11 @@ export const WorksCalendar = forwardRef<CalendarApi, WorksCalendarProps>(functio
 
     if (!eventId) {
       // New event — no scope picker needed.
+      const createdId = String(rawEv.id ?? `event-${Date.now()}`);
       const op = {
         type:  'create',
         event: {
+          id:         createdId,
           title:      rawEv.title      ?? '(untitled)',
           start:      newStart,
           end:        newEnd,
@@ -892,7 +920,11 @@ export const WorksCalendar = forwardRef<CalendarApi, WorksCalendarProps>(functio
         },
         source: 'form',
       };
-      applyEngineOp(op, () => { onEventSave?.(rawEv); setFormEvent(null); });
+      applyEngineOp(op, () => {
+        const savedPayload = getSavedEventPayload(createdId, rawEv, { id: createdId });
+        if (savedPayload) onEventSave?.(savedPayload);
+        setFormEvent(null);
+      });
       return;
     }
 
@@ -915,10 +947,14 @@ export const WorksCalendar = forwardRef<CalendarApi, WorksCalendarProps>(functio
         },
         source: 'form',
       }),
-      () => { onEventSave?.(rawEv); setFormEvent(null); },
+      () => {
+        const savedPayload = getSavedEventPayload(eventId, rawEv);
+        if (savedPayload) onEventSave?.(savedPayload);
+        setFormEvent(null);
+      },
       'Edit',
     );
-  }, [applyEngineOp, applyWithRecurringCheck, onEventSave]);
+  }, [applyEngineOp, applyWithRecurringCheck, getSavedEventPayload, onEventSave]);
 
   const handleEventMove = useCallback((ev, newStart, newEnd) => {
     const raw = ev._raw ?? ev;
@@ -928,11 +964,14 @@ export const WorksCalendar = forwardRef<CalendarApi, WorksCalendarProps>(functio
       (scope) => ({ type: 'move', id, newStart, newEnd, source: 'drag' }),
       () => {
         if (onEventMove) onEventMove(ev, newStart, newEnd);
-        else onEventSave?.({ ...raw, start: newStart, end: newEnd });
+        else {
+          const savedPayload = getSavedEventPayload(id, raw, { start: newStart, end: newEnd });
+          if (savedPayload) onEventSave?.(savedPayload);
+        }
       },
       'Move',
     );
-  }, [applyWithRecurringCheck, onEventMove, onEventSave]);
+  }, [applyWithRecurringCheck, getSavedEventPayload, onEventMove, onEventSave]);
 
   const handleEventResize = useCallback((ev, newStart, newEnd) => {
     const raw = ev._raw ?? ev;
@@ -942,11 +981,14 @@ export const WorksCalendar = forwardRef<CalendarApi, WorksCalendarProps>(functio
       (scope) => ({ type: 'resize', id, newStart, newEnd, source: 'resize' }),
       () => {
         if (onEventResize) onEventResize(ev, newStart, newEnd);
-        else onEventSave?.({ ...raw, start: newStart, end: newEnd });
+        else {
+          const savedPayload = getSavedEventPayload(id, raw, { start: newStart, end: newEnd });
+          if (savedPayload) onEventSave?.(savedPayload);
+        }
       },
       'Resize',
     );
-  }, [applyWithRecurringCheck, onEventResize, onEventSave]);
+  }, [applyWithRecurringCheck, getSavedEventPayload, onEventResize, onEventSave]);
 
   const handleEventDelete = useCallback((id) => {
     // Find the event so we can check if it's recurring.
@@ -1011,12 +1053,14 @@ export const WorksCalendar = forwardRef<CalendarApi, WorksCalendarProps>(functio
       return;
     }
 
-    result.generated.forEach((ev) => {
+    result.generated.forEach((ev, index) => {
       const start = ev.start instanceof Date ? ev.start : new Date(ev.start);
       const end = ev.end instanceof Date ? ev.end : new Date(ev.end);
+      const templateEventId = String(ev.id ?? `template-${template.id}-${Date.now()}-${index}`);
       applyEngineOp({
         type: 'create',
         event: {
+          id: templateEventId,
           title: ev.title ?? '(untitled)',
           start,
           end,
@@ -1030,7 +1074,10 @@ export const WorksCalendar = forwardRef<CalendarApi, WorksCalendarProps>(functio
           meta: ev.meta ?? {},
         },
         source: 'template',
-      }, () => onEventSave?.(ev));
+      }, () => {
+        const savedPayload = getSavedEventPayload(templateEventId, ev, { id: templateEventId });
+        if (savedPayload) onEventSave?.(savedPayload);
+      });
     });
     trackScheduleTemplateAnalytics('schedule_instantiate_succeeded', {
       templateId: template.id,
@@ -1038,7 +1085,7 @@ export const WorksCalendar = forwardRef<CalendarApi, WorksCalendarProps>(functio
       elapsedMs: Date.now() - startedAt,
     });
     setScheduleOpen(false);
-  }, [applyEngineOp, onEventSave, resolvedScheduleLimits.createMax, trackScheduleTemplateAnalytics, visibleScheduleTemplates]);
+  }, [applyEngineOp, getSavedEventPayload, onEventSave, resolvedScheduleLimits.createMax, trackScheduleTemplateAnalytics, visibleScheduleTemplates]);
 
   const buildSchedulePreview = useCallback((request) => {
     const startedAt = Date.now();
@@ -1158,10 +1205,11 @@ export const WorksCalendar = forwardRef<CalendarApi, WorksCalendarProps>(functio
       patch:  { title: patch.title, color: patch.color, meta: patch.meta },
       source: 'inline-edit',
     }, () => {
-      onEventSave?.({ ...ev, ...patch });
+      const savedPayload = getSavedEventPayload(eventId, ev, patch);
+      if (savedPayload) onEventSave?.(savedPayload);
       setInlineEditTarget(null);
     });
-  }, [inlineEditTarget, applyEngineOp, onEventSave]);
+  }, [inlineEditTarget, applyEngineOp, getSavedEventPayload, onEventSave]);
 
   // ── Context value ────────────────────────────────────────────────────────
   const ctxValue = useMemo(() => ({


### PR DESCRIPTION
### Motivation
- Schedule and availability mutation callbacks were sometimes invoked with the pre-mutation (stale) event objects, causing backend/UI drift and metadata not persisting correctly.
- Ensure host callbacks always receive the engine-persisted event shape (including updated `meta` like `shiftStatus` / `coveredBy`) after an accepted mutation.

### Description
- Added `getSavedEventPayload` helper that reads the authoritative event from `engineRef.current.state.events` and converts it to the legacy shape via `toLegacyEvent`, falling back to merged/fallback data when necessary.
- Updated schedule-related handlers (`handleShiftStatusChange`, `handleCoverageAssign`, `handleAvailabilitySave`) to call `onEventSave` / `onAvailabilitySave` with the saved engine payload after the `applyEngineOp` acceptance callback.
- Assigned deterministic IDs for created schedule/availability/template events (`handleScheduleEditorSave`, schedule template instantiation, and new-event form path) so the created record can be looked up immediately after the engine mutation and passed to callbacks.
- Hardened additional `onEventSave` paths (form create/update, move/resize fallback paths, and `handleInlineSave`) to use the post-mutation payload from the engine instead of the pre-mutation object.

### Testing
- Ran `npm test` which executes the Vitest suite; tests executed and the suite reported all tests passing but the run exited with an unhandled exception (`ReferenceError: window is not defined` in `ScreenReaderAnnouncer`), causing the run to surface an error (35 test files, 608 tests passed, 1 todo).
- Attempted `npm test -- --runInBand` which failed due to Vitest not recognizing the `--runInBand` flag in this setup.
- `npm run build` (Vite build) completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de20359854832ca2461c7153cfc1fa)