### PR TITLE
Theme token wiring (#98) + FilterBar UX polish (#61)

### DIFF
--- a/src/ui/FilterBar.jsx
+++ b/src/ui/FilterBar.jsx
@@ -161,7 +161,7 @@ export default function FilterBar({
             >
               <span>{mergedGroupLabels[groupKey] ?? DEFAULT_GROUP_LABELS[groupKey] ?? groupKey}</span>
               {count > 0 && <span className={styles.countBadge}>{count}</span>}
-              <ChevronDown size={14} />
+              <span className={styles.chevronIcon}><ChevronDown size={14} /></span>
             </button>
 
             {openGroup === groupKey && (

--- a/src/ui/FilterBar.module.css
+++ b/src/ui/FilterBar.module.css
@@ -8,43 +8,6 @@
   background: var(--wc-bg);
 }
 
-.pillGroup {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 4px;
-}
-
-.pill {
-  padding: 4px 10px;
-  border-radius: 100px;
-  font-size: 12px;
-  font-weight: 500;
-  border: 1px solid var(--wc-border);
-  background: var(--wc-surface);
-  color: var(--wc-text-muted);
-  cursor: pointer;
-  transition: all 0.15s;
-  white-space: nowrap;
-}
-.pill:hover {
-  border-color: var(--wc-accent);
-  color: var(--wc-accent);
-}
-.pill.active {
-  background: var(--wc-accent);
-  border-color: var(--wc-accent);
-  color: #fff;
-}
-
-.resource {
-  background: var(--wc-surface-2);
-}
-.resource.active {
-  background: var(--wc-text);
-  border-color: var(--wc-text);
-  color: var(--wc-bg);
-}
-
 .searchWrap {
   position: relative;
   display: flex;
@@ -66,7 +29,7 @@
   color: var(--wc-text);
   outline: none;
   width: 180px;
-  transition: border-color 0.15s, width 0.2s;
+  transition: border-color 0.15s, width 0.15s;
 }
 .search:focus {
   border-color: var(--wc-accent);
@@ -124,12 +87,6 @@
     padding: 6px 8px;
   }
 
-  /* Pills wrap and stay small */
-  .pill {
-    padding: 3px 8px;
-    font-size: 11px;
-  }
-
   /* Search goes full-width on its own line */
   .searchWrap {
     width: 100%;
@@ -149,49 +106,11 @@
   }
 }
 
-/* Source pills */
-.sourcePill {
-  display: inline-flex;
-  align-items: center;
-  gap: 5px;
-  padding: 4px 10px 4px 7px;
-  border-radius: 100px;
-  font-size: 12px;
-  font-weight: 500;
-  border: 1px solid var(--wc-border);
-  background: var(--wc-surface);
-  color: var(--wc-text-muted);
-  cursor: pointer;
-  transition: all 0.15s;
-  white-space: nowrap;
-  max-width: 160px;
-  overflow: hidden;
-}
-.sourcePill:hover {
-  border-color: var(--wc-accent);
-  color: var(--wc-text);
-}
-.sourcePill.active {
-  color: #fff;
-  /* background and border-color set via inline style (source color) */
-}
 .sourceDot {
   width: 8px;
   height: 8px;
   border-radius: 50%;
   flex-shrink: 0;
-}
-.sourceLabel {
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-.sourceType {
-  font-size: 10px;
-  opacity: 0.7;
-  flex-shrink: 0;
-  text-transform: uppercase;
-  letter-spacing: 0.04em;
 }
 
 /* ── Active filter pills ── */
@@ -199,7 +118,9 @@
   display: flex;
   flex-wrap: wrap;
   gap: 6px;
-  padding: 4px 0 0;
+  padding: 6px 0 0;
+  border-top: 1px solid var(--wc-border);
+  margin-top: 2px;
   width: 100%;
   order: 99;
 }
@@ -207,7 +128,7 @@
   display: inline-flex;
   align-items: center;
   gap: 4px;
-  padding: 2px 8px 2px 10px;
+  padding: 3px 8px 3px 10px;
   background: var(--wc-accent);
   color: #fff;
   border-radius: 100px;
@@ -236,6 +157,7 @@
   background: var(--wc-surface);
   color: var(--wc-text);
   font-size: 12px;
+  font-weight: 500;
   cursor: pointer;
 }
 .selectInput:focus { outline: none; border-color: var(--wc-accent); }
@@ -263,7 +185,7 @@
   border-color: var(--wc-accent);
   color: var(--wc-accent);
 }
-.boolCheck { cursor: pointer; }
+.boolCheck { cursor: pointer; accent-color: var(--wc-accent); }
 
 /* ── Date range ── */
 .dateRange {
@@ -355,6 +277,14 @@
   color: var(--wc-accent);
 }
 
+.chevronIcon {
+  display: inline-flex;
+  transition: transform 0.15s;
+}
+.dropdownBtnOpen .chevronIcon {
+  transform: rotate(180deg);
+}
+
 .countBadge {
   display: inline-flex;
   align-items: center;
@@ -386,8 +316,8 @@
 }
 
 .menuSection + .menuSection {
-  margin-top: 8px;
-  padding-top: 8px;
+  margin-top: 6px;
+  padding-top: 6px;
   border-top: 1px solid var(--wc-border);
 }
 
@@ -397,7 +327,7 @@
   color: var(--wc-text-faint);
   text-transform: uppercase;
   letter-spacing: 0.05em;
-  margin-bottom: 6px;
+  margin-bottom: 4px;
 }
 
 .menuOptions {
@@ -416,6 +346,7 @@
   border: 1px solid transparent;
   background: transparent;
   color: var(--wc-text);
+  font-size: 13px;
   cursor: pointer;
   text-align: left;
 }
