### PR TITLE
Add enhanced filtering sprint plan (4 sprints, 16 Codex-sized tasks)

### DIFF
--- a/src/WorksCalendar.tsx
+++ b/src/WorksCalendar.tsx
@@ -138,6 +138,7 @@ export type WorksCalendarProps = {
   showAddButton?: boolean;
   initialView?: CalendarView;
   weekStartDay?: 0 | 1;
+  groupBy?: string;
 };
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
@@ -266,6 +267,9 @@ export const WorksCalendar = forwardRef<CalendarApi, WorksCalendarProps>(functio
 
     // ── Week start day (prop takes priority over owner config) ──
     weekStartDay: weekStartDayProp,
+
+    // ── Grouping ──
+    groupBy,
   }: WorksCalendarProps,
   ref: ForwardedRef<CalendarApi>,
 ) {
@@ -1489,7 +1493,7 @@ export const WorksCalendar = forwardRef<CalendarApi, WorksCalendarProps>(functio
               {cal.view === 'month'    && <MonthView    {...sharedViewProps} />}
               {cal.view === 'week'     && <WeekView     {...sharedViewProps} />}
               {cal.view === 'day'      && <DayView      {...sharedViewProps} />}
-              {cal.view === 'agenda'   && <AgendaView   currentDate={cal.currentDate} events={visibleEvents} onEventClick={handleEventClick} />}
+              {cal.view === 'agenda'   && <AgendaView   currentDate={cal.currentDate} events={visibleEvents} onEventClick={handleEventClick} groupBy={groupBy} />}
               {cal.view === 'schedule' && (
                 <TimelineView
                   currentDate={cal.currentDate}
@@ -1502,6 +1506,7 @@ export const WorksCalendar = forwardRef<CalendarApi, WorksCalendarProps>(functio
                   onShiftStatusChange={handleShiftStatusChange}
                   onCoverageAssign={handleCoverageAssign}
                   onEmployeeAction={handleEmployeeAction}
+                  groupBy={groupBy}
                 />
               )}
             </>

--- a/src/grouping/__tests__/buildFieldAccessor.test.js
+++ b/src/grouping/__tests__/buildFieldAccessor.test.js
@@ -1,0 +1,44 @@
+import { describe, it, expect } from 'vitest';
+import { buildFieldAccessor } from '../buildFieldAccessor.js';
+
+describe('buildFieldAccessor — employee mode', () => {
+  const accessor = buildFieldAccessor('role', 'employee');
+
+  it('extracts emp.role directly', () => {
+    expect(accessor({ emp: { role: 'Nurse' } })).toBe('Nurse');
+  });
+
+  it('falls back to emp.meta.role', () => {
+    expect(accessor({ emp: { meta: { role: 'Doctor' } } })).toBe('Doctor');
+  });
+
+  it('returns null when field is missing', () => {
+    expect(accessor({ emp: {} })).toBeNull();
+  });
+
+  it('returns null when emp is absent', () => {
+    expect(accessor({})).toBeNull();
+  });
+});
+
+describe('buildFieldAccessor — resource mode', () => {
+  const accessor = buildFieldAccessor('department', 'resource');
+
+  it('extracts first event department', () => {
+    const row = { events: [{ department: 'Engineering' }] };
+    expect(accessor(row)).toBe('Engineering');
+  });
+
+  it('falls back to first event meta.department', () => {
+    const row = { events: [{ meta: { department: 'Design' } }] };
+    expect(accessor(row)).toBe('Design');
+  });
+
+  it('returns null when no events', () => {
+    expect(accessor({ events: [] })).toBeNull();
+  });
+
+  it('returns null when field missing from event', () => {
+    expect(accessor({ events: [{}] })).toBeNull();
+  });
+});

--- a/src/grouping/__tests__/groupRows.test.js
+++ b/src/grouping/__tests__/groupRows.test.js
@@ -1,0 +1,69 @@
+import { describe, it, expect } from 'vitest';
+import { groupRows } from '../groupRows.js';
+
+const rows = [
+  { id: 1, emp: { role: 'Nurse' } },
+  { id: 2, emp: { role: 'Nurse' } },
+  { id: 3, emp: { role: 'Doctor' } },
+  { id: 4, emp: { role: 'Doctor' } },
+  { id: 5, emp: { role: 'Nurse' } },
+  { id: 6, emp: { role: null } },
+];
+
+const fieldAccessor = (row) => row.emp?.role ?? null;
+
+describe('groupRows', () => {
+  it('groups rows by field value', () => {
+    const { flatRows, groupOrder } = groupRows(rows, { groupBy: 'role', fieldAccessor });
+    expect(groupOrder).toEqual(['Nurse', 'Doctor', '(Ungrouped)']);
+    expect(flatRows.filter(r => r._type === 'groupHeader').length).toBe(3);
+    expect(flatRows.filter(r => !r._type).length).toBe(6);
+  });
+
+  it('interleaves headers and members correctly', () => {
+    const { flatRows } = groupRows(rows, { groupBy: 'role', fieldAccessor });
+    const nurseHeader = flatRows.find(r => r._type === 'groupHeader' && r.groupKey === 'Nurse');
+    expect(nurseHeader).toBeDefined();
+    expect(nurseHeader.count).toBe(3);
+    const doctorHeader = flatRows.find(r => r._type === 'groupHeader' && r.groupKey === 'Doctor');
+    expect(doctorHeader.count).toBe(2);
+  });
+
+  it('collapsed group keeps header but omits members', () => {
+    const { flatRows } = groupRows(rows, {
+      groupBy: 'role',
+      fieldAccessor,
+      collapsedGroups: new Set(['Nurse']),
+    });
+    const nurseHeader = flatRows.find(r => r._type === 'groupHeader' && r.groupKey === 'Nurse');
+    expect(nurseHeader.collapsed).toBe(true);
+    const nurseMembers = flatRows.filter(r => !r._type && r.emp?.role === 'Nurse');
+    expect(nurseMembers.length).toBe(0);
+    // Doctor members still present
+    expect(flatRows.filter(r => !r._type && r.emp?.role === 'Doctor').length).toBe(2);
+  });
+
+  it('null/undefined values go to (Ungrouped) sorted last', () => {
+    const { groupOrder, flatRows } = groupRows(rows, { groupBy: 'role', fieldAccessor });
+    expect(groupOrder[groupOrder.length - 1]).toBe('(Ungrouped)');
+    const ungrouped = flatRows.find(r => r._type === 'groupHeader' && r.groupKey === '(Ungrouped)');
+    expect(ungrouped.count).toBe(1);
+  });
+
+  it('returns empty flatRows and groupOrder for empty input', () => {
+    const { flatRows, groupOrder } = groupRows([], { groupBy: 'role', fieldAccessor });
+    expect(flatRows).toEqual([]);
+    expect(groupOrder).toEqual([]);
+  });
+
+  it('returns identity (same reference) when groupBy is not set', () => {
+    const { flatRows } = groupRows(rows, {});
+    expect(flatRows).toBe(rows);
+  });
+
+  it('groupOrder reflects insertion order among non-ungrouped keys', () => {
+    const { groupOrder } = groupRows(rows, { groupBy: 'role', fieldAccessor });
+    expect(groupOrder[0]).toBe('Nurse');
+    expect(groupOrder[1]).toBe('Doctor');
+  });
+});

--- a/src/grouping/buildFieldAccessor.js
+++ b/src/grouping/buildFieldAccessor.js
@@ -1,0 +1,18 @@
+export function buildFieldAccessor(fieldName, mode) {
+  if (mode === 'employee') {
+    return (row) => {
+      const val = row.emp?.[fieldName];
+      if (val != null) return val;
+      return row.emp?.meta?.[fieldName] ?? null;
+    };
+  }
+
+  // resource mode: read from first event's fields
+  return (row) => {
+    const firstEvent = row.events?.[0];
+    if (!firstEvent) return null;
+    const val = firstEvent[fieldName];
+    if (val != null) return val;
+    return firstEvent.meta?.[fieldName] ?? null;
+  };
+}

--- a/src/grouping/groupRows.js
+++ b/src/grouping/groupRows.js
@@ -1,0 +1,46 @@
+export function groupRows(rows, options = {}) {
+  const {
+    groupBy,
+    fieldAccessor,
+    collapsedGroups = new Set(),
+    groupHeaderHeight = 36,
+  } = options;
+
+  if (!groupBy || !fieldAccessor || rows.length === 0) {
+    return { flatRows: rows, groupOrder: [] };
+  }
+
+  const groupMap = new Map();
+  for (const row of rows) {
+    const val = fieldAccessor(row);
+    const key = val != null && val !== '' ? String(val) : '(Ungrouped)';
+    if (!groupMap.has(key)) groupMap.set(key, []);
+    groupMap.get(key).push(row);
+  }
+
+  // Insertion order preserved; (Ungrouped) sorted last
+  const groupOrder = [...groupMap.keys()].sort((a, b) => {
+    if (a === '(Ungrouped)') return 1;
+    if (b === '(Ungrouped)') return -1;
+    return 0;
+  });
+
+  const flatRows = [];
+  for (const groupKey of groupOrder) {
+    const members = groupMap.get(groupKey);
+    const collapsed = collapsedGroups.has(groupKey);
+    flatRows.push({
+      _type: 'groupHeader',
+      groupKey,
+      groupLabel: groupKey,
+      collapsed,
+      rowH: groupHeaderHeight,
+      count: members.length,
+    });
+    if (!collapsed) {
+      flatRows.push(...members);
+    }
+  }
+
+  return { flatRows, groupOrder };
+}

--- a/src/hooks/__tests__/useGrouping.test.js
+++ b/src/hooks/__tests__/useGrouping.test.js
@@ -1,0 +1,67 @@
+import { describe, it, expect } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useGrouping } from '../useGrouping.js';
+
+const rows = [
+  { id: 1, emp: { role: 'Nurse' } },
+  { id: 2, emp: { role: 'Nurse' } },
+  { id: 3, emp: { role: 'Doctor' } },
+];
+
+const fieldAccessor = (row) => row.emp?.role ?? null;
+
+describe('useGrouping', () => {
+  it('returns identity flatRows when groupBy is null', () => {
+    const { result } = renderHook(() => useGrouping(rows, {}));
+    expect(result.current.flatRows).toBe(rows);
+    expect(result.current.isGrouped).toBe(false);
+  });
+
+  it('returns grouped flatRows when groupBy is set', () => {
+    const { result } = renderHook(() =>
+      useGrouping(rows, { groupBy: 'role', fieldAccessor }),
+    );
+    expect(result.current.isGrouped).toBe(true);
+    expect(result.current.groupOrder).toEqual(['Nurse', 'Doctor']);
+    const headers = result.current.flatRows.filter(r => r._type === 'groupHeader');
+    expect(headers.length).toBe(2);
+  });
+
+  it('toggleGroup adds key to collapsedGroups', () => {
+    const { result } = renderHook(() =>
+      useGrouping(rows, { groupBy: 'role', fieldAccessor }),
+    );
+    act(() => result.current.toggleGroup('Nurse'));
+    expect(result.current.collapsedGroups.has('Nurse')).toBe(true);
+    const nurseMembers = result.current.flatRows.filter(r => !r._type && r.emp?.role === 'Nurse');
+    expect(nurseMembers.length).toBe(0);
+  });
+
+  it('toggleGroup removes key when already collapsed', () => {
+    const { result } = renderHook(() =>
+      useGrouping(rows, { groupBy: 'role', fieldAccessor }),
+    );
+    act(() => result.current.toggleGroup('Nurse'));
+    act(() => result.current.toggleGroup('Nurse'));
+    expect(result.current.collapsedGroups.has('Nurse')).toBe(false);
+  });
+
+  it('expandAll clears collapsedGroups', () => {
+    const { result } = renderHook(() =>
+      useGrouping(rows, { groupBy: 'role', fieldAccessor }),
+    );
+    act(() => result.current.toggleGroup('Nurse'));
+    act(() => result.current.toggleGroup('Doctor'));
+    act(() => result.current.expandAll());
+    expect(result.current.collapsedGroups.size).toBe(0);
+  });
+
+  it('collapseAll collapses all groups', () => {
+    const { result } = renderHook(() =>
+      useGrouping(rows, { groupBy: 'role', fieldAccessor }),
+    );
+    act(() => result.current.collapseAll());
+    expect(result.current.collapsedGroups.has('Nurse')).toBe(true);
+    expect(result.current.collapsedGroups.has('Doctor')).toBe(true);
+  });
+});

--- a/src/hooks/useGrouping.js
+++ b/src/hooks/useGrouping.js
@@ -1,0 +1,37 @@
+import { useState, useMemo, useCallback } from 'react';
+import { groupRows } from '../grouping/groupRows.js';
+
+export function useGrouping(rows, options = {}) {
+  const { groupBy, fieldAccessor, groupHeaderHeight = 36 } = options;
+  const [collapsedGroups, setCollapsedGroups] = useState(() => new Set());
+
+  const { flatRows, groupOrder } = useMemo(() => {
+    if (!groupBy) return { flatRows: rows, groupOrder: [] };
+    return groupRows(rows, { groupBy, fieldAccessor, collapsedGroups, groupHeaderHeight });
+  }, [rows, groupBy, fieldAccessor, collapsedGroups, groupHeaderHeight]);
+
+  const toggleGroup = useCallback((key) => {
+    setCollapsedGroups(prev => {
+      const next = new Set(prev);
+      if (next.has(key)) next.delete(key);
+      else next.add(key);
+      return next;
+    });
+  }, []);
+
+  const expandAll = useCallback(() => setCollapsedGroups(new Set()), []);
+
+  const collapseAll = useCallback(() => {
+    setCollapsedGroups(new Set(groupOrder));
+  }, [groupOrder]);
+
+  return {
+    flatRows,
+    groupOrder,
+    collapsedGroups,
+    toggleGroup,
+    expandAll,
+    collapseAll,
+    isGrouped: !!groupBy,
+  };
+}

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -485,6 +485,10 @@ export interface WorksCalendarProps {
   /** Show the "Add Event" button. Always shown when owner is authenticated. */
   showAddButton?: boolean;
 
+  // ── Grouping ──
+  /** Field name to group rows by in TimelineView and AgendaView. */
+  groupBy?: string;
+
   // ── Imperative handle ──
   ref?: React.Ref<CalendarApi>;
 }

--- a/src/views/TimelineView.jsx
+++ b/src/views/TimelineView.jsx
@@ -28,6 +28,8 @@ import {
 import { useCalendarContext, resolveColor } from '../core/CalendarContext.js';
 import EmployeeActionCard from '../ui/EmployeeActionCard.jsx';
 import styles from './TimelineView.module.css';
+import { useGrouping } from '../hooks/useGrouping.js';
+import { buildFieldAccessor } from '../grouping/buildFieldAccessor.js';
 
 // ─── Layout constants ─────────────────────────────────────────────────────────
 
@@ -106,6 +108,7 @@ export default function TimelineView({
   onShiftStatusChange,
   onCoverageAssign,
   onEmployeeAction,
+  groupBy,
 }) {
   const ctx        = useCalendarContext();
 
@@ -275,32 +278,42 @@ export default function TimelineView({
     });
   }, [useEmployees, employees, resourceList, events, monthStart.toISOString(), monthEnd.toISOString(), onCallCategory, totalDays]);
 
+  // ── Grouping ───────────────────────────────────────────────────────────────
+  const GROUP_HEADER_H = 36;
+  const fieldAccessor = useMemo(
+    () => groupBy ? buildFieldAccessor(groupBy, useEmployees ? 'employee' : 'resource') : null,
+    [groupBy, useEmployees],
+  );
+  const { flatRows, groupOrder, collapsedGroups, toggleGroup, isGrouped } = useGrouping(rows, {
+    groupBy, fieldAccessor, groupHeaderHeight: GROUP_HEADER_H,
+  });
+
   // ── Cumulative row offsets (for absolute positioning + scroll math) ────────
   const rowOffsets = useMemo(() => {
     const offsets = [0];
-    for (const row of rows) offsets.push(offsets[offsets.length - 1] + row.rowH);
+    for (const row of flatRows) offsets.push(offsets[offsets.length - 1] + row.rowH);
     return offsets;
-  }, [rows]);
+  }, [flatRows]);
 
