### PR TITLE
Fix bookmark pencil tap target and blank-profile schedule rows

### DIFF
--- a/src/WorksCalendar.tsx
+++ b/src/WorksCalendar.tsx
@@ -280,9 +280,19 @@ export const WorksCalendar = forwardRef<CalendarApi, WorksCalendarProps>(functio
   const customThemeVars = useMemo(() => customThemeToCssVars(ownerCfg.config?.customTheme), [ownerCfg.config?.customTheme]);
   const effectiveTheme = theme || ownerCfg.config?.setup?.preferredTheme || 'light';
   const calendarTitle = ownerCfg.config?.title || 'My WorksCalendar';
+  // Merge parent's employees prop with owner-config team.members so edits
+  // made from the Settings → Employees tab (e.g. renaming a member) are
+  // reflected live in the schedule, even when the parent's prop is stale.
+  // Config entries take precedence for matching ids; parent-only entries
+  // (not yet mirrored into config) are preserved.
   const configuredEmployees = useMemo(() => {
-    if (Array.isArray(employees) && employees.length > 0) return employees;
-    return ownerCfg.config?.team?.members ?? [];
+    const configMembers = ownerCfg.config?.team?.members ?? [];
+    const parentMembers = Array.isArray(employees) ? employees : [];
+    if (configMembers.length === 0) return parentMembers;
+    if (parentMembers.length === 0) return configMembers;
+    const configById = new Map(configMembers.map((m) => [String(m.id), m]));
+    const parentOnly = parentMembers.filter((m) => !configById.has(String(m.id)));
+    return [...configMembers, ...parentOnly];
   }, [employees, ownerCfg.config?.team?.members]);
 
   // Wrap parent employee handlers so edits from ANY surface (timeline add-form

--- a/src/ui/ConfigPanel.jsx
+++ b/src/ui/ConfigPanel.jsx
@@ -265,6 +265,15 @@ export function SmartViewsTab({ categories, resources, onSaveView, savedViews = 
 
 export function TeamTab({ config, onUpdate, onEmployeeAdd, onEmployeeDelete }) {
   const teamMembers = config.team?.members ?? [];
+  // Pending (unsaved) new member — holds its name until the user commits.
+  // Keeping it local prevents a blank row from appearing in the schedule.
+  const [pendingName, setPendingName] = useState('');
+  const [isAdding,    setIsAdding]    = useState(false);
+  const pendingInputRef = useRef(null);
+
+  useEffect(() => {
+    if (isAdding) pendingInputRef.current?.focus();
+  }, [isAdding]);
 
   const updateMembers = (nextMembers) => onUpdate(c => ({
     ...c,
@@ -272,11 +281,20 @@ export function TeamTab({ config, onUpdate, onEmployeeAdd, onEmployeeDelete }) {
     setup: { ...(c.setup ?? {}), completed: true },
   }));
 
-  const addMember = () => {
+  const commitPending = () => {
+    const trimmed = pendingName.trim();
+    if (!trimmed) { setIsAdding(false); setPendingName(''); return; }
     const nextId = Math.max(0, ...teamMembers.map((member) => Number(member.id) || 0)) + 1;
-    const newMember = { id: nextId, name: '', color: '#8b5cf6', avatar: null };
+    const newMember = { id: nextId, name: trimmed, color: '#8b5cf6', avatar: null };
     updateMembers([...teamMembers, newMember]);
     onEmployeeAdd?.(newMember);
+    setPendingName('');
+    setIsAdding(false);
+  };
+
+  const cancelPending = () => {
+    setPendingName('');
+    setIsAdding(false);
   };
 
   const updateMember = (id, patch) => {
@@ -327,7 +345,41 @@ export function TeamTab({ config, onUpdate, onEmployeeAdd, onEmployeeDelete }) {
           </button>
         </div>
       ))}
-      <button className={styles.addFieldBtn} onClick={addMember}><Plus size={13} /> Add employee</button>
+      {isAdding ? (
+        <div className={styles.memberRow}>
+          <div className={styles.avatarPicker}>
+            <div className={styles.avatarFrame}>
+              <div className={styles.avatarFallback} style={{ backgroundColor: '#8b5cf6' }}>
+                {(pendingName.trim()?.[0] ?? '?').toUpperCase()}
+              </div>
+            </div>
+          </div>
+          <input
+            ref={pendingInputRef}
+            className={styles.input}
+            value={pendingName}
+            onChange={(e) => setPendingName(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') { e.preventDefault(); commitPending(); }
+              if (e.key === 'Escape') { e.preventDefault(); cancelPending(); }
+            }}
+            onBlur={commitPending}
+            placeholder="Employee name"
+          />
+          <button
+            className={styles.removeBtn}
+            onMouseDown={(e) => e.preventDefault()}
+            onClick={commitPending}
+            aria-label="Add employee"
+          >
+            <Check size={13} />
+          </button>
+        </div>
+      ) : (
+        <button className={styles.addFieldBtn} onClick={() => setIsAdding(true)}>
+          <Plus size={13} /> Add employee
+        </button>
+      )}
     </div>
   );
 }

--- a/src/ui/ProfileBar.jsx
+++ b/src/ui/ProfileBar.jsx
@@ -109,15 +109,16 @@ function ViewChip({ savedView, schema, isActive, isDirty, isManaging, onApply, o
   if (savedView.view) summaryParts.push(`View: ${savedView.view}`);
   const summary = summaryParts.length ? summaryParts.join(' \u00b7 ') : 'No filters applied';
 
+  const chipClass = [styles.chip, isDirty && styles.dirty].filter(Boolean).join(' ');
+
   return (
-    <div ref={chipRef} className={styles.chipWrap}>
+    <div
+      ref={chipRef}
+      className={[styles.chipWrap, isActive && styles.chipWrapActive].filter(Boolean).join(' ')}
+      style={{ '--chip-color': color }}
+    >
       <button
-        className={[
-          styles.chip,
-          isActive && styles.active,
-          isDirty  && styles.dirty,
-        ].filter(Boolean).join(' ')}
-        style={{ '--chip-color': color }}
+        className={chipClass}
         onClick={onApply}
         title={summary}
       >
@@ -130,18 +131,17 @@ function ViewChip({ savedView, schema, isActive, isDirty, isManaging, onApply, o
         {savedView.view && (
           <span className={styles.viewTag}>{savedView.view.slice(0,3)}</span>
         )}
+      </button>
 
-        {/* Manage toggle (pencil) */}
-        <span
-          className={styles.manageBtn}
-          onClick={e => { e.stopPropagation(); onManageToggle(); }}
-          role="button"
-          tabIndex={0}
-          aria-label="Manage saved view"
-          onKeyDown={e => e.key === 'Enter' && (e.stopPropagation(), onManageToggle())}
-        >
-          <Pencil size={10} />
-        </span>
+      {/* Manage toggle (pencil) — sibling of chip, not nested, to avoid invalid
+          button-in-button and the associated mobile tap-handling issues. */}
+      <button
+        type="button"
+        className={styles.manageBtn}
+        onClick={e => { e.stopPropagation(); onManageToggle(); }}
+        aria-label="Manage saved view"
+      >
+        <Pencil size={10} />
       </button>
 
       {/* Manage panel */}

--- a/src/ui/ProfileBar.module.css
+++ b/src/ui/ProfileBar.module.css
@@ -43,41 +43,58 @@
 .chipWrap {
   position: relative;
   flex-shrink: 0;
+  display: inline-flex;
+  align-items: stretch;
+  border-radius: 100px;
+  border: 1.5px solid var(--wc-border);
+  background: var(--wc-bg);
+  transition: border-color 0.15s, background 0.15s;
+  /* chip color exposed via --chip-color on the wrapper */
+}
+
+.chipWrap:hover {
+  border-color: var(--chip-color, var(--wc-accent));
+  background: color-mix(in srgb, var(--chip-color, var(--wc-accent)) 8%, transparent);
+}
+
+.chipWrapActive {
+  background: var(--chip-color, var(--wc-accent));
+  border-color: var(--chip-color, var(--wc-accent));
 }
 
 .chip {
   display: flex;
   align-items: center;
   gap: 5px;
-  padding: 4px 10px 4px 8px;
-  border-radius: 100px;
+  padding: 4px 6px 4px 8px;
+  border-radius: 100px 0 0 100px;
   font-size: 12px;
   font-weight: 500;
   font-family: inherit;
   cursor: pointer;
   white-space: nowrap;
-  border: 1.5px solid var(--wc-border);
-  background: var(--wc-bg);
+  border: none;
+  background: transparent;
   color: var(--wc-text-muted);
-  transition: all 0.15s;
-  position: relative;
-  /* chip color exposed via --chip-color */
+  transition: color 0.15s;
 }
 
-.chip:hover {
-  border-color: var(--chip-color, var(--wc-accent));
+.chipWrap:hover .chip {
   color: var(--chip-color, var(--wc-accent));
-  background: color-mix(in srgb, var(--chip-color, var(--wc-accent)) 8%, transparent);
 }
 
-.chip.active {
-  background: var(--chip-color, var(--wc-accent));
-  border-color: var(--chip-color, var(--wc-accent));
+.chipWrapActive .chip {
   color: #fff;
 }
 
 .chip.dirty {
   border-style: dashed;
+}
+
+/* When the pencil is not visible, the chip takes the full rounded shape. */
+.chipWrap:not(:hover):not(.chipWrapActive) .chip {
+  padding-right: 10px;
+  border-radius: 100px;
 }
 
 .chipIcon { flex-shrink: 0; opacity: 0.8; }
@@ -105,22 +122,28 @@
   flex-shrink: 0;
 }
 
-/* Manage toggle (pencil icon — shown on hover) */
+/* Manage toggle (pencil icon — sibling of .chip inside .chipWrap).
+   Hidden by default; shown when the chip is hovered or active so users
+   can reliably tap it on mobile without nested-button issues. */
 .manageBtn {
   display: none;
   align-items: center;
   justify-content: center;
-  margin-left: 2px;
-  width: 16px;
-  height: 16px;
-  border-radius: 50%;
+  padding: 0 8px 0 4px;
+  min-width: 22px;
+  border: none;
+  background: transparent;
+  border-radius: 0 100px 100px 0;
   cursor: pointer;
-  opacity: 0.7;
+  opacity: 0.8;
+  color: inherit;
   flex-shrink: 0;
+  font-family: inherit;
 }
 .manageBtn:hover { opacity: 1; }
-.chip:hover .manageBtn { display: flex; }
-.chip.active .manageBtn { display: flex; }
+.chipWrap:hover .manageBtn,
+.chipWrapActive .manageBtn { display: inline-flex; }
+.chipWrapActive .manageBtn { color: #fff; }
 
 /* ─── Manage panel (popover below chip) ──────────────────────── */
 .managePanel {

--- a/src/ui/__tests__/ConfigPanel.teamTab.test.jsx
+++ b/src/ui/__tests__/ConfigPanel.teamTab.test.jsx
@@ -32,19 +32,36 @@ function renderTab({ initialMembers = [], onUpdate, onEmployeeAdd, onEmployeeDel
 }
 
 describe('TeamTab bidirectional sync (issue #101)', () => {
-  it('clicking "Add employee" patches config.team.members', () => {
+  it('committing a new employee (with name) patches config.team.members', () => {
     const { update, getConfig } = renderTab();
     fireEvent.click(screen.getByRole('button', { name: /Add employee/ }));
+    const input = screen.getByPlaceholderText('Employee name');
+    fireEvent.change(input, { target: { value: 'Nora' } });
+    fireEvent.keyDown(input, { key: 'Enter' });
     expect(update).toHaveBeenCalledTimes(1);
     expect(getConfig().team.members).toHaveLength(1);
-    expect(getConfig().team.members[0]).toMatchObject({ id: 1, name: '' });
+    expect(getConfig().team.members[0]).toMatchObject({ id: 1, name: 'Nora' });
   });
 
-  it('clicking "Add employee" also emits onEmployeeAdd upstream', () => {
+  it('committing a new employee emits onEmployeeAdd upstream', () => {
     const { add } = renderTab();
     fireEvent.click(screen.getByRole('button', { name: /Add employee/ }));
+    const input = screen.getByPlaceholderText('Employee name');
+    fireEvent.change(input, { target: { value: 'Nora' } });
+    fireEvent.keyDown(input, { key: 'Enter' });
     expect(add).toHaveBeenCalledTimes(1);
-    expect(add.mock.calls[0][0]).toMatchObject({ id: 1 });
+    expect(add.mock.calls[0][0]).toMatchObject({ id: 1, name: 'Nora' });
+  });
+
+  it('blank name does not add a member (prevents ghost rows in schedule)', () => {
+    const { update, add, getConfig } = renderTab();
+    fireEvent.click(screen.getByRole('button', { name: /Add employee/ }));
+    const input = screen.getByPlaceholderText('Employee name');
+    // Submitting without typing should cancel — no add.
+    fireEvent.keyDown(input, { key: 'Enter' });
+    expect(update).not.toHaveBeenCalled();
+    expect(add).not.toHaveBeenCalled();
+    expect(getConfig().team.members).toHaveLength(0);
   });
 
   it('removing an employee patches config AND emits onEmployeeDelete', () => {
@@ -61,10 +78,12 @@ describe('TeamTab bidirectional sync (issue #101)', () => {
     expect(del).toHaveBeenCalledWith(1);
   });
 
-  it('does not emit onEmployeeAdd when callback is omitted', () => {
-    // No onEmployeeAdd supplied → should not throw.
+  it('does not throw when onEmployeeAdd is omitted', () => {
     render(<TeamTab config={{ team: { members: [] } }} onUpdate={vi.fn()} />);
     fireEvent.click(screen.getByRole('button', { name: /Add employee/ }));
+    const input = screen.getByPlaceholderText('Employee name');
+    fireEvent.change(input, { target: { value: 'Nora' } });
+    fireEvent.keyDown(input, { key: 'Enter' });
     // If we got here without throwing, the test passes.
     expect(true).toBe(true);
   });
@@ -80,10 +99,15 @@ describe('TeamTab bidirectional sync (issue #101)', () => {
   });
 
   it('auto-assigns incrementing ids when adding multiple employees', () => {
-    const { update, getConfig } = renderTab({
+    const { getConfig } = renderTab({
       initialMembers: [{ id: 5, name: 'Existing', color: '#111', avatar: null }],
     });
     fireEvent.click(screen.getByRole('button', { name: /Add employee/ }));
+    // The pending input is the newly-added one (empty value); filter it out.
+    const inputs = screen.getAllByPlaceholderText('Employee name');
+    const pending = inputs.find(el => el.value === '');
+    fireEvent.change(pending, { target: { value: 'Nora' } });
+    fireEvent.keyDown(pending, { key: 'Enter' });
     expect(getConfig().team.members.map(m => m.id)).toEqual([5, 6]);
   });
 });


### PR DESCRIPTION
The pencil "manage" icon on saved-view chips was rendered as a
nested button (role="button" span inside a <button>), which is
invalid HTML and made the icon unreliable to tap on mobile — taps
hit the outer chip and applied the view instead of opening the
manage panel. Restructure the chip so the chip button and the
pencil button are siblings inside a chipWrap container, and move
the active/hover styling to the wrapper.

Adding an employee from the Settings → Employees tab created a
member with an empty name immediately and only synced later edits
to owner config, not to the parent's employees prop. The schedule
(which preferred the stale parent list) showed a blank row. Fix
by (a) prompting for a name inline before committing the new
member, and (b) merging config.team.members over the parent prop
in configuredEmployees so edits made in Settings are reflected
live in the schedule.

https://claude.ai/code/session_01BUAx9y6c5MiM5aEKHZEaZN

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Employee addition now uses a two-step input flow: type the employee name and confirm to create the entry.
  * Team members from parent settings now intelligently merge with configured team members instead of being replaced.

* **UI/UX Updates**
  * Manage button refactored for improved accessibility.
  * Chip component styling and layout enhanced.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->