### PR TITLE
Consolidate timeline shift quick-actions into employee-driven workflow

### DIFF
--- a/src/WorksCalendar.tsx
+++ b/src/WorksCalendar.tsx
@@ -706,8 +706,13 @@ export const WorksCalendar = forwardRef<CalendarApi, WorksCalendarProps>(functio
    * - 'schedule' → opens ScheduleEditorForm
    * All actions also bubble to the external onEmployeeAction prop.
    */
-  const handleEmployeeAction = useCallback((empId, action) => {
+  const handleEmployeeAction = useCallback((empId, actionInput) => {
     const emp = employees.find(e => String(e.id) === String(empId)) ?? { id: empId, name: empId };
+    const actionPayload = typeof actionInput === 'string'
+      ? { type: actionInput }
+      : (actionInput ?? {});
+    const action = actionPayload.type;
+    if (!action) return;
     const AVAILABILITY_ACTIONS = new Set(['pto', 'unavailable', 'availability']);
     if (AVAILABILITY_ACTIONS.has(action)) {
       const initialEvent = action === 'availability'
@@ -724,12 +729,23 @@ export const WorksCalendar = forwardRef<CalendarApi, WorksCalendarProps>(functio
             return bStart - aStart;
           })
           .map((ev) => ({ ...ev, id: ev?._eventId ?? ev?.id }))[0] ?? null
+        : actionPayload.sourceShift
+          ? {
+            title: action === 'pto' ? 'PTO' : 'Unavailable',
+            start: actionPayload.sourceShift.start,
+            end: actionPayload.sourceShift.end,
+            allDay: actionPayload.sourceShift.allDay ?? true,
+            meta: actionPayload.sourceShift.meta ?? {},
+          }
         : null;
-      setAvailabilityState({ emp, kind: action, start: new Date(), initialEvent });
+      const initialStart = actionPayload.sourceShift?.start
+        ? new Date(actionPayload.sourceShift.start)
+        : new Date();
+      setAvailabilityState({ emp, kind: action, start: initialStart, initialEvent });
     } else if (action === 'schedule') {
       setScheduleEditorState({ emp, start: new Date() });
     }
-    onEmployeeAction?.(empId, action);
+    onEmployeeAction?.(empId, actionInput);
   }, [employees, expandedEvents, onEmployeeAction]);
 
   /** Save an availability/PTO event through the engine then notify the host.

--- a/src/views/TimelineView.jsx
+++ b/src/views/TimelineView.jsx
@@ -116,6 +116,12 @@ export default function TimelineView({
   const shiftMenuRef = useRef(null);
   const coverMenuRef = useRef(null);
 
+  const triggerEmployeeAction = useCallback((empId, action, options = {}) => {
+    if (!onEmployeeAction) return false;
+    onEmployeeAction(empId, typeof action === 'string' ? { type: action, ...options } : action);
+    return true;
+  }, [onEmployeeAction]);
+
   const anyMenuOpen = !!(shiftMenu || coverMenu);
   useEffect(() => {
     if (!anyMenuOpen) return;
@@ -748,10 +754,32 @@ export default function TimelineView({
           className={styles.shiftMenu}
           style={{ top: shiftMenu.rect.bottom + 4, left: shiftMenu.rect.left }}
         >
-          <button className={styles.shiftMenuItem} onClick={() => { onShiftStatusChange?.(shiftMenu.ev, 'pto'); setShiftMenu(null); }}>
+          <button
+            className={styles.shiftMenuItem}
+            onClick={() => {
+              const handled = triggerEmployeeAction(
+                shiftMenu.ev.resource ?? shiftMenu.ev.employeeId,
+                'pto',
+                { source: 'shift-quick-action', sourceShift: shiftMenu.ev },
+              );
+              if (!handled) onShiftStatusChange?.(shiftMenu.ev, 'pto');
+              setShiftMenu(null);
+            }}
+          >
             🏖 Mark as PTO
           </button>
-          <button className={styles.shiftMenuItem} onClick={() => { onShiftStatusChange?.(shiftMenu.ev, 'unavailable'); setShiftMenu(null); }}>
+          <button
+            className={styles.shiftMenuItem}
+            onClick={() => {
+              const handled = triggerEmployeeAction(
+                shiftMenu.ev.resource ?? shiftMenu.ev.employeeId,
+                'unavailable',
+                { source: 'shift-quick-action', sourceShift: shiftMenu.ev },
+              );
+              if (!handled) onShiftStatusChange?.(shiftMenu.ev, 'unavailable');
+              setShiftMenu(null);
+            }}
+          >
             🚫 Mark as Unavailable
           </button>
           {shiftMenu.ev.meta?.shiftStatus && (


### PR DESCRIPTION
### Motivation
- Reduce workflow drift by making the Employee Action Card the primary entrypoint for PTO / unavailable / availability flows while keeping the old shift end-cap/status menu as an optional quick action.
- Ensure all schedule actions share the same underlying logic so host callbacks and UI flows behave consistently.

### Description
- Added `triggerEmployeeAction` in `src/views/TimelineView.jsx` and routed the timeline shift end-cap quick-action buttons (`Mark as PTO` / `Mark as Unavailable`) through it so they dispatch the same structured action payloads as the row-header EmployeeActionCard.
- Updated `src/WorksCalendar.tsx` `handleEmployeeAction` to accept structured action payloads (object or string), prefill `AvailabilityForm` when actions originate from a source shift, and bubble the original payload back to the external `onEmployeeAction` prop.
- Preserved legacy direct-mutation fallback by calling `onShiftStatusChange` when no `onEmployeeAction` handler is present, and left the existing "Clear Status" path untouched.
- Files changed: `src/views/TimelineView.jsx`, `src/WorksCalendar.tsx`.

### Testing
- Ran `npm test -- --runInBand`, which failed due to an invalid Vitest flag (unknown `--runInBand`).
- Ran `npm test`, which reported the test suite executed (35 test files; tests passed) but Vitest surfaced an unrelated unhandled async error (`ReferenceError: window is not defined` in `ScreenReaderAnnouncer`) during teardown; test assertions themselves completed successfully but the run reported an error.
- Ran `npm run build`, which completed successfully and produced a working production bundle.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de20ab175c832c8a3cd3dbfa5a42f3)