### PR TITLE
Complete issue #98 config migration wiring in setup + live calendar

### DIFF
--- a/src/WorksCalendar.module.css
+++ b/src/WorksCalendar.module.css
@@ -21,9 +21,10 @@
   --wc-warning:     #f59e0b;
 
   font-family: var(--wc-font);
+  font-size: var(--wc-base-font-size, 14px);
   background: var(--wc-bg);
   color: var(--wc-text);
-  border: 1px solid var(--wc-border);
+  border: var(--wc-border-width, 1px) solid var(--wc-border);
   border-radius: var(--wc-radius);
   overflow: hidden;
   display: flex;
@@ -218,8 +219,8 @@
   display: flex;
   align-items: center;
   gap: 8px;
-  padding: 10px 12px;
-  border-bottom: 1px solid var(--wc-border);
+  padding: calc(10px * var(--wc-density, 1)) calc(12px * var(--wc-density, 1));
+  border-bottom: var(--wc-border-width, 1px) solid var(--wc-border);
   background: var(--wc-bg);
   flex-shrink: 0;
   flex-wrap: wrap;
@@ -239,7 +240,7 @@
   height: 32px;
   border-radius: var(--wc-radius-sm);
   background: transparent;
-  border: 1px solid var(--wc-border);
+  border: var(--wc-border-width, 1px) solid var(--wc-border);
   cursor: pointer;
   color: var(--wc-text-muted);
   transition: all 0.15s;
@@ -251,11 +252,11 @@
 }
 
 .todayBtn {
-  padding: 0 12px;
+  padding: 0 calc(12px * var(--wc-density, 1));
   height: 32px;
   border-radius: var(--wc-radius-sm);
   background: transparent;
-  border: 1px solid var(--wc-border);
+  border: var(--wc-border-width, 1px) solid var(--wc-border);
   font-size: 13px;
   font-weight: 500;
   color: var(--wc-text-muted);
@@ -277,23 +278,31 @@
   white-space: nowrap;
 }
 
+.calendarTitle {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--wc-text-muted);
+  padding-left: 8px;
+  white-space: nowrap;
+}
+
 /* View switcher */
 .viewGroup {
   display: flex;
   background: var(--wc-surface);
-  border: 1px solid var(--wc-border);
+  border: var(--wc-border-width, 1px) solid var(--wc-border);
   border-radius: var(--wc-radius-sm);
   overflow: hidden;
   margin-left: auto;
 }
 
 .viewBtn {
-  padding: 6px 12px;
+  padding: calc(6px * var(--wc-density, 1)) calc(12px * var(--wc-density, 1));
   font-size: 12px;
   font-weight: 500;
   background: transparent;
   border: none;
-  border-right: 1px solid var(--wc-border);
+  border-right: var(--wc-border-width, 1px) solid var(--wc-border);
   cursor: pointer;
   color: var(--wc-text-muted);
   transition: all 0.15s;
@@ -331,7 +340,7 @@
   display: flex;
   align-items: center;
   gap: 5px;
-  padding: 6px 12px;
+  padding: calc(6px * var(--wc-density, 1)) calc(12px * var(--wc-density, 1));
   background: var(--wc-accent);
   color: #fff;
   border: none;
@@ -353,7 +362,7 @@
   height: 32px;
   border-radius: var(--wc-radius-sm);
   background: transparent;
-  border: 1px solid var(--wc-border);
+  border: var(--wc-border-width, 1px) solid var(--wc-border);
   cursor: pointer;
   color: var(--wc-text-muted);
   transition: all 0.15s;
@@ -373,7 +382,7 @@
   height: 32px;
   border-radius: var(--wc-radius-sm);
   background: transparent;
-  border: 1px solid var(--wc-border);
+  border: var(--wc-border-width, 1px) solid var(--wc-border);
   cursor: pointer;
   color: var(--wc-text-muted);
   transition: all 0.15s;
@@ -399,7 +408,7 @@
   display: flex;
   align-items: center;
   gap: 7px;
-  padding: 6px 12px;
+  padding: calc(6px * var(--wc-density, 1)) calc(12px * var(--wc-density, 1));
   background: var(--wc-accent-dim);
   color: var(--wc-accent);
   font-size: 12px;
@@ -440,7 +449,7 @@
 
 /* Custom toolbar wrapper */
 .customToolbar {
-  border-bottom: 1px solid var(--wc-border);
+  border-bottom: var(--wc-border-width, 1px) solid var(--wc-border);
   flex-shrink: 0;
 }
 
@@ -464,7 +473,7 @@
 /* Tablet (≤ 768px): compress toolbar, allow view strip to scroll */
 @media (max-width: 768px) {
   .toolbar {
-    padding: 8px 10px;
+    padding: calc(8px * var(--wc-density, 1)) calc(10px * var(--wc-density, 1));
     gap: 6px;
     row-gap: 6px;
   }
@@ -489,7 +498,7 @@
   .viewGroup::-webkit-scrollbar { display: none; }
 
   .viewBtn {
-    padding: 6px 10px;
+    padding: calc(6px * var(--wc-density, 1)) calc(10px * var(--wc-density, 1));
     font-size: 11px;
   }
 
@@ -503,7 +512,7 @@
     display: none;
   }
   .addBtn {
-    padding: 6px 8px;
+    padding: calc(6px * var(--wc-density, 1)) calc(8px * var(--wc-density, 1));
   }
 }
 
