### PR TITLE
Fix calendar event visibility in regression tests (issue #98 follow-up)

### DIFF
--- a/demo/regression-bugs.jsx
+++ b/demo/regression-bugs.jsx
@@ -136,6 +136,7 @@ function App() {
             theme="light"
             showAddButton={true}
             initialView="month"
+            initialDate={today}
           />
         </div>
       </div>


### PR DESCRIPTION
Add initialDate prop to regression-bugs fixture to ensure events are visible. The calendar was defaulting to show the current month, but test events are created relative to "today" using offsets (today+2, today+3, etc.). When today is near the end of a month, these offset events can fall into the next month, making them invisible in the default view and causing test failures.

Fixes failing tests:
- calendar.pill-rendering.spec.ts: cross-day month pill spans test
- calendar.regressions.spec.ts: hover card cross-day range test

Agent-Logs-Url: https://github.com/natehorst240-sketch/CalendarThatWorks/sessions/87595268-e113-4b12-947f-c2ca9b10bb94

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the calendar component's initial state to correctly display today's date on first load, rather than relying on a potentially inconsistent default date selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->