-  const totalBodyH = rowOffsets[rows.length] ?? 0;
+  const totalBodyH = rowOffsets[flatRows.length] ?? 0;
 
   // ── Visible row window ─────────────────────────────────────────────────────
   const [visStart, visEnd] = useMemo(() => {
     const { top, height } = scrollState;
     const viewH = height || 2000;
     let s = 0;
-    let e = rows.length - 1;
-    for (let i = 0; i < rows.length; i++) {
+    let e = flatRows.length - 1;
+    for (let i = 0; i < flatRows.length; i++) {
       if (rowOffsets[i + 1] <= top) s = i + 1;
     }
-    for (let i = rows.length - 1; i >= 0; i--) {
+    for (let i = flatRows.length - 1; i >= 0; i--) {
       if (rowOffsets[i] < top + viewH) { e = i; break; }
     }
     return [
       Math.max(0, s - OVERSCAN_ROWS),
-      Math.min(rows.length - 1, e + OVERSCAN_ROWS),
+      Math.min(flatRows.length - 1, e + OVERSCAN_ROWS),
     ];
-  }, [scrollState, rowOffsets, rows.length]);
+  }, [scrollState, rowOffsets, flatRows.length]);
 
   // ── Keyboard grid navigation ───────────────────────────────────────────────
 
