### PR TITLE
Fix theme selector: named themes now override custom theme vars corre…

### DIFF
--- a/demo/App.jsx
+++ b/demo/App.jsx
@@ -5,8 +5,17 @@ import { WorksCalendar } from '../src/index.js';
 import { THEMES } from '../src/styles/themes.js';
 import { saveProfiles } from '../src/core/profileStore.js';
 
-/* ─── Demo profiles ─────────────────────────────────────────────── */
+/* ─── Demo calendar ID ──────────────────────────────────────────── */
 const DEMO_CALENDAR_ID = 'ihc-oncall-demo';
+
+/* ─── Read initial theme / savedThemes / customTheme from persisted config ── */
+function loadDemoConfig() {
+  try {
+    const raw = localStorage.getItem(`wc-config-${DEMO_CALENDAR_ID}`);
+    if (!raw) return {};
+    return JSON.parse(raw);
+  } catch { return {}; }
+}
 const DEMO_PROFILES = [
   { id:'p1', name:'Full Schedule',       color:'#10b981', filters:{ categories:[],              resources:[], search:'' }, view:'schedule' },
   { id:'p2', name:'On-Call Only',        color:'#ef4444', filters:{ categories:['on-call'],      resources:[], search:'' }, view:'schedule' },
@@ -118,9 +127,15 @@ const INITIAL_EVENTS = [
 ];
 
 /* ─── Theme picker ──────────────────────────────────────────────── */
-function ThemePicker({ current, onChange }) {
+// onChange(themeId, customTheme?) — customTheme is only passed for saved custom themes
+function ThemePicker({ current, onChange, savedThemes = [] }) {
   const [open, setOpen] = useState(false);
-  const active = THEMES.find(t => t.id === current) ?? THEMES[0];
+  const active = THEMES.find(t => t.id === current)
+    ?? savedThemes.find(t => t.id === current)
+    ?? THEMES[0];
+
+  // Build preview swatches for the trigger button
+  const triggerPreview = active.preview ?? { accent: '#3b82f6', bg: '#fff', surface: '#f8fafc', text: '#0f172a' };
 
   return (
     <div style={{ position: 'relative' }}>
@@ -129,16 +144,16 @@ function ThemePicker({ current, onChange }) {
         style={{
           display: 'flex', alignItems: 'center', gap: 8,
           padding: '6px 10px',
-          background: active.preview.bg,
-          border: `2px solid ${active.preview.accent}`,
+          background: triggerPreview.bg,
+          border: `2px solid ${triggerPreview.accent}`,
           borderRadius: 8, cursor: 'pointer', fontSize: 12,
-          color: active.preview.text, fontWeight: 600,
+          color: triggerPreview.text, fontWeight: 600,
           boxShadow: '0 1px 4px rgba(0,0,0,.12)',
         }}
         title="Change theme"
       >
         <span style={{ display:'flex', gap:3 }}>
-          {[active.preview.accent, active.preview.bg, active.preview.surface].map((c, i) => (
+          {[triggerPreview.accent, triggerPreview.bg, triggerPreview.surface].map((c, i) => (
             <span key={i} style={{ width:12, height:12, borderRadius:'50%', background:c, border:'1px solid rgba(0,0,0,.15)', display:'inline-block' }} />
           ))}
         </span>
@@ -152,7 +167,7 @@ function ThemePicker({ current, onChange }) {
           background: '#fff', border: '1px solid #e2e8f0',
           borderRadius: 12, boxShadow: '0 8px 32px rgba(0,0,0,.15)',
           padding: 10, display: 'flex', flexDirection: 'column', gap: 4,
-          zIndex: 1000, minWidth: 220,
+          zIndex: 1000, minWidth: 220, maxHeight: '80vh', overflowY: 'auto',
         }}>
           <div style={{ fontSize: 10, fontWeight: 700, textTransform: 'uppercase', letterSpacing: '0.08em', color: '#94a3b8', padding: '2px 6px 6px' }}>
             Choose a theme
@@ -160,7 +175,7 @@ function ThemePicker({ current, onChange }) {
           {THEMES.map(t => (
             <button
               key={t.id}
-              onClick={() => { onChange(t.id); setOpen(false); }}
+              onClick={() => { onChange(t.id, null); setOpen(false); }}
               style={{
                 display: 'flex', alignItems: 'center', gap: 10,
                 padding: '8px 10px', border: 'none', borderRadius: 8,
@@ -187,6 +202,39 @@ function ThemePicker({ current, onChange }) {
               </div>
             </button>
           ))}
+
+          {savedThemes.length > 0 && (
+            <>
+              <div style={{ height: 1, background: '#e2e8f0', margin: '4px 0' }} />
+              <div style={{ fontSize: 10, fontWeight: 700, textTransform: 'uppercase', letterSpacing: '0.08em', color: '#94a3b8', padding: '2px 6px 4px' }}>
+                Custom themes
+              </div>
+              {savedThemes.map(t => (
+                <button
+                  key={t.id}
+                  onClick={() => { onChange(t.id, t.customTheme); setOpen(false); }}
+                  style={{
+                    display: 'flex', alignItems: 'center', gap: 10,
+                    padding: '8px 10px', border: 'none', borderRadius: 8,
+                    background: t.id === current ? '#6366f118' : 'transparent',
+                    cursor: 'pointer', textAlign: 'left',
+                    outline: t.id === current ? '2px solid #6366f1' : 'none',
+                    outlineOffset: -2,
+                  }}
+                >
+                  <div style={{
+                    width: 36, height: 28, borderRadius: 5, flexShrink: 0,
+                    background: '#f8fafc', border: '1px solid #e2e8f0',
+                    display: 'flex', alignItems: 'center', justifyContent: 'center',
+                    fontSize: 14,
+                  }}>
+                    🎨
+                  </div>
+                  <div style={{ fontSize: 13, fontWeight: 600, color: '#0f172a' }}>{t.label}</div>
+                </button>
+              ))}
+            </>
+          )}
         </div>
       )}
     </div>
@@ -229,12 +277,17 @@ function UpdateToast({ onUpdate, onDismiss }) {
 
 /* ─── Demo App ──────────────────────────────────────────────────── */
 function App() {
-  const [events,       setEvents]       = useState(INITIAL_EVENTS);
-  const [notes,        setNotes]        = useState({});
-  const [theme,        setTheme]        = useState('light');
-  const [employees,    setEmployees]    = useState(INITIAL_EMPLOYEES);
-  const [eventLog,     setEventLog]     = useState([]);
-  const [needsRefresh, setNeedsRefresh] = useState(false);
+  const [events,            setEvents]            = useState(INITIAL_EVENTS);
+  const [notes,             setNotes]             = useState({});
+  const [employees,         setEmployees]         = useState(INITIAL_EMPLOYEES);
+  const [eventLog,          setEventLog]          = useState([]);
+  const [needsRefresh,      setNeedsRefresh]      = useState(false);
+
+  // Initialize theme, savedThemes, and activeCustomTheme from persisted owner config
+  const _initConfig      = loadDemoConfig();
+  const [theme,            setTheme]            = useState(_initConfig.display?.theme ?? 'light');
+  const [savedThemes,      setSavedThemes]      = useState(_initConfig.savedThemes ?? []);
+  const [activeCustomTheme, setActiveCustomTheme] = useState(_initConfig.customTheme ?? null);
 
   const [updateSW] = useState(() =>
     registerSW({
@@ -308,7 +361,14 @@ function App() {
         </div>
 
         <div style={{ marginLeft: 'auto', display: 'flex', gap: 8, alignItems: 'center', flexWrap: 'wrap' }}>
-          <ThemePicker current={theme} onChange={setTheme} />
+          <ThemePicker
+            current={theme}
+            savedThemes={savedThemes}
+            onChange={(id, customTheme) => {
+              setTheme(id);
+              setActiveCustomTheme(customTheme ?? null);
+            }}
+          />
         </div>
       </header>
 
@@ -322,7 +382,14 @@ function App() {
             onEmployeeDelete={handleEmployeeDelete}
             calendarId={DEMO_CALENDAR_ID}
             ownerPassword="demo1234"
-            onConfigSave={() => log('Config saved')}
+            onConfigSave={(config) => {
+              log('Config saved');
+              // Sync theme, savedThemes, and customTheme from persisted config
+              if (config.display?.theme) setTheme(config.display.theme);
+              setSavedThemes(config.savedThemes ?? []);
+              setActiveCustomTheme(config.customTheme ?? null);
+            }}
+            customTheme={activeCustomTheme}
             notes={notes}
             onNoteSave={handleNoteSave}
             onNoteDelete={handleNoteDelete}

--- a/src/WorksCalendar.tsx
+++ b/src/WorksCalendar.tsx
@@ -113,6 +113,8 @@ export type WorksCalendarProps = {
   onEmployeeDelete?: (...args: unknown[]) => void;
   blockedWindows?: Array<Record<string, unknown>>;
   theme?: string;
+  /** Override the active custom theme entirely (bypasses owner-config customTheme). */
+  customTheme?: Record<string, unknown>;
   colorRules?: Array<Record<string, unknown>>;
   businessHours?: Record<string, unknown>;
   renderEvent?: (...args: unknown[]) => ReactNode;
@@ -231,6 +233,7 @@ export const WorksCalendar = forwardRef<CalendarApi, WorksCalendarProps>(functio
 
     // ── Appearance ──
     theme       = 'light',
+    customTheme: customThemeProp,
     colorRules,
     businessHours,
 
@@ -264,7 +267,9 @@ export const WorksCalendar = forwardRef<CalendarApi, WorksCalendarProps>(functio
   const cal      = useCalendar([], initialView ?? 'month', schema);
   const ownerCfg = useOwnerConfig({ calendarId, ownerPassword, onConfigSave, devMode });
   const weekStartDay = weekStartDayProp ?? ownerCfg.config?.display?.weekStartDay ?? 0;
-  const customThemeVars = useMemo(() => customThemeToCssVars(ownerCfg.config?.customTheme), [ownerCfg.config?.customTheme]);
+  const activeCustomTheme = customThemeProp ?? ownerCfg.config?.customTheme;
+  const customThemeVars = useMemo(() => customThemeToCssVars(activeCustomTheme), [activeCustomTheme]);
+  const effectiveTheme = ownerCfg.config?.display?.theme || theme;
 
   // Honor defaultView from owner config (applied once after config loads)
   const defaultViewApplied = useRef(false);
@@ -275,6 +280,16 @@ export const WorksCalendar = forwardRef<CalendarApi, WorksCalendarProps>(functio
       cal.setView(defaultView);
     }
   }, [ownerCfg.config?.display?.defaultView]);
+
+  // Sync `theme` prop → config.display.theme so the theme picker dropdown
+  // reflects the currently active named theme when the owner is logged in.
+  useEffect(() => {
+    if (!ownerCfg.isOwner) return;
+    if (theme && ownerCfg.config?.display?.theme !== theme) {
+      ownerCfg.updateConfig({ display: { ...ownerCfg.config?.display, theme } });
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [theme, ownerCfg.isOwner]);
 
   // ── Permissions ──────────────────────────────────────────────────────────
   const perms = usePermissions(role);
@@ -1129,7 +1144,7 @@ export const WorksCalendar = forwardRef<CalendarApi, WorksCalendarProps>(functio
   return (
     <CalendarErrorBoundary>
       <CalendarContext.Provider value={ctxValue}>
-        <div className={styles.root} data-wc-theme={theme} data-testid="works-calendar" data-wc-edit-mode={editMode ? '' : undefined} style={customThemeVars}>
+        <div className={styles.root} data-wc-theme={effectiveTheme} data-testid="works-calendar" data-wc-edit-mode={editMode ? '' : undefined} style={customThemeVars}>
 
         {/* ── Toolbar ── */}
         {renderToolbar ? (

--- a/src/core/configSchema.js
+++ b/src/core/configSchema.js
@@ -24,6 +24,7 @@ export const DEFAULT_CONFIG = {
     dayEnd:       22,       // hour (0-23)
     showWeekNumbers: false,
     enlargeMonthRowOnHover: false,
+    theme: 'light',         // active named theme id; synced with the theme prop
   },
 
   // Filter UI labels editable by owner/dev
@@ -40,6 +41,10 @@ export const DEFAULT_CONFIG = {
 
   // Full custom theme object applied via CSS variable injection.
   customTheme: {},
+
+  // User-saved named custom themes (built in the ThemeCustomizer).
+  // Each entry: { id: string, label: string, customTheme: object }
+  savedThemes: [],
 
   // Access control
   access: {

--- a/src/core/themeSchema.js
+++ b/src/core/themeSchema.js
@@ -49,28 +49,47 @@ export function normalizeCustomTheme(theme) {
 export function customThemeToCssVars(themeInput) {
   if (!themeInput || (typeof themeInput === 'object' && Object.keys(themeInput).length === 0)) return undefined;
   const theme = normalizeCustomTheme(themeInput);
-  const e = Math.max(0, Number(theme.shadows.elevation) || 0);
-  const density = Math.max(0.8, Math.min(1.2, Number(theme.spacing.density) || 1));
+  const def   = DEFAULT_CUSTOM_THEME;
+  const vars  = {};
 
-  return {
-    '--wc-accent': theme.colors.accent,
-    '--wc-accent-dim': theme.colors.accentDim,
-    '--wc-bg': theme.colors.bg,
-    '--wc-surface': theme.colors.surface,
-    '--wc-surface-2': theme.colors.surface2,
-    '--wc-border': theme.colors.border,
-    '--wc-border-dark': theme.colors.borderDark,
-    '--wc-text': theme.colors.text,
-    '--wc-text-muted': theme.colors.textMuted,
-    '--wc-font': theme.typography.fontFamily,
-    '--wc-font-heading': theme.typography.headingFontFamily || theme.typography.fontFamily,
-    '--wc-font-mono': theme.typography.monoFontFamily || "ui-monospace, 'Cascadia Code', 'SFMono-Regular', Menlo, monospace",
-    '--wc-radius': `${theme.borders.radius}px`,
-    '--wc-radius-sm': `${theme.borders.radiusSm}px`,
-    '--wc-border-width': `${theme.borders.borderWidth}px`,
-    '--wc-shadow': `0 4px ${12 + Math.round(e)}px rgba(0,0,0,${(0.08 + e / 200).toFixed(2)})`,
-    '--wc-shadow-sm': `0 1px ${3 + Math.round(e / 3)}px rgba(0,0,0,${(0.05 + e / 250).toFixed(2)})`,
-    '--wc-base-font-size': `${theme.typography.baseSize}px`,
-    '--wc-density': density,
-  };
+  // Only emit a CSS custom property when the value explicitly differs from the
+  // built-in default.  This prevents a stored customTheme from overriding named
+  // CSS themes (aviation, dark, ocean …) via inline-style specificity when the
+  // user hasn't actually changed that particular token.
+  const c = theme.colors;
+  const dc = def.colors;
+  if (c.accent     !== dc.accent)     vars['--wc-accent']      = c.accent;
+  if (c.accentDim  !== dc.accentDim)  vars['--wc-accent-dim']  = c.accentDim;
+  if (c.bg         !== dc.bg)         vars['--wc-bg']          = c.bg;
+  if (c.surface    !== dc.surface)    vars['--wc-surface']     = c.surface;
+  if (c.surface2   !== dc.surface2)   vars['--wc-surface-2']   = c.surface2;
+  if (c.border     !== dc.border)     vars['--wc-border']      = c.border;
+  if (c.borderDark !== dc.borderDark) vars['--wc-border-dark'] = c.borderDark;
+  if (c.text       !== dc.text)       vars['--wc-text']        = c.text;
+  if (c.textMuted  !== dc.textMuted)  vars['--wc-text-muted']  = c.textMuted;
+
+  const t = theme.typography;
+  const dt = def.typography;
+  if (t.fontFamily        !== dt.fontFamily)        vars['--wc-font']            = t.fontFamily;
+  if (t.headingFontFamily !== dt.headingFontFamily) vars['--wc-font-heading']    = t.headingFontFamily || t.fontFamily;
+  if (t.monoFontFamily    !== dt.monoFontFamily)    vars['--wc-font-mono']       = t.monoFontFamily;
+  if (t.baseSize          !== dt.baseSize)          vars['--wc-base-font-size']  = `${t.baseSize}px`;
+
+  const density = Math.max(0.8, Math.min(1.2, Number(theme.spacing.density) || 1));
+  if (theme.spacing.density !== def.spacing.density) vars['--wc-density'] = density;
+
+  const b = theme.borders;
+  const db = def.borders;
+  if (b.radius      !== db.radius)      vars['--wc-radius']       = `${b.radius}px`;
+  if (b.radiusSm    !== db.radiusSm)    vars['--wc-radius-sm']    = `${b.radiusSm}px`;
+  if (b.borderWidth !== db.borderWidth) vars['--wc-border-width'] = `${b.borderWidth}px`;
+
+  const e  = Math.max(0, Number(theme.shadows.elevation) || 0);
+  const de = Math.max(0, Number(def.shadows.elevation)   || 0);
+  if (e !== de) {
+    vars['--wc-shadow']    = `0 4px ${12 + Math.round(e)}px rgba(0,0,0,${(0.08 + e / 200).toFixed(2)})`;
+    vars['--wc-shadow-sm'] = `0 1px ${3  + Math.round(e / 3)}px rgba(0,0,0,${(0.05 + e / 250).toFixed(2)})`;
+  }
+
+  return Object.keys(vars).length > 0 ? vars : undefined;
 }

--- a/src/ui/ConfigPanel.jsx
+++ b/src/ui/ConfigPanel.jsx
@@ -84,7 +84,7 @@ export default function ConfigPanel({
 }
 
 function SetupTab({ config, onUpdate }) {
-  const selectedTheme = config.wizardData?.preferredTheme ?? 'corporate';
+  const selectedTheme = config.display?.theme ?? config.wizardData?.preferredTheme ?? 'corporate';
   const calendarName = config.wizardData?.calendarName ?? 'My WorksCalendar';
 
   const setCalendarName = (name) => onUpdate(c => ({
@@ -94,6 +94,7 @@ function SetupTab({ config, onUpdate }) {
 
   const setPreferredTheme = (themeId) => onUpdate(c => ({
     ...c,
+    display: { ...(c.display ?? {}), theme: themeId },
     wizardData: { ...(c.wizardData ?? {}), preferredTheme: themeId },
     setupCompleted: true,
   }));

--- a/src/ui/ThemeCustomizer.jsx
+++ b/src/ui/ThemeCustomizer.jsx
@@ -1,6 +1,6 @@
 import { normalizeCustomTheme, customThemeToCssVars } from '../core/themeSchema.js';
 import styles from './ThemeCustomizer.module.css';
-import { useMemo, useState } from 'react';
+import { useMemo, useState, useRef } from 'react';
 
 const COLOR_CONTROLS = [
   ['accent', 'Accent'],
@@ -147,6 +147,9 @@ export default function ThemeCustomizer({ theme, onChange }) {
   const [importMode, setImportMode] = useState('merge');
   const [importSuccess, setImportSuccess] = useState('');
   const [copyState, setCopyState] = useState('');
+  const [saveThemeName, setSaveThemeName] = useState('');
+  const [saveFeedback, setSaveFeedback] = useState('');
+  const saveFeedbackTimer = useRef(null);
   const merged = normalizeCustomTheme(theme);
   const selectedFontOptionByRole = useMemo(() => Object.fromEntries(
     FONT_ROLE_CONTROLS.map(({ key }) => {
@@ -178,19 +181,38 @@ export default function ThemeCustomizer({ theme, onChange }) {
 
   function update(path, value) {
     onChange((config) => {
-      const current = normalizeCustomTheme(config.customTheme);
+      // Store only the delta — do NOT normalise before spreading.
+      // Spreading the full normalised object would fill every default value
+      // into customTheme, causing inline CSS vars to override named CSS themes.
+      const current = config.customTheme ?? {};
       const [group, key] = path;
       return {
         ...config,
         customTheme: {
           ...current,
           [group]: {
-            ...current[group],
+            ...(current[group] ?? {}),
             [key]: value,
           },
         },
       };
     });
+  }
+
+  function handleSaveTheme() {
+    const name = saveThemeName.trim();
+    if (!name) return;
+    onChange((config) => ({
+      ...config,
+      savedThemes: [
+        ...(config.savedThemes ?? []).filter(t => t.label !== name),
+        { id: `custom-${Date.now()}`, label: name, customTheme: config.customTheme ?? {} },
+      ],
+    }));
+    setSaveThemeName('');
+    clearTimeout(saveFeedbackTimer.current);
+    setSaveFeedback(`"${name}" saved to theme picker`);
+    saveFeedbackTimer.current = setTimeout(() => setSaveFeedback(''), 3000);
   }
 
   function applyPreset(preset) {
@@ -326,6 +348,28 @@ export default function ThemeCustomizer({ theme, onChange }) {
 
       <div className={styles.actions}>
         <button className={styles.btn} onClick={() => onChange((c) => ({ ...c, customTheme: {} }))}>Reset to default</button>
+      </div>
+
+      <div className={styles.ioSection}>
+        <strong className={styles.blockLabel}>Save as theme option</strong>
+        <p style={{ fontSize: 12, color: 'var(--wc-text-muted)', margin: '4px 0 8px' }}>
+          Give this look a name and it will appear in the theme picker.
+        </p>
+        <div className={styles.inlineActions}>
+          <input
+            className={styles.textarea}
+            style={{ height: 'auto', padding: '6px 8px', fontSize: 13, flex: 1 }}
+            value={saveThemeName}
+            onChange={e => setSaveThemeName(e.target.value)}
+            onKeyDown={e => { if (e.key === 'Enter') { e.preventDefault(); handleSaveTheme(); } }}
+            placeholder="e.g. Our Brand Theme"
+            aria-label="Theme name"
+          />
+          <button className={styles.btn} onClick={handleSaveTheme} disabled={!saveThemeName.trim()}>
+            Save
+          </button>
+        </div>
+        {saveFeedback && <span className={styles.importSuccess}>{saveFeedback}</span>}
       </div>
 
       <div className={styles.ioSection}>


### PR DESCRIPTION
…ctly

- customThemeToCssVars only emits CSS vars that differ from DEFAULT_CUSTOM_THEME, so named themes (aviation, dark, etc.) are no longer overridden by inline styles
- ThemeCustomizer stores a raw delta instead of a fully-normalized theme object, preventing the entire default theme from being persisted after a single edit
- Add "Save as theme option" to ThemeCustomizer so custom themes appear in the top-right theme picker dropdown
- configSchema gains display.theme and savedThemes fields
- ConfigPanel SetupTab writes theme selection to config.display.theme (primary) and config.wizardData.preferredTheme (compat fallback)
- WorksCalendar: effectiveTheme = config.display.theme || theme prop; syncs the theme prop into config.display.theme for the owner; accepts customTheme prop
- demo/App: initializes theme/savedThemes/customTheme from localStorage config, onConfigSave syncs all three, ThemePicker shows saved custom themes as options

https://claude.ai/code/session_01Qe61nrbs3DFX4awRXqzy8q