### PR TITLE
feat(filters): add operator definitions to filterSchema (Task 1.1)

### DIFF
--- a/src/filters/__tests__/filterOperators.test.ts
+++ b/src/filters/__tests__/filterOperators.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect } from 'vitest'
+import {
+  defaultOperatorsForType,
+  DEFAULT_FILTER_SCHEMA,
+  statusField,
+  priorityField,
+  ownerField,
+  tagsField,
+  metaSelectField,
+} from '../filterSchema.js'
+
+describe('defaultOperatorsForType', () => {
+  it('returns 2 operators for multi-select', () => {
+    const ops = defaultOperatorsForType('multi-select')
+    expect(ops).toHaveLength(2)
+    expect(ops.map(o => o.value)).toEqual(['is', 'is_not'])
+  })
+
+  it('returns 2 operators for select', () => {
+    const ops = defaultOperatorsForType('select')
+    expect(ops).toHaveLength(2)
+    expect(ops.map(o => o.value)).toEqual(['is', 'is_not'])
+  })
+
+  it('returns 3 operators for text', () => {
+    const ops = defaultOperatorsForType('text')
+    expect(ops).toHaveLength(3)
+    expect(ops.map(o => o.value)).toEqual(['contains', 'not_contains', 'is'])
+  })
+
+  it('returns 3 operators for date-range', () => {
+    const ops = defaultOperatorsForType('date-range')
+    expect(ops).toHaveLength(3)
+    expect(ops.map(o => o.value)).toEqual(['between', 'before', 'after'])
+  })
+
+  it('returns 1 operator for boolean', () => {
+    const ops = defaultOperatorsForType('boolean')
+    expect(ops).toHaveLength(1)
+    expect(ops[0].value).toBe('is')
+  })
+
+  it('returns empty array for custom', () => {
+    expect(defaultOperatorsForType('custom')).toEqual([])
+  })
+})
+
+describe('field factories include operators', () => {
+  it('statusField has select operators', () => {
+    const field = statusField()
+    expect(field.operators).toBeDefined()
+    expect(field.operators!.map(o => o.value)).toEqual(['is', 'is_not'])
+  })
+
+  it('priorityField has select operators', () => {
+    const field = priorityField()
+    expect(field.operators).toBeDefined()
+    expect(field.operators!.map(o => o.value)).toEqual(['is', 'is_not'])
+  })
+
+  it('ownerField has multi-select operators', () => {
+    const field = ownerField()
+    expect(field.operators).toBeDefined()
+    expect(field.operators!.map(o => o.value)).toEqual(['is', 'is_not'])
+  })
+
+  it('tagsField has multi-select operators', () => {
+    const field = tagsField()
+    expect(field.operators).toBeDefined()
+    expect(field.operators!.map(o => o.value)).toEqual(['is', 'is_not'])
+  })
+
+  it('metaSelectField has select operators', () => {
+    const field = metaSelectField('department')
+    expect(field.operators).toBeDefined()
+    expect(field.operators!.map(o => o.value)).toEqual(['is', 'is_not'])
+  })
+
+  it('overrides can replace operators', () => {
+    const field = statusField({ operators: [{ value: 'is', label: 'is' }] })
+    expect(field.operators).toHaveLength(1)
+  })
+})
+
+describe('DEFAULT_FILTER_SCHEMA includes operators', () => {
+  it('all fields have operators defined', () => {
+    for (const field of DEFAULT_FILTER_SCHEMA) {
+      expect(field.operators, `${field.key} missing operators`).toBeDefined()
+    }
+  })
+
+  it('categories field has multi-select operators', () => {
+    const field = DEFAULT_FILTER_SCHEMA.find(f => f.key === 'categories')!
+    expect(field.operators!.map(o => o.value)).toEqual(['is', 'is_not'])
+  })
+
+  it('dateRange field has date-range operators', () => {
+    const field = DEFAULT_FILTER_SCHEMA.find(f => f.key === 'dateRange')!
+    expect(field.operators!.map(o => o.value)).toEqual(['between', 'before', 'after'])
+  })
+
+  it('search field has text operators', () => {
+    const field = DEFAULT_FILTER_SCHEMA.find(f => f.key === 'search')!
+    expect(field.operators!.map(o => o.value)).toEqual(['contains', 'not_contains', 'is'])
+  })
+})

--- a/src/filters/filterSchema.ts
+++ b/src/filters/filterSchema.ts
@@ -19,6 +19,42 @@ export type FilterFieldType =
   | 'boolean'
   | 'custom'
 