@@ -334,15 +347,27 @@ export default function TimelineView({
   }, [focusedCell, rowOffsets]);
 
   const handleCellKeyDown = useCallback((e, ri, di, cellRowEvents, resourceId) => {
-    const maxRi = rows.length - 1;
+    const maxRi = flatRows.length - 1;
     const maxDi = totalDays - 1;
     let nextRi = ri, nextDi = di;
     let move = false;
     switch (e.key) {
       case 'ArrowLeft':  nextDi = Math.max(0, di - 1);     move = true; break;
       case 'ArrowRight': nextDi = Math.min(maxDi, di + 1); move = true; break;
-      case 'ArrowUp':    nextRi = Math.max(0, ri - 1);     move = true; break;
-      case 'ArrowDown':  nextRi = Math.min(maxRi, ri + 1); move = true; break;
+      case 'ArrowUp': {
+        nextRi = ri - 1;
+        while (nextRi >= 0 && flatRows[nextRi]?._type === 'groupHeader') nextRi--;
+        nextRi = Math.max(0, nextRi);
+        if (flatRows[nextRi]?._type === 'groupHeader') nextRi = ri;
+        move = true; break;
+      }
+      case 'ArrowDown': {
+        nextRi = ri + 1;
+        while (nextRi <= maxRi && flatRows[nextRi]?._type === 'groupHeader') nextRi++;
+        nextRi = Math.min(maxRi, nextRi);
+        if (flatRows[nextRi]?._type === 'groupHeader') nextRi = ri;
+        move = true; break;
+      }
       case 'Home':       nextDi = 0;                        move = true; break;
       case 'End':        nextDi = maxDi;                    move = true; break;
       case 'Enter':
@@ -366,7 +391,7 @@ export default function TimelineView({
       lastKeyNavCell.current = true;
       setFocusedCell({ rowIdx: nextRi, dayIdx: nextDi });
     }
-  }, [rows.length, totalDays, onEventClick, onDateSelect, days]);
+  }, [flatRows, totalDays, onEventClick, onDateSelect, days]);
 
   // ── Empty state ────────────────────────────────────────────────────────────
 
