### PR TITLE
Saved views: versioned storage, migrations, and validation

### DIFF
--- a/src/hooks/__tests__/useSavedViews.test.js
+++ b/src/hooks/__tests__/useSavedViews.test.js
@@ -197,8 +197,9 @@ describe('useSavedViews', () => {
       });
     });
     const stored = JSON.parse(localStorage.getItem(`wc-saved-views-${CAL_ID}`));
-    expect(stored).toHaveLength(1);
-    expect(stored[0].name).toBe('Persisted');
+    expect(stored.version).toBe(2);
+    expect(stored.views).toHaveLength(1);
+    expect(stored.views[0].name).toBe('Persisted');
   });
 
   it('loads existing views from localStorage on init', () => {
@@ -210,10 +211,28 @@ describe('useSavedViews', () => {
         filters:   { categories: ['PTO'], resources: [], sources: [], search: '', dateRange: null },
       },
     ];
-    localStorage.setItem(`wc-saved-views-${CAL_ID}`, JSON.stringify(existingViews));
+    localStorage.setItem(`wc-saved-views-${CAL_ID}`, JSON.stringify({
+      version: 2,
+      views: existingViews,
+    }));
     const { result } = renderHook(() => useSavedViews(CAL_ID));
     expect(result.current.views).toHaveLength(1);
     expect(result.current.views[0].name).toBe('Stored View');
+  });
+
+  it('migrates old array-only saved views payload', () => {
+    const existingViews = [
+      {
+        id: 'v-old',
+        name: 'Old Shape',
+        createdAt: new Date().toISOString(),
+        filters: { categories: [], resources: [], sources: [], search: '', dateRange: null },
+      },
+    ];
+    localStorage.setItem(`wc-saved-views-${CAL_ID}`, JSON.stringify(existingViews));
+    const { result } = renderHook(() => useSavedViews(CAL_ID));
+    expect(result.current.views).toHaveLength(1);
+    expect(result.current.views[0].name).toBe('Old Shape');
   });
 
   it('calendarId switching reloads from correct localStorage key', () => {
@@ -304,5 +323,18 @@ describe('useSavedViews', () => {
     expect(result.current.views[0].name).toBe('Old Profile');
     expect(result.current.views[0].color).toBe('#3b82f6');
     expect(result.current.views[0].view).toBe('week');
+  });
+});
+
+describe('deserializeFilters dateRange validation', () => {
+  it('nulls malformed dateRange objects', () => {
+    const filters = deserializeFilters({
+      categories: [],
+      resources: [],
+      sources: [],
+      search: '',
+      dateRange: { start: 'not-a-date', end: '2026-04-30T00:00:00.000Z' },
+    });
+    expect(filters.dateRange).toBeNull();
   });
 });

--- a/src/hooks/useSavedViews.js
+++ b/src/hooks/useSavedViews.js
@@ -15,6 +15,53 @@
 import { useState, useEffect, useCallback } from 'react';
 
 function viewsKey(calendarId) { return `wc-saved-views-${calendarId}`; }
