### PR TITLE
Add demo landing and update shift coverage example

### DIFF
--- a/examples/00-DemoLanding.jsx
+++ b/examples/00-DemoLanding.jsx
@@ -1,0 +1,146 @@
+import { useMemo } from 'react';
+
+const CARD_STYLE = {
+  background: '#ffffff',
+  border: '1px solid #e2e8f0',
+  borderRadius: 12,
+  padding: 16,
+  display: 'flex',
+  flexDirection: 'column',
+  gap: 10,
+  boxShadow: '0 1px 2px rgba(15, 23, 42, 0.04)',
+};
+
+function DemoCard({ title, body, cta, onClick }) {
+  return (
+    <article style={CARD_STYLE}>
+      <h3 style={{ margin: 0, fontSize: 15, color: '#0f172a' }}>{title}</h3>
+      <p style={{ margin: 0, fontSize: 13, color: '#475569', lineHeight: 1.45 }}>{body}</p>
+      <button
+        type="button"
+        onClick={onClick}
+        style={{
+          marginTop: 'auto',
+          alignSelf: 'flex-start',
+          border: '1px solid #cbd5e1',
+          background: '#f8fafc',
+          color: '#0f172a',
+          borderRadius: 8,
+          padding: '7px 10px',
+          fontSize: 12,
+          fontWeight: 600,
+          cursor: 'pointer',
+        }}
+      >
+        {cta}
+      </button>
+    </article>
+  );
+}
+
+export function DemoLanding({ onNavigate }) {
+  const sections = useMemo(() => ([
+    {
+      title: 'Schedule demo',
+      body: 'See employee rows, shift coverage, PTO, and availability from the Schedule timeline workflow.',
+      cta: 'Open schedule demo',
+      target: 'timeline',
+    },
+    {
+      title: 'Filter demo',
+      body: 'Show how teams slice a single calendar by source, category, owner, and tags in seconds.',
+      cta: 'Open filter demo',
+      target: 'with-filters',
+    },
+    {
+      title: 'Saved views demo',
+      body: 'Demonstrate reusable smart views so each team can jump to the right context instantly.',
+      cta: 'Open saved views demo',
+      target: 'advanced-filters-new',
+    },
+    {
+      title: 'Shift coverage workflow',
+      body: 'Walk through employee action card requests and automatic uncovered-shift handling.',
+      cta: 'Open coverage demo',
+      target: 'shift-coverage',
+    },
+  ]), []);
+
+  return (
+    <main style={{
+      minHeight: '100%',
+      padding: '28px 24px 36px',
+      background: 'linear-gradient(180deg, #f8fafc 0%, #ffffff 35%)',
+      color: '#0f172a',
+    }}>
+      <header style={{ maxWidth: 920 }}>
+        <div style={{
+          fontSize: 11,
+          letterSpacing: '0.06em',
+          textTransform: 'uppercase',
+          color: '#64748b',
+          fontWeight: 700,
+        }}>
+          Public demo
+        </div>
+        <h1 style={{ margin: '8px 0 10px', fontSize: 32, lineHeight: 1.15 }}>
+          Understand WorksCalendar in under 30 seconds.
+        </h1>
+        <p style={{ margin: 0, maxWidth: 760, fontSize: 15, color: '#475569', lineHeight: 1.6 }}>
+          Start with a focused walkthrough: schedule operations, filtering, saved views, and shift coverage.
+          Use these as the fastest way to explain what the product does to a first-time visitor.
+        </p>
+      </header>
+
+      <section style={{
+        marginTop: 22,
+        display: 'grid',
+        gridTemplateColumns: 'repeat(auto-fit, minmax(220px, 1fr))',
+        gap: 12,
+        maxWidth: 980,
+      }}>
+        {sections.map((section) => (
+          <DemoCard
+            key={section.title}
+            title={section.title}
+            body={section.body}
+            cta={section.cta}
+            onClick={() => onNavigate?.(section.target)}
+          />
+        ))}
+      </section>
+
+      <section style={{
+        marginTop: 20,
+        maxWidth: 980,
+        display: 'grid',
+        gridTemplateColumns: 'repeat(auto-fit, minmax(280px, 1fr))',
+        gap: 12,
+      }}>
+        <article style={CARD_STYLE}>
+          <h3 style={{ margin: 0, fontSize: 14 }}>Docs links</h3>
+          <p style={{ margin: 0, fontSize: 13, color: '#475569', lineHeight: 1.5 }}>
+            Product behavior reference for demos:
+          </p>
+          <ul style={{ margin: 0, paddingLeft: 16, fontSize: 13, color: '#334155', lineHeight: 1.6 }}>
+            <li><code>docs/ScheduleWorkflow.md</code></li>
+            <li><code>docs/Filtering.md</code></li>
+            <li><code>docs/AdvancedFilters.md</code></li>
+          </ul>
+        </article>
+
+        <article style={CARD_STYLE}>
+          <h3 style={{ margin: 0, fontSize: 14 }}>Examples index</h3>
+          <p style={{ margin: 0, fontSize: 13, color: '#475569', lineHeight: 1.5 }}>
+            Continue through focused examples from the sidebar or start with:
+          </p>
+          <ul style={{ margin: 0, paddingLeft: 16, fontSize: 13, color: '#334155', lineHeight: 1.6 }}>
+            <li><code>examples/04-TimelineScheduler.jsx</code></li>
+            <li><code>examples/03-WithFilters.jsx</code></li>
+            <li><code>examples/advanced-filters.jsx</code></li>
+          </ul>
+        </article>
+      </section>
+    </main>
+  );
+}