+export type FilterOperator = {
+  value: string
+  label: string
+  noValue?: boolean
+}
+
+export function defaultOperatorsForType(type: FilterFieldType): FilterOperator[] {
+  switch (type) {
+    case 'multi-select':
+    case 'select':
+      return [
+        { value: 'is',     label: 'is' },
+        { value: 'is_not', label: 'is not' },
+      ]
+    case 'text':
+      return [
+        { value: 'contains',     label: 'contains' },
+        { value: 'not_contains', label: 'does not contain' },
+        { value: 'is',           label: 'is exactly' },
+      ]
+    case 'date-range':
+      return [
+        { value: 'between', label: 'between' },
+        { value: 'before',  label: 'before' },
+        { value: 'after',   label: 'after' },
+      ]
+    case 'boolean':
+      return [
+        { value: 'is', label: 'is' },
+      ]
+    case 'custom':
+    default:
+      return []
+  }
+}
+
 export type FilterOption = {
   /** Human-readable text shown in pills and dropdowns. */
   label: string
@@ -66,6 +102,8 @@ export type FilterField = {
    * Boolean, or a function receiving the current items + active filters.
    */
   hidden?: boolean | ((ctx: { items: unknown[]; filters: Record<string, unknown> }) => boolean)
+  /** Operators available for this field. Defaults to defaultOperatorsForType(type). */
+  operators?: FilterOperator[]
 }
 
 /** Generic filter state — one key per FilterField, value shape depends on type. */
@@ -94,6 +132,7 @@ export function statusField(overrides: Partial<FilterField> = {}): FilterField {
       { label: 'Tentative', value: 'tentative' },
       { label: 'Cancelled', value: 'cancelled' },
     ],
+    operators: defaultOperatorsForType('select'),
     predicate: (item: any, value: any) =>
       (item.status ?? 'confirmed') === value,
     ...overrides,
@@ -116,6 +155,7 @@ export function priorityField(overrides: Partial<FilterField> = {}): FilterField
       { label: 'High',     value: 'high',     color: '#ef4444' },
       { label: 'Critical', value: 'critical', color: '#7c3aed' },
     ],
+    operators: defaultOperatorsForType('select'),
     predicate: (item: any, value: any) =>
       ((item as any).priority ?? (item as any).meta?.priority) === value,
     ...overrides,
@@ -131,6 +171,7 @@ export function ownerField(overrides: Partial<FilterField> = {}): FilterField {
     key:   'owner',
     label: 'Owner',
     type:  'multi-select',
+    operators: defaultOperatorsForType('multi-select'),
     predicate: (item: any, value: any) => {
       const owner = item.owner ?? item.meta?.owner ?? item.meta?.assignee
       return value instanceof Set
@@ -159,6 +200,7 @@ export function tagsField(overrides: Partial<FilterField> = {}): FilterField {
     key:   'tags',
     label: 'Tag',
     type:  'multi-select',
+    operators: defaultOperatorsForType('multi-select'),
     predicate: (item: any, value: any) => {
       const itemTags: string[] = item.tags ?? item.meta?.tags ?? []
       const active = value instanceof Set ? value : new Set(value as string[])
@@ -188,6 +230,7 @@ export function metaSelectField(
     key:   metaKey,
     label: metaKey.charAt(0).toUpperCase() + metaKey.slice(1),
     type:  'select',
+    operators: defaultOperatorsForType('select'),
     predicate: (item: any, value: any) =>
       (item.meta?.[metaKey] ?? item[metaKey]) === value,
     getOptions: (items: any[]) => {
@@ -210,9 +253,10 @@ export function metaSelectField(
 
 export const DEFAULT_FILTER_SCHEMA: FilterField[] = [
   {
-    key:   'categories',
-    label: 'Category',
-    type:  'multi-select',
+    key:       'categories',
+    label:     'Category',
+    type:      'multi-select',
+    operators: defaultOperatorsForType('multi-select'),
     predicate: (item: any, value: any) =>
       value instanceof Set
         ? value.has(item.category)
@@ -224,9 +268,10 @@ export const DEFAULT_FILTER_SCHEMA: FilterField[] = [
     },
   },
   {
-    key:   'resources',
-    label: 'Resource',
-    type:  'multi-select',
+    key:       'resources',
+    label:     'Resource',
+    type:      'multi-select',
+    operators: defaultOperatorsForType('multi-select'),
     predicate: (item: any, value: any) =>
       value instanceof Set
         ? value.has(item.resource)
@@ -238,9 +283,10 @@ export const DEFAULT_FILTER_SCHEMA: FilterField[] = [
     },
   },
   {
-    key:   'sources',
-    label: 'Source',
-    type:  'multi-select',
+    key:       'sources',
+    label:     'Source',
+    type:      'multi-select',
+    operators: defaultOperatorsForType('multi-select'),
     // Events without _sourceId (passed via the events prop) are always visible.
     predicate: (item: any, value: any) =>
       !item._sourceId ||
@@ -262,14 +308,16 @@ export const DEFAULT_FILTER_SCHEMA: FilterField[] = [
     },
   },
   {
-    key:   'dateRange',
-    label: 'Date',
-    type:  'date-range',
+    key:       'dateRange',
+    label:     'Date',
+    type:      'date-range',
+    operators: defaultOperatorsForType('date-range'),
   },
   {
     key:         'search',
     label:       'Search',
     type:        'text',
     placeholder: 'Search events…',
+    operators:   defaultOperatorsForType('text'),
   },
 ]


### PR DESCRIPTION
- Add FilterOperator type with value, label, noValue fields
- Add defaultOperatorsForType() returning per-type operator arrays
- Add operators field to FilterField type
- Wire operators into all field factories and DEFAULT_FILTER_SCHEMA entries
- Add filterOperators.test.ts covering all types, factories, and schema

https://claude.ai/code/session_01Rh96xx91aftedGd8yMcrSi