### PR TITLE
Harden schedule and availability forms

### DIFF
--- a/src/__tests__/WorksCalendar.scheduleWorkflow.test.jsx
+++ b/src/__tests__/WorksCalendar.scheduleWorkflow.test.jsx
@@ -25,7 +25,7 @@ describe('WorksCalendar schedule workflow entry points', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Schedule' }));
     fireEvent.click(await screen.findByRole('gridcell', { name: /^Alex Rivera, April 1, empty/ }));
 
-    expect(await screen.findByRole('dialog', { name: 'Add schedule for Alex Rivera' })).toBeInTheDocument();
+    expect(await screen.findByRole('dialog', { name: 'Create schedule for Alex Rivera' })).toBeInTheDocument();
     expect(screen.queryByRole('dialog', { name: 'Add event' })).not.toBeInTheDocument();
   });
 

--- a/src/ui/AvailabilityForm.jsx
+++ b/src/ui/AvailabilityForm.jsx
@@ -34,14 +34,20 @@ const INTENT_META = {
   pto: {
     heading: 'Request PTO',
     submitLabel: 'Save PTO Request',
+    allDayLocked: true,
+    allDayHelp: 'PTO is tracked as all-day blocks from this action.',
   },
   unavailable: {
     heading: 'Mark Unavailable',
     submitLabel: 'Save Unavailable Time',
+    allDayLocked: true,
+    allDayHelp: 'Unavailable time from this action is all-day only.',
   },
   availability: {
-    heading: 'Edit Availability',
+    heading: 'Set Availability',
     submitLabel: 'Save Availability',
+    allDayLocked: false,
+    allDayHelp: null,
   },
 };
 