+const STORAGE_VERSION = 2;
+
+function isValidDate(value) {
+  const date = new Date(value);
+  return !Number.isNaN(date.getTime());
+}
+
+function normalizeSavedView(view) {
+  if (!view || typeof view !== 'object') return null;
+  if (typeof view.id !== 'string' || typeof view.name !== 'string') return null;
+  if (!view.filters || typeof view.filters !== 'object') return null;
+
+  return {
+    id:        view.id,
+    name:      view.name,
+    createdAt: typeof view.createdAt === 'string' ? view.createdAt : new Date().toISOString(),
+    color:     view.color ?? null,
+    view:      view.view ?? null,
+    filters:   view.filters,
+  };
+}
+
+function normalizeViews(views) {
+  if (!Array.isArray(views)) return [];
+  return views.map(normalizeSavedView).filter(Boolean);
+}
+
+function migrateSavedViewsPayload(payload, calendarId) {
+  if (Array.isArray(payload)) {
+    // v1 shape: direct array
+    return normalizeViews(payload);
+  }
+
+  if (payload && typeof payload === 'object') {
+    if (payload.version === STORAGE_VERSION) {
+      return normalizeViews(payload.views);
+    }
+
+    // Future explicit migration path by version number.
+    if (typeof payload.version === 'number' && payload.version > STORAGE_VERSION) {
+      return [];
+    }
+  }
+
+  // One-time migration from legacy wc-profiles-* key
+  return migrateProfiles(calendarId);
+}
 
 function migrateProfiles(calendarId) {
   try {
@@ -23,31 +70,37 @@ function migrateProfiles(calendarId) {
     if (!raw) return [];
     const profiles = JSON.parse(raw);
     // Convert profile shape to saved view shape
-    return profiles.map(p => ({
+    return normalizeViews(profiles.map(p => ({
       id:        p.id,
       name:      p.name,
       createdAt: p.createdAt ?? new Date().toISOString(),
       color:     p.color ?? null,
       view:      p.view ?? null,
       filters:   p.filters, // already serialized (arrays, not Sets)
-    }));
+    })));
   } catch { return []; }
 }
 
 function loadViews(calendarId) {
   try {
     const raw = localStorage.getItem(viewsKey(calendarId));
-    if (raw) return JSON.parse(raw);
-    // One-time migration from legacy wc-profiles-* key
-    const migrated = migrateProfiles(calendarId);
-    if (migrated.length > 0) return migrated;
+    if (raw) {
+      const migrated = migrateSavedViewsPayload(JSON.parse(raw), calendarId);
+      if (migrated.length > 0) return migrated;
+    } else {
+      const migrated = migrateProfiles(calendarId);
+      if (migrated.length > 0) return migrated;
+    }
   } catch {}
   return [];
 }
 
 function persistViews(calendarId, views) {
   try {
-    localStorage.setItem(viewsKey(calendarId), JSON.stringify(views));
+    localStorage.setItem(viewsKey(calendarId), JSON.stringify({
+      version: STORAGE_VERSION,
+      views,
+    }));
   } catch {}
 }
 
@@ -97,11 +150,18 @@ export function deserializeFilters(saved, schema) {
   }
 
   // Restore dateRange Date objects
-  if (result.dateRange) {
+  if (
+    result.dateRange &&
+    typeof result.dateRange === 'object' &&
+    isValidDate(result.dateRange.start) &&
+    isValidDate(result.dateRange.end)
+  ) {
     result.dateRange = {
       start: new Date(result.dateRange.start),
       end:   new Date(result.dateRange.end),
     };
+  } else if (result.dateRange) {
+    result.dateRange = null;
   }
 
   return result;


### PR DESCRIPTION
### Motivation
- Prevent fragile saved-view payloads from breaking when the shape changes by introducing an explicit storage version and migration path.
- Preserve existing legacy `wc-profiles-*` migration while making future migrations explicit and safe.
- Avoid runtime errors from malformed payloads (e.g. bad dateRange) by normalizing and validating loaded data.

### Description
- Add `STORAGE_VERSION = 2` and persist saved views as an envelope `{ version, views }` instead of a raw array via `persistViews`.
- Implement `normalizeSavedView`/`normalizeViews` to filter out malformed entries and ensure minimal required fields are present when loading.
- Add `migrateSavedViewsPayload` to support legacy array-only payloads, the new versioned payload, and to safely reject unsupported future versions while falling back to the legacy `wc-profiles-*` migration.
- Harden `deserializeFilters` by validating `dateRange.start`/`dateRange.end` with `isValidDate` before converting to `Date`, and set malformed `dateRange` to `null`.

### Testing
- Ran `npm test -- src/hooks/__tests__/useSavedViews.test.js` which executed the updated unit tests for serialization, deserialization, persistence, migration, and date validation.
- Test results: 1 test file ran and all tests passed (`20 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de21380a34832c8ce40e3319f65980)