@@ -388,7 +413,7 @@ export default function TimelineView({
         style={{ width: NAME_W + totalDays * DAY_W }}
         role="grid"
         aria-label={`Timeline for ${format(currentDate, 'MMMM yyyy')}`}
-        aria-rowcount={rows.length + 1}
+        aria-rowcount={flatRows.length + 1}
         aria-colcount={totalDays + 1}
         ref={gridRef}
       >
@@ -462,8 +487,36 @@ export default function TimelineView({
           role="presentation"
           style={{ position: 'relative', height: totalBodyH }}
         >
-          {rows.slice(visStart, visEnd + 1).map((rowData, relIdx) => {
+          {flatRows.slice(visStart, visEnd + 1).map((rowData, relIdx) => {
             const rowIdx  = visStart + relIdx;
+
+            // Render group header pseudo-rows
+            if (rowData._type === 'groupHeader') {
+              const topOffset = rowOffsets[rowIdx];
+              return (
+                <div
+                  key={`gh-${rowData.groupKey}`}
+                  className={styles.groupHeaderRow}
+                  style={{ position: 'absolute', top: topOffset, left: 0, right: 0, height: rowData.rowH }}
+                  role="row"
+                  aria-rowindex={rowIdx + 2}
+                >
+                  <div className={styles.groupHeaderCell} style={{ width: NAME_W + totalDays * DAY_W }}>
+                    <button
+                      className={styles.groupToggleBtn}
+                      onClick={() => toggleGroup(rowData.groupKey)}
+                      aria-expanded={!rowData.collapsed}
+                      aria-label={`${rowData.collapsed ? 'Expand' : 'Collapse'} group ${rowData.groupLabel}`}
+                    >
+                      <span className={styles.groupChevron} data-collapsed={rowData.collapsed || undefined}>&#9656;</span>
+                      <span className={styles.groupLabel}>{rowData.groupLabel}</span>
+                      <span className={styles.groupCount}>{rowData.count}</span>
+                    </button>
+                  </div>
+                </div>
+              );
+            }
+
             const { key, emp, empIdx, resource, events: rowEvents, rowH, baseH, coveringPills, hasStatusPills } = rowData;
             const label = emp ? emp.name : resource;
             const color = emp ? employeeColor(emp, empIdx) : null;

--- a/src/views/TimelineView.module.css
+++ b/src/views/TimelineView.module.css
@@ -695,3 +695,69 @@
     display: none;
   }
 }
+
+/* ── Group header rows ─────────────────────────────────────────── */
+.groupHeaderRow {
+  display: flex;
+  align-items: center;
+  background: var(--wc-surface);
+  border-bottom: 1px solid var(--wc-border);
+  z-index: 5;
+}
+
+.groupHeaderCell {
+  display: flex;
+  align-items: center;
+  height: 100%;
+  padding: 0 8px;
+}
+
+.groupToggleBtn {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 4px 6px;
+  border-radius: 4px;
+  color: var(--wc-text);
+  font: inherit;
+  width: 100%;
+  text-align: left;
+}
+
+.groupToggleBtn:hover {
+  background: var(--wc-hover, rgba(0,0,0,0.06));
+}
+
+.groupChevron {
+  display: inline-block;
+  font-size: 10px;
+  color: var(--wc-text-muted, var(--wc-text));
+  transition: transform 0.15s ease;
+  transform: rotate(90deg);
+}
+
+.groupChevron[data-collapsed] {
+  transform: rotate(0deg);
+}
+
+.groupLabel {
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--wc-text-muted, var(--wc-text));
+  flex: 1;
+}
+
+.groupCount {
+  font-size: 11px;
+  background: var(--wc-border-dark, var(--wc-border));
+  color: var(--wc-text);
+  border-radius: 10px;
+  padding: 1px 7px;
+  min-width: 20px;
+  text-align: center;
+}


### PR DESCRIPTION
Breaks Phase 1 enhanced filtering into manageable implementation
sprints: schema-driven AdvancedFilterBuilder, NOT operators + relative
dates, filter URL serialization + quick presets, and UX polish.

https://claude.ai/code/session_01FhMAnVsP7rJX3K6AtbJaNb