--- a/examples/08-ShiftCoverageTracking.jsx
+++ b/examples/08-ShiftCoverageTracking.jsx
@@ -1,31 +1,28 @@
 /**
  * Example 8 — Shift Coverage Tracking
  *
- * Demonstrates the built-in shift coverage workflow available in the
- * Schedule (Timeline) view.
+ * Demonstrates the current employee-action-card workflow for shift coverage
+ * in the Schedule (Timeline) view.
  *
  * ── The workflow ──────────────────────────────────────────────────────────────
  *
- *  1. MARK UNAVAILABLE
- *     Each on-call / on-shift event pill has a small ▾ toggle on its right
- *     edge.  Clicking it opens a dropdown with two options:
- *       • 🏖 Mark as PTO
- *       • 🚫 Mark as Unavailable
- *     Once marked, the pill shows a "PTO" or "Unavail." badge and the ▾
- *     turns amber (⚠).  "✕ Clear Status" is added to the dropdown.
+ *  1. OPEN THE EMPLOYEE ACTION CARD
+ *     In Schedule view, click an employee row and choose:
+ *       • Edit Schedule
+ *       • Request PTO
+ *       • Edit Availability
+ *     PTO / availability requests are created from this action card workflow.
  *
- *  2. SHIFT NOT COVERED pill
- *     A pulsing red pill — "⚠ Shift not covered / Available" — appears
- *     below the event bar, spanning the same date range.
+ *  2. SHIFT BECOMES UNCOVERED
+ *     If PTO or unavailable time overlaps an on-call shift, the shift is
+ *     automatically marked as uncovered and shown as an open coverage need.
  *
- *  3. PICK UP THE SHIFT
- *     Clicking the red pill opens a coverage picker popover that lists
- *     all other employees.  Selecting one records coverage.
+ *  3. ASSIGN COVERAGE
+ *     Assign another employee to cover the open shift.
  *
  *  4. SHIFT COVERED
- *     The red pill turns green: "✓ Shift covered by [Name]".
- *     In the covering employee's row a new indigo pill appears for those
- *     same dates: "📞 On call (covering for [Original Name])".
+ *     The original shift updates to show coverage and the covering employee
+ *     receives a mirrored on-call assignment for the same dates.
  *
  * ── How state is stored ───────────────────────────────────────────────────────
  *
@@ -82,7 +79,6 @@ const uid = () => `sc-${_id++}`;
 // ── Seed events ───────────────────────────────────────────────────────────────
 //
 // On-call events use category: 'on-call' (the default onCallCategory value).
-// They get the striped pill style and the ▾ availability toggle automatically.
 //
 // The third event demonstrates a pre-seeded "already marked as PTO + covered"
 // state so you can see the green pill and covering-for pill on first load.
@@ -165,7 +161,21 @@ export function ShiftCoverageTracking() {
   }, []);
 
   return (
-    <div style={{ height: '100%' }}>
+    <div style={{ height: '100%', display: 'flex', flexDirection: 'column' }}>
+      <div style={{
+        padding: '12px 16px',
+        borderBottom: '1px solid #e2e8f0',
+        background: '#f8fafc',
+      }}>
+        <div style={{ fontSize: 13, fontWeight: 700, color: '#0f172a' }}>
+          Try the current workflow
+        </div>
+        <div style={{ fontSize: 12, color: '#475569', marginTop: 4, lineHeight: 1.5 }}>
+          In <strong>Schedule</strong> view, click an employee row to open the action card, then use
+          <strong> Request PTO</strong> or <strong>Edit Availability</strong>. Overlapping on-call shifts
+          become uncovered and can be reassigned.
+        </div>
+      </div>
       <WorksCalendar
         devMode
         calendarId="shift-coverage-example"

--- a/examples/App.jsx
+++ b/examples/App.jsx
@@ -9,6 +9,7 @@
 import { StrictMode, useState } from 'react';
 import { createRoot } from 'react-dom/client';
 
+import { DemoLanding }            from './00-DemoLanding.jsx';
 import { GettingStarted }          from './01-GettingStarted.jsx';
 import { BasicCalendar }           from './02-BasicCalendar.jsx';
 import { WithFilters }             from './03-WithFilters.jsx';
@@ -25,6 +26,13 @@ import { ExternalFormExample }     from './external-form.jsx';
 
 // ── Nav config ────────────────────────────────────────────────────────────────
 const EXAMPLES = [
+  {
+    id:    'demo-landing',
+    label: 'Demo Landing',
+    tag:   'Start here',
+    desc:  'Polished entry page for first-time visitors. Jump to schedule, filters, saved views, and docs.',
+    component: DemoLanding,
+  },
   {
     id:    'getting-started',
     label: 'Getting Started',
@@ -194,6 +202,7 @@ function Sidebar({ active, onSelect }) {
 function SourceHint({ id }) {
   const file = {
     'getting-started': '01-GettingStarted.jsx',
+    'demo-landing':    '00-DemoLanding.jsx',
     'basic-calendar':  '02-BasicCalendar.jsx',
     'with-filters':    '03-WithFilters.jsx',
     'timeline':        '04-TimelineScheduler.jsx',
@@ -226,7 +235,7 @@ function SourceHint({ id }) {
 
 // ── App ───────────────────────────────────────────────────────────────────────
 function App() {
-  const [active, setActive] = useState('getting-started');
+  const [active, setActive] = useState('demo-landing');
   const example = EXAMPLES.find(e => e.id === active);
   const Component = example.component;
 
@@ -237,7 +246,7 @@ function App() {
       <div style={{ flex: 1, display: 'flex', flexDirection: 'column', overflow: 'hidden' }}>
         <SourceHint id={active} />
         <div style={{ flex: 1, overflow: 'auto', minHeight: 0 }}>
-          <Component />
+          <Component onNavigate={setActive} />
         </div>
       </div>
     </div>

--- a/examples/README.md
+++ b/examples/README.md
@@ -8,6 +8,7 @@ npm run examples
 
 ## Core examples
 
+- `00-DemoLanding.jsx` — polished demo entry page (schedule/filter/saved views/docs)
 - `01-GettingStarted.jsx` — minimum setup
 - `02-BasicCalendar.jsx` — standard calendar configuration
 - `03-WithFilters.jsx` — baseline filter bar usage
@@ -20,6 +21,7 @@ npm run examples
 
 - `setup-wizard.jsx` — owner onboarding wizard flow
 - `advanced-filters.jsx` — nested AND/OR smart-view filter builder
+- `08-ShiftCoverageTracking.jsx` — employee action card + shift coverage workflow
 - `data-adapter-local.jsx` — `DataAdapter` with local storage persistence
 - `data-adapter-microsoft365.jsx` — `DataAdapter` with Microsoft 365 integration
 - `external-form.jsx` — standalone `CalendarExternalForm` intake workflow

--- a/examples/WORKFLOWS.md
+++ b/examples/WORKFLOWS.md
@@ -14,6 +14,7 @@ Use these examples:
 What they show:
 - employees as rows
 - schedule/timeline layout
+- employee action card entry point (Edit Schedule / Request PTO / Edit Availability)
 - PTO and unavailable states
 - shift coverage logic
 
@@ -58,13 +59,13 @@ What it shows:
 
 ---
 
-## Important Note
+## Demo entry flow
 
-Some older examples (like shift coverage) still demonstrate legacy UI flows.
+Use this example:
+- `00-DemoLanding.jsx`
 
-The current workflow is:
-- click employee
-- use action card
-- manage schedule / PTO / availability from there
-
-Refer to docs/ScheduleWorkflow.md for the latest behavior.
+What it shows:
+- schedule demo path
+- filter demo path
+- saved views demo path
+- docs/examples handoff links for first-time visitors


### PR DESCRIPTION
### Motivation
- Make the public demo approachable for first-time visitors so the product is understandable in under 30 seconds. 
- Align examples and docs with the current employee-action-card schedule workflow to remove mismatch between demo text and actual UX.

### Description
- Added a new polished demo entry page at `examples/00-DemoLanding.jsx` with quick-entry cards for schedule, filters, saved views, and shift coverage plus links to docs and examples. 
- Wired the examples app to surface the landing page by default and added in-app navigation from the landing cards by updating `examples/App.jsx`. 
- Refreshed `examples/08-ShiftCoverageTracking.jsx` to describe the current employee-action-card workflow and added an in-example guidance header to show how to trigger PTO/availability and coverage flows. 
- Updated example index and workflow docs in `examples/README.md` and `examples/WORKFLOWS.md` so the examples list and workflow guidance reflect the new landing flow and current UX.

### Testing
- Built the examples with `npm run build:examples` which completed successfully (vite build completed). 
- Ran the test suite with `npm test` and `vitest` completed with all tests passing (`36` test files; `620` tests passed, `1` todo).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dee5d5e56c832c9465e7b47707287c)