### PR TITLE
Add enhanced filtering sprint plan (4 sprints, 16 Codex-sized tasks)

### DIFF
--- a/src/filters/__tests__/conditionEngine.test.js
+++ b/src/filters/__tests__/conditionEngine.test.js
@@ -1,0 +1,152 @@
+import { describe, it, expect } from 'vitest'
+import { conditionsToFilters, conditionsMatchSchema } from '../conditionEngine.js'
+import { DEFAULT_FILTER_SCHEMA } from '../filterSchema.js'
+
+const schema = DEFAULT_FILTER_SCHEMA
+
+// ── conditionsToFilters ───────────────────────────────────────────────────────
+
+describe('conditionsToFilters', () => {
+  it('single "is" on multi-select produces a Set', () => {
+    const conditions = [
+      { field: 'categories', operator: 'is', value: 'Meeting' },
+    ]
+    const result = conditionsToFilters(conditions, schema)
+    expect(result.categories).toBeInstanceOf(Set)
+    expect(result.categories.has('Meeting')).toBe(true)
+  })
+
+  it('multiple "is" on same multi-select field accumulates into one Set', () => {
+    const conditions = [
+      { field: 'categories', operator: 'is', value: 'Meeting' },
+      { field: 'categories', operator: 'is', value: 'PTO' },
+    ]
+    const result = conditionsToFilters(conditions, schema)
+    expect(result.categories).toBeInstanceOf(Set)
+    expect(result.categories.size).toBe(2)
+    expect(result.categories.has('PTO')).toBe(true)
+  })
+
+  it('"contains" on text produces search string', () => {
+    const conditions = [
+      { field: 'search', operator: 'contains', value: 'quarterly' },
+    ]
+    const result = conditionsToFilters(conditions, schema)
+    expect(result.search).toBe('quarterly')
+  })
+
+  it('"is" on text produces search string', () => {
+    const conditions = [
+      { field: 'search', operator: 'is', value: 'standup' },
+    ]
+    const result = conditionsToFilters(conditions, schema)
+    expect(result.search).toBe('standup')
+  })
+
+  it('"is_not" produces negation wrapper with Set', () => {
+    const conditions = [
+      { field: 'categories', operator: 'is_not', value: 'PTO' },
+    ]
+    const result = conditionsToFilters(conditions, schema)
+    expect(result.categories).toMatchObject({ __not: true })
+    expect(result.categories.values).toBeInstanceOf(Set)
+    expect(result.categories.values.has('PTO')).toBe(true)
+  })
+
+  it('multiple "is_not" on same field accumulates into one negation wrapper', () => {
+    const conditions = [
+      { field: 'categories', operator: 'is_not', value: 'PTO' },
+      { field: 'categories', operator: 'is_not', value: 'Holiday' },
+    ]
+    const result = conditionsToFilters(conditions, schema)
+    expect(result.categories.__not).toBe(true)
+    expect(result.categories.values.size).toBe(2)
+  })
+
+  it('"not_contains" on text produces negation wrapper', () => {
+    const conditions = [
+      { field: 'search', operator: 'not_contains', value: 'standup' },
+    ]
+    const result = conditionsToFilters(conditions, schema)
+    expect(result.search.__not).toBe(true)
+    expect(result.search.values.has('standup')).toBe(true)
+  })
+
+  it('unknown field key is skipped gracefully', () => {
+    const conditions = [
+      { field: 'nonexistent', operator: 'is', value: 'foo' },
+      { field: 'categories',  operator: 'is', value: 'Meeting' },
+    ]
+    const result = conditionsToFilters(conditions, schema)
+    expect(result.nonexistent).toBeUndefined()
+    expect(result.categories).toBeInstanceOf(Set)
+  })
+
+  it('unknown operator on a known field is skipped gracefully', () => {
+    const conditions = [
+      { field: 'categories', operator: 'unknown_op', value: 'Meeting' },
+    ]
+    const result = conditionsToFilters(conditions, schema)
+    expect(result.categories).toBeUndefined()
+  })
+
+  it('empty value is skipped', () => {
+    const conditions = [
+      { field: 'categories', operator: 'is', value: '' },
+      { field: 'categories', operator: 'is', value: '   ' },
+    ]
+    const result = conditionsToFilters(conditions, schema)
+    expect(result.categories).toBeUndefined()
+  })
+
+  it('multiple fields are processed independently', () => {
+    const conditions = [
+      { field: 'categories', operator: 'is',       value: 'Meeting'   },
+      { field: 'resources',  operator: 'is',       value: 'Alice'     },
+      { field: 'search',     operator: 'contains', value: 'quarterly' },
+    ]
+    const result = conditionsToFilters(conditions, schema)
+    expect(result.categories.has('Meeting')).toBe(true)
+    expect(result.resources.has('Alice')).toBe(true)
+    expect(result.search).toBe('quarterly')
+  })
+})
+
+// ── conditionsMatchSchema ─────────────────────────────────────────────────────
+
+describe('conditionsMatchSchema', () => {
+  it('returns valid=true when all field keys exist in schema', () => {
+    const conditions = [
+      { field: 'categories', operator: 'is', value: 'Meeting' },
+      { field: 'search',     operator: 'contains', value: 'foo' },
+    ]
+    const { valid, invalidKeys } = conditionsMatchSchema(conditions, schema)
+    expect(valid).toBe(true)
+    expect(invalidKeys).toHaveLength(0)
+  })
+
+  it('returns valid=false with unknown keys listed', () => {
+    const conditions = [
+      { field: 'categories', operator: 'is', value: 'Meeting' },
+      { field: 'ghost',      operator: 'is', value: 'foo'     },
+    ]
+    const { valid, invalidKeys } = conditionsMatchSchema(conditions, schema)
+    expect(valid).toBe(false)
+    expect(invalidKeys).toContain('ghost')
+  })
+
+  it('deduplicates repeated invalid keys', () => {
+    const conditions = [
+      { field: 'ghost', operator: 'is', value: 'a' },
+      { field: 'ghost', operator: 'is', value: 'b' },
+    ]
+    const { invalidKeys } = conditionsMatchSchema(conditions, schema)
+    expect(invalidKeys.filter(k => k === 'ghost')).toHaveLength(1)
+  })
+
+  it('returns valid=true for an empty conditions array', () => {
+    const { valid, invalidKeys } = conditionsMatchSchema([], schema)
+    expect(valid).toBe(true)
+    expect(invalidKeys).toHaveLength(0)
+  })
+})