@@ -511,7 +520,7 @@
 @media (max-width: 480px) {
   .toolbar {
     flex-wrap: wrap;
-    padding: 8px;
+    padding: calc(8px * var(--wc-density, 1));
     row-gap: 6px;
   }
 
@@ -535,7 +544,7 @@
   .viewBtn {
     flex: 1;
     text-align: center;
-    padding: 5px 6px;
+    padding: calc(5px * var(--wc-density, 1)) calc(6px * var(--wc-density, 1));
     font-size: 11px;
   }
 
@@ -546,6 +555,6 @@
 
   .todayBtn {
     font-size: 12px;
-    padding: 0 8px;
+    padding: 0 calc(8px * var(--wc-density, 1));
   }
 }

--- a/src/WorksCalendar.tsx
+++ b/src/WorksCalendar.tsx
@@ -278,7 +278,7 @@ export const WorksCalendar = forwardRef<CalendarApi, WorksCalendarProps>(functio
   const ownerCfg = useOwnerConfig({ calendarId, ownerPassword, onConfigSave, devMode });
   const weekStartDay = weekStartDayProp ?? ownerCfg.config?.display?.weekStartDay ?? 0;
   const customThemeVars = useMemo(() => customThemeToCssVars(ownerCfg.config?.customTheme), [ownerCfg.config?.customTheme]);
-  const effectiveTheme = ownerCfg.config?.setup?.preferredTheme || theme || 'light';
+  const effectiveTheme = theme || ownerCfg.config?.setup?.preferredTheme || 'light';
   const calendarTitle = ownerCfg.config?.title || 'My WorksCalendar';
   const configuredEmployees = useMemo(() => {
     if (Array.isArray(employees) && employees.length > 0) return employees;

--- a/src/WorksCalendar.tsx
+++ b/src/WorksCalendar.tsx
@@ -278,6 +278,12 @@ export const WorksCalendar = forwardRef<CalendarApi, WorksCalendarProps>(functio
   const ownerCfg = useOwnerConfig({ calendarId, ownerPassword, onConfigSave, devMode });
   const weekStartDay = weekStartDayProp ?? ownerCfg.config?.display?.weekStartDay ?? 0;
   const customThemeVars = useMemo(() => customThemeToCssVars(ownerCfg.config?.customTheme), [ownerCfg.config?.customTheme]);
+  const effectiveTheme = ownerCfg.config?.setup?.preferredTheme || theme || 'light';
+  const calendarTitle = ownerCfg.config?.title || 'My WorksCalendar';
+  const configuredEmployees = useMemo(() => {
+    if (Array.isArray(employees) && employees.length > 0) return employees;
+    return ownerCfg.config?.team?.members ?? [];
+  }, [employees, ownerCfg.config?.team?.members]);
 
   // Honor defaultView from owner config (applied once after config loads)
   const defaultViewApplied = useRef(false);
@@ -724,7 +730,7 @@ export const WorksCalendar = forwardRef<CalendarApi, WorksCalendarProps>(functio
    * All actions also bubble to the external onEmployeeAction prop.
    */
   const handleEmployeeAction = useCallback((empId, actionInput) => {
-    const emp = employees.find(e => String(e.id) === String(empId)) ?? { id: empId, name: empId };
+    const emp = configuredEmployees.find(e => String(e.id) === String(empId)) ?? { id: empId, name: empId };
     const actionPayload = typeof actionInput === 'string'
       ? { type: actionInput }
       : (actionInput ?? {});
@@ -763,7 +769,7 @@ export const WorksCalendar = forwardRef<CalendarApi, WorksCalendarProps>(functio
       setScheduleEditorState({ emp, start: new Date() });
     }
     onEmployeeAction?.(empId, actionInput);
-  }, [employees, expandedEvents, onEmployeeAction]);
+  }, [configuredEmployees, expandedEvents, onEmployeeAction]);
 
   /** Save an availability/PTO event through the engine then notify the host.
    *  Also runs overlap detection: any uncovered shift that overlaps the PTO/
@@ -1272,7 +1278,7 @@ export const WorksCalendar = forwardRef<CalendarApi, WorksCalendarProps>(functio
     if (!hasAddButton) return;
     onDateSelect?.(start, end, resourceId);
 
-    const emp = employees.find(e => String(e.id) === String(resourceId));
+    const emp = configuredEmployees.find(e => String(e.id) === String(resourceId));
     if (!emp) return;
 
     setScheduleEditorState({
@@ -1280,7 +1286,7 @@ export const WorksCalendar = forwardRef<CalendarApi, WorksCalendarProps>(functio
       start: start instanceof Date ? start : new Date(start),
       end: end instanceof Date ? end : new Date(end),
     });
-  }, [employees, hasAddButton, onDateSelect]);
+  }, [configuredEmployees, hasAddButton, onDateSelect]);
 
   const sharedViewProps = {
     currentDate:   cal.currentDate,
@@ -1297,7 +1303,7 @@ export const WorksCalendar = forwardRef<CalendarApi, WorksCalendarProps>(functio
   return (
     <CalendarErrorBoundary>
       <CalendarContext.Provider value={ctxValue}>
-        <div className={styles.root} data-wc-theme={theme} data-testid="works-calendar" data-wc-edit-mode={editMode ? '' : undefined} style={customThemeVars}>
+        <div className={styles.root} data-wc-theme={effectiveTheme} data-testid="works-calendar" data-wc-edit-mode={editMode ? '' : undefined} style={customThemeVars}>
 
         {/* ── Toolbar ── */}
         {renderToolbar ? (
@@ -1323,6 +1329,7 @@ export const WorksCalendar = forwardRef<CalendarApi, WorksCalendarProps>(functio
                 <ChevronRight size={18} aria-hidden="true" />
               </button>
               <span className={styles.dateLabel} aria-live="polite" aria-atomic="true">{getDateLabel()}</span>
+              <span className={styles.calendarTitle}>{calendarTitle}</span>
               {fetchLoading && <span className={styles.loadingDot} title="Loading…" aria-label="Loading events" role="status" />}
             </div>
 
@@ -1489,7 +1496,7 @@ export const WorksCalendar = forwardRef<CalendarApi, WorksCalendarProps>(functio
                   events={visibleEvents}
                   onEventClick={handleEventClick}
                   onDateSelect={handleScheduleDateSelect}
-                  employees={employees}
+                  employees={configuredEmployees}
                   onEmployeeAdd={perms.canManagePeople ? onEmployeeAdd : undefined}
                   onEmployeeDelete={perms.canManagePeople ? onEmployeeDelete : undefined}
                   onShiftStatusChange={handleShiftStatusChange}

--- a/src/ui/ConfigPanel.jsx
+++ b/src/ui/ConfigPanel.jsx
@@ -98,18 +98,17 @@ export default function ConfigPanel({
 }
 
 function SetupTab({ config, onUpdate }) {
-  const selectedTheme = config.wizardData?.preferredTheme ?? 'corporate';
-  const calendarName = config.wizardData?.calendarName ?? 'My WorksCalendar';
+  const selectedTheme = config.setup?.preferredTheme ?? 'corporate';
+  const calendarName = config.title ?? 'My WorksCalendar';
 
   const setCalendarName = (name) => onUpdate(c => ({
     ...c,
-    wizardData: { ...(c.wizardData ?? {}), calendarName: name },
+    title: name,
   }));
 
   const setPreferredTheme = (themeId) => onUpdate(c => ({
     ...c,
-    wizardData: { ...(c.wizardData ?? {}), preferredTheme: themeId },
-    setupCompleted: true,
+    setup: { ...(c.setup ?? {}), preferredTheme: themeId },
   }));
 
   return (
@@ -162,12 +161,12 @@ function SmartViewsTab({ categories, resources, onSaveView }) {
 }
 
 function TeamTab({ config, onUpdate }) {
-  const teamMembers = config.wizardData?.teamMembers ?? [];
+  const teamMembers = config.team?.members ?? [];
 
   const updateMembers = (nextMembers) => onUpdate(c => ({
     ...c,
-    wizardData: { ...(c.wizardData ?? {}), teamMembers: nextMembers },
-    setupCompleted: true,
+    team: { ...(c.team ?? {}), members: nextMembers },
+    setup: { ...(c.setup ?? {}), completed: true },
   }));
 
   const addMember = () => {

--- a/src/ui/SetupWizardModal.jsx
+++ b/src/ui/SetupWizardModal.jsx
@@ -56,11 +56,13 @@ export default function SetupWizardModal({
 
   const handleFinish = () => {
     updateConfig?.({
-      setupCompleted: true,
-      wizardData: {
-        calendarName:   calendarName.trim() || 'My WorksCalendar',
+      title: calendarName.trim() || 'My WorksCalendar',
+      setup: {
         preferredTheme: selectedTheme,
-        teamMembers:    teamMembers.map(({ id, name, color, avatar }) => ({ id, name: name.trim() || 'Teammate', color, avatar })),
+        completed: true,
+      },
+      team: {
+        members: teamMembers.map(({ id, name, color, avatar }) => ({ id, name: name.trim() || 'Teammate', color, avatar })),
       },
     });
     onClose?.();


### PR DESCRIPTION
### Motivation
- Finish migrating UI to the new owner config shape so runtime reads/writes match the schema introduced in the prior change and fix issue #98. 

### Description
- `src/ui/ConfigPanel.jsx`: `SetupTab` now reads/writes `config.title` and `config.setup.preferredTheme`, and `TeamTab` now reads/writes `config.team.members` and sets `config.setup.completed = true` when updating members. 
- `src/ui/SetupWizardModal.jsx`: `handleFinish()` now saves `title`, `setup: { preferredTheme, completed: true }`, and `team: { members }` instead of the legacy `setupCompleted`/`wizardData` shape. 
- `src/WorksCalendar.tsx`: added `effectiveTheme = ownerCfg.config?.setup?.preferredTheme || theme || 'light'`, `calendarTitle = ownerCfg.config?.title || 'My WorksCalendar'`, and `configuredEmployees` fallback to `ownerCfg.config?.team?.members`; switched root `data-wc-theme` to `effectiveTheme`, rendered `calendarTitle` in the toolbar, passed `configuredEmployees` to `TimelineView`, and updated employee lookup callbacks to use `configuredEmployees`. 
- `src/WorksCalendar.module.css`: wired live calendar to theme tokens by adding `font-size: var(--wc-base-font-size, 14px)`, using `border: var(--wc-border-width, 1px) solid var(--wc-border)`, adding `var(--wc-density, 1)` for padding calculations, updating control borders to use `var(--wc-border-width, 1px)`, and adding `.calendarTitle` styling. 

### Testing
- Ran `npm test` and the test suite passed (`Tests 642 passed | 1 todo`).
- Ran `npm run build` and the production build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dfb3bb8e20832ca0c6bbd69c055e20)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Calendar title now displays from configuration.
  * Theme selection is respected from configuration.
  * UI sizing, density and border thickness are controllable via styling variables.

* **Improvements**
  * Settings and setup wizard persist theme, title and team into a streamlined configuration structure.
  * Calendar falls back to configured team members when an explicit employee list isn’t provided, improving schedule consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->