@@ -83,15 +89,21 @@ export default function AvailabilityForm({ emp, kind: initialKind, initialStart,
   const meta = KIND_META[kind] ?? KIND_META.pto;
   const isEdit = Boolean(initialEvent?.id);
   const intentMeta = INTENT_META[kind] ?? INTENT_META.pto;
+  const isAllDayLocked = Boolean(intentMeta.allDayLocked && !isEdit);
+  const heading = isEdit && kind === 'availability' ? 'Edit Availability' : intentMeta.heading;
 
   const eventStart = initialEvent?.start ?? initialStart;
   const startDefault = eventStart ?? new Date();
   const endDefault   = initialEvent?.end ?? new Date(startDefault.getTime() + (meta.allDayDefault ? 24 * 60 * 60 * 1000 : 60 * 60 * 1000));
+  const initialAllDay = isAllDayLocked ? true : (initialEvent?.allDay ?? meta.allDayDefault);
+  const initialTitle = kind === 'availability'
+    ? (initialEvent?.title ?? meta.defaultTitle)
+    : meta.defaultTitle;
 
-  const [allDay, setAllDay] = useState(initialEvent?.allDay ?? meta.allDayDefault);
-  const [title,  setTitle]  = useState(initialEvent?.title ?? meta.defaultTitle);
-  const [start,  setStart]  = useState(toDateInput(startDefault, initialEvent?.allDay ?? meta.allDayDefault));
-  const [end,    setEnd]    = useState(toDateInput(endDefault,   initialEvent?.allDay ?? meta.allDayDefault));
+  const [allDay, setAllDay] = useState(initialAllDay);
+  const [title,  setTitle]  = useState(initialTitle);
+  const [start,  setStart]  = useState(toDateInput(startDefault, initialAllDay));
+  const [end,    setEnd]    = useState(toDateInput(endDefault, initialAllDay));
   const [notes,  setNotes]  = useState(initialEvent?.meta?.notes ?? '');
   const [errors, setErrors] = useState({});
 
@@ -102,7 +114,9 @@ export default function AvailabilityForm({ emp, kind: initialKind, initialStart,
     if (!end)           errs.end   = 'End date is required';
     const s = fromInput(start, allDay);
     const e = fromInput(end, allDay);
-    if (s && e && s > e) errs.end = 'End must be after start';
+    if (start && !s) errs.start = `Enter a valid ${allDay ? 'start date' : 'start date/time'}`;
+    if (end && !e) errs.end = `Enter a valid ${allDay ? 'end date' : 'end date/time'}`;
+    if (s && e && s >= e) errs.end = 'End must be after start';
     setErrors(errs);
     return Object.keys(errs).length === 0;
   }
@@ -138,12 +152,12 @@ export default function AvailabilityForm({ emp, kind: initialKind, initialStart,
         className={styles.modal}
         role="dialog"
         aria-modal="true"
-        aria-label={`${intentMeta.heading} for ${emp.name}`}
+        aria-label={`${heading} for ${emp.name}`}
       >
         {/* Header */}
         <div className={styles.header}>
           <div className={styles.headerInfo}>
-            <h2 className={styles.title}>{intentMeta.heading}</h2>
+            <h2 className={styles.title}>{heading}</h2>
             <span className={styles.empName}>{emp.name}{emp.role ? ` · ${emp.role}` : ''}</span>
           </div>
           <button className={styles.closeBtn} onClick={onClose} aria-label="Close">
@@ -173,6 +187,7 @@ export default function AvailabilityForm({ emp, kind: initialKind, initialStart,
             <input
               type="checkbox"
               checked={allDay}
+              disabled={isAllDayLocked}
               onChange={e => {
                 const next = e.target.checked;
                 setAllDay(next);
@@ -185,6 +200,9 @@ export default function AvailabilityForm({ emp, kind: initialKind, initialStart,
             />
             All day
           </label>
+          {isAllDayLocked && intentMeta.allDayHelp && (
+            <span className={styles.helperText}>{intentMeta.allDayHelp}</span>
+          )}
 
           {/* Start / End */}
           <div className={styles.row2}>
@@ -244,7 +262,9 @@ export default function AvailabilityForm({ emp, kind: initialKind, initialStart,
           {/* Actions */}
           <div className={styles.actions}>
             <button type="button" className={styles.btnCancel} onClick={onClose}>Cancel</button>
-            <button type="submit" className={styles.btnSave}>{isEdit && kind === 'availability' ? 'Save Availability Changes' : intentMeta.submitLabel}</button>
+            <button type="submit" className={styles.btnSave}>
+              {isEdit && kind === 'availability' ? 'Save Availability Changes' : intentMeta.submitLabel}
+            </button>
           </div>
         </form>
       </div>

--- a/src/ui/ScheduleEditorForm.jsx
+++ b/src/ui/ScheduleEditorForm.jsx
@@ -114,15 +114,32 @@ export default function ScheduleEditorForm({
 
   const selectedTemplate = SHIFT_TEMPLATES.find(t => t.id === templateId) ?? SHIFT_TEMPLATES[0];
 
+  function validateDateRange(startStr, endStr) {
+    const s = fromInput(startStr, false);
+    const e = fromInput(endStr, false);
+    if (!s || !e) return { isValid: false, message: 'Enter valid start and end date/times' };
+    if (e <= s) return { isValid: false, message: 'End must be after start' };
+    return { isValid: true, message: '' };
+  }
+
   function validate() {
     const errs = {};
     if (!title.trim()) errs.title = 'Title is required';
-    if (!start)        errs.start = 'Start is required';
+    if (!start) {
+      errs.start = 'Start is required';
+    } else if (!fromInput(start, false)) {
+      errs.start = 'Enter a valid start date/time';
+    }
+
     if (mode !== 'template') {
-      if (!end) errs.end = 'End is required';
-      const s = fromInput(start, false);
-      const e = fromInput(end, false);
-      if (s && e && s >= e) errs.end = 'End must be after start';
+      if (!end) {
+        errs.end = 'End is required';
+      } else if (!fromInput(end, false)) {
+        errs.end = 'Enter a valid end date/time';
+      } else {
+        const { isValid, message } = validateDateRange(start, end);
+        if (!isValid) errs.end = message;
+      }
     }
     if (mode === 'recurring' && rrulePreset === 'custom' && !customRrule.trim()) {
       errs.rrule = 'Enter a valid RRULE string';
@@ -191,12 +208,12 @@ export default function ScheduleEditorForm({
         className={styles.modal}
         role="dialog"
         aria-modal="true"
-        aria-label={`Add schedule for ${emp.name}`}
+        aria-label={`Create schedule for ${emp.name}`}
       >
         {/* Header */}
         <div className={styles.header}>
           <div className={styles.headerInfo}>
-            <h2 className={styles.title}>Add Schedule</h2>
+            <h2 className={styles.title}>Create Shift Schedule</h2>
             <span className={styles.empName}>{emp.name}{emp.role ? ` · ${emp.role}` : ''}</span>
           </div>
           <button className={styles.closeBtn} onClick={onClose} aria-label="Close">
@@ -332,7 +349,7 @@ export default function ScheduleEditorForm({
             <button type="submit" className={styles.btnSave}>
               {mode === 'template' && selectedTemplate.id === '7on7off'
                 ? 'Create 7-Day Block'
-                : 'Add Shift'}
+                : 'Create Shift'}
             </button>
           </div>
         </form>


### PR DESCRIPTION
### Motivation
- Make forms safer and more intentional by reducing optimistic behavior, clarifying create vs edit intent, and enforcing stricter start/end validation. 
- Ensure availability actions (PTO / unavailable / availability) default and lock sensible fields based on the entry intent so employee actions feel deliberate.

### Description
- Tightened `ScheduleEditorForm` validation by adding `validateDateRange` and explicit checks to reject malformed start/end inputs and enforce `end > start`. 
- Updated `ScheduleEditorForm` copy to reflect a create-focused flow (`aria-label`, dialog title, and submit label changed to "Create…" variants). 
- Strengthened `AvailabilityForm` defaults and UX so PTO/unavailable entry defaults to all-day and can lock the all-day toggle for non-edit flows, and availability editing preserves an "Edit Availability" heading; also tightened date/date-time validation. 
- Updated the schedule workflow test (`src/__tests__/WorksCalendar.scheduleWorkflow.test.jsx`) to match the new dialog labeling.

### Testing
- Attempted `npm test -- --runInBand`, which failed due to an unsupported Vitest CLI flag. 
- Ran `npm test`, which completed successfully with all unit tests passing: 35 test files, 608 tests passed and 1 todo.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de21024b38832c908bcaa962730f23)