--- a/src/filters/conditionEngine.js
+++ b/src/filters/conditionEngine.js
@@ -1,0 +1,88 @@
+/**
+ * conditionEngine — schema-driven conversion between visual conditions and filter state.
+ *
+ * A "condition" is a single row from AdvancedFilterBuilder:
+ *   { id, field, operator, value, logic }
+ * where `field` matches a FilterField.key in the schema.
+ */
+
+// ── conditionsToFilters ───────────────────────────────────────────────────────
+
+/**
+ * Convert an array of visual conditions into a filter state object.
+ *
+ * Rules per type/operator:
+ *   multi-select + is         → accumulate value into a Set at result[field.key]
+ *   select       + is         → set result[field.key] = value directly (last wins)
+ *   text         + contains   → set result[field.key] = value (last wins)
+ *   text         + is         → set result[field.key] = value (last wins)
+ *   any          + is_not     → accumulate into { __not: true, values: Set }
+ *   any          + not_contains → accumulate into { __not: true, values: Set }
+ *   unknown field/operator    → skipped gracefully
+ */
+export function conditionsToFilters(conditions, schema) {
+  const schemaMap = new Map(schema.map(f => [f.key, f]))
+  const result = {}
+
+  for (const cond of conditions) {
+    const raw = cond.value
+    const val = typeof raw === 'string' ? raw.trim() : raw
+    if (!val) continue
+
+    const field = schemaMap.get(cond.field)
+    if (!field) continue
+
+    const { operator } = cond
+
+    if (operator === 'is_not' || operator === 'not_contains') {
+      const existing = result[field.key]
+      if (existing && existing.__not === true) {
+        existing.values.add(val)
+      } else {
+        result[field.key] = { __not: true, values: new Set([val]) }
+      }
+      continue
+    }
+
+    if (field.type === 'multi-select') {
+      if (operator === 'is') {
+        const existing = result[field.key]
+        if (existing instanceof Set) {
+          existing.add(val)
+        } else {
+          result[field.key] = new Set([val])
+        }
+      }
+    } else if (field.type === 'select') {
+      if (operator === 'is') {
+        result[field.key] = val
+      }
+    } else if (field.type === 'text') {
+      if (operator === 'contains' || operator === 'is') {
+        result[field.key] = val
+      }
+    }
+    // date-range, boolean, custom: no operator-aware mapping at this stage
+  }
+
+  return result
+}
+
+// ── conditionsMatchSchema ─────────────────────────────────────────────────────
+
+/**
+ * Validate that every condition's field key exists in the schema.
+ * Returns { valid: boolean, invalidKeys: string[] }.
+ */
+export function conditionsMatchSchema(conditions, schema) {
+  const knownKeys = new Set(schema.map(f => f.key))
+  const invalidKeys = []
+
+  for (const cond of conditions) {
+    if (!knownKeys.has(cond.field) && !invalidKeys.includes(cond.field)) {
+      invalidKeys.push(cond.field)
+    }
+  }
+
+  return { valid: invalidKeys.length === 0, invalidKeys }
+}


### PR DESCRIPTION
Breaks Phase 1 enhanced filtering into manageable implementation
sprints: schema-driven AdvancedFilterBuilder, NOT operators + relative
dates, filter URL serialization + quick presets, and UX polish.

https://claude.ai/code/session_01FhMAnVsP7rJX3K6AtbJaNb

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive implementation roadmap for filtering system enhancements planned across four sprints.

* **Tests**
  * New test suite validates filter operator definitions and operator configuration for all field types in the filter schema.

* **Chores**
  * Extended filter schema infrastructure to support configurable operator definitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->