@@ -458,7 +389,12 @@
 .dropdownBtn:focus-visible,
 .selectInput:focus-visible,
 .dateInput:focus-visible,
-.boolLabel:focus-visible {
+.boolLabel:focus-visible,
+.search:focus-visible,
+.clearSearch:focus-visible,
+.dateClear:focus-visible,
+.clearAll:focus-visible,
+.hoverToggle:focus-visible {
   outline: 2px solid var(--wc-accent);
   outline-offset: 1px;
 }


### PR DESCRIPTION
## Summary

Two sprints addressing open issues, plus a date-sensitive E2E test fix:

### 1. Wire theme customizer tokens to live calendar (#98)
- Fix ThemeCustomizer preview: replace `--tc-density` with `--wc-density`
- Replace 13 hardcoded `box-shadow` values with `var(--wc-shadow)` / `var(--wc-shadow-sm)` across 9 files
- Add `--wc-font-scale` ratio and apply `calc()` scaling to 17 key visible text elements (date labels, event titles, hour labels, resource names)
- Extend `--wc-density` `calc()` to view padding in MonthView, WeekView, DayView, AgendaView, TimelineView, ScheduleView
- Replace hardcoded error colors (`#fecaca`) with `var(--wc-danger)` tokens

### 2. FilterBar UX polish and consistency pass (#61)
- Remove ~55 lines of dead CSS (`.pill`, `.pillGroup`, `.resource`, `.sourcePill`, `.sourceLabel`, `.sourceType`)
- Fix active pill vertical padding (2px → 3px)
- Add explicit `font-size: 13px` on dropdown option rows
- Tighten dropdown section spacing (16px → 12px gap, 6px → 4px head margin)
- Theme boolean checkbox with `accent-color: var(--wc-accent)`
- Add chevron rotation (180deg) on dropdown open with smooth transition
- Add `border-top` separator on active pills row
- Expand `focus-visible` rules to search, clear buttons, clear-all, hover toggle
- Add `font-weight: 500` to `<select>` matching dropdown button weight
- Standardize search transition to 0.15s

### 3. Fix date-dependent E2E test failures
- Cross-day hover range event (today+2 → today+3) can land on Sat→Sun boundary, splitting span bars across week rows
- Relaxed test regexes to handle "continues next week" aria-label suffix
- Made multi-cell width assertion conditional on same-row layout

## Test plan

- [ ] Verify default appearance is pixel-identical (all theme tokens default to 1)
- [ ] Test font size slider at 12px and 20px — visible text should scale
- [ ] Test shadow slider at 0 and 32 — modals/popovers should respond
- [ ] Test density slider at 0.8x and 1.2x — toolbar AND view padding should respond
- [ ] Open FilterBar with no filters — verify no visual regression
- [ ] Activate filters across all types — verify pills, dropdowns, checkboxes render consistently
- [ ] Tab through FilterBar controls — verify focus rings on every element
- [ ] Open/close dropdown menus — verify chevron rotates smoothly
- [ ] Test with dark and light themes
- [ ] E2E tests pass (84 passing + 2 previously flaky now resilient)

https://claude.ai/code/session_01ELnwLQxfqBsEZ1dK8A8Vvb