### PR TITLE
feat(AssetsView): migrate grouping to useGroupingEngine + GroupHeader

### DIFF
--- a/docs/GROUPING_API.md
+++ b/docs/GROUPING_API.md
@@ -190,3 +190,83 @@ import {
 ```
 
 See `src/grouping/` and `src/hooks/useGrouping.{js,ts}` for full signatures.
+
+---
+
+## AssetsView — first-class assets registry
+
+AssetsView is a Gantt-style resource timeline. Unlike the other views, its
+rows are driven by a dedicated **assets registry** rather than by events —
+which means an asset shows up even if it has zero events on screen. The
+registry is **owner-configurable** via the ConfigPanel → Assets tab and
+persists through `useOwnerConfig`. Host apps never need to redeploy to add,
+rename, or regroup an asset.
+
+### `assets` prop
+
+```ts
+type Asset = {
+  id:    string;             // stable key; matches event.resource
+  label: string;             // display name
+  group?: string;            // optional grouping key (owner-chosen dimension)
+  meta?: Record<string, unknown>;  // arbitrary metadata surfaced to getLabel etc.
+};
+
+<WorksCalendar assets={assets} /* ... */ />
+```
+
+When `assets` is provided, AssetsView renders **one row per registered asset**
+in registry order (or per the toolbar's Sort-by selection). Events whose
+`resource` does not match any asset `id` are treated as unassigned and
+bucketed under `(Unassigned)`.
+
+### On-page toolbar
+
+Above the grid, AssetsView renders a toolbar with:
+
+| Control       | Purpose                                                                              |
+| ------------- | ------------------------------------------------------------------------------------ |
+| **Group by**  | Switches `groupBy` on the fly. Options come from asset `group` + `meta.*` fields.    |
+| **Sort by**   | `registry` (default), `label`, `group`, or `lastEvent` (most recent activity first). |
+| **Edit assets** | Deep-links to ConfigPanel's Assets tab. Owner-only; hidden for non-owners.         |
+
+The Edit button calls `useOwnerConfig.openConfigToTab('assets')`, which sets
+both `configOpen` and `configInitialTab`; `ConfigPanel`'s `initialTab` prop
+re-applies on change, so subsequent clicks re-target the Assets tab even if
+the panel is already open on another tab.
+
+### Keyboard contract
+
+AssetsView implements the WAI-ARIA tree-interleaved-with-grid pattern. Both
+`GroupHeader` rows (role=`treeitem`) and data cells (role=`gridcell`)
+participate in the same roving-tabindex chain:
+
+| Key          | On a `treeitem` header                    | On a `gridcell`                       |
+| ------------ | ----------------------------------------- | ------------------------------------- |
+| `ArrowUp`    | Move to row above (header or data cell)   | Move to row above                     |
+| `ArrowDown`  | Move to row below (header or data cell)   | Move to row below                     |
+| `ArrowLeft`  | Expanded → collapse; collapsed → no-op    | Move one day left (existing behavior) |
+| `ArrowRight` | Collapsed → expand; expanded → descend to first child cell | Move one day right |
+| `Enter` / `Space` | Toggle collapse                       | (view-specific click behavior)        |
+
+The contract is pinned by `src/views/__tests__/AssetsView.keyboardNav.test.jsx`.
+
+### Saved-view fields
+
+AssetsView extends the v3 saved-view schema with two Gantt-specific fields:
+
+| Field            | Type                      | Notes                                                          |
+| ---------------- | ------------------------- | -------------------------------------------------------------- |
+| `zoomLevel`      | `'day' \| 'week' \| 'month' \| 'quarter'` | Restores the zoom control's aria-pressed state. |
+| `collapsedGroups`| `string[]`                | Group keys to restore in the collapsed state on apply.         |
+
+Round-trip (seed → reload → click chip → state restored) is proven end-to-end
+by `tests-e2e/calendar.assets-grouping.spec.ts`.
+
+### ConfigPanel — Assets tab
+
+Owners can edit the registry from ConfigPanel → Assets without leaving the
+calendar. Changes flow through `useOwnerConfig.updateConfig`, so saved-view
+pins, group counts, and row order all refresh live. `openConfigToTab(tabId)`
+is the recommended deep-link API; it validates that the requested tab id
+exists in `TABS` before applying.

--- a/docs/GROUPING_API.md
+++ b/docs/GROUPING_API.md
@@ -270,3 +270,89 @@ calendar. Changes flow through `useOwnerConfig.updateConfig`, so saved-view
 pins, group counts, and row order all refresh live. `openConfigToTab(tabId)`
 is the recommended deep-link API; it validates that the requested tab id
 exists in `TABS` before applying.
+
+---
+
+## Phase B — owner-configurable workflow blocks
+
+Phase B extends owner config with three data-driven workflow systems. All
+three ship disabled (or with safe minimal defaults) and read exclusively
+from the owner-config blob — no host redeploy required to tune them.
+
+### Schema version
+
+`config.schemaVersion = 4`. Migration from v3 is purely additive: the
+`mergeDeep` call in `loadConfig` stamps the new default blocks onto any
+older stored config, so previously-persisted calendars see the new tabs
+without losing state.
+
+### 1. Request form (ticket #134-12)
+
+Shape: `config.requestForm.fields: Array<{ key, label, type, required?, placeholder?, options? }>`.
+
+Supported `type` values: `text`, `textarea`, `number`, `date`, `datetime`,
+`select`, `checkbox`. For `select`, `options` is a comma-separated string
+(e.g. `"one, two, three"`); first rendered option is an empty placeholder.
+
+`RequestForm` emits `{ values }` on submit. Required fields (including
+required-truthy checkboxes) gate submission; host-level validators remain
+the escape hatch via `onSubmit` rejection. Owners edit the schema from
+ConfigPanel → Request Form (CRUD + move up/down).
+
+### 2. Conflict engine (ticket #134-13)
+
+Shape: `config.conflicts: { enabled: boolean, rules: ConflictRule[] }`.
+
+Supported rule types:
+
+| `type`              | Parameters                              | Behavior                                     |
+| ------------------- | --------------------------------------- | -------------------------------------------- |
+| `resource-overlap`  | `ignoreCategories?: string[]`           | Flag any event on the same resource whose `[start, end)` intersects the proposed event. |
+| `category-mutex`    | `categories: string[]`                  | Flag overlap on same resource when both events' categories are in the listed set.       |
+| `min-rest`          | `minutes: number`                       | Flag same-resource back-to-back events closer than `minutes` apart.                     |
+
+Each rule carries `severity?: 'soft' \| 'hard'` (default `hard`). The
+engine returns `{ violations, severity, allowed }` — `allowed` is `true`
+for `'soft'`/`'none'`, `false` for `'hard'`. Host apps gate their save
+path on `allowed`; `ConflictModal` presents violations and a
+Proceed/Cancel pair, enabling Proceed only for soft severity.
+
+Overlap semantics are half-open: touching endpoints (A ends at T, B
+starts at T) do **not** count as overlapping.
+
+### 3. Approvals policy (ticket #134-14, #134-15)
+
+Shape:
+
+```ts
+config.approvals = {
+  enabled: boolean,
+  tiers: Array<{ id, label, requires: 'any' | 'all', roles: string[] }>,
+  rules: {
+    [stage in 'requested' | 'approved' | 'finalized' | 'pending_higher' | 'denied']:
+      { allow: Array<'approve' | 'deny' | 'finalize' | 'revoke'>, prefix: string }
+  },
+  labels: { approve, deny, finalize, revoke },
+}
+```
+
+- **`rules[stage].allow`** drives which buttons `ApprovalActionMenu`
+  renders for that stage (both the pill caret popover in AssetsView and
+  the inline menu in AuditDrawer). Empty `allow` hides the caret.
+- **`rules[stage].prefix`** rides on the left of the pill label, e.g.
+  `Req · Flight 202`.
+- **`labels`** supplies the button copy, letting owners rename
+  `Approve`/`Deny`/etc. to match their organization's vocabulary.
+- **`tiers[].requires`** determines quorum: `any` promotes on the first
+  approver action, `all` waits for every listed role.
+
+The calendar emits `onApprovalAction(event, action)`; the host mutates
+`event.meta.approvalStage.stage` + appends to `.history`, then echoes
+the updated event back. The calendar never writes stage state itself.
+
+### Cross-cutting
+
+`src/__tests__/phaseB.integration.test.jsx` pins the end-to-end glue
+(RequestForm → conflictEngine → ConflictModal → persist + pill menu)
+so any future refactor that breaks the contract between these three
+systems fails loudly.

--- a/docs/GROUPING_SPRINT_EXECUTIVE_SUMMARY.md
+++ b/docs/GROUPING_SPRINT_EXECUTIVE_SUMMARY.md
@@ -1,7 +1,7 @@
 # Sprint Review: Infinite Grouping, Filtering & Sorting
 
-**Date:** 2026-04-16 (initial review) · **Updated:** 2026-04-18 (Phase A delivery)
-**Status:** ✅ Phase A shipped — original scope reshaped; see **Delivery Update** at bottom.
+**Date:** 2026-04-16 (initial review) · **Updated:** 2026-04-18 (Phase A+B delivery)
+**Status:** ✅ Phases A + B shipped — original scope reshaped; see **Delivery Update** at bottom.
 **Full Analysis:** [INFINITE_GROUPING_VIABILITY_ANALYSIS.md](./INFINITE_GROUPING_VIABILITY_ANALYSIS.md)
 
 > **If you only read one thing, skip to the [Delivery Update](#delivery-update--2026-04-sprint) section.** The body below is preserved as the original pre-implementation risk analysis. It correctly flagged that the 5-day scope was unrealistic; the sprint reshaped into phased delivery (A/B) under GitHub issue #134.
@@ -297,16 +297,29 @@ not the default path.**
   expands a collapsed header, or on an already-expanded header descends
   to the first child cell; ← on an already-collapsed header is a no-op.
 
-### Phase B — queued
+### Phase B — shipped (this sprint)
 
-| Ticket | Summary |
-|--------|---------|
-| #134-14 | Approvals tab in ConfigPanel — policy, tiers, rules, labels + v3→v4 schema migration |
-| #134-13 | Conflict check + ConflictModal (owner-defined rules in `src/core/conflictEngine.ts`) |
-| #134-12 | Schema-driven RequestForm, owner-configurable |
-| #134-15 | Inline approval actions on pills, driven by policy/tier config |
-| #134-16 | Integration matrix: approval policy × conflict rules × request schema |
-| #134-8  | Docs pass — Approvals config section (pairs with Ticket 14) |
+| Ticket | Summary | Ships as |
+|--------|---------|----------|
+| #134-14 | Approvals tab in ConfigPanel — policy, tiers, rules, labels + v3→v4 schema migration | `0ececa2` |
+| #134-13 | Conflict check + ConflictModal (owner-defined rules in `src/core/conflictEngine.ts`) | `ae345ba` |
+| #134-12 | Schema-driven RequestForm, owner-configurable | `69ee3e6` |
+| #134-15 | Inline approval actions on pills, driven by policy/tier config | `9a97f83` |
+| #134-16 | Integration matrix: approval policy × conflict rules × request schema | `76e851f` |
+| #134-8  | Docs pass — Phase B owner-config section (pairs with Tickets 12/13/14/15) | (this commit) |
+
+**Net effect for operators:**
+- Approvals, conflicts, and the request-form schema are all editable from
+  ConfigPanel tabs and persist through `useOwnerConfig`. No host-code change
+  is required to change who can approve from a stage, which conflict rules
+  block a save, or what fields the request form displays.
+- Calendar emits `onApprovalAction(event, action)` — host persists the new
+  stage + audit history, calendar re-renders with the updated event. The
+  calendar never mutates `meta.approvalStage` itself, keeping the storage
+  story unchanged.
+- Schema version bumped to 4; the migration is additive (mergeDeep folds
+  in the new default blocks), so previously-persisted v3 calendars load
+  untouched and the new tabs appear with defaults.
 
 ### What the original risk table got right vs. wrong
 

--- a/docs/GROUPING_SPRINT_EXECUTIVE_SUMMARY.md
+++ b/docs/GROUPING_SPRINT_EXECUTIVE_SUMMARY.md
@@ -1,8 +1,10 @@
 # Sprint Review: Infinite Grouping, Filtering & Sorting
 
-**Date:** 2026-04-16
-**Status:** ⚠️ NOT RECOMMENDED AS PROPOSED
+**Date:** 2026-04-16 (initial review) · **Updated:** 2026-04-18 (Phase A delivery)
+**Status:** ✅ Phase A shipped — original scope reshaped; see **Delivery Update** at bottom.
 **Full Analysis:** [INFINITE_GROUPING_VIABILITY_ANALYSIS.md](./INFINITE_GROUPING_VIABILITY_ANALYSIS.md)
+
+> **If you only read one thing, skip to the [Delivery Update](#delivery-update--2026-04-sprint) section.** The body below is preserved as the original pre-implementation risk analysis. It correctly flagged that the 5-day scope was unrealistic; the sprint reshaped into phased delivery (A/B) under GitHub issue #134.
 
 ---
 
@@ -256,3 +258,75 @@ The calendar is a valuable product. Let's build grouping features properly, not 
 **Reviewed by:** Claude Code Agent
 **Full Analysis:** [INFINITE_GROUPING_VIABILITY_ANALYSIS.md](./INFINITE_GROUPING_VIABILITY_ANALYSIS.md)
 **Next Steps:** Stakeholder review + scope decision
+
+---
+
+## Delivery Update — 2026-04 Sprint
+
+**Tracking issue:** [#134 — Sprint: Close the Grouping Plan A gap](https://github.com/natehorst240-sketch/calendarthatworks/issues/134)
+
+The original 5-day "infinite grouping" ambition was correctly flagged above as
+infeasible. Work landed in two phases instead, with a strict owner-config-first
+principle: **every new UX surface must be tunable from ConfigPanel and persisted
+to owner config with zero host-app redeploy. Host callbacks are escape hatches,
+not the default path.**
+
+### Phase A — shipped (this sprint)
+
+| Ticket | Summary | Ships as |
+|--------|---------|----------|
+| #134-1 | Swap TimelineView grouping onto the TS `buildGroupTree` engine | `f1ecbba` |
+| #134-2 | Persist `zoomLevel` + `collapsedGroups` in saved-views schema v3 | `832cffb` |
+| #134-3 | AssetsView grouping via `useGroupingEngine` + `GroupHeader` | `c94539c` |
+| #134-9 | First-class `assets[]` registry + ConfigPanel **Assets** tab | `e004c49` |
+| #134-10 | On-page AssetsView toolbar — GroupBy / SortBy / "Edit assets" deep-link | `f045433` |
+| #134-4 | Cross-group keyboard navigation (↑/↓ rows + headers, ←/→ tree) | `ceb6854` |
+| #134-5 | Integration matrix: filter × sort × group (17 specs) | `dcb37e7` |
+| #134-6 | Playwright E2E: Assets grid + zoom + saved-view round-trip | `56b3e85` |
+
+**Net effect for operators (owners):**
+- Assets tab in ConfigPanel edits the registry in place, persists via
+  `useOwnerConfig`, no redeploy, no host code change.
+- AssetsView toolbar deep-links to that tab via the new
+  `useOwnerConfig.openConfigToTab('assets')` helper; `ConfigPanel` accepts
+  `initialTab` reactively (re-applies on prop change).
+- Saved views round-trip `zoomLevel` + `collapsedGroups`, so chips reproduce
+  the exact Gantt state a user pinned — proven by the E2E round-trip spec.
+- Keyboard contract matches WAI-ARIA tree conventions: ↑/↓ traverse headers
+  and data rows without skipping; ← collapses an expanded header; →
+  expands a collapsed header, or on an already-expanded header descends
+  to the first child cell; ← on an already-collapsed header is a no-op.
+
+### Phase B — queued
+
+| Ticket | Summary |
+|--------|---------|
+| #134-14 | Approvals tab in ConfigPanel — policy, tiers, rules, labels + v3→v4 schema migration |
+| #134-13 | Conflict check + ConflictModal (owner-defined rules in `src/core/conflictEngine.ts`) |
+| #134-12 | Schema-driven RequestForm, owner-configurable |
+| #134-15 | Inline approval actions on pills, driven by policy/tier config |
+| #134-16 | Integration matrix: approval policy × conflict rules × request schema |
+| #134-8  | Docs pass — Approvals config section (pairs with Ticket 14) |
+
+### What the original risk table got right vs. wrong
+
+| Original risk | Outcome |
+|---------------|---------|
+| Timeline (5 days → weeks) | ✅ Right. Phase A alone took a full sprint; Phase B still queued. |
+| All five views touched | ⚠️ Partly. Scope narrowed to Assets + Timeline — Month/Week/Day correctly left flat. |
+| Performance unknowns | ✅ Mitigated. `groupRows()` budget held at p95 < 0.5ms for 2000ev × 3-level (see `perf-baselines.json`). |
+| Testing scope underestimated | ✅ Addressed. Integration matrix (17 specs) + keyboard spec (7) + E2E (3) added this sprint. |
+| 5-level nesting untested | ↩️ Parked. Phase A covers 1–2 levels; deeper nesting deferred until a real use case appears. |
+
+### Where to look for the work
+
+- **API surface:** [`GROUPING_API.md`](./GROUPING_API.md) — now includes the
+  AssetsView / Assets tab section covering the `assets[]` prop shape, the
+  ConfigPanel deep-link, and the cross-group keyboard contract.
+- **Engine:** `src/grouping/groupRows.ts`, `src/hooks/useGrouping.ts`,
+  `src/core/sortEngine.ts`, `src/filters/filterEngine.js`.
+- **View:** `src/views/AssetsView.jsx`, `src/ui/GroupHeader.tsx`.
+- **Owner config:** `src/hooks/useOwnerConfig.js`, `src/ui/ConfigPanel.jsx`.
+- **Tests:** `src/views/__tests__/AssetsView.*.test.jsx`,
+  `src/__tests__/groupingFilteringSorting.integration.test.js`,
+  `tests-e2e/calendar.assets-grouping.spec.ts`.

--- a/src/WorksCalendar.tsx
+++ b/src/WorksCalendar.tsx
@@ -1654,6 +1654,8 @@ export const WorksCalendar = forwardRef<CalendarApi, WorksCalendarProps>(functio
                   locationProvider={effectiveLocationProvider}
                   renderAssetLocation={renderAssetLocation}
                   onEditAssets={ownerCfg.isOwner ? () => ownerCfg.openConfigToTab('assets') : undefined}
+                  approvalsConfig={ownerCfg.config?.approvals}
+                  onApprovalAction={onApprovalAction}
                 />
               )}
             </>

--- a/src/WorksCalendar.tsx
+++ b/src/WorksCalendar.tsx
@@ -152,6 +152,7 @@ export type WorksCalendarProps = {
   // ── Assets view ──
   locationProvider?: LocationProvider;
   categoriesConfig?: Record<string, unknown>;
+  assets?: { id: string; label: string; group?: string; meta?: Record<string, unknown> }[];
   onConflictCheck?: (...args: unknown[]) => Promise<unknown>;
   onApprovalAction?: (...args: unknown[]) => void | Promise<void>;
   renderAssetLocation?: (...args: unknown[]) => ReactNode;
@@ -296,6 +297,7 @@ export const WorksCalendar = forwardRef<CalendarApi, WorksCalendarProps>(functio
     // ── Assets view ──
     locationProvider,
     categoriesConfig,
+    assets,
     onConflictCheck,
     onApprovalAction,
     renderAssetLocation,
@@ -1643,6 +1645,7 @@ export const WorksCalendar = forwardRef<CalendarApi, WorksCalendarProps>(functio
                   onDateSelect={handleScheduleDateSelect}
                   groupBy={activeGroupBy}
                   categoriesConfig={categoriesConfig ?? ownerCfg.config?.categoriesConfig}
+                  assets={assets ?? ownerCfg.config?.assets}
                   zoomLevel={activeAssetsZoom}
                   onZoomChange={setActiveAssetsZoom}
                   collapsedGroups={activeAssetsCollapsed}

--- a/src/WorksCalendar.tsx
+++ b/src/WorksCalendar.tsx
@@ -392,19 +392,23 @@ export const WorksCalendar = forwardRef<CalendarApi, WorksCalendarProps>(functio
   const [activeShowAllGroups, setActiveShowAllGroups] = useState<boolean>(!!showAllGroups);
   useEffect(() => setActiveShowAllGroups(!!showAllGroups), [showAllGroups]);
 
-  // ── Assets view: zoom level + location provider ──
+  // ── Assets view: zoom level + collapse state + location provider ──
   const [activeAssetsZoom, setActiveAssetsZoom] = useState<AssetsZoomLevel>('month');
+  const [activeAssetsCollapsed, setActiveAssetsCollapsed] = useState<Set<string>>(
+    () => new Set(),
+  );
   const effectiveLocationProvider = useMemo<LocationProvider>(
     () => locationProvider ?? createManualLocationProvider(),
     [locationProvider],
   );
 
-  // Mark dirty when filters/view/groupBy/sort/showAllGroups change after a saved view was applied
-  // Use a ref to skip the first effect run immediately after applying
+  // Mark dirty when filters/view/groupBy/sort/showAllGroups/assets-state change
+  // after a saved view was applied. A ref skips the first run that fires
+  // synchronously after handleApplyView seeds state from the saved view.
   useEffect(() => {
     if (skipDirtyRef.current) { skipDirtyRef.current = false; return; }
     if (savedViewActiveId)    setSavedViewDirty(true);
-  }, [cal.filters, cal.view, activeGroupBy, activeSort, activeShowAllGroups]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [cal.filters, cal.view, activeGroupBy, activeSort, activeShowAllGroups, activeAssetsZoom, activeAssetsCollapsed]); // eslint-disable-line react-hooks/exhaustive-deps
 
   const handleApplyView = useCallback((savedView) => {
     skipDirtyRef.current = true;
@@ -413,6 +417,12 @@ export const WorksCalendar = forwardRef<CalendarApi, WorksCalendarProps>(functio
     setActiveGroupBy(savedView.groupBy ?? null);
     setActiveSort(Array.isArray(savedView.sort) ? savedView.sort : null);
     setActiveShowAllGroups(!!savedView.showAllGroups);
+    if (savedView.zoomLevel) setActiveAssetsZoom(savedView.zoomLevel);
+    setActiveAssetsCollapsed(
+      Array.isArray(savedView.collapsedGroups)
+        ? new Set(savedView.collapsedGroups)
+        : new Set(),
+    );
     setSavedViewActiveId(savedView.id);
     setSavedViewDirty(false);
   }, [cal, schema]);
@@ -1538,9 +1548,9 @@ export const WorksCalendar = forwardRef<CalendarApi, WorksCalendarProps>(functio
               activeId:    savedViewActiveId,
               isDirty:     savedViewDirty,
               applyView:   handleApplyView,
-              saveView:    (name, opts) => savedViews.saveView(name, cal.filters, { groupBy: activeGroupBy, sort: activeSort, showAllGroups: activeShowAllGroups, ...opts }),
+              saveView:    (name, opts) => savedViews.saveView(name, cal.filters, { groupBy: activeGroupBy, sort: activeSort, showAllGroups: activeShowAllGroups, zoomLevel: activeAssetsZoom, collapsedGroups: activeAssetsCollapsed, ...opts }),
               updateView:  savedViews.updateView,
-              resaveView:  (id) => savedViews.resaveView(id, cal.filters, cal.view, activeGroupBy, { sort: activeSort, showAllGroups: activeShowAllGroups }),
+              resaveView:  (id) => savedViews.resaveView(id, cal.filters, cal.view, activeGroupBy, { sort: activeSort, showAllGroups: activeShowAllGroups, zoomLevel: activeAssetsZoom, collapsedGroups: activeAssetsCollapsed }),
               deleteView:  handleDeleteView,
               currentFilters: cal.filters,
               currentView:    cal.view,
@@ -1555,9 +1565,9 @@ export const WorksCalendar = forwardRef<CalendarApi, WorksCalendarProps>(functio
               schema={schema}
               onApply={handleApplyView}
               onAdd={({ name, color, pinView }) =>
-                savedViews.saveView(name, cal.filters, { color, view: pinView ? cal.view : null, groupBy: activeGroupBy, sort: activeSort, showAllGroups: activeShowAllGroups })
+                savedViews.saveView(name, cal.filters, { color, view: pinView ? cal.view : null, groupBy: activeGroupBy, sort: activeSort, showAllGroups: activeShowAllGroups, zoomLevel: activeAssetsZoom, collapsedGroups: activeAssetsCollapsed })
               }
-              onResave={(id) => savedViews.resaveView(id, cal.filters, cal.view, activeGroupBy, { sort: activeSort, showAllGroups: activeShowAllGroups })}
+              onResave={(id) => savedViews.resaveView(id, cal.filters, cal.view, activeGroupBy, { sort: activeSort, showAllGroups: activeShowAllGroups, zoomLevel: activeAssetsZoom, collapsedGroups: activeAssetsCollapsed })}
               onUpdate={savedViews.updateView}
               onDelete={handleDeleteView}
             />
@@ -1635,6 +1645,8 @@ export const WorksCalendar = forwardRef<CalendarApi, WorksCalendarProps>(functio
                   categoriesConfig={categoriesConfig ?? ownerCfg.config?.categoriesConfig}
                   zoomLevel={activeAssetsZoom}
                   onZoomChange={setActiveAssetsZoom}
+                  collapsedGroups={activeAssetsCollapsed}
+                  onCollapsedGroupsChange={setActiveAssetsCollapsed}
                   locationProvider={effectiveLocationProvider}
                   renderAssetLocation={renderAssetLocation}
                 />

--- a/src/WorksCalendar.tsx
+++ b/src/WorksCalendar.tsx
@@ -1644,6 +1644,7 @@ export const WorksCalendar = forwardRef<CalendarApi, WorksCalendarProps>(functio
                   onEventClick={handleEventClick}
                   onDateSelect={handleScheduleDateSelect}
                   groupBy={activeGroupBy}
+                  onGroupByChange={setActiveGroupBy}
                   categoriesConfig={categoriesConfig ?? ownerCfg.config?.categoriesConfig}
                   assets={assets ?? ownerCfg.config?.assets}
                   zoomLevel={activeAssetsZoom}
@@ -1652,6 +1653,7 @@ export const WorksCalendar = forwardRef<CalendarApi, WorksCalendarProps>(functio
                   onCollapsedGroupsChange={setActiveAssetsCollapsed}
                   locationProvider={effectiveLocationProvider}
                   renderAssetLocation={renderAssetLocation}
+                  onEditAssets={ownerCfg.isOwner ? () => ownerCfg.openConfigToTab('assets') : undefined}
                 />
               )}
             </>
@@ -1759,6 +1761,7 @@ export const WorksCalendar = forwardRef<CalendarApi, WorksCalendarProps>(functio
             resources={resources}
             schema={schema}
             items={expandedEvents}
+            initialTab={ownerCfg.configInitialTab}
             onUpdate={ownerCfg.updateConfig}
             onClose={ownerCfg.closeConfig}
             onSaveView={(name, filters, opts) => savedViews.saveView(name, filters, opts)}

--- a/src/__tests__/WorksCalendar.scheduleModel.integration.test.jsx
+++ b/src/__tests__/WorksCalendar.scheduleModel.integration.test.jsx
@@ -83,7 +83,7 @@ describe('WorksCalendar schedule model integration', () => {
       const ptoEvents = visible.filter((ev) => String(ev?.meta?.kind ?? '') === 'pto');
       expect(ptoEvents.length).toBeGreaterThan(0);
     });
-  });
+  }, 15000);
 
   it('does not create duplicate open-shift records when PTO is re-saved', async () => {
     const apiRef = createRef();

--- a/src/__tests__/groupingFilteringSorting.integration.test.js
+++ b/src/__tests__/groupingFilteringSorting.integration.test.js
@@ -1,0 +1,236 @@
+/**
+ * Integration matrix — grouping × filtering × sorting (ticket #134-5).
+ *
+ * The WorksCalendar event pipeline is:
+ *
+ *   events
+ *     → applyFilters(events, filters, schema)        (filtered)
+ *     → sortEvents(filtered, sortConfigs)            (sorted, stable)
+ *     → buildGroupTree(sorted, groupBy)              (grouped, in views)
+ *
+ * These specs exercise the three stages in combination so we catch
+ * interactions the single-stage unit tests miss: e.g. group sort is
+ * alphabetical by key regardless of event sort, but *within* a leaf group
+ * the event sort must be preserved; filtering must shrink group counts and
+ * can fully remove a group when its last event is filtered out; etc.
+ *
+ * Ticket scope called for ~15 specs covering the matrix.
+ */
+import { describe, it, expect } from 'vitest';
+
+import { applyFilters } from '../filters/filterEngine.js';
+import { DEFAULT_FILTER_SCHEMA } from '../filters/filterSchema.ts';
+import { sortEvents } from '../core/sortEngine.ts';
+import { buildGroupTree } from '../hooks/useGrouping.ts';
+
+const baseDay = (day) => new Date(2026, 3, day);
+
+const events = [
+  { id: 'e1', title: 'Charlie Flight', start: baseDay(2), end: baseDay(2),  category: 'training',    resource: 'N100', meta: { region: 'West', priority: 1 } },
+  { id: 'e2', title: 'Alpha Flight',   start: baseDay(1), end: baseDay(1),  category: 'training',    resource: 'N200', meta: { region: 'East', priority: 3 } },
+  { id: 'e3', title: 'Bravo Flight',   start: baseDay(3), end: baseDay(3),  category: 'maintenance', resource: 'N100', meta: { region: 'West', priority: 2 } },
+  { id: 'e4', title: 'Delta Flight',   start: baseDay(4), end: baseDay(4),  category: 'pr',          resource: 'N300', meta: { region: 'East', priority: 3 } },
+  { id: 'e5', title: 'Echo Flight',    start: baseDay(5), end: baseDay(5),  category: 'training',    resource: 'N100', meta: { region: 'West', priority: 2 } },
+  { id: 'e6', title: 'Foxtrot Flight', start: baseDay(6), end: baseDay(6),  category: 'maintenance', resource: 'N200', meta: { region: 'East', priority: 1 } },
+];
+
+/** Apply the three-stage pipeline end-to-end. */
+function pipeline({ filters = {}, sort = [], groupBy = null } = {}) {
+  const filtered = applyFilters(events, filters, DEFAULT_FILTER_SCHEMA);
+  const sorted   = sortEvents(filtered, sort);
+  const tree     = groupBy ? buildGroupTree(sorted, groupBy) : [];
+  return { filtered, sorted, tree };
+}
+
+// ── Sort + group (no filter) ────────────────────────────────────────────────
+
+describe('integration — sort × group', () => {
+  it('1-level group retains within-group event sort (title asc)', () => {
+    const { tree } = pipeline({
+      sort: [{ field: 'title', direction: 'asc' }],
+      groupBy: 'category',
+    });
+    // category groups sort alphabetically (maintenance, pr, training).
+    const maintenanceTitles = tree.find(g => g.key === 'maintenance').events.map(e => e.title);
+    expect(maintenanceTitles).toEqual(['Bravo Flight', 'Foxtrot Flight']);
+    const trainingTitles = tree.find(g => g.key === 'training').events.map(e => e.title);
+    expect(trainingTitles).toEqual(['Alpha Flight', 'Charlie Flight', 'Echo Flight']);
+  });
+
+  it('within-group sort is stable across sort direction flips', () => {
+    const { tree } = pipeline({
+      sort: [{ field: 'title', direction: 'desc' }],
+      groupBy: 'category',
+    });
+    const trainingTitles = tree.find(g => g.key === 'training').events.map(e => e.title);
+    expect(trainingTitles).toEqual(['Echo Flight', 'Charlie Flight', 'Alpha Flight']);
+  });
+
+  it('multi-field sort survives the grouping step', () => {
+    // Primary: meta.priority asc; tiebreaker: title asc.
+    const { tree } = pipeline({
+      sort: [
+        { field: 'priority', direction: 'asc' },
+        { field: 'title',    direction: 'asc' },
+      ],
+      groupBy: 'category',
+    });
+    const training = tree.find(g => g.key === 'training').events.map(e => ({
+      title: e.title, priority: e.meta.priority,
+    }));
+    expect(training).toEqual([
+      { title: 'Charlie Flight', priority: 1 },
+      { title: 'Echo Flight',    priority: 2 },
+      { title: 'Alpha Flight',   priority: 3 },
+    ]);
+  });
+
+  it('2-level nested group preserves inner sort in deepest leaves', () => {
+    const { tree } = pipeline({
+      sort: [{ field: 'start', direction: 'asc' }],
+      groupBy: ['region', 'category'],
+    });
+    // East → training: [Alpha only]; East → pr: [Delta]; East → maintenance: [Foxtrot].
+    const east = tree.find(g => g.key === 'East');
+    expect(east.children.map(c => c.key)).toEqual(['maintenance', 'pr', 'training']);
+    expect(east.children.find(c => c.key === 'training').events.map(e => e.id)).toEqual(['e2']);
+    expect(east.children.find(c => c.key === 'maintenance').events.map(e => e.id)).toEqual(['e6']);
+  });
+});
+
+// ── Filter + sort ────────────────────────────────────────────────────────────
+
+describe('integration — filter × sort', () => {
+  it('filtering then sorting returns only surviving events in sort order', () => {
+    const filters = { categories: ['training'] };
+    const { sorted } = pipeline({
+      filters,
+      sort: [{ field: 'title', direction: 'asc' }],
+    });
+    expect(sorted.map(e => e.title)).toEqual(['Alpha Flight', 'Charlie Flight', 'Echo Flight']);
+  });
+
+  it('resource filter narrows to a single asset before sorting by start', () => {
+    const { sorted } = pipeline({
+      filters: { resources: ['N100'] },
+      sort: [{ field: 'start', direction: 'asc' }],
+    });
+    expect(sorted.map(e => e.id)).toEqual(['e1', 'e3', 'e5']);
+  });
+
+  it('text search filter runs before the sort step', () => {
+    const { sorted } = pipeline({
+      filters: { search: 'Alpha' },
+      sort: [{ field: 'title', direction: 'asc' }],
+    });
+    expect(sorted.map(e => e.id)).toEqual(['e2']);
+  });
+
+  it('empty filters pass every event through to the sort step', () => {
+    const { sorted } = pipeline({
+      filters: {},
+      sort: [{ field: 'start', direction: 'asc' }],
+    });
+    expect(sorted).toHaveLength(events.length);
+  });
+});
+
+// ── Filter + group ──────────────────────────────────────────────────────────
+
+describe('integration — filter × group', () => {
+  it('category filter removes groups with no surviving events', () => {
+    const { tree } = pipeline({
+      filters: { categories: ['training'] },
+      groupBy: 'category',
+    });
+    expect(tree.map(g => g.key)).toEqual(['training']);
+    expect(tree[0].events).toHaveLength(3);
+  });
+
+  it('resource filter shrinks per-group counts without dropping the group', () => {
+    // Filter to resource N100 (West region only).
+    const { tree } = pipeline({
+      filters: { resources: ['N100'] },
+      groupBy: 'region',
+    });
+    expect(tree.map(g => g.key)).toEqual(['West']);
+    expect(tree[0].events.map(e => e.id)).toEqual(['e1', 'e3', 'e5']);
+  });
+
+  it('filtering to zero events produces an empty tree', () => {
+    const { tree } = pipeline({
+      filters: { categories: ['does-not-exist'] },
+      groupBy: 'category',
+    });
+    expect(tree).toEqual([]);
+  });
+
+  it('2-level nested group drops empty inner branches after filter', () => {
+    // After filtering to training only, East group keeps just Alpha;
+    // West group keeps Charlie + Echo. Inner "maintenance" and "pr" go away.
+    const { tree } = pipeline({
+      filters: { categories: ['training'] },
+      groupBy: ['region', 'category'],
+    });
+    const east = tree.find(g => g.key === 'East');
+    const west = tree.find(g => g.key === 'West');
+    expect(east.children.map(c => c.key)).toEqual(['training']);
+    expect(west.children.map(c => c.key)).toEqual(['training']);
+  });
+});
+
+// ── Full matrix: filter × sort × group ──────────────────────────────────────
+
+describe('integration — filter × sort × group', () => {
+  it('all three stages compose: filter → sort → group with inner order preserved', () => {
+    const { tree } = pipeline({
+      filters: { categories: ['training'] },
+      sort:    [{ field: 'start', direction: 'desc' }],
+      groupBy: 'region',
+    });
+    // Only training events survive; sorted by start desc; grouped by region.
+    const east = tree.find(g => g.key === 'East');
+    const west = tree.find(g => g.key === 'West');
+    expect(east.events.map(e => e.id)).toEqual(['e2']); // Alpha only
+    expect(west.events.map(e => e.id)).toEqual(['e5', 'e1']); // Echo, Charlie (desc)
+  });
+
+  it('group order is alphabetical regardless of event sort direction', () => {
+    const { tree: asc } = pipeline({
+      sort: [{ field: 'start', direction: 'asc' }],
+      groupBy: 'category',
+    });
+    const { tree: desc } = pipeline({
+      sort: [{ field: 'start', direction: 'desc' }],
+      groupBy: 'category',
+    });
+    expect(asc.map(g => g.key)).toEqual(desc.map(g => g.key));
+    expect(asc.map(g => g.key)).toEqual(['maintenance', 'pr', 'training']);
+  });
+
+  it('changing sort mid-pipeline does not mutate the source events array', () => {
+    const snapshot = events.map(e => e.id);
+    pipeline({ sort: [{ field: 'title', direction: 'desc' }], groupBy: 'category' });
+    expect(events.map(e => e.id)).toEqual(snapshot);
+  });
+
+  it('group event counts equal post-filter event totals per bucket', () => {
+    const { tree } = pipeline({
+      filters: { resources: ['N100', 'N200'] },
+      groupBy: 'region',
+    });
+    const total = tree.reduce((sum, g) => sum + g.events.length, 0);
+    const filteredCount = pipeline({ filters: { resources: ['N100', 'N200'] } }).filtered.length;
+    expect(total).toBe(filteredCount);
+  });
+
+  it('absent groupBy leaves the tree empty while filter + sort still apply', () => {
+    const { filtered, sorted, tree } = pipeline({
+      filters: { categories: ['training'] },
+      sort:    [{ field: 'title', direction: 'asc' }],
+    });
+    expect(filtered).toHaveLength(3);
+    expect(sorted.map(e => e.title)).toEqual(['Alpha Flight', 'Charlie Flight', 'Echo Flight']);
+    expect(tree).toEqual([]);
+  });
+});

--- a/src/__tests__/phaseB.integration.test.jsx
+++ b/src/__tests__/phaseB.integration.test.jsx
@@ -1,0 +1,340 @@
+// @vitest-environment happy-dom
+/**
+ * Phase B integration matrix — ticket #134-16.
+ *
+ * End-to-end glue test across the three owner-configurable systems landed
+ * in Phase B: RequestForm (schema-driven input), conflictEngine (data-
+ * driven rules), and the approvals policy (config.approvals.rules). All
+ * three read from the same `config` blob, so the test harness mutates the
+ * blob directly and asserts the observable end-state — no mocks.
+ *
+ * Pipeline:
+ *   RequestForm.onSubmit → evaluateConflicts → ConflictModal
+ *                     ↓ (allowed)
+ *                   persist event with meta.approvalStage = 'requested'
+ *                     ↓
+ *                   pill caret reveals the owner-configured approve/deny
+ *                   actions via ApprovalActionMenu.
+ */
+import { render, screen, fireEvent, within } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { useState } from 'react';
+import '@testing-library/jest-dom';
+
+import RequestForm from '../ui/RequestForm.jsx';
+import ConflictModal from '../ui/ConflictModal.jsx';
+import ApprovalActionMenu, { allowedActionsFor } from '../ui/ApprovalActionMenu.jsx';
+import { evaluateConflicts } from '../core/conflictEngine.ts';
+import { DEFAULT_CONFIG } from '../core/configSchema.js';
+
+// ─── Test fixtures ────────────────────────────────────────────────────────────
+
+/** Cross-cutting config the three systems all read. */
+const fullConfig = {
+  requestForm: {
+    fields: [
+      { key: 'title',    label: 'Title',    type: 'text',     required: true },
+      { key: 'start',    label: 'Starts',   type: 'datetime', required: true },
+      { key: 'end',      label: 'Ends',     type: 'datetime', required: true },
+      { key: 'resource', label: 'Resource', type: 'text',     required: true },
+      { key: 'category', label: 'Category', type: 'select',   options: 'training, maintenance, pr' },
+    ],
+  },
+  conflicts: {
+    enabled: true,
+    rules: [
+      { id: 'ro-1', type: 'resource-overlap', severity: 'hard' },
+    ],
+  },
+  approvals: {
+    enabled: true,
+    rules: {
+      requested: { allow: ['approve', 'deny'], prefix: 'Req' },
+      approved:  { allow: ['finalize', 'revoke'], prefix: '' },
+      finalized: { allow: ['revoke'], prefix: 'Final' },
+      denied:    { allow: ['revoke'], prefix: 'Denied' },
+      pending_higher: { allow: ['approve', 'deny'], prefix: 'Pend' },
+    },
+    labels: {
+      approve: 'Approve',
+      deny:    'Reject',
+      finalize: 'Lock',
+      revoke:  'Undo',
+    },
+  },
+};
+
+/** Seed event that will overlap with some request-form submissions. */
+const seededEvent = {
+  id: 'seed-1',
+  title: 'Existing block',
+  start: new Date('2026-04-20T09:00:00'),
+  end:   new Date('2026-04-20T11:00:00'),
+  resource: 'N121AB',
+  category: 'training',
+};
+
+/**
+ * Small orchestrator that wires the three systems the way a host app would.
+ * Not production code — exists only for the test pipeline.
+ */
+function Pipeline({ config, initialEvents = [seededEvent], onCommit }) {
+  const [events, setEvents]     = useState(initialEvents);
+  const [proposed, setProposed] = useState(null);
+  const [conflict, setConflict] = useState(null);
+  const [committed, setCommitted] = useState(null);
+
+  const handleSubmit = ({ values }) => {
+    const evt = {
+      id: `new-${events.length + 1}`,
+      title: values.title,
+      start: new Date(values.start),
+      end:   new Date(values.end),
+      resource: values.resource,
+      category: values.category,
+    };
+    const result = evaluateConflicts({
+      proposed: evt,
+      events,
+      rules: config.conflicts.rules,
+      enabled: config.conflicts.enabled,
+    });
+    setProposed(evt);
+    if (result.severity === 'none') {
+      persist(evt);
+    } else {
+      setConflict(result);
+    }
+  };
+
+  const persist = (evt) => {
+    const withStage = {
+      ...evt,
+      meta: { approvalStage: { stage: 'requested', updatedAt: '', history: [] } },
+    };
+    setEvents(prev => [...prev, withStage]);
+    setCommitted(withStage);
+    onCommit?.(withStage);
+  };
+
+  const proceed = () => {
+    if (proposed && conflict?.allowed) persist(proposed);
+    setConflict(null);
+  };
+
+  return (
+    <div>
+      <RequestForm
+        schema={config.requestForm}
+        onSubmit={handleSubmit}
+        onCancel={vi.fn()}
+      />
+      <ConflictModal result={conflict} onProceed={proceed} onCancel={() => setConflict(null)} />
+      {committed && (
+        <div data-testid="committed-pill">
+          <span>{committed.title}</span>
+          <ApprovalActionMenu
+            stage={committed.meta.approvalStage.stage}
+            approvalsConfig={config.approvals}
+            onAction={vi.fn()}
+            variant="inline"
+          />
+        </div>
+      )}
+    </div>
+  );
+}
+
+function fillRequestForm({ title, start, end, resource, category }) {
+  fireEvent.change(screen.getByLabelText('Title'),    { target: { value: title } });
+  fireEvent.change(screen.getByLabelText('Starts'),   { target: { value: start } });
+  fireEvent.change(screen.getByLabelText('Ends'),     { target: { value: end } });
+  fireEvent.change(screen.getByLabelText('Resource'), { target: { value: resource } });
+  if (category !== undefined) {
+    fireEvent.change(screen.getByLabelText('Category'), { target: { value: category } });
+  }
+  fireEvent.click(screen.getByRole('button', { name: /Submit request/ }));
+}
+
+// ─── Specs ────────────────────────────────────────────────────────────────────
+
+describe('Phase B pipeline — RequestForm → conflictEngine → approval pill', () => {
+  it('owner config defaults include all three Phase B blocks', () => {
+    // Guards against someone removing a block from the default — every host
+    // app relies on the union being present for the integration to compose.
+    expect(DEFAULT_CONFIG.requestForm?.fields?.length).toBeGreaterThan(0);
+    expect(DEFAULT_CONFIG.conflicts).toMatchObject({ enabled: expect.any(Boolean), rules: expect.any(Array) });
+    expect(DEFAULT_CONFIG.approvals).toMatchObject({ enabled: expect.any(Boolean), rules: expect.any(Object) });
+  });
+
+  it('commits the event unchanged when no rules trigger', () => {
+    const onCommit = vi.fn();
+    render(<Pipeline config={fullConfig} onCommit={onCommit} />);
+    fillRequestForm({
+      title: 'PR shoot',
+      start: '2026-04-21T09:00',
+      end:   '2026-04-21T11:00',
+      resource: 'N121AB',
+      category: 'pr',
+    });
+    expect(onCommit).toHaveBeenCalledTimes(1);
+    expect(onCommit.mock.calls[0][0].title).toBe('PR shoot');
+    expect(onCommit.mock.calls[0][0].meta.approvalStage.stage).toBe('requested');
+    // No conflict modal rendered.
+    expect(screen.queryByRole('alertdialog')).not.toBeInTheDocument();
+  });
+
+  it('blocks a submission that hits a hard resource-overlap rule', () => {
+    const onCommit = vi.fn();
+    render(<Pipeline config={fullConfig} onCommit={onCommit} />);
+    fillRequestForm({
+      title: 'Overlap',
+      start: '2026-04-20T10:00',
+      end:   '2026-04-20T12:00',
+      resource: 'N121AB',
+      category: 'training',
+    });
+    // Modal appears and proceed is disabled (hard).
+    const dialog = screen.getByRole('alertdialog');
+    expect(dialog).toBeInTheDocument();
+    expect(within(dialog).getByRole('button', { name: /Resolve to continue/ })).toBeDisabled();
+    expect(onCommit).not.toHaveBeenCalled();
+  });
+
+  it('allows a submission past a soft rule once the user confirms', () => {
+    const softConfig = {
+      ...fullConfig,
+      conflicts: {
+        enabled: true,
+        rules: [{ id: 'ro-soft', type: 'resource-overlap', severity: 'soft' }],
+      },
+    };
+    const onCommit = vi.fn();
+    render(<Pipeline config={softConfig} onCommit={onCommit} />);
+    fillRequestForm({
+      title: 'Soft overlap',
+      start: '2026-04-20T10:00',
+      end:   '2026-04-20T12:00',
+      resource: 'N121AB',
+      category: 'training',
+    });
+    const dialog = screen.getByRole('alertdialog');
+    const proceed = within(dialog).getByRole('button', { name: /Proceed anyway/ });
+    expect(proceed).not.toBeDisabled();
+    fireEvent.click(proceed);
+    expect(onCommit).toHaveBeenCalledTimes(1);
+    expect(onCommit.mock.calls[0][0].meta.approvalStage.stage).toBe('requested');
+  });
+
+  it('bypasses the conflict engine entirely when conflicts.enabled is false', () => {
+    const disabled = { ...fullConfig, conflicts: { enabled: false, rules: fullConfig.conflicts.rules } };
+    const onCommit = vi.fn();
+    render(<Pipeline config={disabled} onCommit={onCommit} />);
+    fillRequestForm({
+      title: 'Would overlap',
+      start: '2026-04-20T10:00',
+      end:   '2026-04-20T12:00',
+      resource: 'N121AB',
+      category: 'training',
+    });
+    // No modal; committed directly.
+    expect(screen.queryByRole('alertdialog')).not.toBeInTheDocument();
+    expect(onCommit).toHaveBeenCalledTimes(1);
+  });
+
+  it('blocks submit when a required request-form field is empty', () => {
+    const onCommit = vi.fn();
+    render(<Pipeline config={fullConfig} onCommit={onCommit} />);
+    // Title is required but left blank.
+    fireEvent.change(screen.getByLabelText('Starts'),   { target: { value: '2026-04-21T09:00' } });
+    fireEvent.change(screen.getByLabelText('Ends'),     { target: { value: '2026-04-21T11:00' } });
+    fireEvent.change(screen.getByLabelText('Resource'), { target: { value: 'N121AB' } });
+    fireEvent.click(screen.getByRole('button', { name: /Submit request/ }));
+    expect(onCommit).not.toHaveBeenCalled();
+    expect(screen.getByLabelText('Title')).toHaveAttribute('aria-invalid', 'true');
+  });
+});
+
+describe('Phase B pipeline — committed event exposes approval actions', () => {
+  it('pill menu exposes the configured approve/deny buttons', () => {
+    render(<Pipeline config={fullConfig} onCommit={vi.fn()} />);
+    fillRequestForm({
+      title: 'Auto-approve flow',
+      start: '2026-04-22T09:00',
+      end:   '2026-04-22T11:00',
+      resource: 'N121AB',
+      category: 'pr',
+    });
+    const pill = screen.getByTestId('committed-pill');
+    expect(within(pill).getByRole('menuitem', { name: 'Approve' })).toBeInTheDocument();
+    expect(within(pill).getByRole('menuitem', { name: 'Reject' })).toBeInTheDocument();
+  });
+
+  it('owner can strip all actions off a stage and the pill menu disappears', () => {
+    const locked = {
+      ...fullConfig,
+      approvals: {
+        ...fullConfig.approvals,
+        rules: {
+          ...fullConfig.approvals.rules,
+          requested: { allow: [], prefix: 'Req' },
+        },
+      },
+    };
+    render(<Pipeline config={locked} onCommit={vi.fn()} />);
+    fillRequestForm({
+      title: 'Locked',
+      start: '2026-04-23T09:00',
+      end:   '2026-04-23T11:00',
+      resource: 'N121AB',
+      category: 'pr',
+    });
+    const pill = screen.getByTestId('committed-pill');
+    expect(within(pill).queryByRole('menuitem')).not.toBeInTheDocument();
+  });
+
+  it('disabling approvals globally silences all pill actions', () => {
+    const silent = { ...fullConfig, approvals: { ...fullConfig.approvals, enabled: false } };
+    render(<Pipeline config={silent} onCommit={vi.fn()} />);
+    fillRequestForm({
+      title: 'Silent flow',
+      start: '2026-04-24T09:00',
+      end:   '2026-04-24T11:00',
+      resource: 'N121AB',
+      category: 'pr',
+    });
+    const pill = screen.getByTestId('committed-pill');
+    expect(within(pill).queryByRole('menuitem')).not.toBeInTheDocument();
+  });
+});
+
+describe('Phase B pipeline — policy helper invariants', () => {
+  it('allowedActionsFor derives the same list the pill menu renders', () => {
+    // Single source of truth: the pill menu + audit drawer + inline tests
+    // all use the same resolver, so the policy helper is the
+    // canonical checkpoint.
+    expect(allowedActionsFor('requested', fullConfig.approvals)).toEqual(['approve', 'deny']);
+    expect(allowedActionsFor('approved',  fullConfig.approvals)).toEqual(['finalize', 'revoke']);
+    expect(allowedActionsFor('finalized', fullConfig.approvals)).toEqual(['revoke']);
+  });
+
+  it('evaluateConflicts returns { allowed: false } for hard + true for soft', () => {
+    const proposed = {
+      id: 'p', title: 'x', resource: 'N121AB',
+      start: new Date('2026-04-20T10:00:00'), end: new Date('2026-04-20T12:00:00'),
+    };
+    const hardResult = evaluateConflicts({
+      proposed, events: [seededEvent],
+      rules: [{ id: 'r', type: 'resource-overlap', severity: 'hard' }],
+    });
+    expect(hardResult.allowed).toBe(false);
+    expect(hardResult.severity).toBe('hard');
+
+    const softResult = evaluateConflicts({
+      proposed, events: [seededEvent],
+      rules: [{ id: 'r', type: 'resource-overlap', severity: 'soft' }],
+    });
+    expect(softResult.allowed).toBe(true);
+    expect(softResult.severity).toBe('soft');
+  });
+});

--- a/src/core/__tests__/configSchema.test.js
+++ b/src/core/__tests__/configSchema.test.js
@@ -1,0 +1,107 @@
+// @vitest-environment happy-dom
+/**
+ * configSchema — schema-version migration + approvals defaults (ticket #134-14).
+ *
+ * These specs pin the v3 → v4 on-disk migration introduced with the approvals
+ * tab. The migration is additive: every calendar loaded from pre-v4 storage
+ * must come out with the new `approvals` block seeded to defaults, and the
+ * schemaVersion stamp must be bumped so subsequent loads skip the default
+ * merge step.
+ */
+import { describe, it, expect, beforeEach } from 'vitest';
+
+import {
+  loadConfig,
+  saveConfig,
+  DEFAULT_CONFIG,
+  CONFIG_SCHEMA_VERSION,
+  APPROVAL_STAGE_IDS,
+} from '../configSchema.js';
+
+const CAL_ID = 'test-cal';
+const key = `wc-config-${CAL_ID}`;
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+describe('configSchema — defaults', () => {
+  it('DEFAULT_CONFIG includes an approvals block with all five stages', () => {
+    expect(DEFAULT_CONFIG.approvals).toBeTruthy();
+    expect(DEFAULT_CONFIG.approvals.enabled).toBe(false);
+    for (const stage of APPROVAL_STAGE_IDS) {
+      expect(DEFAULT_CONFIG.approvals.rules[stage]).toBeDefined();
+      expect(Array.isArray(DEFAULT_CONFIG.approvals.rules[stage].allow)).toBe(true);
+    }
+  });
+
+  it('DEFAULT_CONFIG carries the current schemaVersion', () => {
+    expect(DEFAULT_CONFIG.schemaVersion).toBe(CONFIG_SCHEMA_VERSION);
+  });
+});
+
+describe('configSchema — v3 → v4 migration', () => {
+  it('loads a legacy payload without schemaVersion and stamps the current version', () => {
+    // Legacy shape: title + assets only, no schemaVersion.
+    localStorage.setItem(key, JSON.stringify({
+      title: 'Legacy Cal',
+      assets: [{ id: 'a1', label: 'Asset 1' }],
+    }));
+
+    const loaded = loadConfig(CAL_ID);
+    expect(loaded.title).toBe('Legacy Cal');
+    expect(loaded.assets).toEqual([{ id: 'a1', label: 'Asset 1' }]);
+    expect(loaded.schemaVersion).toBe(CONFIG_SCHEMA_VERSION);
+  });
+
+  it('fills in the approvals block on load when the legacy payload lacks it', () => {
+    localStorage.setItem(key, JSON.stringify({
+      title: 'Legacy Cal',
+    }));
+
+    const loaded = loadConfig(CAL_ID);
+    expect(loaded.approvals).toBeTruthy();
+    expect(loaded.approvals.enabled).toBe(false);
+    expect(loaded.approvals.tiers.length).toBeGreaterThan(0);
+    for (const stage of APPROVAL_STAGE_IDS) {
+      expect(loaded.approvals.rules[stage]).toBeDefined();
+    }
+  });
+
+  it('preserves an existing approvals block when one is already persisted', () => {
+    localStorage.setItem(key, JSON.stringify({
+      title: 'Saved Cal',
+      schemaVersion: CONFIG_SCHEMA_VERSION,
+      approvals: {
+        enabled: true,
+        tiers: [{ id: 'only-tier', label: 'Only', requires: 'all', roles: ['x'] }],
+        rules: { requested: { allow: ['approve'], prefix: 'R' } },
+        labels: { approve: 'Sign' },
+      },
+    }));
+
+    const loaded = loadConfig(CAL_ID);
+    expect(loaded.approvals.enabled).toBe(true);
+    expect(loaded.approvals.tiers).toHaveLength(1);
+    expect(loaded.approvals.tiers[0].id).toBe('only-tier');
+    // Default rules merge in for stages the owner didn't override.
+    expect(loaded.approvals.rules.requested.allow).toEqual(['approve']);
+    expect(loaded.approvals.rules.approved).toBeDefined();
+    expect(loaded.approvals.labels.approve).toBe('Sign');
+  });
+
+  it('saveConfig round-trips the approvals block through localStorage', () => {
+    const next = {
+      ...DEFAULT_CONFIG,
+      approvals: {
+        ...DEFAULT_CONFIG.approvals,
+        enabled: true,
+        labels: { ...DEFAULT_CONFIG.approvals.labels, approve: 'Okay' },
+      },
+    };
+    saveConfig(CAL_ID, next);
+    const loaded = loadConfig(CAL_ID);
+    expect(loaded.approvals.enabled).toBe(true);
+    expect(loaded.approvals.labels.approve).toBe('Okay');
+  });
+});

--- a/src/core/__tests__/conflictEngine.test.ts
+++ b/src/core/__tests__/conflictEngine.test.ts
@@ -1,0 +1,303 @@
+/**
+ * conflictEngine — unit specs (ticket #134-13).
+ *
+ * Owner-configurable conflict detection. These specs pin the built-in rule
+ * semantics (resource-overlap, category-mutex, min-rest) and the engine's
+ * aggregation + allowed/severity contract. Runtime consumers rely on
+ * `allowed === false` for hard violations and truthy `violations[]` for soft
+ * ones — so a regression here would silently break the ConflictModal.
+ */
+import { describe, it, expect } from 'vitest';
+
+import {
+  evaluateConflicts,
+  type ConflictEvent,
+  type ConflictRule,
+} from '../conflictEngine.js';
+
+const day = (d: number, h = 9) => new Date(2026, 3, d, h);
+
+const base: ConflictEvent = {
+  id: 'proposed',
+  start: day(10, 9),
+  end:   day(10, 11),
+  resource: 'N100',
+  category: 'flight',
+};
+
+describe('conflictEngine — no-op paths', () => {
+  it('returns allowed=true with no violations when `enabled` is false', () => {
+    const result = evaluateConflicts({
+      proposed: base,
+      events: [{ ...base, id: 'other' }],
+      rules: [{ id: 'r1', type: 'resource-overlap' }],
+      enabled: false,
+    });
+    expect(result.allowed).toBe(true);
+    expect(result.severity).toBe('none');
+    expect(result.violations).toEqual([]);
+  });
+
+  it('returns allowed=true when rules[] is empty', () => {
+    const result = evaluateConflicts({
+      proposed: base,
+      events: [{ ...base, id: 'other' }],
+      rules: [],
+    });
+    expect(result.allowed).toBe(true);
+    expect(result.violations).toEqual([]);
+  });
+
+  it('skips the proposed event itself (same id)', () => {
+    const result = evaluateConflicts({
+      proposed: { ...base, id: 'e1' },
+      events: [{ ...base, id: 'e1' }],
+      rules: [{ id: 'r1', type: 'resource-overlap' }],
+    });
+    expect(result.allowed).toBe(true);
+  });
+});
+
+describe('conflictEngine — resource-overlap rule', () => {
+  const rule: ConflictRule = { id: 'ovr', type: 'resource-overlap', severity: 'hard' };
+
+  it('flags an overlapping same-resource event as hard', () => {
+    const other: ConflictEvent = {
+      id: 'e1',
+      start: day(10, 10),
+      end:   day(10, 12),
+      resource: 'N100',
+      category: 'maintenance',
+    };
+    const result = evaluateConflicts({ proposed: base, events: [other], rules: [rule] });
+    expect(result.allowed).toBe(false);
+    expect(result.severity).toBe('hard');
+    expect(result.violations).toHaveLength(1);
+    expect(result.violations[0].conflictingEventId).toBe('e1');
+  });
+
+  it('ignores a non-overlapping event', () => {
+    const other: ConflictEvent = {
+      id: 'e1',
+      start: day(11, 9),
+      end:   day(11, 11),
+      resource: 'N100',
+    };
+    const result = evaluateConflicts({ proposed: base, events: [other], rules: [rule] });
+    expect(result.allowed).toBe(true);
+  });
+
+  it('ignores a different-resource event', () => {
+    const other: ConflictEvent = {
+      id: 'e1',
+      start: day(10, 10),
+      end:   day(10, 12),
+      resource: 'N200',
+    };
+    const result = evaluateConflicts({ proposed: base, events: [other], rules: [rule] });
+    expect(result.allowed).toBe(true);
+  });
+
+  it('treats touching endpoints (aEnd === bStart) as NOT overlapping', () => {
+    const other: ConflictEvent = {
+      id: 'e1',
+      start: day(10, 11),
+      end:   day(10, 13),
+      resource: 'N100',
+    };
+    const result = evaluateConflicts({ proposed: base, events: [other], rules: [rule] });
+    expect(result.allowed).toBe(true);
+  });
+
+  it('respects the ignoreCategories allowlist', () => {
+    const ignoreRule: ConflictRule = {
+      id: 'ovr',
+      type: 'resource-overlap',
+      severity: 'hard',
+      ignoreCategories: ['flight'],
+    };
+    const other: ConflictEvent = {
+      id: 'e1',
+      start: day(10, 10),
+      end:   day(10, 12),
+      resource: 'N100',
+    };
+    const result = evaluateConflicts({ proposed: base, events: [other], rules: [ignoreRule] });
+    expect(result.allowed).toBe(true);
+  });
+
+  it('accepts soft severity and sets allowed=true', () => {
+    const softRule: ConflictRule = { id: 'ovr', type: 'resource-overlap', severity: 'soft' };
+    const other: ConflictEvent = {
+      id: 'e1',
+      start: day(10, 10),
+      end:   day(10, 12),
+      resource: 'N100',
+    };
+    const result = evaluateConflicts({ proposed: base, events: [other], rules: [softRule] });
+    expect(result.allowed).toBe(true);
+    expect(result.severity).toBe('soft');
+    expect(result.violations).toHaveLength(1);
+  });
+});
+
+describe('conflictEngine — category-mutex rule', () => {
+  const rule: ConflictRule = {
+    id: 'pto-shift',
+    type: 'category-mutex',
+    severity: 'hard',
+    categories: ['pto', 'shift'],
+  };
+
+  it('flags overlapping events whose categories are both in the mutex set', () => {
+    const proposed: ConflictEvent = { ...base, id: 'req', category: 'pto' };
+    const shift: ConflictEvent = {
+      id: 's1',
+      start: day(10, 10),
+      end:   day(10, 12),
+      resource: 'N100',
+      category: 'shift',
+    };
+    const result = evaluateConflicts({ proposed, events: [shift], rules: [rule] });
+    expect(result.allowed).toBe(false);
+    expect(result.violations[0].details).toMatchObject({ type: 'category-mutex' });
+  });
+
+  it('does not flag when only one side is in the mutex set', () => {
+    const proposed: ConflictEvent = { ...base, id: 'req', category: 'meeting' };
+    const shift: ConflictEvent = {
+      id: 's1',
+      start: day(10, 10),
+      end:   day(10, 12),
+      resource: 'N100',
+      category: 'shift',
+    };
+    const result = evaluateConflicts({ proposed, events: [shift], rules: [rule] });
+    expect(result.allowed).toBe(true);
+  });
+
+  it('does not flag when same category on both sides', () => {
+    const proposed: ConflictEvent = { ...base, id: 'req', category: 'pto' };
+    const other: ConflictEvent = {
+      id: 's1',
+      start: day(10, 10),
+      end:   day(10, 12),
+      resource: 'N100',
+      category: 'pto',
+    };
+    const result = evaluateConflicts({ proposed, events: [other], rules: [rule] });
+    expect(result.allowed).toBe(true);
+  });
+
+  it('no-ops when categories[] has fewer than two entries', () => {
+    const badRule: ConflictRule = { ...rule, categories: ['pto'] };
+    const proposed: ConflictEvent = { ...base, id: 'req', category: 'pto' };
+    const shift: ConflictEvent = {
+      id: 's1',
+      start: day(10, 10),
+      end:   day(10, 12),
+      resource: 'N100',
+      category: 'shift',
+    };
+    const result = evaluateConflicts({ proposed, events: [shift], rules: [badRule] });
+    expect(result.allowed).toBe(true);
+  });
+});
+
+describe('conflictEngine — min-rest rule', () => {
+  const rule: ConflictRule = { id: 'rest', type: 'min-rest', severity: 'soft', minutes: 60 };
+
+  it('flags when the gap is shorter than the required rest', () => {
+    const other: ConflictEvent = {
+      id: 'e1',
+      start: day(10, 11, ), // proposed ends at 11:00, this starts at 11:30
+      end:   day(10, 13),
+      resource: 'N100',
+    };
+    // Nudge start to 11:30 so gap = 30 min.
+    const otherClose: ConflictEvent = {
+      ...other,
+      start: new Date(2026, 3, 10, 11, 30),
+    };
+    const result = evaluateConflicts({
+      proposed: base,
+      events: [otherClose],
+      rules: [rule],
+    });
+    expect(result.allowed).toBe(true); // soft severity
+    expect(result.severity).toBe('soft');
+    expect(result.violations).toHaveLength(1);
+    expect(result.violations[0].details).toMatchObject({ type: 'min-rest' });
+  });
+
+  it('does not flag when the gap meets the rest requirement', () => {
+    const other: ConflictEvent = {
+      id: 'e1',
+      start: day(10, 12, ),
+      end:   day(10, 14),
+      resource: 'N100',
+    };
+    const result = evaluateConflicts({ proposed: base, events: [other], rules: [rule] });
+    expect(result.allowed).toBe(true);
+    expect(result.violations).toHaveLength(0);
+  });
+
+  it('does not flag overlapping events (overlap owned by resource-overlap rule)', () => {
+    const other: ConflictEvent = {
+      id: 'e1',
+      start: day(10, 10),
+      end:   day(10, 12),
+      resource: 'N100',
+    };
+    const result = evaluateConflicts({ proposed: base, events: [other], rules: [rule] });
+    expect(result.allowed).toBe(true);
+  });
+
+  it('no-ops when minutes <= 0', () => {
+    const zeroRule: ConflictRule = { ...rule, minutes: 0 };
+    const other: ConflictEvent = {
+      id: 'e1',
+      start: day(10, 11, 30),
+      end:   day(10, 13),
+      resource: 'N100',
+    };
+    const result = evaluateConflicts({ proposed: base, events: [other], rules: [zeroRule] });
+    expect(result.allowed).toBe(true);
+  });
+});
+
+describe('conflictEngine — aggregation', () => {
+  it('collects violations from multiple rules; severity is worst-case', () => {
+    const other: ConflictEvent = {
+      id: 'e1',
+      start: day(10, 10),
+      end:   day(10, 12),
+      resource: 'N100',
+      category: 'shift',
+    };
+    const proposed: ConflictEvent = { ...base, category: 'pto' };
+    const rules: ConflictRule[] = [
+      { id: 'ovr',       type: 'resource-overlap', severity: 'soft' },
+      { id: 'pto-shift', type: 'category-mutex',   severity: 'hard', categories: ['pto', 'shift'] },
+    ];
+    const result = evaluateConflicts({ proposed, events: [other], rules });
+    expect(result.violations).toHaveLength(2);
+    expect(result.severity).toBe('hard');
+    expect(result.allowed).toBe(false);
+  });
+
+  it('returns severity=soft when every violation is soft', () => {
+    const other: ConflictEvent = {
+      id: 'e1',
+      start: day(10, 10),
+      end:   day(10, 12),
+      resource: 'N100',
+    };
+    const rules: ConflictRule[] = [
+      { id: 'ovr', type: 'resource-overlap', severity: 'soft' },
+    ];
+    const result = evaluateConflicts({ proposed: base, events: [other], rules });
+    expect(result.severity).toBe('soft');
+    expect(result.allowed).toBe(true);
+  });
+});

--- a/src/core/configSchema.js
+++ b/src/core/configSchema.js
@@ -103,6 +103,20 @@ export const DEFAULT_CONFIG = {
   // Shape: { id: string, label: string, group?: string, meta?: object }
   assets: [],
 
+  // Owner-configurable conflict rules (ticket #134-13). Runs via
+  // src/core/conflictEngine.ts before an event write. Rules are data, not
+  // code — owners add / tune them from ConfigPanel → Conflicts without
+  // touching host-app JS. Host callbacks remain the escape hatch.
+  //
+  // Shape per rule: { id, type, severity?, ...params }. See conflictEngine
+  // for the `ConflictRule` union; supported types are 'resource-overlap',
+  // 'category-mutex', and 'min-rest'. Default config ships no rules so the
+  // engine is a no-op until the owner enables + configures one.
+  conflicts: {
+    enabled: false,
+    rules: [],
+  },
+
   // Owner-configurable approval workflow (ticket #134-14). The runtime
   // machinery (AssetsView pill prefixes, AuditDrawer menus, inline approve
   // actions added later in #134-15) reads this block. `enabled: false`

--- a/src/core/configSchema.js
+++ b/src/core/configSchema.js
@@ -54,6 +54,13 @@ export const DEFAULT_CONFIG = {
   access: {
     viewerPassword: '',
   },
+
+  // First-class asset registry. When non-empty, AssetsView renders one row
+  // per entry (label for display, id matched against event.resource). Empty
+  // array preserves the legacy event.resource-derived behavior. Edited from
+  // the ConfigPanel → Assets tab; no host redeploy needed to change the fleet.
+  // Shape: { id: string, label: string, group?: string, meta?: object }
+  assets: [],
 };
 
 function mergeDeep(target, source) {

--- a/src/core/configSchema.js
+++ b/src/core/configSchema.js
@@ -103,6 +103,24 @@ export const DEFAULT_CONFIG = {
   // Shape: { id: string, label: string, group?: string, meta?: object }
   assets: [],
 
+  // Owner-configurable RequestForm schema (ticket #134-12). Drives the
+  // schema-driven request form in src/ui/RequestForm.jsx. Owners add/
+  // remove/reorder fields from ConfigPanel → Request Form with zero
+  // host-app redeploy. Host-level validators / onSubmit remain the escape
+  // hatch for domain logic.
+  //
+  // Shape per field: { key, label, type, required?, placeholder?, options? }
+  // `options` is a comma-separated string (used by select-type fields).
+  // Default ships a minimal three-field schema covering the common case;
+  // owners override in place.
+  requestForm: {
+    fields: [
+      { key: 'title',  label: 'Title',  type: 'text',     required: true,  placeholder: 'Short summary' },
+      { key: 'start',  label: 'Starts', type: 'datetime', required: true },
+      { key: 'notes',  label: 'Notes',  type: 'textarea', required: false, placeholder: 'Optional details' },
+    ],
+  },
+
   // Owner-configurable conflict rules (ticket #134-13). Runs via
   // src/core/conflictEngine.ts before an event write. Rules are data, not
   // code — owners add / tune them from ConfigPanel → Conflicts without

--- a/src/core/configSchema.js
+++ b/src/core/configSchema.js
@@ -2,8 +2,49 @@
  * configSchema.js — Owner config schema, defaults, and localStorage persistence.
  */
 
+/**
+ * On-disk schema version for `wc-config-<calendarId>`.
+ *
+ * History:
+ *   (no version)  legacy pre-sprint owner config.
+ *   3            implicit version once first-class assets[] landed (#134-9).
+ *   4            adds config.approvals block (#134-14). Additive only —
+ *                calendars with schemaVersion < 4 auto-merge the defaults on
+ *                load so nothing in the UI changes until the owner toggles
+ *                `approvals.enabled`.
+ */
+export const CONFIG_SCHEMA_VERSION = 4;
+
+/** 5-state approval machine shared with AssetsView + AuditDrawer. */
+export const APPROVAL_STAGE_IDS = Object.freeze([
+  'requested',
+  'approved',
+  'finalized',
+  'pending_higher',
+  'denied',
+]);
+
+/** Named actions the owner can allow/deny per stage. */
+export const APPROVAL_ACTIONS = Object.freeze([
+  'approve',
+  'deny',
+  'finalize',
+  'revoke',
+]);
+
+function defaultApprovalRules() {
+  return {
+    requested:      { allow: ['approve', 'deny'], prefix: 'Req' },
+    pending_higher: { allow: ['approve', 'deny'], prefix: 'Pend' },
+    approved:       { allow: ['finalize', 'revoke'], prefix: '' },
+    finalized:      { allow: ['revoke'], prefix: 'Final' },
+    denied:         { allow: ['revoke'], prefix: 'Denied' },
+  };
+}
+
 export const DEFAULT_CONFIG = {
   title: 'My WorksCalendar',
+  schemaVersion: CONFIG_SCHEMA_VERSION,
 
   setup: {
     completed: false,
@@ -61,6 +102,33 @@ export const DEFAULT_CONFIG = {
   // the ConfigPanel → Assets tab; no host redeploy needed to change the fleet.
   // Shape: { id: string, label: string, group?: string, meta?: object }
   assets: [],
+
+  // Owner-configurable approval workflow (ticket #134-14). The runtime
+  // machinery (AssetsView pill prefixes, AuditDrawer menus, inline approve
+  // actions added later in #134-15) reads this block. `enabled: false`
+  // keeps the surface invisible so calendars that never opt in see no
+  // behavioral change.
+  //
+  //   tiers   — ordered approver levels; events promote through this list.
+  //             `requires: 'any' | 'all'` decides whether one approver is
+  //             enough or every listed role must sign off before promotion.
+  //   rules   — per-stage: which actions are allowed and what label prefix
+  //             the pill wears (keeps AssetsView prefixes owner-editable).
+  //   labels  — button copy shown in the audit drawer + inline pill menu.
+  approvals: {
+    enabled: false,
+    tiers: [
+      { id: 'tier-1', label: 'Supervisor', requires: 'any', roles: [] },
+      { id: 'tier-2', label: 'Director',   requires: 'any', roles: [] },
+    ],
+    rules: defaultApprovalRules(),
+    labels: {
+      approve:  'Approve',
+      deny:     'Deny',
+      finalize: 'Finalize',
+      revoke:   'Revoke',
+    },
+  },
 };
 
 function mergeDeep(target, source) {
@@ -99,6 +167,17 @@ export function loadConfig(calendarId) {
 
     if (parsed?.setupCompleted && !parsed?.setup?.completed) {
       merged.setup.completed = true;
+    }
+
+    // Schema-version migration. mergeDeep above already folds in any new
+    // DEFAULT_CONFIG keys (e.g. the `approvals` block added in v4), so the
+    // migration here is just stamping the current version so we can branch
+    // on it in the future without re-scanning every field.
+    const storedVersion = typeof parsed.schemaVersion === 'number'
+      ? parsed.schemaVersion
+      : 3;
+    if (storedVersion < CONFIG_SCHEMA_VERSION) {
+      merged.schemaVersion = CONFIG_SCHEMA_VERSION;
     }
 
     return merged;

--- a/src/core/conflictEngine.ts
+++ b/src/core/conflictEngine.ts
@@ -1,0 +1,225 @@
+/**
+ * conflictEngine — owner-configurable conflict detection (ticket #134-13).
+ *
+ * Runs before an event write (create / edit / group-change) to surface
+ * violations produced by the owner's rule set. Rules are *data*, not code:
+ * they live in `config.conflicts.rules` so owners can add / tune them from
+ * ConfigPanel without touching host-app JS. Host callbacks remain the
+ * escape hatch for custom checks via the existing `CalendarEngine`
+ * validator pipeline (`src/core/engine/validation/*`); this engine is the
+ * default path.
+ *
+ * The module is deliberately tiny: a single `evaluateConflicts()` entry
+ * point + a registry of pure rule evaluators. Every evaluator returns
+ * `Violation | null`; the engine aggregates violations and computes an
+ * overall severity.
+ */
+import type { Violation } from './engine/validation/validationTypes.js'
+
+// ─── Types ──────────────────────────────────────────────────────────────────
+
+/** Minimum shape we need from an event to run conflict rules. */
+export interface ConflictEvent {
+  readonly id: string
+  readonly start: Date | string | number
+  readonly end: Date | string | number
+  readonly resource?: string | null
+  readonly category?: string | null
+  readonly meta?: Readonly<Record<string, unknown>>
+}
+
+/** Data-driven rule configuration persisted to `config.conflicts.rules`. */
+export type ConflictRule =
+  | ResourceOverlapRule
+  | CategoryMutexRule
+  | MinRestRule
+
+export interface ResourceOverlapRule {
+  readonly id: string
+  readonly type: 'resource-overlap'
+  readonly severity?: 'soft' | 'hard'
+  /** Skip when the proposed event's category matches any of these. */
+  readonly ignoreCategories?: readonly string[]
+}
+
+export interface CategoryMutexRule {
+  readonly id: string
+  readonly type: 'category-mutex'
+  readonly severity?: 'soft' | 'hard'
+  /** Categories that MUST NOT coexist for the same resource in an overlapping window. */
+  readonly categories: readonly string[]
+}
+
+export interface MinRestRule {
+  readonly id: string
+  readonly type: 'min-rest'
+  readonly severity?: 'soft' | 'hard'
+  /** Required gap (in minutes) between consecutive events on the same resource. */
+  readonly minutes: number
+}
+
+export interface ConflictEvaluationResult {
+  readonly violations: readonly Violation[]
+  readonly severity: 'none' | 'soft' | 'hard'
+  /** True when there are no hard violations — caller may proceed (with warnings). */
+  readonly allowed: boolean
+}
+
+export interface EvaluateConflictsInput {
+  /** The event the user is trying to write. `id` may be empty for a create. */
+  readonly proposed: ConflictEvent
+  /** All currently-visible events. The proposed event is removed by id. */
+  readonly events: readonly ConflictEvent[]
+  /** Active rule set (owner-configured). */
+  readonly rules: readonly ConflictRule[]
+  /** Master switch — when false, returns `VALID` without running any rule. */
+  readonly enabled?: boolean
+}
+
+const VALID: ConflictEvaluationResult = {
+  violations: [],
+  severity: 'none',
+  allowed: true,
+}
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+function toDate(value: Date | string | number): Date {
+  return value instanceof Date ? value : new Date(value)
+}
+
+/** Half-open interval overlap — touching endpoints are NOT a conflict. */
+function overlaps(aStart: Date, aEnd: Date, bStart: Date, bEnd: Date): boolean {
+  return aStart < bEnd && bStart < aEnd
+}
+
+function sameResource(a: ConflictEvent, b: ConflictEvent): boolean {
+  const ra = a.resource ?? ''
+  const rb = b.resource ?? ''
+  return ra !== '' && ra === rb
+}
+
+// ─── Built-in rule evaluators ───────────────────────────────────────────────
+
+function evalResourceOverlap(
+  rule: ResourceOverlapRule,
+  proposed: ConflictEvent,
+  other: ConflictEvent,
+): Violation | null {
+  const ignore = new Set(rule.ignoreCategories ?? [])
+  if (proposed.category && ignore.has(proposed.category)) return null
+  if (!sameResource(proposed, other)) return null
+
+  const ps = toDate(proposed.start)
+  const pe = toDate(proposed.end)
+  const os = toDate(other.start)
+  const oe = toDate(other.end)
+  if (!overlaps(ps, pe, os, oe)) return null
+
+  return {
+    rule: rule.id,
+    severity: rule.severity ?? 'hard',
+    message: `Conflicts with "${(other as { title?: string }).title ?? other.id}" on the same resource.`,
+    conflictingEventId: other.id,
+    details: { type: 'resource-overlap' },
+  }
+}
+
+function evalCategoryMutex(
+  rule: CategoryMutexRule,
+  proposed: ConflictEvent,
+  other: ConflictEvent,
+): Violation | null {
+  const mutex = new Set(rule.categories)
+  if (mutex.size < 2) return null
+  if (!proposed.category || !other.category) return null
+  if (!mutex.has(proposed.category) || !mutex.has(other.category)) return null
+  if (proposed.category === other.category) return null
+  if (!sameResource(proposed, other)) return null
+
+  const ps = toDate(proposed.start)
+  const pe = toDate(proposed.end)
+  const os = toDate(other.start)
+  const oe = toDate(other.end)
+  if (!overlaps(ps, pe, os, oe)) return null
+
+  return {
+    rule: rule.id,
+    severity: rule.severity ?? 'hard',
+    message: `Categories "${proposed.category}" and "${other.category}" cannot overlap on the same resource.`,
+    conflictingEventId: other.id,
+    details: { type: 'category-mutex' },
+  }
+}
+
+function evalMinRest(
+  rule: MinRestRule,
+  proposed: ConflictEvent,
+  other: ConflictEvent,
+): Violation | null {
+  if (!(rule.minutes > 0)) return null
+  if (!sameResource(proposed, other)) return null
+
+  const ps = toDate(proposed.start)
+  const pe = toDate(proposed.end)
+  const os = toDate(other.start)
+  const oe = toDate(other.end)
+
+  // Gap = time between the two intervals (if non-overlapping).
+  if (overlaps(ps, pe, os, oe)) return null
+
+  const gapMs = ps >= oe ? ps.getTime() - oe.getTime() : os.getTime() - pe.getTime()
+  const requiredMs = rule.minutes * 60_000
+  if (gapMs >= requiredMs) return null
+
+  return {
+    rule: rule.id,
+    severity: rule.severity ?? 'soft',
+    message: `Only ${Math.round(gapMs / 60_000)} min between shifts; rule requires ≥${rule.minutes}.`,
+    conflictingEventId: other.id,
+    details: { type: 'min-rest', gapMinutes: gapMs / 60_000 },
+  }
+}
+
+// ─── Public API ─────────────────────────────────────────────────────────────
+
+/**
+ * Run every rule against every other event and return aggregated violations.
+ *
+ * Complexity is O(rules × events); for the calendar's typical working set
+ * (<1000 events, <10 rules) this is well under the perf budget. Rules are
+ * pure and side-effect-free so the result is fully memoisable by caller.
+ */
+export function evaluateConflicts(input: EvaluateConflictsInput): ConflictEvaluationResult {
+  const { proposed, events, rules, enabled = true } = input
+  if (!enabled || rules.length === 0) return VALID
+
+  const violations: Violation[] = []
+  for (const other of events) {
+    if (other.id && proposed.id && other.id === proposed.id) continue
+    for (const rule of rules) {
+      let v: Violation | null = null
+      switch (rule.type) {
+        case 'resource-overlap': v = evalResourceOverlap(rule, proposed, other); break
+        case 'category-mutex':   v = evalCategoryMutex(rule, proposed, other);   break
+        case 'min-rest':         v = evalMinRest(rule, proposed, other);         break
+        default: break
+      }
+      if (v) violations.push(v)
+    }
+  }
+
+  if (violations.length === 0) return VALID
+  const hasHard = violations.some(v => v.severity === 'hard')
+  return {
+    violations,
+    severity: hasHard ? 'hard' : 'soft',
+    allowed: !hasHard,
+  }
+}
+
+export const CONFLICT_RULE_TYPES: readonly ConflictRule['type'][] = [
+  'resource-overlap',
+  'category-mutex',
+  'min-rest',
+] as const

--- a/src/hooks/__tests__/useSavedViews.test.js
+++ b/src/hooks/__tests__/useSavedViews.test.js
@@ -822,3 +822,52 @@ describe('useSavedViews — zoomLevel persistence', () => {
     expect(result.current.views[0].zoomLevel).toBe('month');
   });
 });
+
+describe('useSavedViews — resaveView collapsedGroups persistence', () => {
+  it('resaveView updates collapsedGroups via opts', () => {
+    const { result } = renderHook(() => useSavedViews(CAL_ID));
+    act(() => {
+      result.current.saveView('Cg', EMPTY_FILTERS, { collapsedGroups: new Set(['A']) });
+    });
+    const id = result.current.views[0].id;
+    act(() => {
+      result.current.resaveView(id, EMPTY_FILTERS, undefined, undefined, {
+        collapsedGroups: new Set(['B', 'C']),
+      });
+    });
+    expect(result.current.views[0].collapsedGroups).toEqual(
+      expect.arrayContaining(['B', 'C']),
+    );
+    expect(result.current.views[0].collapsedGroups).not.toContain('A');
+  });
+
+  it('resaveView preserves collapsedGroups when opts.collapsedGroups is omitted', () => {
+    const { result } = renderHook(() => useSavedViews(CAL_ID));
+    act(() => {
+      result.current.saveView('Cg preserve', EMPTY_FILTERS, {
+        collapsedGroups: new Set(['keep']),
+      });
+    });
+    const id = result.current.views[0].id;
+    act(() => {
+      result.current.resaveView(id, EMPTY_FILTERS, 'agenda', 'department');
+    });
+    expect(result.current.views[0].collapsedGroups).toEqual(['keep']);
+  });
+
+  it('resaveView clears collapsedGroups when given an empty Set', () => {
+    const { result } = renderHook(() => useSavedViews(CAL_ID));
+    act(() => {
+      result.current.saveView('Cg clear', EMPTY_FILTERS, {
+        collapsedGroups: new Set(['X']),
+      });
+    });
+    const id = result.current.views[0].id;
+    act(() => {
+      result.current.resaveView(id, EMPTY_FILTERS, undefined, undefined, {
+        collapsedGroups: new Set(),
+      });
+    });
+    expect(result.current.views[0].collapsedGroups).toBeNull();
+  });
+});

--- a/src/hooks/useGrouping.ts
+++ b/src/hooks/useGrouping.ts
@@ -131,8 +131,9 @@ export type UseGroupingEngineResult = {
  * When groupBy is unset the hook is a pass-through: groups is [] and ungrouped
  * holds all events, so rendering code can rely on a single code path.
  *
- * Named useGroupingEngine to coexist with the row-based useGrouping (JS) used
- * by TimelineView until Sprint 4 migrates that view to this API.
+ * Named useGroupingEngine to coexist with the row-based useGrouping (JS),
+ * which is retained only for external consumers of the package API; all
+ * bundled views (Agenda, Assets, Timeline) now route through buildGroupTree.
  */
 export function useGroupingEngine(
   options: UseGroupingEngineOptions,

--- a/src/hooks/useOwnerConfig.js
+++ b/src/hooks/useOwnerConfig.js
@@ -13,6 +13,7 @@ export function useOwnerConfig({ calendarId, ownerPassword, onConfigSave, devMod
   const [config,        setConfig]        = useState(() => loadConfig(calendarId));
   const [isOwner,       setIsOwner]       = useState(devMode);
   const [configOpen,    setConfigOpen]    = useState(false);
+  const [configInitialTab, setConfigInitialTab] = useState(null);
   const [authError,     setAuthError]     = useState('');
   const [isAuthLoading, setIsAuthLoading] = useState(false);
   const pendingNotifyRef = useRef(false);
@@ -70,15 +71,25 @@ export function useOwnerConfig({ calendarId, ownerPassword, onConfigSave, devMod
     // else OwnerLock component handles the prompt
   }, [isOwner]);
 
+  // Deep-link helper: open ConfigPanel focused on a specific tab id. Used by
+  // view toolbars (e.g. AssetsView's "Edit assets") so owners can jump
+  // straight to the relevant registry without hunting through tabs.
+  const openConfigToTab = useCallback((tabId) => {
+    setConfigInitialTab(tabId ?? null);
+    setConfigOpen(true);
+  }, []);
+
   return {
     config,
     isOwner,
     configOpen, setConfigOpen,
+    configInitialTab,
     authError,
     isAuthLoading,
     authenticate,
     updateConfig,
     closeConfig,
     openGear,
+    openConfigToTab,
   };
 }

--- a/src/hooks/useSavedViews.js
+++ b/src/hooks/useSavedViews.js
@@ -289,7 +289,7 @@ export function useSavedViews(calendarId) {
   }, []);
 
   const resaveView = useCallback((id, filters, viewName, groupBy, opts = {}) => {
-    const { sort, showAllGroups, sortBy, zoomLevel } = opts || {};
+    const { sort, showAllGroups, sortBy, zoomLevel, collapsedGroups } = opts || {};
     setViews(prev => prev.map(v =>
       v.id === id
         ? {
@@ -300,6 +300,9 @@ export function useSavedViews(calendarId) {
             ...(sort !== undefined ? { sort: sanitizeSort(sort) } : {}),
             ...(sortBy !== undefined ? { sortBy: sanitizeSort(sortBy) } : {}),
             ...(zoomLevel !== undefined ? { zoomLevel: sanitizeZoomLevel(zoomLevel) } : {}),
+            ...(collapsedGroups !== undefined
+              ? { collapsedGroups: sanitizeCollapsedGroups(collapsedGroups) }
+              : {}),
             ...(showAllGroups !== undefined
               ? { showAllGroups: typeof showAllGroups === 'boolean' ? showAllGroups : null }
               : {}),

--- a/src/ui/ApprovalActionMenu.jsx
+++ b/src/ui/ApprovalActionMenu.jsx
@@ -1,0 +1,109 @@
+/**
+ * ApprovalActionMenu — ticket #134-15.
+ *
+ * Inline action menu rendered next to an approval pill (AssetsView) or in
+ * the AuditDrawer header. The action list is owner-configurable via
+ * `config.approvals.rules[stage].allow`; button copy comes from
+ * `config.approvals.labels`.
+ *
+ * The calendar never mutates `event.meta.approvalStage` — this component
+ * fires `onAction(actionId)` and the host persists the new stage + history
+ * entry, then re-renders with the updated event.
+ */
+import { useEffect, useRef } from 'react';
+import styles from './ApprovalActionMenu.module.css';
+
+const DEFAULT_LABELS = {
+  approve:  'Approve',
+  deny:     'Deny',
+  finalize: 'Finalize',
+  revoke:   'Revoke',
+};
+
+/**
+ * Resolves the allowed actions for a given stage from the owner-configured
+ * approvals block. Returns [] when the feature is disabled, the stage is
+ * unknown, or the stage has no rules.
+ */
+export function allowedActionsFor(stage, approvalsConfig) {
+  if (!approvalsConfig || approvalsConfig.enabled !== true) return [];
+  const stageRule = approvalsConfig.rules?.[stage];
+  const allow = Array.isArray(stageRule?.allow) ? stageRule.allow : [];
+  return allow;
+}
+
+/**
+ * `variant: 'popover'` (default) renders as a fixed-position overlay anchored
+ * to `anchorRect` with Escape + click-outside dismissal — used by the pill
+ * caret. `variant: 'inline'` renders statically, meant for embedding inside
+ * another dialog (the AuditDrawer uses this).
+ */
+export default function ApprovalActionMenu({
+  stage,
+  approvalsConfig,
+  onAction,
+  onClose,
+  labelledBy,
+  anchorRect,
+  variant = 'popover',
+}) {
+  const ref = useRef(null);
+  const actions = allowedActionsFor(stage, approvalsConfig);
+
+  useEffect(() => {
+    if (variant !== 'popover' || actions.length === 0) return;
+    const onKey = e => { if (e.key === 'Escape') onClose?.(); };
+    const onDown = e => {
+      if (ref.current && !ref.current.contains(e.target)) onClose?.();
+    };
+    window.addEventListener('keydown', onKey);
+    window.addEventListener('mousedown', onDown);
+    return () => {
+      window.removeEventListener('keydown', onKey);
+      window.removeEventListener('mousedown', onDown);
+    };
+  }, [variant, actions.length, onClose]);
+
+  if (actions.length === 0) return null;
+  const labels = approvalsConfig?.labels ?? {};
+
+  const style = variant === 'popover' && anchorRect
+    ? {
+        position: 'fixed',
+        top:  (anchorRect.bottom ?? 0) + 4,
+        left: anchorRect.left ?? 0,
+      }
+    : undefined;
+
+  return (
+    <div
+      ref={ref}
+      role="menu"
+      aria-labelledby={labelledBy}
+      className={[
+        styles.menu,
+        variant === 'inline' ? styles.menuInline : '',
+      ].filter(Boolean).join(' ')}
+      data-testid="approval-action-menu"
+      data-variant={variant}
+      style={style}
+    >
+      {actions.map(action => (
+        <button
+          key={action}
+          type="button"
+          role="menuitem"
+          className={styles.menuItem}
+          data-action={action}
+          onClick={(e) => {
+            e.stopPropagation();
+            onAction?.(action);
+            onClose?.();
+          }}
+        >
+          {labels[action] ?? DEFAULT_LABELS[action] ?? action}
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/src/ui/ApprovalActionMenu.module.css
+++ b/src/ui/ApprovalActionMenu.module.css
@@ -1,0 +1,56 @@
+.menu {
+  z-index: 540;
+  min-width: 160px;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  padding: 4px;
+  background: var(--wc-bg, #fff);
+  border: 1px solid var(--wc-border, #d1d5db);
+  border-radius: 6px;
+  box-shadow: var(--wc-shadow, 0 6px 18px rgba(0, 0, 0, 0.12));
+}
+
+.menuInline {
+  position: static;
+  box-shadow: none;
+  border: 0;
+  padding: 0;
+  background: transparent;
+  flex-direction: row;
+  flex-wrap: wrap;
+  gap: 6px;
+  min-width: 0;
+}
+
+.menuItem {
+  padding: 6px 10px;
+  text-align: left;
+  font-size: 13px;
+  font-weight: 500;
+  background: transparent;
+  color: var(--wc-text, #111827);
+  border: 1px solid transparent;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.menuItem:hover,
+.menuItem:focus-visible {
+  background: var(--wc-bg-muted, #f3f4f6);
+  outline: none;
+}
+
+.menuInline .menuItem {
+  border-color: var(--wc-border, #d1d5db);
+  background: var(--wc-bg, #fff);
+}
+
+.menuInline .menuItem:hover {
+  background: var(--wc-bg-muted, #f3f4f6);
+}
+
+.menuItem[data-action='deny'],
+.menuItem[data-action='revoke'] {
+  color: var(--wc-danger, #dc2626);
+}

--- a/src/ui/ConfigPanel.jsx
+++ b/src/ui/ConfigPanel.jsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from 'react';
-import { X, Plus, Trash2, Check, Camera, Pencil } from 'lucide-react';
+import { X, Plus, Trash2, Check, Camera, Pencil, ArrowUp, ArrowDown } from 'lucide-react';
 import { FIELD_TYPES } from '../core/configSchema.js';
 import { DEFAULT_CATEGORIES } from '../types/assets.ts';
 import { useFocusTrap } from '../hooks/useFocusTrap.js';
@@ -15,6 +15,7 @@ const TABS = [
   { id: 'hoverCard',   label: 'Hover Card' },
   { id: 'eventFields', label: 'Event Fields' },
   { id: 'categories',  label: 'Categories' },
+  { id: 'assets',      label: 'Assets' },
   { id: 'display',     label: 'Display' },
   { id: 'theme',       label: 'Theme' },
   { id: 'feeds',       label: 'Feeds' },
@@ -76,6 +77,7 @@ export default function ConfigPanel({
           {tab === 'hoverCard'   && <HoverCardTab   config={config} onUpdate={onUpdate} />}
           {tab === 'eventFields' && <EventFieldsTab config={config} categories={categories} onUpdate={onUpdate} />}
           {tab === 'categories'  && <CategoriesTab   config={config} onUpdate={onUpdate} />}
+          {tab === 'assets'      && <AssetsTab       config={config} onUpdate={onUpdate} />}
           {tab === 'display'     && <DisplayTab     config={config} onUpdate={onUpdate} />}
           {tab === 'theme'       && <ThemeCustomizer theme={config.customTheme} onChange={onUpdate} />}
           {tab === 'feeds'       && (
@@ -733,6 +735,120 @@ export function CategoriesTab({ config, onUpdate }) {
         <span>Reset to shipped defaults</span>
         <button className={styles.addBtn} onClick={resetToDefaults}>Reset</button>
       </div>
+    </div>
+  );
+}
+
+/* ----- Assets tab ----- */
+/**
+ * Owner-editable asset registry. Persists to config.assets; WorksCalendar
+ * threads `props.assets ?? config.assets` into AssetsView. An empty array
+ * preserves the legacy event.resource-derived behavior so the tab is
+ * strictly additive — existing calendars keep rendering unchanged until the
+ * owner adds at least one asset.
+ *
+ * Each entry: { id, label, group?, meta: { sublabel? } }
+ *   id     — matched against event.resource; stable key, not user-facing.
+ *   label  — display name rendered in the AssetsView rowheader.
+ *   group  — optional group bucket (e.g. "CJ3", "West"); surfaces in
+ *            groupBy dropdowns added by ticket 10.
+ *   meta   — free-form; sublabel appears under label in the asset cell.
+ */
+export function AssetsTab({ config, onUpdate }) {
+  const assets = Array.isArray(config.assets) ? config.assets : [];
+
+  const writeAssets = (next) => onUpdate(c => ({ ...c, assets: next }));
+
+  const addAsset = () => {
+    const n = assets.length + 1;
+    writeAssets([
+      ...assets,
+      { id: `asset-${n}`, label: `Asset ${n}`, group: '', meta: {} },
+    ]);
+  };
+
+  const updateAsset = (idx, patch) => {
+    writeAssets(assets.map((a, i) => (i === idx ? { ...a, ...patch } : a)));
+  };
+
+  const updateAssetMeta = (idx, metaPatch) => {
+    writeAssets(assets.map((a, i) => (
+      i === idx ? { ...a, meta: { ...(a.meta ?? {}), ...metaPatch } } : a
+    )));
+  };
+
+  const removeAsset = (idx) => writeAssets(assets.filter((_, i) => i !== idx));
+
+  const moveAsset = (idx, delta) => {
+    const target = idx + delta;
+    if (target < 0 || target >= assets.length) return;
+    const next = [...assets];
+    const [moved] = next.splice(idx, 1);
+    next.splice(target, 0, moved);
+    writeAssets(next);
+  };
+
+  return (
+    <div className={styles.section}>
+      <p className={styles.sectionDesc}>
+        Register the assets that appear as rows in the Assets view. Rows
+        follow this order; leave empty to fall back to deriving rows from
+        <code> event.resource</code> values.
+      </p>
+
+      {assets.map((asset, i) => (
+        <div key={asset.id + ':' + i} className={styles.fieldRow} data-asset-id={asset.id}>
+          <input
+            className={styles.input}
+            value={asset.label ?? ''}
+            onChange={e => updateAsset(i, { label: e.target.value })}
+            placeholder="Label"
+            aria-label={`Label for ${asset.id}`}
+          />
+          <input
+            className={styles.input}
+            value={asset.id}
+            onChange={e => updateAsset(i, { id: e.target.value.trim() || asset.id })}
+            placeholder="id"
+            aria-label={`Id for ${asset.label || asset.id}`}
+          />
+          <input
+            className={styles.input}
+            value={asset.group ?? ''}
+            onChange={e => updateAsset(i, { group: e.target.value })}
+            placeholder="Group"
+            aria-label={`Group for ${asset.label || asset.id}`}
+          />
+          <input
+            className={styles.input}
+            value={asset.meta?.sublabel ?? ''}
+            onChange={e => updateAssetMeta(i, { sublabel: e.target.value })}
+            placeholder="Sublabel"
+            aria-label={`Sublabel for ${asset.label || asset.id}`}
+          />
+          <button
+            className={styles.removeBtn}
+            onClick={() => moveAsset(i, -1)}
+            disabled={i === 0}
+            aria-label={`Move ${asset.label || asset.id} up`}
+          ><ArrowUp size={13} /></button>
+          <button
+            className={styles.removeBtn}
+            onClick={() => moveAsset(i, 1)}
+            disabled={i === assets.length - 1}
+            aria-label={`Move ${asset.label || asset.id} down`}
+          ><ArrowDown size={13} /></button>
+          <button
+            className={styles.removeBtn}
+            onClick={() => removeAsset(i)}
+            aria-label={`Remove ${asset.label || asset.id}`}
+          ><Trash2 size={13} /></button>
+        </div>
+      ))}
+
+      <button className={styles.addFieldBtn} onClick={addAsset}>
+        <Plus size={13} /> Add asset
+      </button>
     </div>
   );
 }

--- a/src/ui/ConfigPanel.jsx
+++ b/src/ui/ConfigPanel.jsx
@@ -1,6 +1,10 @@
 import { useEffect, useRef, useState } from 'react';
 import { X, Plus, Trash2, Check, Camera, Pencil, ArrowUp, ArrowDown } from 'lucide-react';
-import { FIELD_TYPES } from '../core/configSchema.js';
+import {
+  FIELD_TYPES,
+  APPROVAL_STAGE_IDS,
+  APPROVAL_ACTIONS,
+} from '../core/configSchema.js';
 import { DEFAULT_CATEGORIES } from '../types/assets.ts';
 import { useFocusTrap } from '../hooks/useFocusTrap.js';
 import { serializeFilters } from '../hooks/useSavedViews.js';
@@ -22,6 +26,7 @@ const TABS = [
   { id: 'templates',   label: 'Templates' },
   { id: 'smartViews',  label: 'Smart Views' },
   { id: 'team',        label: 'Employees' },
+  { id: 'approvals',   label: 'Approvals' },
   { id: 'access',      label: 'Access' },
 ];
 
@@ -130,6 +135,7 @@ export default function ConfigPanel({
               onEmployeeDelete={onEmployeeDelete}
             />
           )}
+          {tab === 'approvals'   && <ApprovalsTab   config={config} onUpdate={onUpdate} />}
           {tab === 'access'      && <AccessTab      config={config} onUpdate={onUpdate} />}
         </div>
       </div>
@@ -991,6 +997,227 @@ function DisplayTab({ config, onUpdate }) {
             placeholder="More"
           />
         </label>
+      </div>
+    </div>
+  );
+}
+
+/* ----- Approvals tab ----- */
+const STAGE_LABELS = {
+  requested:      'Requested',
+  approved:       'Approved',
+  finalized:      'Finalized',
+  pending_higher: 'Pending higher tier',
+  denied:         'Denied',
+};
+
+/**
+ * Owner-editable approval policy. Writes to `config.approvals`; runtime
+ * surfaces (AssetsView pill prefixes, AuditDrawer menus, #134-15 inline
+ * actions) read from the same block so a calendar owner can tune the
+ * workflow — add/rename tiers, restrict actions per stage, change pill
+ * copy — without redeploying the host app.
+ *
+ * Shape notes:
+ *   approvals.enabled — master off switch; false keeps the whole UX silent.
+ *   approvals.tiers[] — ordered; `requires: 'any' | 'all'` controls the
+ *                       quorum rule for promotion out of that tier.
+ *   approvals.rules   — per-stage `{ allow: ApprovalAction[], prefix }`.
+ *   approvals.labels  — per-action button copy shown to approvers.
+ */
+export function ApprovalsTab({ config, onUpdate }) {
+  const approvals = config.approvals ?? {};
+  const enabled   = !!approvals.enabled;
+  const tiers     = Array.isArray(approvals.tiers) ? approvals.tiers : [];
+  const rules     = approvals.rules ?? {};
+  const labels    = approvals.labels ?? {};
+
+  const patch = (next) => onUpdate(c => ({
+    ...c,
+    approvals: { ...(c.approvals ?? {}), ...next },
+  }));
+
+  const writeTiers = (next) => patch({ tiers: next });
+  const writeRules = (next) => patch({ rules: next });
+  const writeLabels = (next) => patch({ labels: next });
+
+  const addTier = () => {
+    const n = tiers.length + 1;
+    writeTiers([...tiers, { id: `tier-${n}`, label: `Tier ${n}`, requires: 'any', roles: [] }]);
+  };
+
+  const updateTier = (idx, delta) => {
+    writeTiers(tiers.map((t, i) => (i === idx ? { ...t, ...delta } : t)));
+  };
+
+  const removeTier = (idx) => writeTiers(tiers.filter((_, i) => i !== idx));
+
+  const moveTier = (idx, delta) => {
+    const target = idx + delta;
+    if (target < 0 || target >= tiers.length) return;
+    const next = [...tiers];
+    const [moved] = next.splice(idx, 1);
+    next.splice(target, 0, moved);
+    writeTiers(next);
+  };
+
+  const toggleAction = (stage, action) => {
+    const stageRule = rules[stage] ?? { allow: [], prefix: '' };
+    const allow = stageRule.allow ?? [];
+    const next  = allow.includes(action)
+      ? allow.filter(a => a !== action)
+      : [...allow, action];
+    writeRules({ ...rules, [stage]: { ...stageRule, allow: next } });
+  };
+
+  const setStagePrefix = (stage, prefix) => {
+    const stageRule = rules[stage] ?? { allow: [], prefix: '' };
+    writeRules({ ...rules, [stage]: { ...stageRule, prefix } });
+  };
+
+  return (
+    <div className={styles.section}>
+      <p className={styles.sectionDesc}>
+        Configure the approval workflow applied to events with
+        <code> meta.approvalStage</code>. While disabled, approval pills render
+        as plain category pills and no inline actions appear.
+      </p>
+
+      <label className={styles.toggle}>
+        <span>Enable approvals workflow</span>
+        <input
+          type="checkbox"
+          checked={enabled}
+          onChange={e => patch({ enabled: e.target.checked })}
+          aria-label="Enable approvals workflow"
+        />
+        <span className={styles.toggleTrack} />
+      </label>
+
+      <div className={styles.section} style={{ paddingTop: 12 }}>
+        <p className={styles.sectionDesc}>
+          Tiers are evaluated in order. <code>requires: any</code> promotes on
+          the first approver action; <code>all</code> waits for every listed
+          role to sign off.
+        </p>
+
+        {tiers.map((tier, i) => (
+          <div key={tier.id + ':' + i} className={styles.fieldRow} data-tier-id={tier.id}>
+            <input
+              className={styles.input}
+              value={tier.label ?? ''}
+              onChange={e => updateTier(i, { label: e.target.value })}
+              placeholder="Label"
+              aria-label={`Label for ${tier.id}`}
+            />
+            <input
+              className={styles.input}
+              value={tier.id}
+              onChange={e => updateTier(i, { id: e.target.value.trim() || tier.id })}
+              placeholder="id"
+              aria-label={`Id for ${tier.label || tier.id}`}
+            />
+            <select
+              className={styles.select}
+              value={tier.requires ?? 'any'}
+              onChange={e => updateTier(i, { requires: e.target.value })}
+              aria-label={`Quorum for ${tier.label || tier.id}`}
+            >
+              <option value="any">Any approver</option>
+              <option value="all">All approvers</option>
+            </select>
+            <input
+              className={styles.input}
+              value={(tier.roles ?? []).join(', ')}
+              onChange={e => updateTier(i, {
+                roles: e.target.value.split(',').map(r => r.trim()).filter(Boolean),
+              })}
+              placeholder="Roles (comma-separated)"
+              aria-label={`Roles for ${tier.label || tier.id}`}
+            />
+            <button
+              className={styles.removeBtn}
+              onClick={() => moveTier(i, -1)}
+              disabled={i === 0}
+              aria-label={`Move ${tier.label || tier.id} up`}
+            ><ArrowUp size={13} /></button>
+            <button
+              className={styles.removeBtn}
+              onClick={() => moveTier(i, 1)}
+              disabled={i === tiers.length - 1}
+              aria-label={`Move ${tier.label || tier.id} down`}
+            ><ArrowDown size={13} /></button>
+            <button
+              className={styles.removeBtn}
+              onClick={() => removeTier(i)}
+              aria-label={`Remove ${tier.label || tier.id}`}
+            ><Trash2 size={13} /></button>
+          </div>
+        ))}
+
+        <button className={styles.addFieldBtn} onClick={addTier}>
+          <Plus size={13} /> Add tier
+        </button>
+      </div>
+
+      <div className={styles.section} style={{ paddingTop: 12 }}>
+        <p className={styles.sectionDesc}>
+          Per-stage rules. The prefix rides on the left of the pill label
+          (e.g. <code>Req · Flight 202</code>); leave blank for no prefix.
+        </p>
+
+        {APPROVAL_STAGE_IDS.map(stage => {
+          const stageRule = rules[stage] ?? { allow: [], prefix: '' };
+          return (
+            <div key={stage} className={styles.fieldRow} data-stage-id={stage}>
+              <span style={{ minWidth: 120, fontWeight: 600 }}>
+                {STAGE_LABELS[stage] ?? stage}
+              </span>
+              <input
+                className={styles.input}
+                value={stageRule.prefix ?? ''}
+                onChange={e => setStagePrefix(stage, e.target.value)}
+                placeholder="Prefix"
+                aria-label={`Prefix for ${stage}`}
+                style={{ maxWidth: 120 }}
+              />
+              {APPROVAL_ACTIONS.map(action => {
+                const checked = (stageRule.allow ?? []).includes(action);
+                return (
+                  <label key={action} className={styles.reqLabel}>
+                    <input
+                      type="checkbox"
+                      checked={checked}
+                      onChange={() => toggleAction(stage, action)}
+                      aria-label={`Allow ${action} on ${stage}`}
+                    />
+                    {action}
+                  </label>
+                );
+              })}
+            </div>
+          );
+        })}
+      </div>
+
+      <div className={styles.section} style={{ paddingTop: 12 }}>
+        <p className={styles.sectionDesc}>
+          Button copy shown to approvers in the audit drawer and inline pill
+          menu. Rename these to match your organisation's vocabulary.
+        </p>
+
+        {APPROVAL_ACTIONS.map(action => (
+          <label key={action} className={styles.formRow}>
+            <span>{action.charAt(0).toUpperCase() + action.slice(1)} label</span>
+            <input
+              className={styles.input}
+              value={labels[action] ?? ''}
+              onChange={e => writeLabels({ ...labels, [action]: e.target.value })}
+              placeholder={action}
+              aria-label={`${action} button label`}
+            />
+          </label>
+        ))}
       </div>
     </div>
   );

--- a/src/ui/ConfigPanel.jsx
+++ b/src/ui/ConfigPanel.jsx
@@ -29,6 +29,7 @@ const TABS = [
   { id: 'team',        label: 'Employees' },
   { id: 'approvals',   label: 'Approvals' },
   { id: 'conflicts',   label: 'Conflicts' },
+  { id: 'requestForm', label: 'Request Form' },
   { id: 'access',      label: 'Access' },
 ];
 
@@ -139,6 +140,7 @@ export default function ConfigPanel({
           )}
           {tab === 'approvals'   && <ApprovalsTab   config={config} onUpdate={onUpdate} />}
           {tab === 'conflicts'   && <ConflictsTab   config={config} onUpdate={onUpdate} />}
+          {tab === 'requestForm' && <RequestFormTab config={config} onUpdate={onUpdate} />}
           {tab === 'access'      && <AccessTab      config={config} onUpdate={onUpdate} />}
         </div>
       </div>
@@ -1222,6 +1224,142 @@ export function ApprovalsTab({ config, onUpdate }) {
           </label>
         ))}
       </div>
+    </div>
+  );
+}
+
+/* ----- Request Form tab ----- */
+const REQUEST_FIELD_TYPES = [
+  { value: 'text',     label: 'Text' },
+  { value: 'textarea', label: 'Textarea' },
+  { value: 'number',   label: 'Number' },
+  { value: 'date',     label: 'Date' },
+  { value: 'datetime', label: 'Datetime' },
+  { value: 'select',   label: 'Select' },
+  { value: 'checkbox', label: 'Checkbox' },
+];
+
+/**
+ * Owner-editable RequestForm schema. Writes to `config.requestForm.fields`;
+ * src/ui/RequestForm.jsx renders one input per entry. Field types match
+ * the RequestForm renderer's built-in handlers — adding a new type means
+ * updating both sides.
+ */
+export function RequestFormTab({ config, onUpdate }) {
+  const schema = config.requestForm ?? {};
+  const fields = Array.isArray(schema.fields) ? schema.fields : [];
+
+  const patch = (next) => onUpdate(c => ({
+    ...c,
+    requestForm: { ...(c.requestForm ?? {}), ...next },
+  }));
+
+  const writeFields = (next) => patch({ fields: next });
+
+  const addField = () => {
+    const n = fields.length + 1;
+    writeFields([
+      ...fields,
+      { key: `field-${n}`, label: `Field ${n}`, type: 'text', required: false },
+    ]);
+  };
+
+  const updateField = (idx, delta) =>
+    writeFields(fields.map((f, i) => (i === idx ? { ...f, ...delta } : f)));
+
+  const removeField = (idx) => writeFields(fields.filter((_, i) => i !== idx));
+
+  const moveField = (idx, delta) => {
+    const target = idx + delta;
+    if (target < 0 || target >= fields.length) return;
+    const next = [...fields];
+    const [moved] = next.splice(idx, 1);
+    next.splice(target, 0, moved);
+    writeFields(next);
+  };
+
+  return (
+    <div className={styles.section}>
+      <p className={styles.sectionDesc}>
+        Fields rendered by the request form (src/ui/RequestForm.jsx).
+        Changes apply to every open request form on next render — no host
+        redeploy required.
+      </p>
+
+      {fields.map((field, i) => (
+        <div key={field.key + ':' + i} className={styles.fieldRow} data-field-key={field.key}>
+          <input
+            className={styles.input}
+            value={field.label ?? ''}
+            onChange={e => updateField(i, { label: e.target.value })}
+            placeholder="Label"
+            aria-label={`Label for ${field.key}`}
+          />
+          <input
+            className={styles.input}
+            value={field.key}
+            onChange={e => updateField(i, { key: e.target.value.trim() || field.key })}
+            placeholder="key"
+            aria-label={`Key for ${field.label || field.key}`}
+          />
+          <select
+            className={styles.select}
+            value={field.type}
+            onChange={e => updateField(i, { type: e.target.value })}
+            aria-label={`Type for ${field.label || field.key}`}
+          >
+            {REQUEST_FIELD_TYPES.map(t => (
+              <option key={t.value} value={t.value}>{t.label}</option>
+            ))}
+          </select>
+          {field.type === 'select' && (
+            <input
+              className={styles.input}
+              value={field.options ?? ''}
+              onChange={e => updateField(i, { options: e.target.value })}
+              placeholder="Option 1, Option 2, …"
+              aria-label={`Options for ${field.label || field.key}`}
+            />
+          )}
+          <input
+            className={styles.input}
+            value={field.placeholder ?? ''}
+            onChange={e => updateField(i, { placeholder: e.target.value })}
+            placeholder="Placeholder"
+            aria-label={`Placeholder for ${field.label || field.key}`}
+          />
+          <label className={styles.reqLabel}>
+            <input
+              type="checkbox"
+              checked={!!field.required}
+              onChange={e => updateField(i, { required: e.target.checked })}
+              aria-label={`Required for ${field.label || field.key}`}
+            />
+            Required
+          </label>
+          <button
+            className={styles.removeBtn}
+            onClick={() => moveField(i, -1)}
+            disabled={i === 0}
+            aria-label={`Move ${field.label || field.key} up`}
+          ><ArrowUp size={13} /></button>
+          <button
+            className={styles.removeBtn}
+            onClick={() => moveField(i, 1)}
+            disabled={i === fields.length - 1}
+            aria-label={`Move ${field.label || field.key} down`}
+          ><ArrowDown size={13} /></button>
+          <button
+            className={styles.removeBtn}
+            onClick={() => removeField(i)}
+            aria-label={`Remove ${field.label || field.key}`}
+          ><Trash2 size={13} /></button>
+        </div>
+      ))}
+
+      <button className={styles.addFieldBtn} onClick={addField}>
+        <Plus size={13} /> Add field
+      </button>
     </div>
   );
 }

--- a/src/ui/ConfigPanel.jsx
+++ b/src/ui/ConfigPanel.jsx
@@ -5,6 +5,7 @@ import {
   APPROVAL_STAGE_IDS,
   APPROVAL_ACTIONS,
 } from '../core/configSchema.js';
+import { CONFLICT_RULE_TYPES } from '../core/conflictEngine.ts';
 import { DEFAULT_CATEGORIES } from '../types/assets.ts';
 import { useFocusTrap } from '../hooks/useFocusTrap.js';
 import { serializeFilters } from '../hooks/useSavedViews.js';
@@ -27,6 +28,7 @@ const TABS = [
   { id: 'smartViews',  label: 'Smart Views' },
   { id: 'team',        label: 'Employees' },
   { id: 'approvals',   label: 'Approvals' },
+  { id: 'conflicts',   label: 'Conflicts' },
   { id: 'access',      label: 'Access' },
 ];
 
@@ -136,6 +138,7 @@ export default function ConfigPanel({
             />
           )}
           {tab === 'approvals'   && <ApprovalsTab   config={config} onUpdate={onUpdate} />}
+          {tab === 'conflicts'   && <ConflictsTab   config={config} onUpdate={onUpdate} />}
           {tab === 'access'      && <AccessTab      config={config} onUpdate={onUpdate} />}
         </div>
       </div>
@@ -1219,6 +1222,145 @@ export function ApprovalsTab({ config, onUpdate }) {
           </label>
         ))}
       </div>
+    </div>
+  );
+}
+
+/* ----- Conflicts tab ----- */
+/**
+ * Owner-editable conflict rule registry. Writes to `config.conflicts.rules`;
+ * src/core/conflictEngine.ts consumes the rules to evaluate a proposed
+ * event before it's written, returning Violation[] that ConflictModal
+ * surfaces to the user. Rules are pure data so the whole workflow can be
+ * re-tuned without a host-app redeploy.
+ *
+ * Supported types (see conflictEngine.ts for the full union):
+ *   resource-overlap — same resource in an overlapping window → violation.
+ *   category-mutex   — listed categories cannot coexist on one resource.
+ *   min-rest         — minimum gap (in minutes) between same-resource events.
+ */
+export function ConflictsTab({ config, onUpdate }) {
+  const conflicts = config.conflicts ?? {};
+  const enabled   = !!conflicts.enabled;
+  const rules     = Array.isArray(conflicts.rules) ? conflicts.rules : [];
+
+  const patch = (next) => onUpdate(c => ({
+    ...c,
+    conflicts: { ...(c.conflicts ?? {}), ...next },
+  }));
+
+  const writeRules = (next) => patch({ rules: next });
+
+  const addRule = () => {
+    const n = rules.length + 1;
+    writeRules([
+      ...rules,
+      { id: `rule-${n}`, type: 'resource-overlap', severity: 'hard' },
+    ]);
+  };
+
+  const updateRule = (idx, delta) => {
+    writeRules(rules.map((r, i) => (i === idx ? { ...r, ...delta } : r)));
+  };
+
+  const removeRule = (idx) => writeRules(rules.filter((_, i) => i !== idx));
+
+  return (
+    <div className={styles.section}>
+      <p className={styles.sectionDesc}>
+        Conflict rules run before an event write. The engine returns
+        violations; the ConflictModal surfaces them. While disabled, no
+        rule runs and writes proceed silently.
+      </p>
+
+      <label className={styles.toggle}>
+        <span>Enable conflict checks</span>
+        <input
+          type="checkbox"
+          checked={enabled}
+          onChange={e => patch({ enabled: e.target.checked })}
+          aria-label="Enable conflict checks"
+        />
+        <span className={styles.toggleTrack} />
+      </label>
+
+      {rules.map((rule, i) => (
+        <div key={rule.id + ':' + i} className={styles.fieldRow} data-rule-id={rule.id}>
+          <input
+            className={styles.input}
+            value={rule.id}
+            onChange={e => updateRule(i, { id: e.target.value.trim() || rule.id })}
+            placeholder="id"
+            aria-label={`Id for rule ${rule.id}`}
+          />
+          <select
+            className={styles.select}
+            value={rule.type}
+            onChange={e => updateRule(i, { type: e.target.value })}
+            aria-label={`Type for rule ${rule.id}`}
+          >
+            {CONFLICT_RULE_TYPES.map(type => (
+              <option key={type} value={type}>{type}</option>
+            ))}
+          </select>
+          <select
+            className={styles.select}
+            value={rule.severity ?? 'hard'}
+            onChange={e => updateRule(i, { severity: e.target.value })}
+            aria-label={`Severity for rule ${rule.id}`}
+          >
+            <option value="hard">hard</option>
+            <option value="soft">soft</option>
+          </select>
+
+          {rule.type === 'category-mutex' && (
+            <input
+              className={styles.input}
+              value={Array.isArray(rule.categories) ? rule.categories.join(', ') : ''}
+              onChange={e => updateRule(i, {
+                categories: e.target.value.split(',').map(s => s.trim()).filter(Boolean),
+              })}
+              placeholder="categories (comma-separated)"
+              aria-label={`Categories for rule ${rule.id}`}
+            />
+          )}
+
+          {rule.type === 'min-rest' && (
+            <input
+              type="number"
+              min={0}
+              className={styles.input}
+              style={{ width: 88 }}
+              value={rule.minutes ?? 0}
+              onChange={e => updateRule(i, { minutes: Math.max(0, Number(e.target.value) || 0) })}
+              placeholder="minutes"
+              aria-label={`Minutes for rule ${rule.id}`}
+            />
+          )}
+
+          {rule.type === 'resource-overlap' && (
+            <input
+              className={styles.input}
+              value={Array.isArray(rule.ignoreCategories) ? rule.ignoreCategories.join(', ') : ''}
+              onChange={e => updateRule(i, {
+                ignoreCategories: e.target.value.split(',').map(s => s.trim()).filter(Boolean),
+              })}
+              placeholder="ignore categories"
+              aria-label={`Ignore categories for rule ${rule.id}`}
+            />
+          )}
+
+          <button
+            className={styles.removeBtn}
+            onClick={() => removeRule(i)}
+            aria-label={`Remove rule ${rule.id}`}
+          ><Trash2 size={13} /></button>
+        </div>
+      ))}
+
+      <button className={styles.addFieldBtn} onClick={addRule}>
+        <Plus size={13} /> Add rule
+      </button>
     </div>
   );
 }

--- a/src/ui/ConfigPanel.jsx
+++ b/src/ui/ConfigPanel.jsx
@@ -34,10 +34,22 @@ export default function ConfigPanel({
   // Team-tab hooks: when provided, TeamTab emits add/delete upstream so the
   // parent's employees prop can stay in sync with config-side edits.
   onEmployeeAdd, onEmployeeDelete,
+  // Deep-link: open ConfigPanel focused on a specific tab. Re-applied when
+  // the prop changes so consecutive deep-links (e.g. two clicks of "Edit
+  // assets" with a different target each time) land on the right tab.
+  initialTab,
 }) {
-  const [tab, setTab] = useState('setup');
+  const [tab, setTab] = useState(() =>
+    initialTab && TABS.some(t => t.id === initialTab) ? initialTab : 'setup',
+  );
   const trapRef = useFocusTrap(onClose);
   const tabRefs = useRef({});
+
+  useEffect(() => {
+    if (initialTab && TABS.some(t => t.id === initialTab)) {
+      setTab(initialTab);
+    }
+  }, [initialTab]);
 
   useEffect(() => {
     tabRefs.current[tab]?.scrollIntoView({

--- a/src/ui/ConflictModal.jsx
+++ b/src/ui/ConflictModal.jsx
@@ -1,0 +1,100 @@
+/**
+ * ConflictModal — surfaces conflict-engine violations for user override.
+ *
+ * Host code runs `evaluateConflicts()` (src/core/conflictEngine.ts) before
+ * an event write. When violations come back, the modal lists them with
+ * severity, the offending event id, and the rule id, then offers:
+ *   - Proceed  — only enabled when every violation is `soft` (engine sets
+ *                `allowed: true` in that case). Hard violations block.
+ *   - Cancel   — dismiss without writing.
+ *
+ * The component is purely presentational: it takes a `result` from the
+ * engine and two callbacks. It does not mutate state itself.
+ */
+import { AlertTriangle, X } from 'lucide-react';
+import { useFocusTrap } from '../hooks/useFocusTrap.js';
+import styles from './ConflictModal.module.css';
+
+export default function ConflictModal({
+  result,
+  onProceed,
+  onCancel,
+  title = 'Conflict detected',
+}) {
+  const trapRef = useFocusTrap(onCancel);
+
+  if (!result || result.severity === 'none' || result.violations.length === 0) {
+    return null;
+  }
+
+  const canProceed = result.allowed; // soft-only violations
+
+  return (
+    <div
+      className={styles.overlay}
+      onClick={(e) => e.target === e.currentTarget && onCancel()}
+    >
+      <div
+        ref={trapRef}
+        role="alertdialog"
+        aria-modal="true"
+        aria-labelledby="conflict-modal-title"
+        className={styles.panel}
+        data-severity={result.severity}
+      >
+        <div className={styles.head}>
+          <AlertTriangle size={18} aria-hidden="true" />
+          <h2 id="conflict-modal-title" className={styles.title}>
+            {title}
+          </h2>
+          <button
+            type="button"
+            className={styles.closeBtn}
+            onClick={onCancel}
+            aria-label="Close conflict dialog"
+          >
+            <X size={16} />
+          </button>
+        </div>
+
+        <ul className={styles.list} aria-label="Conflict violations">
+          {result.violations.map((v, i) => (
+            <li
+              key={`${v.rule}:${v.conflictingEventId ?? i}`}
+              className={styles.item}
+              data-severity={v.severity}
+              data-rule={v.rule}
+            >
+              <span className={styles.severityTag}>{v.severity}</span>
+              <span className={styles.message}>{v.message}</span>
+              <span className={styles.ruleTag} aria-label={`rule ${v.rule}`}>
+                {v.rule}
+              </span>
+            </li>
+          ))}
+        </ul>
+
+        <div className={styles.footer}>
+          <button
+            type="button"
+            className={styles.btnSecondary}
+            onClick={onCancel}
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            className={styles.btnPrimary}
+            onClick={onProceed}
+            disabled={!canProceed}
+            title={canProceed
+              ? 'Proceed despite warnings'
+              : 'Cannot proceed — hard violations must be resolved first'}
+          >
+            {canProceed ? 'Proceed anyway' : 'Resolve to continue'}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/ui/ConflictModal.module.css
+++ b/src/ui/ConflictModal.module.css
@@ -1,0 +1,144 @@
+.overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.45);
+  z-index: 600;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 16px;
+}
+
+.panel {
+  background: var(--wc-bg, #fff);
+  border-radius: var(--wc-radius, 10px);
+  box-shadow: var(--wc-shadow, 0 10px 32px rgba(0, 0, 0, 0.2));
+  width: 520px;
+  max-width: 100%;
+  max-height: 80vh;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  border-top: 3px solid var(--wc-warning, #d97706);
+}
+
+.panel[data-severity='hard'] {
+  border-top-color: var(--wc-danger, #dc2626);
+}
+
+.head {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 14px 18px;
+  border-bottom: 1px solid var(--wc-border, #e5e7eb);
+  color: var(--wc-text, #111827);
+}
+
+.title {
+  font-size: 15px;
+  font-weight: 700;
+  margin: 0;
+  flex: 1 1 auto;
+}
+
+.closeBtn {
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 4px;
+  border-radius: 4px;
+  color: var(--wc-text-muted, #6b7280);
+}
+
+.closeBtn:hover {
+  background: var(--wc-bg-hover, #f3f4f6);
+}
+
+.list {
+  list-style: none;
+  margin: 0;
+  padding: 12px 18px;
+  overflow-y: auto;
+  flex: 1 1 auto;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.item {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  gap: 10px;
+  align-items: center;
+  padding: 8px 10px;
+  border: 1px solid var(--wc-border, #e5e7eb);
+  border-radius: 6px;
+  background: var(--wc-bg-muted, #f9fafb);
+}
+
+.item[data-severity='hard'] {
+  border-color: var(--wc-danger, #dc2626);
+  background: color-mix(in srgb, var(--wc-danger, #dc2626) 8%, transparent);
+}
+
+.severityTag {
+  font-size: 10px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  padding: 2px 6px;
+  border-radius: 3px;
+  background: var(--wc-warning, #d97706);
+  color: white;
+}
+
+.item[data-severity='hard'] .severityTag {
+  background: var(--wc-danger, #dc2626);
+}
+
+.message {
+  font-size: 13px;
+  color: var(--wc-text, #111827);
+}
+
+.ruleTag {
+  font-family: var(--wc-font-mono, ui-monospace, monospace);
+  font-size: 11px;
+  color: var(--wc-text-muted, #6b7280);
+}
+
+.footer {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  padding: 12px 18px;
+  border-top: 1px solid var(--wc-border, #e5e7eb);
+}
+
+.btnSecondary,
+.btnPrimary {
+  padding: 6px 14px;
+  font-size: 13px;
+  font-weight: 600;
+  border-radius: 6px;
+  cursor: pointer;
+  border: 1px solid var(--wc-border, #d1d5db);
+}
+
+.btnSecondary {
+  background: var(--wc-bg, #fff);
+  color: var(--wc-text, #111827);
+}
+
+.btnPrimary {
+  background: var(--wc-primary, #2563eb);
+  color: white;
+  border-color: transparent;
+}
+
+.btnPrimary:disabled {
+  background: var(--wc-bg-muted, #e5e7eb);
+  color: var(--wc-text-muted, #6b7280);
+  cursor: not-allowed;
+}

--- a/src/ui/GroupHeader.tsx
+++ b/src/ui/GroupHeader.tsx
@@ -16,6 +16,13 @@ export type GroupHeaderProps = {
   fieldLabel?: string
   className?: string
   id?: string
+  /**
+   * Cross-row arrow-key hook used by views that interleave headers with data
+   * rows (Assets, Timeline). The header handles Enter/Space internally (toggle
+   * collapse); when this prop is provided the parent gets the chance to move
+   * focus across rows or to drive collapse/expand via ← / →.
+   */
+  onArrowKey?: (key: 'ArrowUp' | 'ArrowDown' | 'ArrowLeft' | 'ArrowRight') => void
 }
 
 const INDENT_PX_PER_LEVEL = 16
@@ -31,11 +38,24 @@ export default function GroupHeader({
   fieldLabel,
   className,
   id,
+  onArrowKey,
 }: GroupHeaderProps) {
   const handleKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
     if (event.key === 'Enter' || event.key === ' ') {
       event.preventDefault()
       onToggle()
+      return
+    }
+    if (
+      event.key === 'ArrowUp' ||
+      event.key === 'ArrowDown' ||
+      event.key === 'ArrowLeft' ||
+      event.key === 'ArrowRight'
+    ) {
+      if (onArrowKey) {
+        event.preventDefault()
+        onArrowKey(event.key)
+      }
     }
   }
 

--- a/src/ui/ProfileBar.jsx
+++ b/src/ui/ProfileBar.jsx
@@ -129,7 +129,7 @@ function ViewChip({ savedView, schema, isActive, isDirty, isManaging, onApply, o
         <span className={styles.chipName}>{savedView.name}</span>
         {isDirty && <span className={styles.dirtyDot} title="Filters changed since saved" />}
         {savedView.view && (
-          <span className={styles.viewTag}>{savedView.view.slice(0,3)}</span>
+          <span className={styles.viewTag} aria-hidden="true">{savedView.view.slice(0,3)}</span>
         )}
       </button>
 

--- a/src/ui/RequestForm.jsx
+++ b/src/ui/RequestForm.jsx
@@ -1,0 +1,234 @@
+/**
+ * RequestForm — schema-driven, owner-configurable event request form
+ * (ticket #134-12).
+ *
+ * The form renders one input per entry in `schema.fields`, validates
+ * required values, and emits a normalized `{ values }` object on submit.
+ * The schema itself lives in `config.requestForm` so owners can add,
+ * remove, or rename fields from ConfigPanel → Request Form without
+ * redeploying the host app. Host-level validators / onSubmit callbacks
+ * remain the escape hatch for domain logic.
+ *
+ * Field types:
+ *   text       single-line input
+ *   textarea   multi-line input
+ *   number     numeric input
+ *   date       date-only input
+ *   datetime   datetime-local input
+ *   select     dropdown, options parsed from comma-separated string
+ *   checkbox   boolean toggle
+ */
+import { useMemo, useState } from 'react';
+import { useFocusTrap } from '../hooks/useFocusTrap.js';
+import styles from './RequestForm.module.css';
+
+const INPUT_TYPES = new Set(['text', 'textarea', 'number', 'date', 'datetime', 'select', 'checkbox']);
+
+function normalizeField(field, idx) {
+  const key = typeof field?.key === 'string' && field.key.trim()
+    ? field.key.trim()
+    : `field-${idx + 1}`;
+  const type = INPUT_TYPES.has(field?.type) ? field.type : 'text';
+  return {
+    key,
+    label:       typeof field?.label === 'string' ? field.label : key,
+    type,
+    required:    !!field?.required,
+    placeholder: typeof field?.placeholder === 'string' ? field.placeholder : '',
+    options:     typeof field?.options === 'string' ? field.options : '',
+  };
+}
+
+function defaultForField(field) {
+  switch (field.type) {
+    case 'checkbox': return false;
+    case 'number':   return '';
+    default:         return '';
+  }
+}
+
+function parseOptions(raw) {
+  return String(raw ?? '')
+    .split(',')
+    .map(s => s.trim())
+    .filter(Boolean);
+}
+
+/**
+ * @param {object}   props
+ * @param {{ fields?: Array<object> }} props.schema
+ * @param {object}   [props.initialValues]
+ * @param {(payload:{values:object}) => void} props.onSubmit
+ * @param {() => void} props.onCancel
+ * @param {string}   [props.title]
+ */
+export default function RequestForm({
+  schema,
+  initialValues = {},
+  onSubmit,
+  onCancel,
+  title = 'New request',
+}) {
+  const trapRef = useFocusTrap(onCancel);
+
+  const fields = useMemo(() => {
+    const raw = Array.isArray(schema?.fields) ? schema.fields : [];
+    return raw.map(normalizeField);
+  }, [schema]);
+
+  const [values, setValues] = useState(() => {
+    const seed = {};
+    for (const f of fields) {
+      seed[f.key] = initialValues[f.key] ?? defaultForField(f);
+    }
+    return seed;
+  });
+  const [errors, setErrors] = useState({});
+
+  const setValue = (key, next) => setValues(prev => ({ ...prev, [key]: next }));
+
+  const validate = () => {
+    const next = {};
+    for (const f of fields) {
+      if (!f.required) continue;
+      const v = values[f.key];
+      if (f.type === 'checkbox') {
+        if (!v) next[f.key] = 'Required';
+      } else if (v == null || String(v).trim() === '') {
+        next[f.key] = 'Required';
+      }
+    }
+    setErrors(next);
+    return Object.keys(next).length === 0;
+  };
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    if (!validate()) return;
+    onSubmit?.({ values });
+  };
+
+  return (
+    <div
+      className={styles.overlay}
+      onClick={(e) => e.target === e.currentTarget && onCancel()}
+    >
+      <form
+        ref={trapRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="request-form-title"
+        className={styles.panel}
+        onSubmit={handleSubmit}
+        noValidate
+      >
+        <div className={styles.head}>
+          <h2 id="request-form-title" className={styles.title}>{title}</h2>
+        </div>
+
+        <div className={styles.body}>
+          {fields.length === 0 && (
+            <p className={styles.empty} role="note">
+              No request fields configured. Ask your owner to add fields in
+              ConfigPanel → Request Form.
+            </p>
+          )}
+
+          {fields.map(field => {
+            const err = errors[field.key];
+            const ariaInvalid = err ? 'true' : undefined;
+
+            if (field.type === 'textarea') {
+              return (
+                <label key={field.key} className={styles.formRow}>
+                  <span>{field.label}{field.required ? ' *' : ''}</span>
+                  <textarea
+                    className={styles.textarea}
+                    value={values[field.key] ?? ''}
+                    onChange={e => setValue(field.key, e.target.value)}
+                    placeholder={field.placeholder}
+                    aria-label={field.label}
+                    aria-invalid={ariaInvalid}
+                    rows={3}
+                  />
+                  {err && <span className={styles.err} role="alert">{err}</span>}
+                </label>
+              );
+            }
+
+            if (field.type === 'select') {
+              const opts = parseOptions(field.options);
+              return (
+                <label key={field.key} className={styles.formRow}>
+                  <span>{field.label}{field.required ? ' *' : ''}</span>
+                  <select
+                    className={styles.select}
+                    value={values[field.key] ?? ''}
+                    onChange={e => setValue(field.key, e.target.value)}
+                    aria-label={field.label}
+                    aria-invalid={ariaInvalid}
+                  >
+                    <option value="">{field.placeholder || 'Select…'}</option>
+                    {opts.map(o => <option key={o} value={o}>{o}</option>)}
+                  </select>
+                  {err && <span className={styles.err} role="alert">{err}</span>}
+                </label>
+              );
+            }
+
+            if (field.type === 'checkbox') {
+              return (
+                <label key={field.key} className={styles.toggle}>
+                  <span>{field.label}{field.required ? ' *' : ''}</span>
+                  <input
+                    type="checkbox"
+                    checked={!!values[field.key]}
+                    onChange={e => setValue(field.key, e.target.checked)}
+                    aria-label={field.label}
+                    aria-invalid={ariaInvalid}
+                  />
+                  {err && <span className={styles.err} role="alert">{err}</span>}
+                </label>
+              );
+            }
+
+            const htmlType =
+              field.type === 'number'   ? 'number'
+              : field.type === 'date'   ? 'date'
+              : field.type === 'datetime' ? 'datetime-local'
+              : 'text';
+
+            return (
+              <label key={field.key} className={styles.formRow}>
+                <span>{field.label}{field.required ? ' *' : ''}</span>
+                <input
+                  type={htmlType}
+                  className={styles.input}
+                  value={values[field.key] ?? ''}
+                  onChange={e => setValue(field.key, e.target.value)}
+                  placeholder={field.placeholder}
+                  aria-label={field.label}
+                  aria-invalid={ariaInvalid}
+                />
+                {err && <span className={styles.err} role="alert">{err}</span>}
+              </label>
+            );
+          })}
+        </div>
+
+        <div className={styles.footer}>
+          <button
+            type="button"
+            className={styles.btnSecondary}
+            onClick={onCancel}
+          >Cancel</button>
+          <button
+            type="submit"
+            className={styles.btnPrimary}
+            disabled={fields.length === 0}
+          >Submit request</button>
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/src/ui/RequestForm.module.css
+++ b/src/ui/RequestForm.module.css
@@ -1,0 +1,131 @@
+.overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.4);
+  z-index: 520;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 16px;
+}
+
+.panel {
+  background: var(--wc-bg, #fff);
+  border-radius: var(--wc-radius, 10px);
+  box-shadow: var(--wc-shadow, 0 10px 32px rgba(0, 0, 0, 0.2));
+  width: 480px;
+  max-width: 100%;
+  max-height: 85vh;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.head {
+  padding: 14px 18px;
+  border-bottom: 1px solid var(--wc-border, #e5e7eb);
+}
+
+.title {
+  font-size: 15px;
+  font-weight: 700;
+  margin: 0;
+  color: var(--wc-text, #111827);
+}
+
+.body {
+  padding: 14px 18px;
+  overflow-y: auto;
+  flex: 1 1 auto;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.empty {
+  color: var(--wc-text-muted, #6b7280);
+  font-size: 13px;
+  padding: 20px 0;
+  text-align: center;
+}
+
+.formRow {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  font-size: 13px;
+  color: var(--wc-text, #111827);
+}
+
+.formRow > span {
+  font-weight: 600;
+}
+
+.input,
+.textarea,
+.select {
+  padding: 6px 8px;
+  border: 1px solid var(--wc-border, #d1d5db);
+  border-radius: 6px;
+  font-size: 13px;
+  font-family: inherit;
+  background: var(--wc-bg, #fff);
+  color: var(--wc-text, #111827);
+}
+
+.textarea {
+  resize: vertical;
+  min-height: 60px;
+}
+
+.toggle {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 6px 0;
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--wc-text, #111827);
+}
+
+.err {
+  color: var(--wc-danger, #dc2626);
+  font-size: 11px;
+  font-weight: 600;
+}
+
+.footer {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  padding: 12px 18px;
+  border-top: 1px solid var(--wc-border, #e5e7eb);
+}
+
+.btnSecondary,
+.btnPrimary {
+  padding: 6px 14px;
+  font-size: 13px;
+  font-weight: 600;
+  border-radius: 6px;
+  cursor: pointer;
+  border: 1px solid var(--wc-border, #d1d5db);
+}
+
+.btnSecondary {
+  background: var(--wc-bg, #fff);
+  color: var(--wc-text, #111827);
+}
+
+.btnPrimary {
+  background: var(--wc-primary, #2563eb);
+  color: white;
+  border-color: transparent;
+}
+
+.btnPrimary:disabled {
+  background: var(--wc-bg-muted, #e5e7eb);
+  color: var(--wc-text-muted, #6b7280);
+  cursor: not-allowed;
+}

--- a/src/ui/__tests__/ApprovalActionMenu.test.jsx
+++ b/src/ui/__tests__/ApprovalActionMenu.test.jsx
@@ -1,0 +1,194 @@
+// @vitest-environment happy-dom
+/**
+ * ApprovalActionMenu — ticket #134-15.
+ *
+ * Inline action surface driven by `config.approvals.rules[stage].allow` and
+ * `config.approvals.labels`. These specs pin the "data-in → buttons-out"
+ * contract so the AssetsView + AuditDrawer integrations stay thin.
+ */
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import '@testing-library/jest-dom';
+
+import ApprovalActionMenu, { allowedActionsFor } from '../ApprovalActionMenu.jsx';
+
+const baseConfig = {
+  enabled: true,
+  rules: {
+    requested:      { allow: ['approve', 'deny'], prefix: 'Req' },
+    pending_higher: { allow: ['approve', 'deny'], prefix: 'Pend' },
+    approved:       { allow: ['finalize', 'revoke'], prefix: '' },
+    finalized:      { allow: ['revoke'], prefix: 'Final' },
+    denied:         { allow: ['revoke'], prefix: 'Denied' },
+  },
+  labels: {
+    approve:  'Approve',
+    deny:     'Reject',
+    finalize: 'Lock',
+    revoke:   'Undo',
+  },
+};
+
+describe('allowedActionsFor', () => {
+  it('returns [] when approvals.enabled is false', () => {
+    expect(allowedActionsFor('requested', { ...baseConfig, enabled: false })).toEqual([]);
+  });
+
+  it('returns [] when the config is missing', () => {
+    expect(allowedActionsFor('requested', null)).toEqual([]);
+    expect(allowedActionsFor('requested', undefined)).toEqual([]);
+  });
+
+  it('returns [] when the stage is unknown', () => {
+    expect(allowedActionsFor('no-such-stage', baseConfig)).toEqual([]);
+  });
+
+  it('returns the declared allow[] for a configured stage', () => {
+    expect(allowedActionsFor('requested', baseConfig)).toEqual(['approve', 'deny']);
+    expect(allowedActionsFor('denied',    baseConfig)).toEqual(['revoke']);
+  });
+});
+
+describe('ApprovalActionMenu — rendering', () => {
+  it('renders a menuitem per allowed action with the configured label', () => {
+    render(
+      <ApprovalActionMenu
+        stage="requested"
+        approvalsConfig={baseConfig}
+        onAction={vi.fn()}
+      />,
+    );
+    const items = screen.getAllByRole('menuitem');
+    expect(items).toHaveLength(2);
+    expect(items[0]).toHaveTextContent('Approve');
+    expect(items[1]).toHaveTextContent('Reject');
+  });
+
+  it('renders nothing when approvals.enabled is false', () => {
+    const { container } = render(
+      <ApprovalActionMenu
+        stage="requested"
+        approvalsConfig={{ ...baseConfig, enabled: false }}
+        onAction={vi.fn()}
+      />,
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders nothing when the stage has no allow[]', () => {
+    const { container } = render(
+      <ApprovalActionMenu
+        stage="denied"
+        approvalsConfig={{ ...baseConfig, rules: { ...baseConfig.rules, denied: { allow: [] } } }}
+        onAction={vi.fn()}
+      />,
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('falls back to built-in labels when config.labels is missing for an action', () => {
+    render(
+      <ApprovalActionMenu
+        stage="approved"
+        approvalsConfig={{ ...baseConfig, labels: {} }}
+        onAction={vi.fn()}
+      />,
+    );
+    expect(screen.getByRole('menuitem', { name: 'Finalize' })).toBeInTheDocument();
+    expect(screen.getByRole('menuitem', { name: 'Revoke' })).toBeInTheDocument();
+  });
+
+  it('applies anchorRect as fixed positioning in popover variant', () => {
+    render(
+      <ApprovalActionMenu
+        stage="requested"
+        approvalsConfig={baseConfig}
+        anchorRect={{ top: 10, bottom: 36, left: 120, right: 220 }}
+        onAction={vi.fn()}
+      />,
+    );
+    const menu = screen.getByTestId('approval-action-menu');
+    expect(menu).toHaveStyle({ position: 'fixed', top: '40px', left: '120px' });
+    expect(menu).toHaveAttribute('data-variant', 'popover');
+  });
+
+  it('inline variant skips absolute positioning', () => {
+    render(
+      <ApprovalActionMenu
+        stage="requested"
+        approvalsConfig={baseConfig}
+        anchorRect={{ top: 10, bottom: 36, left: 120, right: 220 }}
+        variant="inline"
+        onAction={vi.fn()}
+      />,
+    );
+    const menu = screen.getByTestId('approval-action-menu');
+    expect(menu).toHaveAttribute('data-variant', 'inline');
+    // No inline style when inline variant.
+    expect(menu.getAttribute('style')).toBeFalsy();
+  });
+});
+
+describe('ApprovalActionMenu — interaction', () => {
+  it('calls onAction with the action id and then onClose', () => {
+    const onAction = vi.fn();
+    const onClose  = vi.fn();
+    render(
+      <ApprovalActionMenu
+        stage="requested"
+        approvalsConfig={baseConfig}
+        onAction={onAction}
+        onClose={onClose}
+      />,
+    );
+    fireEvent.click(screen.getByRole('menuitem', { name: 'Reject' }));
+    expect(onAction).toHaveBeenCalledWith('deny');
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('Escape closes the popover variant', () => {
+    const onClose = vi.fn();
+    render(
+      <ApprovalActionMenu
+        stage="requested"
+        approvalsConfig={baseConfig}
+        onAction={vi.fn()}
+        onClose={onClose}
+      />,
+    );
+    fireEvent.keyDown(window, { key: 'Escape' });
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('mousedown outside the popover closes it', () => {
+    const onClose = vi.fn();
+    render(
+      <div>
+        <ApprovalActionMenu
+          stage="requested"
+          approvalsConfig={baseConfig}
+          onAction={vi.fn()}
+          onClose={onClose}
+        />
+        <button>outside</button>
+      </div>,
+    );
+    fireEvent.mouseDown(screen.getByText('outside'));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('inline variant does NOT auto-dismiss on Escape', () => {
+    const onClose = vi.fn();
+    render(
+      <ApprovalActionMenu
+        stage="requested"
+        approvalsConfig={baseConfig}
+        variant="inline"
+        onAction={vi.fn()}
+        onClose={onClose}
+      />,
+    );
+    fireEvent.keyDown(window, { key: 'Escape' });
+    expect(onClose).not.toHaveBeenCalled();
+  });
+});

--- a/src/ui/__tests__/ConfigPanel.approvalsTab.test.jsx
+++ b/src/ui/__tests__/ConfigPanel.approvalsTab.test.jsx
@@ -1,0 +1,206 @@
+// @vitest-environment happy-dom
+/**
+ * ApprovalsTab — ticket #134-14.
+ *
+ * The Approvals tab is the owner-configurable policy surface for the
+ * approvals workflow. Every mutation flows through `onUpdate` into
+ * `config.approvals`; runtime surfaces (AssetsView pill prefixes, AuditDrawer
+ * menus, #134-15 inline actions) read from the same block. These specs pin
+ * the contract so subsequent phases can depend on a stable shape.
+ */
+import { render, screen, fireEvent, within } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import '@testing-library/jest-dom';
+
+import { ApprovalsTab } from '../ConfigPanel.jsx';
+
+function renderTab({ initialConfig = {}, onUpdate } = {}) {
+  let currentConfig = { ...initialConfig };
+  const update = onUpdate ?? vi.fn(updater => {
+    currentConfig = typeof updater === 'function'
+      ? updater(currentConfig)
+      : { ...currentConfig, ...updater };
+  });
+  const utils = render(<ApprovalsTab config={currentConfig} onUpdate={update} />);
+  const rerender = () =>
+    utils.rerender(<ApprovalsTab config={currentConfig} onUpdate={update} />);
+  return { ...utils, update, getConfig: () => currentConfig, rerender };
+}
+
+const seededConfig = {
+  approvals: {
+    enabled: false,
+    tiers: [
+      { id: 'tier-1', label: 'Supervisor', requires: 'any', roles: [] },
+      { id: 'tier-2', label: 'Director',   requires: 'any', roles: [] },
+    ],
+    rules: {
+      requested:      { allow: ['approve', 'deny'], prefix: 'Req' },
+      pending_higher: { allow: ['approve', 'deny'], prefix: 'Pend' },
+      approved:       { allow: ['finalize', 'revoke'], prefix: '' },
+      finalized:      { allow: ['revoke'], prefix: 'Final' },
+      denied:         { allow: ['revoke'], prefix: 'Denied' },
+    },
+    labels: { approve: 'Approve', deny: 'Deny', finalize: 'Finalize', revoke: 'Revoke' },
+  },
+};
+
+describe('ApprovalsTab — enable toggle', () => {
+  it('renders with enabled=false by default when config.approvals is empty', () => {
+    renderTab();
+    const toggle = screen.getByLabelText('Enable approvals workflow');
+    expect(toggle).not.toBeChecked();
+  });
+
+  it('flips approvals.enabled when toggled', () => {
+    const { getConfig, rerender } = renderTab({ initialConfig: seededConfig });
+    fireEvent.click(screen.getByLabelText('Enable approvals workflow'));
+    rerender();
+    expect(getConfig().approvals.enabled).toBe(true);
+  });
+});
+
+describe('ApprovalsTab — tiers', () => {
+  it('renders seeded tiers in order', () => {
+    renderTab({ initialConfig: seededConfig });
+    const supervisor = screen.getByLabelText('Label for tier-1');
+    const director   = screen.getByLabelText('Label for tier-2');
+    expect(supervisor).toHaveValue('Supervisor');
+    expect(director).toHaveValue('Director');
+  });
+
+  it('Add tier appends a new row with a fresh id', () => {
+    const { getConfig, rerender } = renderTab({ initialConfig: seededConfig });
+    fireEvent.click(screen.getByRole('button', { name: /Add tier/i }));
+    rerender();
+    const { tiers } = getConfig().approvals;
+    expect(tiers).toHaveLength(3);
+    expect(tiers[2].id).toBe('tier-3');
+    expect(tiers[2].label).toBe('Tier 3');
+  });
+
+  it('renaming a tier writes through to config', () => {
+    const { getConfig, rerender } = renderTab({ initialConfig: seededConfig });
+    fireEvent.change(screen.getByLabelText('Label for tier-1'), {
+      target: { value: 'Shift Lead' },
+    });
+    rerender();
+    expect(getConfig().approvals.tiers[0].label).toBe('Shift Lead');
+  });
+
+  it('changing quorum (any → all) writes through', () => {
+    const { getConfig, rerender } = renderTab({ initialConfig: seededConfig });
+    fireEvent.change(screen.getByLabelText('Quorum for Supervisor'), {
+      target: { value: 'all' },
+    });
+    rerender();
+    expect(getConfig().approvals.tiers[0].requires).toBe('all');
+  });
+
+  it('editing roles as comma-separated list splits into an array', () => {
+    const { getConfig, rerender } = renderTab({ initialConfig: seededConfig });
+    fireEvent.change(screen.getByLabelText('Roles for Supervisor'), {
+      target: { value: 'pilot, dispatcher, ops' },
+    });
+    rerender();
+    expect(getConfig().approvals.tiers[0].roles).toEqual(['pilot', 'dispatcher', 'ops']);
+  });
+
+  it('Move tier down swaps order', () => {
+    const { getConfig, rerender } = renderTab({ initialConfig: seededConfig });
+    fireEvent.click(screen.getByLabelText('Move Supervisor down'));
+    rerender();
+    expect(getConfig().approvals.tiers.map(t => t.id)).toEqual(['tier-2', 'tier-1']);
+  });
+
+  it('Move tier up on the topmost row is a no-op (button disabled)', () => {
+    renderTab({ initialConfig: seededConfig });
+    expect(screen.getByLabelText('Move Supervisor up')).toBeDisabled();
+  });
+
+  it('Remove tier drops the row from config', () => {
+    const { getConfig, rerender } = renderTab({ initialConfig: seededConfig });
+    fireEvent.click(screen.getByLabelText('Remove Director'));
+    rerender();
+    const { tiers } = getConfig().approvals;
+    expect(tiers).toHaveLength(1);
+    expect(tiers[0].id).toBe('tier-1');
+  });
+});
+
+describe('ApprovalsTab — stage rules', () => {
+  it('renders one row per stage with a label, prefix input, and four action checkboxes', () => {
+    renderTab({ initialConfig: seededConfig });
+    // Five stage rows; each exposes `allow <action> on <stage>` checkboxes.
+    const stages = ['requested', 'approved', 'finalized', 'pending_higher', 'denied'];
+    for (const stage of stages) {
+      expect(screen.getByLabelText(`Prefix for ${stage}`)).toBeInTheDocument();
+      for (const action of ['approve', 'deny', 'finalize', 'revoke']) {
+        expect(screen.getByLabelText(`Allow ${action} on ${stage}`)).toBeInTheDocument();
+      }
+    }
+  });
+
+  it('toggling an action off removes it from the stage.allow list', () => {
+    const { getConfig, rerender } = renderTab({ initialConfig: seededConfig });
+    // Seeded requested.allow = ['approve', 'deny']; un-check approve.
+    fireEvent.click(screen.getByLabelText('Allow approve on requested'));
+    rerender();
+    expect(getConfig().approvals.rules.requested.allow).toEqual(['deny']);
+  });
+
+  it('toggling an action on appends it to the stage.allow list', () => {
+    const { getConfig, rerender } = renderTab({ initialConfig: seededConfig });
+    // Seeded finalized.allow = ['revoke']; add approve.
+    fireEvent.click(screen.getByLabelText('Allow approve on finalized'));
+    rerender();
+    expect(getConfig().approvals.rules.finalized.allow).toContain('approve');
+    expect(getConfig().approvals.rules.finalized.allow).toContain('revoke');
+  });
+
+  it('editing the prefix writes through to the stage rule', () => {
+    const { getConfig, rerender } = renderTab({ initialConfig: seededConfig });
+    fireEvent.change(screen.getByLabelText('Prefix for requested'), {
+      target: { value: 'Pending' },
+    });
+    rerender();
+    expect(getConfig().approvals.rules.requested.prefix).toBe('Pending');
+  });
+});
+
+describe('ApprovalsTab — labels', () => {
+  it('renders a row per action with its current label', () => {
+    renderTab({ initialConfig: seededConfig });
+    expect(screen.getByLabelText('approve button label')).toHaveValue('Approve');
+    expect(screen.getByLabelText('deny button label')).toHaveValue('Deny');
+    expect(screen.getByLabelText('finalize button label')).toHaveValue('Finalize');
+    expect(screen.getByLabelText('revoke button label')).toHaveValue('Revoke');
+  });
+
+  it('renaming a label writes through', () => {
+    const { getConfig, rerender } = renderTab({ initialConfig: seededConfig });
+    fireEvent.change(screen.getByLabelText('approve button label'), {
+      target: { value: 'Sign off' },
+    });
+    rerender();
+    expect(getConfig().approvals.labels.approve).toBe('Sign off');
+  });
+});
+
+describe('ApprovalsTab — robustness', () => {
+  it('treats missing approvals block as an empty policy (no crash, no tier rows)', () => {
+    renderTab({ initialConfig: {} });
+    expect(screen.queryByLabelText(/Remove Supervisor/)).not.toBeInTheDocument();
+    // Add-tier button is still present and functional.
+    expect(screen.getByRole('button', { name: /Add tier/i })).toBeInTheDocument();
+  });
+
+  it('Add tier from an empty policy starts at tier-1', () => {
+    const { getConfig, rerender } = renderTab({ initialConfig: {} });
+    fireEvent.click(screen.getByRole('button', { name: /Add tier/i }));
+    rerender();
+    const { tiers } = getConfig().approvals;
+    expect(tiers).toHaveLength(1);
+    expect(tiers[0]).toMatchObject({ id: 'tier-1', label: 'Tier 1', requires: 'any' });
+  });
+});

--- a/src/ui/__tests__/ConfigPanel.assetsTab.test.jsx
+++ b/src/ui/__tests__/ConfigPanel.assetsTab.test.jsx
@@ -1,0 +1,146 @@
+// @vitest-environment happy-dom
+/**
+ * AssetsTab — ticket #134-9.
+ *
+ * Verifies the owner-editable asset registry. The tab mutates config.assets
+ * via onUpdate; WorksCalendar merges `props.assets ?? config.assets` before
+ * handing the list to AssetsView so a calendar owner can add, rename,
+ * reorder, or remove a fleet entry without any host-app redeploy.
+ */
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import '@testing-library/jest-dom';
+
+import { AssetsTab } from '../ConfigPanel.jsx';
+
+function renderTab({ initialConfig = {}, onUpdate } = {}) {
+  let currentConfig = { ...initialConfig };
+  const update = onUpdate ?? vi.fn(updater => {
+    currentConfig = typeof updater === 'function'
+      ? updater(currentConfig)
+      : { ...currentConfig, ...updater };
+  });
+  const utils = render(<AssetsTab config={currentConfig} onUpdate={update} />);
+  const rerender = () =>
+    utils.rerender(<AssetsTab config={currentConfig} onUpdate={update} />);
+  return { ...utils, update, getConfig: () => currentConfig, rerender };
+}
+
+describe('AssetsTab — defaults', () => {
+  it('renders no rows when config.assets is unset', () => {
+    renderTab();
+    expect(screen.queryByRole('button', { name: /^Remove / })).not.toBeInTheDocument();
+  });
+
+  it('shows the "Add asset" button out of the box', () => {
+    renderTab();
+    expect(screen.getByRole('button', { name: /Add asset/i })).toBeInTheDocument();
+  });
+});
+
+describe('AssetsTab — mutations', () => {
+  it('Add asset appends a new row with a unique id', () => {
+    const { getConfig, rerender } = renderTab();
+    fireEvent.click(screen.getByRole('button', { name: /Add asset/i }));
+    rerender();
+    const assets = getConfig().assets;
+    expect(assets).toHaveLength(1);
+    expect(assets[0].id).toBe('asset-1');
+    expect(assets[0].label).toBe('Asset 1');
+
+    fireEvent.click(screen.getByRole('button', { name: /Add asset/i }));
+    rerender();
+    expect(getConfig().assets).toHaveLength(2);
+    expect(getConfig().assets[1].id).toBe('asset-2');
+  });
+
+  it('editing a label writes config.assets[i].label', () => {
+    const { getConfig, rerender } = renderTab({
+      initialConfig: { assets: [{ id: 'n100aa', label: 'N100AA', meta: {} }] },
+    });
+    const input = screen.getByLabelText('Label for n100aa');
+    fireEvent.change(input, { target: { value: 'Alpha 1' } });
+    rerender();
+    expect(getConfig().assets[0].label).toBe('Alpha 1');
+  });
+
+  it('editing an id keeps the trimmed value', () => {
+    const { getConfig, rerender } = renderTab({
+      initialConfig: { assets: [{ id: 'old', label: 'Old', meta: {} }] },
+    });
+    const input = screen.getByLabelText('Id for Old');
+    fireEvent.change(input, { target: { value: '  new-id  ' } });
+    rerender();
+    expect(getConfig().assets[0].id).toBe('new-id');
+  });
+
+  it('editing a group persists', () => {
+    const { getConfig, rerender } = renderTab({
+      initialConfig: { assets: [{ id: 'a', label: 'A', meta: {} }] },
+    });
+    const input = screen.getByLabelText('Group for A');
+    fireEvent.change(input, { target: { value: 'West' } });
+    rerender();
+    expect(getConfig().assets[0].group).toBe('West');
+  });
+
+  it('editing the sublabel writes to meta.sublabel', () => {
+    const { getConfig, rerender } = renderTab({
+      initialConfig: { assets: [{ id: 'a', label: 'A', meta: {} }] },
+    });
+    const input = screen.getByLabelText('Sublabel for A');
+    fireEvent.change(input, { target: { value: 'CJ3' } });
+    rerender();
+    expect(getConfig().assets[0].meta.sublabel).toBe('CJ3');
+  });
+
+  it('Remove button drops the asset at the expected index', () => {
+    const { getConfig, rerender } = renderTab({
+      initialConfig: {
+        assets: [
+          { id: 'a', label: 'Alpha', meta: {} },
+          { id: 'b', label: 'Bravo', meta: {} },
+          { id: 'c', label: 'Charlie', meta: {} },
+        ],
+      },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Remove Bravo' }));
+    rerender();
+    const ids = getConfig().assets.map(a => a.id);
+    expect(ids).toEqual(['a', 'c']);
+  });
+});
+
+describe('AssetsTab — reorder', () => {
+  const initialConfig = {
+    assets: [
+      { id: 'a', label: 'Alpha', meta: {} },
+      { id: 'b', label: 'Bravo', meta: {} },
+      { id: 'c', label: 'Charlie', meta: {} },
+    ],
+  };
+
+  it('Move down swaps with the next entry', () => {
+    const { getConfig, rerender } = renderTab({ initialConfig });
+    fireEvent.click(screen.getByRole('button', { name: 'Move Alpha down' }));
+    rerender();
+    expect(getConfig().assets.map(a => a.id)).toEqual(['b', 'a', 'c']);
+  });
+
+  it('Move up swaps with the previous entry', () => {
+    const { getConfig, rerender } = renderTab({ initialConfig });
+    fireEvent.click(screen.getByRole('button', { name: 'Move Charlie up' }));
+    rerender();
+    expect(getConfig().assets.map(a => a.id)).toEqual(['a', 'c', 'b']);
+  });
+
+  it('Move up is disabled on the first row', () => {
+    renderTab({ initialConfig });
+    expect(screen.getByRole('button', { name: 'Move Alpha up' })).toBeDisabled();
+  });
+
+  it('Move down is disabled on the last row', () => {
+    renderTab({ initialConfig });
+    expect(screen.getByRole('button', { name: 'Move Charlie down' })).toBeDisabled();
+  });
+});

--- a/src/ui/__tests__/ConfigPanel.conflictsTab.test.jsx
+++ b/src/ui/__tests__/ConfigPanel.conflictsTab.test.jsx
@@ -1,0 +1,149 @@
+// @vitest-environment happy-dom
+/**
+ * ConflictsTab — ticket #134-13.
+ *
+ * Owner-editable conflict rules. Every mutation flows through `onUpdate`
+ * into `config.conflicts`; src/core/conflictEngine.ts consumes the same
+ * block at evaluation time. These specs pin the CRUD contract so the
+ * downstream integration matrix (#134-16) can depend on a stable shape.
+ */
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import '@testing-library/jest-dom';
+
+import { ConflictsTab } from '../ConfigPanel.jsx';
+
+function renderTab({ initialConfig = {}, onUpdate } = {}) {
+  let currentConfig = { ...initialConfig };
+  const update = onUpdate ?? vi.fn(updater => {
+    currentConfig = typeof updater === 'function'
+      ? updater(currentConfig)
+      : { ...currentConfig, ...updater };
+  });
+  const utils = render(<ConflictsTab config={currentConfig} onUpdate={update} />);
+  const rerender = () =>
+    utils.rerender(<ConflictsTab config={currentConfig} onUpdate={update} />);
+  return { ...utils, update, getConfig: () => currentConfig, rerender };
+}
+
+describe('ConflictsTab — enable toggle', () => {
+  it('defaults to disabled when config.conflicts is absent', () => {
+    renderTab();
+    expect(screen.getByLabelText('Enable conflict checks')).not.toBeChecked();
+  });
+
+  it('flips conflicts.enabled on click', () => {
+    const { getConfig, rerender } = renderTab();
+    fireEvent.click(screen.getByLabelText('Enable conflict checks'));
+    rerender();
+    expect(getConfig().conflicts.enabled).toBe(true);
+  });
+});
+
+describe('ConflictsTab — rule CRUD', () => {
+  it('Add rule appends a resource-overlap rule by default', () => {
+    const { getConfig, rerender } = renderTab();
+    fireEvent.click(screen.getByRole('button', { name: /Add rule/i }));
+    rerender();
+    const rules = getConfig().conflicts.rules;
+    expect(rules).toHaveLength(1);
+    expect(rules[0]).toMatchObject({
+      id: 'rule-1',
+      type: 'resource-overlap',
+      severity: 'hard',
+    });
+  });
+
+  it('changing rule type swaps the param inputs', () => {
+    const { getConfig, rerender } = renderTab({
+      initialConfig: {
+        conflicts: { enabled: true, rules: [{ id: 'r1', type: 'resource-overlap', severity: 'hard' }] },
+      },
+    });
+    fireEvent.change(screen.getByLabelText('Type for rule r1'), {
+      target: { value: 'min-rest' },
+    });
+    rerender();
+    expect(getConfig().conflicts.rules[0].type).toBe('min-rest');
+    // min-rest row exposes a minutes input.
+    expect(screen.getByLabelText('Minutes for rule r1')).toBeInTheDocument();
+  });
+
+  it('category-mutex edit persists comma-separated categories as an array', () => {
+    const { getConfig, rerender } = renderTab({
+      initialConfig: {
+        conflicts: {
+          enabled: true,
+          rules: [{ id: 'r1', type: 'category-mutex', severity: 'hard', categories: [] }],
+        },
+      },
+    });
+    fireEvent.change(screen.getByLabelText('Categories for rule r1'), {
+      target: { value: 'pto, shift, on-call' },
+    });
+    rerender();
+    expect(getConfig().conflicts.rules[0].categories).toEqual(['pto', 'shift', 'on-call']);
+  });
+
+  it('min-rest edit persists minutes as a number', () => {
+    const { getConfig, rerender } = renderTab({
+      initialConfig: {
+        conflicts: {
+          enabled: true,
+          rules: [{ id: 'r1', type: 'min-rest', severity: 'soft', minutes: 0 }],
+        },
+      },
+    });
+    fireEvent.change(screen.getByLabelText('Minutes for rule r1'), {
+      target: { value: '45' },
+    });
+    rerender();
+    expect(getConfig().conflicts.rules[0].minutes).toBe(45);
+  });
+
+  it('resource-overlap edit persists ignoreCategories', () => {
+    const { getConfig, rerender } = renderTab({
+      initialConfig: {
+        conflicts: {
+          enabled: true,
+          rules: [{ id: 'r1', type: 'resource-overlap', severity: 'hard' }],
+        },
+      },
+    });
+    fireEvent.change(screen.getByLabelText('Ignore categories for rule r1'), {
+      target: { value: 'meeting, training' },
+    });
+    rerender();
+    expect(getConfig().conflicts.rules[0].ignoreCategories).toEqual(['meeting', 'training']);
+  });
+
+  it('severity dropdown flips soft ↔ hard', () => {
+    const { getConfig, rerender } = renderTab({
+      initialConfig: {
+        conflicts: {
+          enabled: true,
+          rules: [{ id: 'r1', type: 'resource-overlap', severity: 'hard' }],
+        },
+      },
+    });
+    fireEvent.change(screen.getByLabelText('Severity for rule r1'), {
+      target: { value: 'soft' },
+    });
+    rerender();
+    expect(getConfig().conflicts.rules[0].severity).toBe('soft');
+  });
+
+  it('Remove rule drops the row from config', () => {
+    const { getConfig, rerender } = renderTab({
+      initialConfig: {
+        conflicts: {
+          enabled: true,
+          rules: [{ id: 'r1', type: 'resource-overlap', severity: 'hard' }],
+        },
+      },
+    });
+    fireEvent.click(screen.getByLabelText('Remove rule r1'));
+    rerender();
+    expect(getConfig().conflicts.rules).toHaveLength(0);
+  });
+});

--- a/src/ui/__tests__/ConfigPanel.initialTab.test.jsx
+++ b/src/ui/__tests__/ConfigPanel.initialTab.test.jsx
@@ -1,0 +1,71 @@
+// @vitest-environment happy-dom
+/**
+ * ConfigPanel — initialTab deep-link (ticket #134-10).
+ *
+ * The Assets view's on-page toolbar opens ConfigPanel focused on the Assets
+ * tab via useOwnerConfig.openConfigToTab('assets'). That path is only
+ * reliable if ConfigPanel honors a string `initialTab` prop at mount and when
+ * the value changes on a subsequent deep-link.
+ */
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import '@testing-library/jest-dom';
+
+import ConfigPanel from '../ConfigPanel.jsx';
+import { DEFAULT_CONFIG } from '../../core/configSchema.js';
+
+function mount(props = {}) {
+  return render(
+    <ConfigPanel
+      config={DEFAULT_CONFIG}
+      schema={{ fields: [] }}
+      items={[]}
+      categories={[]}
+      resources={[]}
+      onUpdate={vi.fn()}
+      onClose={vi.fn()}
+      savedViews={[]}
+      onUpdateView={vi.fn()}
+      onDeleteView={vi.fn()}
+      {...props}
+    />,
+  );
+}
+
+describe('ConfigPanel — initialTab', () => {
+  it('opens on the Setup tab when initialTab is omitted', () => {
+    mount();
+    expect(screen.getByRole('tab', { name: 'Setup' })).toHaveAttribute('aria-selected', 'true');
+  });
+
+  it('opens directly on the requested tab when initialTab is provided', () => {
+    mount({ initialTab: 'assets' });
+    expect(screen.getByRole('tab', { name: 'Assets' })).toHaveAttribute('aria-selected', 'true');
+  });
+
+  it('ignores an unknown initialTab value and falls back to Setup', () => {
+    mount({ initialTab: 'does-not-exist' });
+    expect(screen.getByRole('tab', { name: 'Setup' })).toHaveAttribute('aria-selected', 'true');
+  });
+
+  it('switches tabs when initialTab changes on a re-render', () => {
+    const { rerender } = mount({ initialTab: 'categories' });
+    expect(screen.getByRole('tab', { name: 'Categories' })).toHaveAttribute('aria-selected', 'true');
+    rerender(
+      <ConfigPanel
+        config={DEFAULT_CONFIG}
+        schema={{ fields: [] }}
+        items={[]}
+        categories={[]}
+        resources={[]}
+        onUpdate={vi.fn()}
+        onClose={vi.fn()}
+        savedViews={[]}
+        onUpdateView={vi.fn()}
+        onDeleteView={vi.fn()}
+        initialTab="assets"
+      />,
+    );
+    expect(screen.getByRole('tab', { name: 'Assets' })).toHaveAttribute('aria-selected', 'true');
+  });
+});

--- a/src/ui/__tests__/ConfigPanel.requestFormTab.test.jsx
+++ b/src/ui/__tests__/ConfigPanel.requestFormTab.test.jsx
@@ -1,0 +1,120 @@
+// @vitest-environment happy-dom
+/**
+ * RequestFormTab — ticket #134-12.
+ *
+ * Owner-editable RequestForm schema. Writes to `config.requestForm.fields`;
+ * RequestForm.jsx consumes the same block at render time. These specs pin
+ * the CRUD contract so the integration matrix (#134-16) can depend on a
+ * stable shape.
+ */
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import '@testing-library/jest-dom';
+
+import { RequestFormTab } from '../ConfigPanel.jsx';
+
+function renderTab({ initialConfig = {}, onUpdate } = {}) {
+  let currentConfig = { ...initialConfig };
+  const update = onUpdate ?? vi.fn(updater => {
+    currentConfig = typeof updater === 'function'
+      ? updater(currentConfig)
+      : { ...currentConfig, ...updater };
+  });
+  const utils = render(<RequestFormTab config={currentConfig} onUpdate={update} />);
+  const rerender = () =>
+    utils.rerender(<RequestFormTab config={currentConfig} onUpdate={update} />);
+  return { ...utils, update, getConfig: () => currentConfig, rerender };
+}
+
+const seededConfig = {
+  requestForm: {
+    fields: [
+      { key: 'title',  label: 'Title',  type: 'text',     required: true },
+      { key: 'start',  label: 'Starts', type: 'datetime', required: true },
+      { key: 'notes',  label: 'Notes',  type: 'textarea', required: false },
+    ],
+  },
+};
+
+describe('RequestFormTab — rendering', () => {
+  it('renders one row per seeded field', () => {
+    renderTab({ initialConfig: seededConfig });
+    expect(screen.getByLabelText('Label for title')).toHaveValue('Title');
+    expect(screen.getByLabelText('Label for start')).toHaveValue('Starts');
+    expect(screen.getByLabelText('Label for notes')).toHaveValue('Notes');
+  });
+
+  it('renders no field rows when config.requestForm is unset', () => {
+    renderTab();
+    expect(screen.queryByLabelText(/^Label for /)).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Add field/i })).toBeInTheDocument();
+  });
+});
+
+describe('RequestFormTab — CRUD', () => {
+  it('Add field appends a text field with a fresh key', () => {
+    const { getConfig, rerender } = renderTab({ initialConfig: seededConfig });
+    fireEvent.click(screen.getByRole('button', { name: /Add field/i }));
+    rerender();
+    const { fields } = getConfig().requestForm;
+    expect(fields).toHaveLength(4);
+    expect(fields[3]).toMatchObject({
+      key: 'field-4',
+      label: 'Field 4',
+      type: 'text',
+      required: false,
+    });
+  });
+
+  it('editing the label persists to config', () => {
+    const { getConfig, rerender } = renderTab({ initialConfig: seededConfig });
+    fireEvent.change(screen.getByLabelText('Label for notes'), {
+      target: { value: 'Comments' },
+    });
+    rerender();
+    expect(getConfig().requestForm.fields[2].label).toBe('Comments');
+  });
+
+  it('changing field type swaps render-time inputs', () => {
+    const { getConfig, rerender } = renderTab({ initialConfig: seededConfig });
+    fireEvent.change(screen.getByLabelText('Type for Title'), {
+      target: { value: 'select' },
+    });
+    rerender();
+    expect(getConfig().requestForm.fields[0].type).toBe('select');
+    // Options input now appears for this row.
+    expect(screen.getByLabelText('Options for Title')).toBeInTheDocument();
+  });
+
+  it('toggling required writes through', () => {
+    const { getConfig, rerender } = renderTab({ initialConfig: seededConfig });
+    const notesRequired = screen.getByLabelText('Required for Notes');
+    expect(notesRequired).not.toBeChecked();
+    fireEvent.click(notesRequired);
+    rerender();
+    expect(getConfig().requestForm.fields[2].required).toBe(true);
+  });
+
+  it('Move down swaps order', () => {
+    const { getConfig, rerender } = renderTab({ initialConfig: seededConfig });
+    fireEvent.click(screen.getByLabelText('Move Title down'));
+    rerender();
+    expect(getConfig().requestForm.fields.map(f => f.key)).toEqual([
+      'start', 'title', 'notes',
+    ]);
+  });
+
+  it('Move up on the topmost row is disabled', () => {
+    renderTab({ initialConfig: seededConfig });
+    expect(screen.getByLabelText('Move Title up')).toBeDisabled();
+  });
+
+  it('Remove field drops the row from config', () => {
+    const { getConfig, rerender } = renderTab({ initialConfig: seededConfig });
+    fireEvent.click(screen.getByLabelText('Remove Notes'));
+    rerender();
+    const { fields } = getConfig().requestForm;
+    expect(fields).toHaveLength(2);
+    expect(fields.map(f => f.key)).toEqual(['title', 'start']);
+  });
+});

--- a/src/ui/__tests__/ConflictModal.test.jsx
+++ b/src/ui/__tests__/ConflictModal.test.jsx
@@ -1,0 +1,98 @@
+// @vitest-environment happy-dom
+/**
+ * ConflictModal — ticket #134-13.
+ *
+ * The modal is the UX for conflictEngine violations. It renders a list of
+ * violations with severity + rule badges, locks the "Proceed" action when
+ * any hard violation is present, and calls cancel on overlay click / Escape.
+ */
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import '@testing-library/jest-dom';
+
+import ConflictModal from '../ConflictModal.jsx';
+
+const softResult = {
+  violations: [
+    { rule: 'rest', severity: 'soft', message: 'Only 30 min rest between shifts.' },
+  ],
+  severity: 'soft',
+  allowed: true,
+};
+
+const hardResult = {
+  violations: [
+    {
+      rule: 'ovr',
+      severity: 'hard',
+      message: 'Conflicts with "X" on the same resource.',
+      conflictingEventId: 'x1',
+    },
+  ],
+  severity: 'hard',
+  allowed: false,
+};
+
+describe('ConflictModal — rendering', () => {
+  it('returns null when result is null', () => {
+    const { container } = render(
+      <ConflictModal result={null} onProceed={vi.fn()} onCancel={vi.fn()} />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('returns null when severity is none', () => {
+    const { container } = render(
+      <ConflictModal
+        result={{ violations: [], severity: 'none', allowed: true }}
+        onProceed={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders the violation message + rule id + severity tag', () => {
+    render(<ConflictModal result={softResult} onProceed={vi.fn()} onCancel={vi.fn()} />);
+    expect(screen.getByText('Only 30 min rest between shifts.')).toBeInTheDocument();
+    expect(screen.getByText('rest')).toBeInTheDocument();
+    expect(screen.getByText('soft')).toBeInTheDocument();
+  });
+
+  it('stamps the panel with data-severity', () => {
+    render(<ConflictModal result={hardResult} onProceed={vi.fn()} onCancel={vi.fn()} />);
+    const dialog = screen.getByRole('alertdialog');
+    expect(dialog).toHaveAttribute('data-severity', 'hard');
+  });
+});
+
+describe('ConflictModal — actions', () => {
+  it('Proceed is enabled for soft-only violations', () => {
+    const onProceed = vi.fn();
+    render(<ConflictModal result={softResult} onProceed={onProceed} onCancel={vi.fn()} />);
+    const btn = screen.getByRole('button', { name: /Proceed anyway/ });
+    expect(btn).toBeEnabled();
+    fireEvent.click(btn);
+    expect(onProceed).toHaveBeenCalledTimes(1);
+  });
+
+  it('Proceed is disabled for hard violations', () => {
+    render(<ConflictModal result={hardResult} onProceed={vi.fn()} onCancel={vi.fn()} />);
+    const btn = screen.getByRole('button', { name: /Resolve to continue/ });
+    expect(btn).toBeDisabled();
+  });
+
+  it('Cancel fires onCancel', () => {
+    const onCancel = vi.fn();
+    render(<ConflictModal result={softResult} onProceed={vi.fn()} onCancel={onCancel} />);
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+    expect(onCancel).toHaveBeenCalledTimes(1);
+  });
+
+  it('Close button (×) fires onCancel', () => {
+    const onCancel = vi.fn();
+    render(<ConflictModal result={softResult} onProceed={vi.fn()} onCancel={onCancel} />);
+    fireEvent.click(screen.getByRole('button', { name: /Close conflict dialog/ }));
+    expect(onCancel).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/ui/__tests__/RequestForm.test.jsx
+++ b/src/ui/__tests__/RequestForm.test.jsx
@@ -1,0 +1,180 @@
+// @vitest-environment happy-dom
+/**
+ * RequestForm — ticket #134-12.
+ *
+ * Schema-driven, owner-configurable event request form. The schema is
+ * `config.requestForm` (edited via ConfigPanel → Request Form); the form
+ * renders one input per entry, validates required values, and emits a
+ * normalized `{ values }` object on submit.
+ */
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import '@testing-library/jest-dom';
+
+import RequestForm from '../RequestForm.jsx';
+
+const baseSchema = {
+  fields: [
+    { key: 'title',  label: 'Title',  type: 'text',     required: true },
+    { key: 'start',  label: 'Starts', type: 'datetime', required: true },
+    { key: 'notes',  label: 'Notes',  type: 'textarea' },
+  ],
+};
+
+function renderForm(props = {}) {
+  const onSubmit = props.onSubmit ?? vi.fn();
+  const onCancel = props.onCancel ?? vi.fn();
+  const result = render(
+    <RequestForm
+      schema={props.schema ?? baseSchema}
+      initialValues={props.initialValues}
+      onSubmit={onSubmit}
+      onCancel={onCancel}
+      title={props.title}
+    />,
+  );
+  return { ...result, onSubmit, onCancel };
+}
+
+describe('RequestForm — rendering', () => {
+  it('renders one input per schema field with the configured label', () => {
+    renderForm();
+    expect(screen.getByLabelText('Title')).toBeInTheDocument();
+    expect(screen.getByLabelText('Starts')).toBeInTheDocument();
+    expect(screen.getByLabelText('Notes')).toBeInTheDocument();
+  });
+
+  it('shows empty-state when schema has no fields', () => {
+    renderForm({ schema: { fields: [] } });
+    expect(screen.getByText(/No request fields configured/)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Submit request/ })).toBeDisabled();
+  });
+
+  it('renders all supported input types', () => {
+    renderForm({
+      schema: {
+        fields: [
+          { key: 'a', label: 'A', type: 'text' },
+          { key: 'b', label: 'B', type: 'textarea' },
+          { key: 'c', label: 'C', type: 'number' },
+          { key: 'd', label: 'D', type: 'date' },
+          { key: 'e', label: 'E', type: 'datetime' },
+          { key: 'f', label: 'F', type: 'select', options: 'x, y, z' },
+          { key: 'g', label: 'G', type: 'checkbox' },
+        ],
+      },
+    });
+    expect(screen.getByLabelText('A')).toHaveAttribute('type', 'text');
+    expect(screen.getByLabelText('B').tagName).toBe('TEXTAREA');
+    expect(screen.getByLabelText('C')).toHaveAttribute('type', 'number');
+    expect(screen.getByLabelText('D')).toHaveAttribute('type', 'date');
+    expect(screen.getByLabelText('E')).toHaveAttribute('type', 'datetime-local');
+    expect(screen.getByLabelText('F').tagName).toBe('SELECT');
+    expect(screen.getByLabelText('G')).toHaveAttribute('type', 'checkbox');
+  });
+
+  it('parses select options from the comma-separated string', () => {
+    renderForm({
+      schema: {
+        fields: [{ key: 'pick', label: 'Pick', type: 'select', options: 'one, two, three' }],
+      },
+    });
+    const select = screen.getByLabelText('Pick');
+    const options = Array.from(select.querySelectorAll('option')).map(o => o.value);
+    // First option is the empty "Select…" placeholder.
+    expect(options).toEqual(['', 'one', 'two', 'three']);
+  });
+
+  it('seeds values from initialValues', () => {
+    renderForm({
+      initialValues: { title: 'Hello', notes: 'World' },
+    });
+    expect(screen.getByLabelText('Title')).toHaveValue('Hello');
+    expect(screen.getByLabelText('Notes')).toHaveValue('World');
+  });
+});
+
+describe('RequestForm — validation + submit', () => {
+  it('marks required fields with a trailing asterisk', () => {
+    renderForm();
+    expect(screen.getByText('Title *')).toBeInTheDocument();
+    expect(screen.getByText('Notes')).toBeInTheDocument();
+  });
+
+  it('blocks submit when a required text field is empty', () => {
+    const { onSubmit } = renderForm();
+    fireEvent.click(screen.getByRole('button', { name: /Submit request/ }));
+    expect(onSubmit).not.toHaveBeenCalled();
+    // Error row appears for Title.
+    const titleInput = screen.getByLabelText('Title');
+    expect(titleInput).toHaveAttribute('aria-invalid', 'true');
+  });
+
+  it('blocks submit when a required checkbox is unchecked', () => {
+    const { onSubmit } = renderForm({
+      schema: { fields: [{ key: 'agree', label: 'Agree', type: 'checkbox', required: true }] },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /Submit request/ }));
+    expect(onSubmit).not.toHaveBeenCalled();
+    expect(screen.getByLabelText('Agree')).toHaveAttribute('aria-invalid', 'true');
+  });
+
+  it('submits { values } when all required fields are filled', () => {
+    const { onSubmit } = renderForm({
+      initialValues: { title: 'Flight 202', start: '2026-04-20T09:00', notes: '' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /Submit request/ }));
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+    expect(onSubmit).toHaveBeenCalledWith({
+      values: expect.objectContaining({
+        title: 'Flight 202',
+        start: '2026-04-20T09:00',
+      }),
+    });
+  });
+
+  it('reflects user edits in the submitted values', () => {
+    const { onSubmit } = renderForm();
+    fireEvent.change(screen.getByLabelText('Title'), { target: { value: 'New' } });
+    fireEvent.change(screen.getByLabelText('Starts'), { target: { value: '2026-05-01T08:00' } });
+    fireEvent.click(screen.getByRole('button', { name: /Submit request/ }));
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+    const call = onSubmit.mock.calls[0][0];
+    expect(call.values.title).toBe('New');
+    expect(call.values.start).toBe('2026-05-01T08:00');
+  });
+
+  it('Cancel fires onCancel', () => {
+    const { onCancel } = renderForm();
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+    expect(onCancel).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('RequestForm — robustness', () => {
+  it('handles schema=null by showing the empty state', () => {
+    render(
+      <RequestForm schema={null} onSubmit={vi.fn()} onCancel={vi.fn()} />,
+    );
+    expect(screen.getByText(/No request fields configured/)).toBeInTheDocument();
+  });
+
+  it('normalizes fields with missing keys', () => {
+    renderForm({
+      schema: {
+        fields: [{ label: 'Unlabeled', type: 'text' }],
+      },
+    });
+    // Falls back to auto-generated key-derived label when missing.
+    expect(screen.getByLabelText('Unlabeled')).toBeInTheDocument();
+  });
+
+  it('rejects unknown field types by rendering as text', () => {
+    renderForm({
+      schema: {
+        fields: [{ key: 'x', label: 'X', type: 'color' }],
+      },
+    });
+    expect(screen.getByLabelText('X')).toHaveAttribute('type', 'text');
+  });
+});

--- a/src/views/AssetsView.jsx
+++ b/src/views/AssetsView.jsx
@@ -535,15 +535,19 @@ export default function AssetsView({
       }
     }
 
+    const isHeader = flatRows[rowIdx]?._type === 'groupHeader';
+    const selector = isHeader
+      ? `#assets-gh-${rowIdx}`
+      : `[data-cell="${rowIdx}-${dayIdx}"]`;
     const tryFocus = () => {
-      const el = gridRef.current?.querySelector(`[data-cell="${rowIdx}-${dayIdx}"]`);
+      const el = gridRef.current?.querySelector(selector);
       el?.focus({ preventScroll: false });
     };
     tryFocus();
-    if (!gridRef.current?.querySelector(`[data-cell="${rowIdx}-${dayIdx}"]`)) {
+    if (!gridRef.current?.querySelector(selector)) {
       requestAnimationFrame(tryFocus);
     }
-  }, [focusedCell, rowOffsets]);
+  }, [focusedCell, rowOffsets, flatRows]);
 
   const handleCellKeyDown = useCallback((e, ri, di, cellRowEvents, resourceId) => {
     const maxRi = flatRows.length - 1;
@@ -553,20 +557,8 @@ export default function AssetsView({
     switch (e.key) {
       case 'ArrowLeft':  nextDi = Math.max(0, di - 1);     move = true; break;
       case 'ArrowRight': nextDi = Math.min(maxDi, di + 1); move = true; break;
-      case 'ArrowUp': {
-        nextRi = ri - 1;
-        while (nextRi >= 0 && flatRows[nextRi]?._type === 'groupHeader') nextRi--;
-        nextRi = Math.max(0, nextRi);
-        if (flatRows[nextRi]?._type === 'groupHeader') nextRi = ri;
-        move = true; break;
-      }
-      case 'ArrowDown': {
-        nextRi = ri + 1;
-        while (nextRi <= maxRi && flatRows[nextRi]?._type === 'groupHeader') nextRi++;
-        nextRi = Math.min(maxRi, nextRi);
-        if (flatRows[nextRi]?._type === 'groupHeader') nextRi = ri;
-        move = true; break;
-      }
+      case 'ArrowUp':    nextRi = Math.max(0, ri - 1);     move = true; break;
+      case 'ArrowDown':  nextRi = Math.min(maxRi, ri + 1); move = true; break;
       case 'Home': nextDi = 0;     move = true; break;
       case 'End':  nextDi = maxDi; move = true; break;
       case 'Enter':
@@ -590,7 +582,44 @@ export default function AssetsView({
       lastKeyNavCell.current = true;
       setFocusedCell({ rowIdx: nextRi, dayIdx: nextDi });
     }
-  }, [flatRows, totalDays, onEventClick, onDateSelect, days, openAudit]);
+  }, [flatRows.length, totalDays, onEventClick, onDateSelect, days, openAudit]);
+
+  /**
+   * Header-row keyboard handling:
+   *   ArrowUp / ArrowDown — traverse to the previous / next row (header or
+   *     data). Preserves `dayIdx` so landing back on a data cell keeps the
+   *     column.
+   *   ArrowLeft  — if the group is expanded, collapse it; otherwise no-op.
+   *   ArrowRight — if the group is collapsed, expand it; otherwise move to
+   *     the first child row so the tree pattern flows naturally.
+   */
+  const handleHeaderArrowKey = useCallback((rowIdx, key) => {
+    const row = flatRows[rowIdx];
+    if (!row || row._type !== 'groupHeader') return;
+    const maxRi = flatRows.length - 1;
+    if (key === 'ArrowUp') {
+      if (rowIdx <= 0) return;
+      lastKeyNavCell.current = true;
+      setFocusedCell(prev => ({ rowIdx: rowIdx - 1, dayIdx: prev.dayIdx }));
+      return;
+    }
+    if (key === 'ArrowDown') {
+      if (rowIdx >= maxRi) return;
+      lastKeyNavCell.current = true;
+      setFocusedCell(prev => ({ rowIdx: rowIdx + 1, dayIdx: prev.dayIdx }));
+      return;
+    }
+    if (key === 'ArrowLeft') {
+      if (!row.collapsed) toggleGroup(row.groupPath);
+      return;
+    }
+    if (key === 'ArrowRight') {
+      if (row.collapsed) { toggleGroup(row.groupPath); return; }
+      if (rowIdx >= maxRi) return;
+      lastKeyNavCell.current = true;
+      setFocusedCell(prev => ({ rowIdx: rowIdx + 1, dayIdx: prev.dayIdx }));
+    }
+  }, [flatRows, toggleGroup]);
 
   // ── Toolbar (declared above the empty-state branch so owners can still
   // reach the Edit-assets deep-link when the registry has no rows yet) ──
@@ -748,12 +777,14 @@ export default function AssetsView({
                   aria-rowindex={rowIdx + 2}
                   data-depth={rowData.depth}
                   data-group-path={rowData.groupPath}
+                  data-header-idx={rowIdx}
                 >
                   <div
                     className={styles.groupHeaderCell}
                     style={{ width: NAME_W + totalDays * dayColW }}
                   >
                     <GroupHeader
+                      id={`assets-gh-${rowIdx}`}
                       label={rowData.groupLabel}
                       count={rowData.count}
                       depth={rowData.depth}
@@ -762,6 +793,7 @@ export default function AssetsView({
                       posInSet={rowData.posInSet}
                       setSize={rowData.setSize}
                       fieldLabel={rowData.field}
+                      onArrowKey={(key) => handleHeaderArrowKey(rowIdx, key)}
                     />
                   </div>
                 </div>

--- a/src/views/AssetsView.jsx
+++ b/src/views/AssetsView.jsx
@@ -30,6 +30,7 @@ import GroupHeader from '../ui/GroupHeader.tsx';
 import { useResourceLocations } from '../hooks/useResourceLocations.ts';
 import { DEFAULT_CATEGORIES } from '../types/assets.ts';
 import AuditDrawer from './AuditDrawer.jsx';
+import ApprovalActionMenu, { allowedActionsFor } from '../ui/ApprovalActionMenu.jsx';
 
 const AUDIT_STAGES = new Set(['denied', 'pending_higher']);
 
@@ -181,12 +182,40 @@ export default function AssetsView({
   onCollapsedGroupsChange,
   assets,
   onEditAssets,
+  approvalsConfig,
+  onApprovalAction,
 }) {
   const ctx = useCalendarContext();
 
   const [auditEvent, setAuditEvent] = useState(null);
   const [announcement, setAnnouncement] = useState('');
   const drawerOpenerRef = useRef(null);
+  const [approvalMenu, setApprovalMenu] = useState(null);
+  const approvalMenuOpenerRef = useRef(null);
+
+  const openApprovalMenu = useCallback((ev, stage, trigger) => {
+    const rect = trigger?.getBoundingClientRect?.();
+    approvalMenuOpenerRef.current = trigger ?? null;
+    setApprovalMenu({
+      event: ev,
+      stage,
+      anchorRect: rect ? { top: rect.top, bottom: rect.bottom, left: rect.left, right: rect.right } : null,
+    });
+  }, []);
+
+  const closeApprovalMenu = useCallback(() => {
+    setApprovalMenu(null);
+    const opener = approvalMenuOpenerRef.current;
+    if (opener && typeof opener.focus === 'function') {
+      requestAnimationFrame(() => opener.focus());
+    }
+    approvalMenuOpenerRef.current = null;
+  }, []);
+
+  const handleApprovalActionInternal = useCallback((action) => {
+    if (!approvalMenu) return;
+    onApprovalAction?.(approvalMenu.event, action);
+  }, [approvalMenu, onApprovalAction]);
 
   const announce = useCallback((msg) => {
     // Appending a zero-width space forces a diff so screen readers re-read
@@ -909,6 +938,12 @@ export default function AssetsView({
                     const statusClass = ev.status === 'cancelled' ? styles.cancelled
                       : ev.status === 'tentative' ? styles.tentative : '';
 
+                    const approvalActions = stage
+                      ? allowedActionsFor(stage, approvalsConfig)
+                      : [];
+                    const showCaret = approvalActions.length > 0
+                      && typeof onApprovalAction === 'function';
+
                     const ariaLabel = [
                       ev.title,
                       ev.category && `category ${ev.category}`,
@@ -917,27 +952,47 @@ export default function AssetsView({
                     ].filter(Boolean).join(', ');
 
                     return (
-                      <button
-                        key={ev.id}
-                        className={[
-                          styles.event,
-                          styles[`pill_${pillStyle}`] || styles.pill_hue,
-                          approvalClass(stage),
-                          statusClass,
-                        ].filter(Boolean).join(' ')}
-                        style={{ left, top, width, height: LANE_H, '--ev-color': evColor }}
-                        onClick={onClick}
-                        aria-label={ariaLabel}
-                        data-stage={stage || undefined}
-                      >
-                        {prefix && (
-                          <span className={styles.stagePrefix} aria-hidden="true">{prefix}</span>
+                      <div key={ev.id} style={{ display: 'contents' }}>
+                        <button
+                          className={[
+                            styles.event,
+                            styles[`pill_${pillStyle}`] || styles.pill_hue,
+                            approvalClass(stage),
+                            statusClass,
+                          ].filter(Boolean).join(' ')}
+                          style={{ left, top, width, height: LANE_H, '--ev-color': evColor }}
+                          onClick={onClick}
+                          aria-label={ariaLabel}
+                          data-stage={stage || undefined}
+                        >
+                          {prefix && (
+                            <span className={styles.stagePrefix} aria-hidden="true">{prefix}</span>
+                          )}
+                          <span className={styles.evTitle}>{ev.title}</span>
+                          {(ev._dayEnd - ev._dayStart + 1) * dayColW >= 60 && ev.category && (
+                            <span className={styles.evCat} aria-hidden="true">{ev.category}</span>
+                          )}
+                        </button>
+                        {showCaret && (
+                          <button
+                            className={styles.stageCaret}
+                            style={{
+                              left: left + width - 18,
+                              top:  top + (LANE_H - 16) / 2,
+                            }}
+                            onClick={(e) => {
+                              e.stopPropagation();
+                              openApprovalMenu(ev, stage, e.currentTarget);
+                            }}
+                            aria-haspopup="menu"
+                            aria-expanded={approvalMenu?.event?.id === ev.id}
+                            aria-label={`Approval actions for ${ev.title}`}
+                            data-stage={stage}
+                          >
+                            ▾
+                          </button>
                         )}
-                        <span className={styles.evTitle}>{ev.title}</span>
-                        {(ev._dayEnd - ev._dayStart + 1) * dayColW >= 60 && ev.category && (
-                          <span className={styles.evCat} aria-hidden="true">{ev.category}</span>
-                        )}
-                      </button>
+                      </div>
                     );
                   })}
                 </div>
@@ -946,7 +1001,25 @@ export default function AssetsView({
           })}
         </div>
       </div>
-      <AuditDrawer event={auditEvent} onClose={closeAudit} />
+      <AuditDrawer
+        event={auditEvent}
+        onClose={closeAudit}
+        approvalsConfig={approvalsConfig}
+        onAction={
+          auditEvent && typeof onApprovalAction === 'function'
+            ? (action) => onApprovalAction(auditEvent, action)
+            : undefined
+        }
+      />
+      {approvalMenu && (
+        <ApprovalActionMenu
+          stage={approvalMenu.stage}
+          approvalsConfig={approvalsConfig}
+          anchorRect={approvalMenu.anchorRect}
+          onAction={handleApprovalActionInternal}
+          onClose={closeApprovalMenu}
+        />
+      )}
       <div
         className={styles.srOnly}
         role="status"

--- a/src/views/AssetsView.jsx
+++ b/src/views/AssetsView.jsx
@@ -178,6 +178,7 @@ export default function AssetsView({
   renderAssetLocation,
   collapsedGroups: collapsedGroupsProp,
   onCollapsedGroupsChange,
+  assets,
 }) {
   const ctx = useCalendarContext();
 
@@ -254,8 +255,34 @@ export default function AssetsView({
     };
   }, []);
 
-  // ── Row source: all resources appearing in events (for location provider) ──
+  // ── Row source ──
+  // When `assets` is provided (first-class registry from owner config),
+  // rows come from the registry in its declared order. Any event.resource
+  // value not present in the registry falls into an "(Unassigned)" row.
+  // When `assets` is absent/empty, preserve the legacy behavior: derive
+  // rows from the distinct event.resource values alphabetically.
+  const assetRegistry = useMemo(() => {
+    return Array.isArray(assets) && assets.length > 0 ? assets : null;
+  }, [assets]);
+
+  // id → { label, meta, group } lookup for rendering.
+  const assetById = useMemo(() => {
+    const map = new Map();
+    if (assetRegistry) {
+      for (const a of assetRegistry) {
+        if (a && typeof a.id === 'string' && a.id) map.set(a.id, a);
+      }
+    }
+    return map;
+  }, [assetRegistry]);
+
   const resourceList = useMemo(() => {
+    if (assetRegistry) {
+      const ordered = assetRegistry.map(a => a.id);
+      const orderedSet = new Set(ordered);
+      const hasOrphan = events.some(e => !orderedSet.has(e.resource ?? '(Unassigned)'));
+      return hasOrphan ? [...ordered, '(Unassigned)'] : ordered;
+    }
     const set = new Set();
     events.forEach(e => set.add(e.resource ?? '(Unassigned)'));
     return [...set].sort((a, b) => {
@@ -263,7 +290,7 @@ export default function AssetsView({
       if (b === '(Unassigned)') return -1;
       return a.localeCompare(b);
     });
-  }, [events]);
+  }, [assetRegistry, events]);
 
   // ── Live locations (via LocationProvider) ──────────────────────────────────
   const locations = useResourceLocations(resourceList, locationProvider);
@@ -274,26 +301,39 @@ export default function AssetsView({
    * most events are filtered into a different group bucket.
    */
   const buildAssetRow = useCallback((resource, subsetEvents) => {
-    const resEvents = subsetEvents.filter(
-      e => (e.resource ?? '(Unassigned)') === resource,
-    );
+    // "(Unassigned)" bucket catches any event whose resource isn't in the
+    // registry (or is missing entirely). Registry rows keep exact-id match.
+    const matchesRow = assetRegistry
+      ? (e) => {
+          const r = e.resource ?? '(Unassigned)';
+          if (resource === '(Unassigned)') return !assetById.has(r);
+          return r === resource;
+        }
+      : (e) => (e.resource ?? '(Unassigned)') === resource;
+    const resEvents = subsetEvents.filter(matchesRow);
     const { events: laned, laneCount } = assignLanes(resEvents, monthStart, monthEnd);
     const rowH = Math.max(
       laneCount * (LANE_H + LANE_GAP) + ROW_PAD * 2,
       ROW_PAD * 2 + LANE_H + 16,
     );
     const firstWithMeta = resEvents.find(e => e.meta?.assetSublabel || e.meta?.sublabel);
-    const sublabel = firstWithMeta?.meta?.assetSublabel ?? firstWithMeta?.meta?.sublabel ?? null;
+    const registryEntry = assetById.get(resource) ?? null;
+    const sublabel = firstWithMeta?.meta?.assetSublabel
+      ?? firstWithMeta?.meta?.sublabel
+      ?? registryEntry?.meta?.sublabel
+      ?? null;
+    const label = registryEntry?.label ?? resource;
     return {
       _type: 'assetRow',
       key: resource,
       resource,
+      label,
       sublabel,
       events: laned,
       laneCount,
       rowH,
     };
-  }, [monthStart.toISOString(), monthEnd.toISOString()]);
+  }, [monthStart.toISOString(), monthEnd.toISOString(), assetRegistry, assetById]);
 
   const sortResourceKeys = useCallback((keys) => {
     return [...keys].sort((a, b) => {
@@ -612,7 +652,8 @@ export default function AssetsView({
               );
             }
 
-            const { key, resource, sublabel, events: rowEvents, rowH } = rowData;
+            const { key, resource, label, sublabel, events: rowEvents, rowH } = rowData;
+            const displayLabel = label ?? resource;
             const topOffset = rowOffsets[rowIdx];
             const locationData = locations.get(resource) ?? null;
 
@@ -636,10 +677,11 @@ export default function AssetsView({
                   className={styles.nameCell}
                   style={{ width: NAME_W, minWidth: NAME_W, height: rowH }}
                   role="rowheader"
-                  aria-label={resource}
+                  aria-label={displayLabel}
+                  data-resource={resource}
                 >
                   <div className={styles.assetMeta}>
-                    <span className={styles.assetRegistration}>{resource}</span>
+                    <span className={styles.assetRegistration}>{displayLabel}</span>
                     {sublabel && (
                       <span className={styles.assetSublabel}>{sublabel}</span>
                     )}

--- a/src/views/AssetsView.jsx
+++ b/src/views/AssetsView.jsx
@@ -25,8 +25,8 @@ import {
 } from 'date-fns';
 import { useCalendarContext, resolveColor } from '../core/CalendarContext.js';
 import styles from './AssetsView.module.css';
-import { useGrouping } from '../hooks/useGrouping.js';
-import { buildFieldAccessor } from '../grouping/buildFieldAccessor.js';
+import { buildGroupTree } from '../hooks/useGrouping.ts';
+import GroupHeader from '../ui/GroupHeader.tsx';
 import { useResourceLocations } from '../hooks/useResourceLocations.ts';
 import { DEFAULT_CATEGORIES } from '../types/assets.ts';
 import AuditDrawer from './AuditDrawer.jsx';
@@ -176,6 +176,8 @@ export default function AssetsView({
   onZoomChange,
   locationProvider,
   renderAssetLocation,
+  collapsedGroups: collapsedGroupsProp,
+  onCollapsedGroupsChange,
 }) {
   const ctx = useCalendarContext();
 
@@ -252,7 +254,7 @@ export default function AssetsView({
     };
   }, []);
 
-  // ── Row source: derive asset rows from event.resource ──────────────────────
+  // ── Row source: all resources appearing in events (for location provider) ──
   const resourceList = useMemo(() => {
     const set = new Set();
     events.forEach(e => set.add(e.resource ?? '(Unassigned)'));
@@ -266,17 +268,24 @@ export default function AssetsView({
   // ── Live locations (via LocationProvider) ──────────────────────────────────
   const locations = useResourceLocations(resourceList, locationProvider);
 
-  const rows = useMemo(() => resourceList.map(resource => {
-    const resEvents = events.filter(e => (e.resource ?? '(Unassigned)') === resource);
+  /**
+   * Build one asset row for `resource` given a scoped `subsetEvents`.
+   * Row height is computed from the laned events so rows stay tight when
+   * most events are filtered into a different group bucket.
+   */
+  const buildAssetRow = useCallback((resource, subsetEvents) => {
+    const resEvents = subsetEvents.filter(
+      e => (e.resource ?? '(Unassigned)') === resource,
+    );
     const { events: laned, laneCount } = assignLanes(resEvents, monthStart, monthEnd);
     const rowH = Math.max(
       laneCount * (LANE_H + LANE_GAP) + ROW_PAD * 2,
       ROW_PAD * 2 + LANE_H + 16,
     );
-    // Sublabel: first event with meta.assetSublabel / meta.sublabel wins.
     const firstWithMeta = resEvents.find(e => e.meta?.assetSublabel || e.meta?.sublabel);
     const sublabel = firstWithMeta?.meta?.assetSublabel ?? firstWithMeta?.meta?.sublabel ?? null;
     return {
+      _type: 'assetRow',
       key: resource,
       resource,
       sublabel,
@@ -284,17 +293,101 @@ export default function AssetsView({
       laneCount,
       rowH,
     };
-  }), [resourceList, events, monthStart.toISOString(), monthEnd.toISOString()]);
+  }, [monthStart.toISOString(), monthEnd.toISOString()]);
 
-  // ── Grouping ───────────────────────────────────────────────────────────────
+  const sortResourceKeys = useCallback((keys) => {
+    return [...keys].sort((a, b) => {
+      if (a === '(Unassigned)') return 1;
+      if (b === '(Unassigned)') return -1;
+      return a.localeCompare(b);
+    });
+  }, []);
+
+  // ── Grouping (TS engine) ───────────────────────────────────────────────────
   const GROUP_HEADER_H = 36;
-  const fieldAccessor = useMemo(
-    () => groupBy ? buildFieldAccessor(groupBy, 'resource') : null,
-    [groupBy],
+
+  const isGrouped = groupBy != null && (
+    typeof groupBy === 'string' ? true : Array.isArray(groupBy) ? groupBy.length > 0 : true
   );
-  const { flatRows, toggleGroup } = useGrouping(rows, {
-    groupBy, fieldAccessor, groupHeaderHeight: GROUP_HEADER_H,
-  });
+
+  const groupTree = useMemo(() => {
+    if (!isGrouped) return null;
+    return buildGroupTree(events, groupBy);
+  }, [isGrouped, events, groupBy]);
+
+  // Collapse state — controlled via props when provided, otherwise local.
+  const [collapsedLocal, setCollapsedLocal] = useState(() => new Set());
+  const collapsedControlled = collapsedGroupsProp instanceof Set
+    ? collapsedGroupsProp
+    : (Array.isArray(collapsedGroupsProp) ? new Set(collapsedGroupsProp) : null);
+  const collapsedGroups = collapsedControlled ?? collapsedLocal;
+
+  const toggleGroup = useCallback((path) => {
+    if (collapsedControlled && onCollapsedGroupsChange) {
+      const next = new Set(collapsedControlled);
+      if (next.has(path)) next.delete(path);
+      else next.add(path);
+      onCollapsedGroupsChange(next);
+      return;
+    }
+    setCollapsedLocal(prev => {
+      const next = new Set(prev);
+      if (next.has(path)) next.delete(path);
+      else next.add(path);
+      if (onCollapsedGroupsChange) onCollapsedGroupsChange(next);
+      return next;
+    });
+  }, [collapsedControlled, onCollapsedGroupsChange]);
+
+  // Count every leaf event reachable under a group (respecting nested trees).
+  const countEvents = useCallback((node) => {
+    if (!node.children || node.children.length === 0) return node.events.length;
+    return node.children.reduce((sum, c) => sum + countEvents(c), 0);
+  }, []);
+
+  // Flat list of rows for virtualization: interleaves groupHeader pseudo-rows
+  // with asset rows scoped to the leaf group's events.
+  const flatRows = useMemo(() => {
+    if (!groupTree) {
+      return resourceList.map(r => buildAssetRow(r, events));
+    }
+    const out = [];
+    const walk = (nodes, parentPath) => {
+      nodes.forEach((node, i) => {
+        const path = parentPath ? `${parentPath}/${node.key}` : node.key;
+        const collapsed = collapsedGroups.has(path);
+        out.push({
+          _type: 'groupHeader',
+          groupPath: path,
+          groupLabel: node.label,
+          field: node.field,
+          depth: node.depth,
+          collapsed,
+          count: countEvents(node),
+          posInSet: i + 1,
+          setSize: nodes.length,
+          rowH: GROUP_HEADER_H,
+        });
+        if (collapsed) return;
+        if (node.children && node.children.length > 0) {
+          walk(node.children, path);
+        } else {
+          // Leaf: build one asset row per distinct resource in this bucket.
+          const leafResources = new Set();
+          for (const ev of node.events) {
+            leafResources.add(ev.resource ?? '(Unassigned)');
+          }
+          for (const resource of sortResourceKeys(leafResources)) {
+            const row = buildAssetRow(resource, node.events);
+            // Disambiguate keys when an asset appears in multiple groups.
+            out.push({ ...row, key: `${path}::${resource}`, groupPath: path });
+          }
+        }
+      });
+    };
+    walk(groupTree, '');
+    return out;
+  }, [groupTree, collapsedGroups, events, resourceList, buildAssetRow, countEvents, sortResourceKeys]);
 
   // ── Cumulative row offsets ─────────────────────────────────────────────────
   const rowOffsets = useMemo(() => {
@@ -398,7 +491,7 @@ export default function AssetsView({
   }, [flatRows, totalDays, onEventClick, onDateSelect, days, openAudit]);
 
   // ── Empty state ────────────────────────────────────────────────────────────
-  if (rows.length === 0) {
+  if (resourceList.length === 0) {
     if (ctx?.emptyState) return <>{ctx.emptyState}</>;
     return (
       <div className={styles.empty}>
@@ -492,23 +585,28 @@ export default function AssetsView({
               const topOffset = rowOffsets[rowIdx];
               return (
                 <div
-                  key={`gh-${rowData.groupKey}`}
+                  key={`gh-${rowData.groupPath}`}
                   className={styles.groupHeaderRow}
                   style={{ position: 'absolute', top: topOffset, left: 0, right: 0, height: rowData.rowH }}
                   role="row"
                   aria-rowindex={rowIdx + 2}
+                  data-depth={rowData.depth}
+                  data-group-path={rowData.groupPath}
                 >
-                  <div className={styles.groupHeaderCell} style={{ width: NAME_W + totalDays * dayColW }}>
-                    <button
-                      className={styles.groupToggleBtn}
-                      onClick={() => toggleGroup(rowData.groupKey)}
-                      aria-expanded={!rowData.collapsed}
-                      aria-label={`${rowData.collapsed ? 'Expand' : 'Collapse'} group ${rowData.groupLabel}`}
-                    >
-                      <span className={styles.groupChevron} data-collapsed={rowData.collapsed || undefined}>&#9656;</span>
-                      <span className={styles.groupLabel}>{rowData.groupLabel}</span>
-                      <span className={styles.groupCount}>{rowData.count}</span>
-                    </button>
+                  <div
+                    className={styles.groupHeaderCell}
+                    style={{ width: NAME_W + totalDays * dayColW }}
+                  >
+                    <GroupHeader
+                      label={rowData.groupLabel}
+                      count={rowData.count}
+                      depth={rowData.depth}
+                      collapsed={rowData.collapsed}
+                      onToggle={() => toggleGroup(rowData.groupPath)}
+                      posInSet={rowData.posInSet}
+                      setSize={rowData.setSize}
+                      fieldLabel={rowData.field}
+                    />
                   </div>
                 </div>
               );

--- a/src/views/AssetsView.jsx
+++ b/src/views/AssetsView.jsx
@@ -171,6 +171,7 @@ export default function AssetsView({
   onEventClick,
   onDateSelect,
   groupBy,
+  onGroupByChange,
   categoriesConfig,
   zoomLevel = 'month',
   onZoomChange,
@@ -179,6 +180,7 @@ export default function AssetsView({
   collapsedGroups: collapsedGroupsProp,
   onCollapsedGroupsChange,
   assets,
+  onEditAssets,
 }) {
   const ctx = useCalendarContext();
 
@@ -276,12 +278,50 @@ export default function AssetsView({
     return map;
   }, [assetRegistry]);
 
+  // Toolbar sort order. "registry" preserves declared order (default when a
+  // registry is present); "label" / "group" / "lastEvent" resort the rows
+  // without mutating the registry itself.
+  const [sortMode, setSortMode] = useState('registry');
+
+  // Most recent event end-date per resource (used by the "Last event date"
+  // sort). Missing resources sort to the bottom.
+  const lastEventByResource = useMemo(() => {
+    const map = new Map();
+    for (const e of events) {
+      const key = e.resource ?? '(Unassigned)';
+      const ts = e.end instanceof Date ? e.end.getTime() : 0;
+      const prev = map.get(key);
+      if (prev === undefined || ts > prev) map.set(key, ts);
+    }
+    return map;
+  }, [events]);
+
+  const applySort = useCallback((ids) => {
+    if (sortMode === 'registry' || !assetRegistry) return ids;
+    const byId = assetById;
+    const labelOf = (id) => byId.get(id)?.label ?? id;
+    const groupOf = (id) => byId.get(id)?.group ?? '';
+    const lastOf  = (id) => lastEventByResource.get(id) ?? -Infinity;
+    const copy = [...ids];
+    copy.sort((a, b) => {
+      // Always keep "(Unassigned)" at the end.
+      if (a === '(Unassigned)') return 1;
+      if (b === '(Unassigned)') return -1;
+      if (sortMode === 'label')     return labelOf(a).localeCompare(labelOf(b));
+      if (sortMode === 'group')     return groupOf(a).localeCompare(groupOf(b)) || labelOf(a).localeCompare(labelOf(b));
+      if (sortMode === 'lastEvent') return lastOf(b) - lastOf(a);
+      return 0;
+    });
+    return copy;
+  }, [sortMode, assetRegistry, assetById, lastEventByResource]);
+
   const resourceList = useMemo(() => {
     if (assetRegistry) {
       const ordered = assetRegistry.map(a => a.id);
       const orderedSet = new Set(ordered);
       const hasOrphan = events.some(e => !orderedSet.has(e.resource ?? '(Unassigned)'));
-      return hasOrphan ? [...ordered, '(Unassigned)'] : ordered;
+      const base = hasOrphan ? [...ordered, '(Unassigned)'] : ordered;
+      return applySort(base);
     }
     const set = new Set();
     events.forEach(e => set.add(e.resource ?? '(Unassigned)'));
@@ -290,7 +330,29 @@ export default function AssetsView({
       if (b === '(Unassigned)') return -1;
       return a.localeCompare(b);
     });
-  }, [assetRegistry, events]);
+  }, [assetRegistry, events, applySort]);
+
+  // GroupBy options exposed by the toolbar: fixed asset fields + every
+  // distinct `meta.*` key seen across the registry. Empty-string value
+  // maps to "no grouping".
+  const groupByOptions = useMemo(() => {
+    const opts = [{ value: '', label: 'None' }];
+    if (!assetRegistry) return opts;
+    opts.push({ value: 'group', label: 'Group' });
+    const metaKeys = new Set();
+    for (const a of assetRegistry) {
+      if (a?.meta && typeof a.meta === 'object') {
+        for (const k of Object.keys(a.meta)) metaKeys.add(k);
+      }
+    }
+    for (const k of [...metaKeys].sort()) {
+      opts.push({ value: `meta.${k}`, label: `Meta: ${k}` });
+    }
+    return opts;
+  }, [assetRegistry]);
+
+  const currentGroupByValue = typeof groupBy === 'string' ? groupBy : '';
+  const showToolbar = Boolean(assetRegistry) || Boolean(onEditAssets);
 
   // ── Live locations (via LocationProvider) ──────────────────────────────────
   const locations = useResourceLocations(resourceList, locationProvider);
@@ -530,12 +592,65 @@ export default function AssetsView({
     }
   }, [flatRows, totalDays, onEventClick, onDateSelect, days, openAudit]);
 
+  // ── Toolbar (declared above the empty-state branch so owners can still
+  // reach the Edit-assets deep-link when the registry has no rows yet) ──
+  const toolbarNode = showToolbar && (
+    <div className={styles.toolbar} role="toolbar" aria-label="Assets view controls">
+      <div className={styles.toolbarGroup}>
+        <label className={styles.toolbarLabel} htmlFor="assets-group-by">Group by</label>
+        <select
+          id="assets-group-by"
+          className={styles.toolbarSelect}
+          value={currentGroupByValue}
+          onChange={(e) => onGroupByChange?.(e.target.value || null)}
+          disabled={!onGroupByChange || groupByOptions.length <= 1}
+        >
+          {groupByOptions.map(o => (
+            <option key={o.value || '__none'} value={o.value}>{o.label}</option>
+          ))}
+        </select>
+      </div>
+      <div className={styles.toolbarGroup}>
+        <label className={styles.toolbarLabel} htmlFor="assets-sort-by">Sort by</label>
+        <select
+          id="assets-sort-by"
+          className={styles.toolbarSelect}
+          value={sortMode}
+          onChange={(e) => setSortMode(e.target.value)}
+          disabled={!assetRegistry}
+        >
+          <option value="registry">Registry order</option>
+          <option value="label">Label</option>
+          <option value="group">Group</option>
+          <option value="lastEvent">Last event date</option>
+        </select>
+      </div>
+      <div className={styles.toolbarSpacer} />
+      {onEditAssets && (
+        <button
+          type="button"
+          className={styles.toolbarBtn}
+          onClick={onEditAssets}
+          aria-label="Edit assets"
+        >
+          Edit assets
+        </button>
+      )}
+    </div>
+  );
+
   // ── Empty state ────────────────────────────────────────────────────────────
   if (resourceList.length === 0) {
-    if (ctx?.emptyState) return <>{ctx.emptyState}</>;
     return (
-      <div className={styles.empty}>
-        <p>No assets to display in {format(currentDate, 'MMMM yyyy')}.</p>
+      <div className={styles.wrap} ref={wrapRef} data-zoom={activeZoom}>
+        {toolbarNode}
+        {ctx?.emptyState
+          ? ctx.emptyState
+          : (
+            <div className={styles.empty}>
+              <p>No assets to display in {format(currentDate, 'MMMM yyyy')}.</p>
+            </div>
+          )}
       </div>
     );
   }
@@ -548,6 +663,7 @@ export default function AssetsView({
 
   return (
     <div className={styles.wrap} ref={wrapRef} data-zoom={activeZoom}>
+      {toolbarNode}
       <div
         className={styles.inner}
         style={{ width: NAME_W + totalDays * dayColW }}

--- a/src/views/AssetsView.module.css
+++ b/src/views/AssetsView.module.css
@@ -550,6 +550,32 @@
   text-decoration: line-through;
 }
 
+/* ── Approval action caret (ticket #134-15) ─────────────────────── */
+/* Small trigger button overlaid on the right edge of the pill. It
+   opens the inline approval action menu; pill-click retains its
+   existing behavior (audit drawer for denied/pending, edit otherwise). */
+.stageCaret {
+  position: absolute;
+  width: 16px;
+  height: 16px;
+  padding: 0;
+  font-size: 10px;
+  line-height: 1;
+  font-weight: 700;
+  border: 0;
+  border-radius: 3px;
+  background: rgba(0, 0, 0, 0.28);
+  color: #fff;
+  cursor: pointer;
+  z-index: 6;
+}
+
+.stageCaret:hover,
+.stageCaret:focus-visible {
+  background: rgba(0, 0, 0, 0.45);
+  outline: none;
+}
+
 /* ── Empty state ────────────────────────────────────────────────── */
 .empty {
   display: flex;

--- a/src/views/AssetsView.module.css
+++ b/src/views/AssetsView.module.css
@@ -14,6 +14,63 @@
   position: relative;
 }
 
+/* ── On-page toolbar (Group by / Sort by / Edit assets) ────────── */
+.toolbar {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 6px 12px;
+  border-bottom: 1px solid var(--wc-border);
+  background: var(--wc-surface);
+  font-size: 12px;
+  flex-wrap: wrap;
+}
+
+.toolbarGroup {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.toolbarLabel {
+  color: var(--wc-text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  font-weight: 600;
+}
+
+.toolbarSelect {
+  font: inherit;
+  padding: 3px 6px;
+  border: 1px solid var(--wc-border);
+  border-radius: 4px;
+  background: var(--wc-bg);
+  color: var(--wc-text);
+}
+
+.toolbarSpacer {
+  flex: 1;
+}
+
+.toolbarBtn {
+  font: inherit;
+  padding: 4px 10px;
+  border: 1px solid var(--wc-border);
+  border-radius: 4px;
+  background: var(--wc-bg);
+  color: var(--wc-text);
+  cursor: pointer;
+}
+
+.toolbarBtn:hover:not(:disabled) {
+  background: var(--wc-surface);
+}
+
+.toolbarBtn:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
 .inner {
   display: flex;
   flex-direction: column;

--- a/src/views/AuditDrawer.jsx
+++ b/src/views/AuditDrawer.jsx
@@ -9,6 +9,7 @@
 import { useEffect, useRef } from 'react';
 import { X } from 'lucide-react';
 import styles from './AuditDrawer.module.css';
+import ApprovalActionMenu from '../ui/ApprovalActionMenu.jsx';
 
 /**
  * Formats an ISO timestamp as a locale-aware date + time string. Returns the
@@ -34,7 +35,7 @@ const ACTION_LABELS = {
   finalize:  'Finalized',
 };
 
-export default function AuditDrawer({ event, onClose }) {
+export default function AuditDrawer({ event, onClose, approvalsConfig, onAction }) {
   const closeRef = useRef(null);
 
   useEffect(() => {
@@ -69,6 +70,14 @@ export default function AuditDrawer({ event, onClose }) {
               <span className={styles.stageTag} data-stage={stageData.stage}>
                 {stageData.stage.replace('_', ' ')}
               </span>
+            )}
+            {stageData?.stage && typeof onAction === 'function' && (
+              <ApprovalActionMenu
+                stage={stageData.stage}
+                approvalsConfig={approvalsConfig}
+                onAction={onAction}
+                variant="inline"
+              />
             )}
           </div>
           <button

--- a/src/views/TimelineView.jsx
+++ b/src/views/TimelineView.jsx
@@ -28,8 +28,7 @@ import {
 import { useCalendarContext, resolveColor } from '../core/CalendarContext.js';
 import EmployeeActionCard from '../ui/EmployeeActionCard.jsx';
 import styles from './TimelineView.module.css';
-import { useGrouping } from '../hooks/useGrouping.js';
-import { buildFieldAccessor } from '../grouping/buildFieldAccessor.js';
+import { buildGroupTree } from '../hooks/useGrouping.ts';
 import { useTouchDnd } from '../hooks/useTouchDnd.js';
 
 // ─── Layout constants ─────────────────────────────────────────────────────────
@@ -317,14 +316,74 @@ export default function TimelineView({
   }, [useEmployees, employees, resourceList, events, monthStart.toISOString(), monthEnd.toISOString(), onCallCategory, totalDays]);
 
   // ── Grouping ───────────────────────────────────────────────────────────────
+  // Routes through the TS event-level engine (buildGroupTree). TimelineView
+  // rows are employees/resources, so we synthesize one pseudo-event per row
+  // carrying the row's source fields; the engine buckets by those fields and
+  // we walk the resulting tree to emit the legacy flatRows shape consumed by
+  // the render path below.
   const GROUP_HEADER_H = 36;
-  const fieldAccessor = useMemo(
-    () => groupBy ? buildFieldAccessor(groupBy, useEmployees ? 'employee' : 'resource') : null,
-    [groupBy, useEmployees],
+  const isGrouped = groupBy != null && (
+    (typeof groupBy === 'string' && groupBy.length > 0)
+    || (Array.isArray(groupBy) && groupBy.length > 0)
   );
-  const { flatRows, groupOrder, collapsedGroups, toggleGroup, isGrouped } = useGrouping(rows, {
-    groupBy, fieldAccessor, groupHeaderHeight: GROUP_HEADER_H,
-  });
+
+  const pseudoEvents = useMemo(() => {
+    if (!isGrouped) return [];
+    return rows.map(row => {
+      const base = useEmployees ? (row.emp || {}) : (row.events?.[0] || {});
+      return { ...base, meta: base.meta || {}, __row: row };
+    });
+  }, [isGrouped, rows, useEmployees]);
+
+  const groupTree = useMemo(() => {
+    if (!isGrouped) return [];
+    return buildGroupTree(pseudoEvents, groupBy);
+  }, [isGrouped, pseudoEvents, groupBy]);
+
+  const [collapsedGroups, setCollapsedGroups] = useState(() => new Set());
+  const toggleGroup = useCallback((path) => {
+    setCollapsedGroups(prev => {
+      const next = new Set(prev);
+      if (next.has(path)) next.delete(path);
+      else next.add(path);
+      return next;
+    });
+  }, []);
+
+  const { flatRows, groupOrder } = useMemo(() => {
+    if (!isGrouped || rows.length === 0 || groupTree.length === 0) {
+      return { flatRows: rows, groupOrder: [] };
+    }
+    const out = [];
+    const order = [];
+    const countLeaves = (node) => {
+      if (node.children.length === 0) return node.events.length;
+      let s = 0;
+      for (const c of node.children) s += countLeaves(c);
+      return s;
+    };
+    const walk = (nodes, parentPath) => {
+      for (const node of nodes) {
+        const path = parentPath ? `${parentPath}/${node.key}` : node.key;
+        order.push(path);
+        const collapsed = collapsedGroups.has(path);
+        out.push({
+          _type:      'groupHeader',
+          groupKey:   path,
+          groupLabel: node.label,
+          depth:      node.depth,
+          collapsed,
+          rowH:       GROUP_HEADER_H,
+          count:      countLeaves(node),
+        });
+        if (collapsed) continue;
+        if (node.children.length > 0) walk(node.children, path);
+        else for (const ev of node.events) out.push(ev.__row);
+      }
+    };
+    walk(groupTree, '');
+    return { flatRows: out, groupOrder: order };
+  }, [isGrouped, rows, groupTree, collapsedGroups]);
 
   // ── Cumulative row offsets (for absolute positioning + scroll math) ────────
   const rowOffsets = useMemo(() => {

--- a/src/views/__tests__/AssetsView.approvalActions.test.jsx
+++ b/src/views/__tests__/AssetsView.approvalActions.test.jsx
@@ -1,0 +1,171 @@
+// @vitest-environment happy-dom
+/**
+ * AssetsView — inline approval actions (ticket #134-15).
+ *
+ * Pills get a caret trigger when the owner has enabled approvals AND the
+ * current stage has declared `allow[]` actions AND `onApprovalAction` is
+ * wired. Clicking the caret opens an ApprovalActionMenu; clicking an item
+ * fires `onApprovalAction(event, action)`. Pill-click itself is unchanged
+ * (audit drawer for denied/pending_higher, otherwise edit).
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+
+import AssetsView from '../AssetsView.jsx';
+import { CalendarContext } from '../../core/CalendarContext.js';
+
+const currentDate = new Date(2026, 3, 1);
+
+const sampleEvents = [
+  {
+    id: 'ev-approved',
+    title: 'Training block',
+    start: new Date(2026, 3, 3),
+    end:   new Date(2026, 3, 5),
+    resource: 'N121AB',
+    category: 'training',
+    meta: { approvalStage: { stage: 'approved', updatedAt: '', history: [] } },
+  },
+  {
+    id: 'ev-requested',
+    title: 'PR flight',
+    start: new Date(2026, 3, 6),
+    end:   new Date(2026, 3, 9),
+    resource: 'N121AB',
+    category: 'pr',
+    meta: { approvalStage: { stage: 'requested', updatedAt: '', history: [] } },
+  },
+  {
+    id: 'ev-denied',
+    title: 'Maintenance (denied)',
+    start: new Date(2026, 3, 10),
+    end:   new Date(2026, 3, 13),
+    resource: 'N505CD',
+    category: 'maintenance',
+    meta: { approvalStage: { stage: 'denied', updatedAt: '', history: [] } },
+  },
+];
+
+const approvalsConfig = {
+  enabled: true,
+  rules: {
+    requested:      { allow: ['approve', 'deny'], prefix: 'Req' },
+    pending_higher: { allow: ['approve', 'deny'], prefix: 'Pend' },
+    approved:       { allow: ['finalize', 'revoke'], prefix: '' },
+    finalized:      { allow: ['revoke'], prefix: 'Final' },
+    denied:         { allow: ['revoke'], prefix: 'Denied' },
+  },
+  labels: {
+    approve:  'Approve',
+    deny:     'Reject',
+    finalize: 'Lock',
+    revoke:   'Undo',
+  },
+};
+
+function renderAssets(props = {}) {
+  return render(
+    <CalendarContext.Provider value={null}>
+      <AssetsView
+        currentDate={currentDate}
+        events={sampleEvents}
+        onEventClick={vi.fn()}
+        approvalsConfig={approvalsConfig}
+        onApprovalAction={props.onApprovalAction ?? vi.fn()}
+        {...props}
+      />
+    </CalendarContext.Provider>,
+  );
+}
+
+describe('AssetsView approval caret — visibility gating', () => {
+  it('renders a caret when the stage has allow[] and onApprovalAction is wired', () => {
+    renderAssets();
+    expect(
+      screen.getByRole('button', { name: 'Approval actions for PR flight' }),
+    ).toBeInTheDocument();
+  });
+
+  it('does NOT render a caret when onApprovalAction is omitted', () => {
+    renderAssets({ onApprovalAction: undefined });
+    expect(
+      screen.queryByRole('button', { name: /Approval actions for/ }),
+    ).not.toBeInTheDocument();
+  });
+
+  it('does NOT render a caret when approvals.enabled is false', () => {
+    renderAssets({ approvalsConfig: { ...approvalsConfig, enabled: false } });
+    expect(
+      screen.queryByRole('button', { name: /Approval actions for/ }),
+    ).not.toBeInTheDocument();
+  });
+
+  it('does NOT render a caret for a stage whose allow[] is empty', () => {
+    renderAssets({
+      approvalsConfig: {
+        ...approvalsConfig,
+        rules: {
+          ...approvalsConfig.rules,
+          denied: { allow: [], prefix: 'Denied' },
+        },
+      },
+    });
+    // 'denied' event: no caret.
+    expect(
+      screen.queryByRole('button', { name: 'Approval actions for Maintenance (denied)' }),
+    ).not.toBeInTheDocument();
+    // 'requested' + 'approved' events still show carets.
+    expect(
+      screen.getByRole('button', { name: 'Approval actions for PR flight' }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'Approval actions for Training block' }),
+    ).toBeInTheDocument();
+  });
+});
+
+describe('AssetsView approval caret — opens + fires action', () => {
+  it('clicking the caret opens the action menu with configured labels', () => {
+    renderAssets();
+    fireEvent.click(screen.getByRole('button', { name: 'Approval actions for PR flight' }));
+    const menu = screen.getByTestId('approval-action-menu');
+    expect(menu).toBeInTheDocument();
+    expect(screen.getByRole('menuitem', { name: 'Approve' })).toBeInTheDocument();
+    expect(screen.getByRole('menuitem', { name: 'Reject' })).toBeInTheDocument();
+  });
+
+  it('clicking a menu item fires onApprovalAction(event, actionId)', () => {
+    const onApprovalAction = vi.fn();
+    renderAssets({ onApprovalAction });
+    fireEvent.click(screen.getByRole('button', { name: 'Approval actions for PR flight' }));
+    fireEvent.click(screen.getByRole('menuitem', { name: 'Approve' }));
+    expect(onApprovalAction).toHaveBeenCalledTimes(1);
+    expect(onApprovalAction.mock.calls[0][0].id).toBe('ev-requested');
+    expect(onApprovalAction.mock.calls[0][1]).toBe('approve');
+  });
+
+  it('caret click does not fire the pill onEventClick (stopPropagation)', () => {
+    const onEventClick = vi.fn();
+    renderAssets({ onEventClick });
+    fireEvent.click(screen.getByRole('button', { name: 'Approval actions for PR flight' }));
+    expect(onEventClick).not.toHaveBeenCalled();
+  });
+
+  it('closes the menu after an action is taken', () => {
+    renderAssets();
+    fireEvent.click(screen.getByRole('button', { name: 'Approval actions for PR flight' }));
+    fireEvent.click(screen.getByRole('menuitem', { name: 'Approve' }));
+    expect(screen.queryByTestId('approval-action-menu')).not.toBeInTheDocument();
+  });
+
+  it('Escape closes the menu without firing an action', () => {
+    const onApprovalAction = vi.fn();
+    renderAssets({ onApprovalAction });
+    fireEvent.click(screen.getByRole('button', { name: 'Approval actions for PR flight' }));
+    expect(screen.getByTestId('approval-action-menu')).toBeInTheDocument();
+    fireEvent.keyDown(window, { key: 'Escape' });
+    expect(screen.queryByTestId('approval-action-menu')).not.toBeInTheDocument();
+    expect(onApprovalAction).not.toHaveBeenCalled();
+  });
+});

--- a/src/views/__tests__/AssetsView.assetsProp.test.jsx
+++ b/src/views/__tests__/AssetsView.assetsProp.test.jsx
@@ -1,0 +1,117 @@
+// @vitest-environment happy-dom
+/**
+ * AssetsView — first-class `assets` prop (ticket #134-9).
+ *
+ * When the owner has registered assets (via ConfigPanel → Assets tab, or the
+ * host app passes an `assets` prop), AssetsView renders one row per entry in
+ * declared order. Event.resource values that don't match any registry id
+ * fall into a trailing "(Unassigned)" row. When the registry is empty or
+ * absent the view preserves its legacy derived-from-events behavior.
+ */
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import '@testing-library/jest-dom';
+import React from 'react';
+
+import AssetsView from '../AssetsView.jsx';
+import { CalendarContext } from '../../core/CalendarContext.js';
+
+const currentDate = new Date(2026, 3, 1); // April 2026
+const evOn = (day) => new Date(2026, 3, day);
+
+function renderView(props = {}) {
+  return render(
+    <CalendarContext.Provider value={null}>
+      <AssetsView
+        currentDate={currentDate}
+        events={[]}
+        onEventClick={vi.fn()}
+        {...props}
+      />
+    </CalendarContext.Provider>,
+  );
+}
+
+describe('AssetsView — assets registry prop', () => {
+  it('renders one row per registry entry in declared order', () => {
+    renderView({
+      assets: [
+        { id: 'n100aa', label: 'N100AA', meta: {} },
+        { id: 'n200bb', label: 'N200BB', meta: {} },
+        { id: 'n300cc', label: 'N300CC', meta: {} },
+      ],
+      events: [],
+    });
+    const rowheaders = screen.getAllByRole('rowheader');
+    const labels = rowheaders.map(el => el.getAttribute('aria-label'));
+    expect(labels).toEqual(['N100AA', 'N200BB', 'N300CC']);
+  });
+
+  it('uses the registry label, not the id, for the rowheader', () => {
+    renderView({
+      assets: [{ id: 'emp-sarah', label: 'Sarah Chen', meta: {} }],
+      events: [],
+    });
+    expect(screen.getByRole('rowheader', { name: 'Sarah Chen' })).toBeInTheDocument();
+  });
+
+  it('shows registry meta.sublabel when no event provides one', () => {
+    renderView({
+      assets: [{ id: 'n100aa', label: 'N100AA', meta: { sublabel: 'CJ3' } }],
+      events: [],
+    });
+    expect(screen.getByText('CJ3')).toBeInTheDocument();
+  });
+
+  it('adds a trailing (Unassigned) row when events reference unknown resources', () => {
+    renderView({
+      assets: [{ id: 'n100aa', label: 'N100AA', meta: {} }],
+      events: [
+        {
+          id: 'orphan',
+          title: 'Unknown flight',
+          start: evOn(3),
+          end: evOn(4),
+          resource: 'mystery-asset',
+        },
+      ],
+    });
+    const rowheaders = screen.getAllByRole('rowheader');
+    const labels = rowheaders.map(el => el.getAttribute('aria-label'));
+    expect(labels).toEqual(['N100AA', '(Unassigned)']);
+  });
+
+  it('does NOT add (Unassigned) when every event matches a registered id', () => {
+    renderView({
+      assets: [{ id: 'n100aa', label: 'N100AA', meta: {} }],
+      events: [
+        { id: 'e1', title: 'flight', start: evOn(3), end: evOn(4), resource: 'n100aa' },
+      ],
+    });
+    const rowheaders = screen.getAllByRole('rowheader');
+    expect(rowheaders).toHaveLength(1);
+    expect(rowheaders[0].getAttribute('aria-label')).toBe('N100AA');
+  });
+
+  it('falls back to event.resource-derived rows when the registry is absent', () => {
+    renderView({
+      events: [
+        { id: 'e1', title: 'a', start: evOn(3), end: evOn(4), resource: 'N999ZZ' },
+        { id: 'e2', title: 'b', start: evOn(5), end: evOn(6), resource: 'N100AA' },
+      ],
+    });
+    // Legacy behavior: alphabetical order, id rendered as the label.
+    const labels = screen.getAllByRole('rowheader').map(el => el.getAttribute('aria-label'));
+    expect(labels).toEqual(['N100AA', 'N999ZZ']);
+  });
+
+  it('falls back to legacy behavior when the registry is empty []', () => {
+    renderView({
+      assets: [],
+      events: [
+        { id: 'e1', title: 'a', start: evOn(3), end: evOn(4), resource: 'N500XX' },
+      ],
+    });
+    expect(screen.getByRole('rowheader', { name: 'N500XX' })).toBeInTheDocument();
+  });
+});

--- a/src/views/__tests__/AssetsView.grouping.test.jsx
+++ b/src/views/__tests__/AssetsView.grouping.test.jsx
@@ -1,0 +1,203 @@
+/**
+ * AssetsView — grouping behaviour under the TS engine (ticket #134-1).
+ *
+ * Covers 1- and 2-level trees, collapse/expand, aria parity with AgendaView
+ * (treeitem + aria-level + aria-expanded), and the render-prop controlled
+ * collapsedGroups round-trip that ticket #134-2 relies on.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent, within } from '@testing-library/react';
+import React, { useState } from 'react';
+import AssetsView from '../AssetsView.jsx';
+import { CalendarContext } from '../../core/CalendarContext.js';
+
+const currentDate = new Date(2026, 3, 1); // April 2026
+
+const evOn = (day) => new Date(2026, 3, day);
+
+const events = [
+  {
+    id: 'e1', title: 'Training', category: 'training',
+    start: evOn(3), end: evOn(4),
+    resource: 'N100AA',
+    meta: { region: 'West',    sublabel: 'CJ3' },
+  },
+  {
+    id: 'e2', title: 'Maintenance', category: 'maintenance',
+    start: evOn(6), end: evOn(7),
+    resource: 'N100AA',
+    meta: { region: 'West',    sublabel: 'CJ3' },
+  },
+  {
+    id: 'e3', title: 'PR flight', category: 'pr',
+    start: evOn(8), end: evOn(9),
+    resource: 'N200BB',
+    meta: { region: 'East',    sublabel: 'PC-24' },
+  },
+  {
+    id: 'e4', title: 'Training', category: 'training',
+    start: evOn(10), end: evOn(11),
+    resource: 'N300CC',
+    meta: { region: 'East',    sublabel: 'King Air' },
+  },
+];
+
+function renderAssets(props = {}) {
+  return render(
+    <CalendarContext.Provider value={null}>
+      <AssetsView
+        currentDate={currentDate}
+        events={events}
+        onEventClick={vi.fn()}
+        {...props}
+      />
+    </CalendarContext.Provider>,
+  );
+}
+
+describe('AssetsView grouping — 1-level tree', () => {
+  it('renders a GroupHeader treeitem per group value', () => {
+    renderAssets({ groupBy: 'region' });
+    const items = screen.getAllByRole('treeitem');
+    const labels = items.map(i => i.getAttribute('aria-label'));
+    expect(labels.some(l => l?.startsWith('region: East'))).toBe(true);
+    expect(labels.some(l => l?.startsWith('region: West'))).toBe(true);
+  });
+
+  it('headers are depth-0 and report event counts via aria-label', () => {
+    renderAssets({ groupBy: 'region' });
+    const items = screen.getAllByRole('treeitem');
+    for (const item of items) {
+      expect(item.getAttribute('aria-level')).toBe('1');
+    }
+    const west = items.find(i => i.getAttribute('aria-label')?.startsWith('region: West'));
+    // West has 2 events (training + maintenance on N100AA)
+    expect(west?.getAttribute('aria-label')).toMatch(/2 events/);
+    const east = items.find(i => i.getAttribute('aria-label')?.startsWith('region: East'));
+    // East has 2 events (PR on N200BB + training on N300CC)
+    expect(east?.getAttribute('aria-label')).toMatch(/2 events/);
+  });
+
+  it('renders one asset rowheader per resource with events in the group', () => {
+    renderAssets({ groupBy: 'region' });
+    expect(screen.getByRole('rowheader', { name: 'N100AA' })).toBeInTheDocument();
+    expect(screen.getByRole('rowheader', { name: 'N200BB' })).toBeInTheDocument();
+    expect(screen.getByRole('rowheader', { name: 'N300CC' })).toBeInTheDocument();
+  });
+
+  it('clicking a group header toggles collapse state', () => {
+    renderAssets({ groupBy: 'region' });
+    const west = screen.getAllByRole('treeitem').find(
+      i => i.getAttribute('aria-label')?.startsWith('region: West'),
+    );
+    expect(west).toHaveAttribute('aria-expanded', 'true');
+    expect(screen.getByRole('rowheader', { name: 'N100AA' })).toBeInTheDocument();
+
+    fireEvent.click(west);
+    expect(west).toHaveAttribute('aria-expanded', 'false');
+    // N100AA lives under West — hidden after collapse.
+    expect(screen.queryByRole('rowheader', { name: 'N100AA' })).not.toBeInTheDocument();
+    // East side unaffected.
+    expect(screen.getByRole('rowheader', { name: 'N200BB' })).toBeInTheDocument();
+    expect(screen.getByRole('rowheader', { name: 'N300CC' })).toBeInTheDocument();
+  });
+
+  it('renders no treeitem headers when groupBy is unset', () => {
+    renderAssets();
+    expect(screen.queryByRole('treeitem')).not.toBeInTheDocument();
+    expect(screen.getByRole('rowheader', { name: 'N100AA' })).toBeInTheDocument();
+    expect(screen.getByRole('rowheader', { name: 'N200BB' })).toBeInTheDocument();
+  });
+});
+
+describe('AssetsView grouping — 2-level tree', () => {
+  it('nests depth-1 treeitems beneath depth-0 parents', () => {
+    renderAssets({ groupBy: ['region', 'category'] });
+    const top = screen.getAllByRole('treeitem').filter(
+      i => i.getAttribute('aria-level') === '1',
+    );
+    expect(top.length).toBe(2); // East, West
+    const nested = screen.getAllByRole('treeitem').filter(
+      i => i.getAttribute('aria-level') === '2',
+    );
+    // East has pr + training; West has training + maintenance → 4 total
+    expect(nested.length).toBe(4);
+  });
+
+  it('collapsing a parent hides its nested headers and asset rows', () => {
+    renderAssets({ groupBy: ['region', 'category'] });
+    const west = screen.getAllByRole('treeitem').find(
+      i => i.getAttribute('aria-label')?.startsWith('region: West')
+        && i.getAttribute('aria-level') === '1',
+    );
+    fireEvent.click(west);
+    // Nested training/maintenance under West are gone.
+    const remaining = screen.getAllByRole('treeitem').filter(
+      i => i.getAttribute('aria-level') === '2',
+    );
+    // Only East's two nested headers remain.
+    expect(remaining.length).toBe(2);
+    // East still has its assets.
+    expect(screen.getByRole('rowheader', { name: 'N200BB' })).toBeInTheDocument();
+  });
+
+  it('an asset appearing under two leaf groups is rendered once per group', () => {
+    renderAssets({ groupBy: ['region', 'category'] });
+    // N100AA has events in both `training` and `maintenance` under West →
+    // it should surface under both nested buckets.
+    const rowheaders = screen.getAllByRole('rowheader', { name: 'N100AA' });
+    expect(rowheaders.length).toBe(2);
+  });
+});
+
+describe('AssetsView grouping — controlled collapsedGroups', () => {
+  function Controlled(props) {
+    const [collapsed, setCollapsed] = useState(() => new Set());
+    return (
+      <CalendarContext.Provider value={null}>
+        <AssetsView
+          currentDate={currentDate}
+          events={events}
+          onEventClick={vi.fn()}
+          groupBy="region"
+          collapsedGroups={collapsed}
+          onCollapsedGroupsChange={setCollapsed}
+          {...props}
+        />
+      </CalendarContext.Provider>
+    );
+  }
+
+  it('round-trips toggle state through the onCollapsedGroupsChange callback', () => {
+    render(<Controlled />);
+    const west = screen.getAllByRole('treeitem').find(
+      i => i.getAttribute('aria-label')?.startsWith('region: West'),
+    );
+    expect(west).toHaveAttribute('aria-expanded', 'true');
+    fireEvent.click(west);
+    expect(west).toHaveAttribute('aria-expanded', 'false');
+    // Re-expand
+    fireEvent.click(west);
+    expect(west).toHaveAttribute('aria-expanded', 'true');
+  });
+
+  it('honours an initial collapsed prop value', () => {
+    render(
+      <CalendarContext.Provider value={null}>
+        <AssetsView
+          currentDate={currentDate}
+          events={events}
+          onEventClick={vi.fn()}
+          groupBy="region"
+          collapsedGroups={['West']}
+          onCollapsedGroupsChange={vi.fn()}
+        />
+      </CalendarContext.Provider>,
+    );
+    const west = screen.getAllByRole('treeitem').find(
+      i => i.getAttribute('aria-label')?.startsWith('region: West'),
+    );
+    expect(west).toHaveAttribute('aria-expanded', 'false');
+    expect(screen.queryByRole('rowheader', { name: 'N100AA' })).not.toBeInTheDocument();
+  });
+});

--- a/src/views/__tests__/AssetsView.keyboardNav.test.jsx
+++ b/src/views/__tests__/AssetsView.keyboardNav.test.jsx
@@ -1,0 +1,129 @@
+// @vitest-environment happy-dom
+/**
+ * AssetsView — cross-group keyboard navigation (ticket #134-4).
+ *
+ * Under the TS engine's tree layout a user now navigates through a mix of
+ * GroupHeader rows and data-cell rows. Arrow keys must:
+ *   ↑ / ↓  — step across both kinds of rows without skipping headers,
+ *   ← / →  — on a header, collapse / expand the group,
+ *   →      — on an already-expanded header, descend to the first child,
+ *   ←      — on an already-collapsed header, stay put (tree root has no
+ *            meaningful "move to parent" target here).
+ *
+ * These specs exercise the contract end-to-end: they render AssetsView with a
+ * 1-level tree, focus a starting point, press arrow keys, and assert the new
+ * focused element (or the collapse state after the key).
+ */
+import { render, screen, fireEvent, act } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import '@testing-library/jest-dom';
+import React from 'react';
+
+import AssetsView from '../AssetsView.jsx';
+import { CalendarContext } from '../../core/CalendarContext.js';
+
+const currentDate = new Date(2026, 3, 1);
+const evOn = (day) => new Date(2026, 3, day);
+
+const events = [
+  { id: 'e1', title: 'T1', start: evOn(3),  end: evOn(3),  resource: 'N100', meta: { region: 'West' } },
+  { id: 'e2', title: 'T2', start: evOn(5),  end: evOn(5),  resource: 'N200', meta: { region: 'East' } },
+];
+
+function renderView(props = {}) {
+  return render(
+    <CalendarContext.Provider value={null}>
+      <AssetsView
+        currentDate={currentDate}
+        events={events}
+        onEventClick={vi.fn()}
+        groupBy="region"
+        {...props}
+      />
+    </CalendarContext.Provider>,
+  );
+}
+
+describe('AssetsView keyboard — header focus + arrow key contract', () => {
+  it('ArrowDown from a group header focuses the first data cell in the group', () => {
+    renderView();
+    // Two headers ("region: East", "region: West") + their data rows.
+    const headers = screen.getAllByRole('treeitem');
+    // Focus the first header and press ArrowDown.
+    headers[0].focus();
+    fireEvent.keyDown(headers[0], { key: 'ArrowDown' });
+    // Focus should have moved onto a gridcell in the row immediately below.
+    const active = document.activeElement;
+    expect(active?.getAttribute('role')).toBe('gridcell');
+  });
+
+  it('ArrowUp from a data cell in the first data row focuses the preceding header', () => {
+    renderView();
+    const headers = screen.getAllByRole('treeitem');
+    const firstHeaderId = headers[0].getAttribute('id');
+    // Find a gridcell whose row is right after the first header. The
+    // rowheader in that row has data-resource; its sibling cells are the
+    // day columns. We pick the first day cell (data-cell ends in "-0").
+    const firstDataCell = document.querySelector('[data-cell$="-0"]');
+    expect(firstDataCell).toBeTruthy();
+    firstDataCell.focus();
+    fireEvent.keyDown(firstDataCell, { key: 'ArrowUp' });
+    expect(document.activeElement?.id).toBe(firstHeaderId);
+  });
+
+  it('ArrowLeft on an expanded header collapses that group', () => {
+    renderView();
+    const header = screen.getAllByRole('treeitem')[0];
+    expect(header.getAttribute('aria-expanded')).toBe('true');
+    header.focus();
+    fireEvent.keyDown(header, { key: 'ArrowLeft' });
+    // Same text but now collapsed (headers re-render with same ARIA label).
+    const refreshed = screen.getAllByRole('treeitem')[0];
+    expect(refreshed.getAttribute('aria-expanded')).toBe('false');
+  });
+
+  it('ArrowRight on a collapsed header expands it', () => {
+    renderView();
+    const header = screen.getAllByRole('treeitem')[0];
+    fireEvent.keyDown(header, { key: 'ArrowLeft' }); // collapse first
+    expect(screen.getAllByRole('treeitem')[0].getAttribute('aria-expanded')).toBe('false');
+    fireEvent.keyDown(screen.getAllByRole('treeitem')[0], { key: 'ArrowRight' });
+    expect(screen.getAllByRole('treeitem')[0].getAttribute('aria-expanded')).toBe('true');
+  });
+
+  it('ArrowRight on an already-expanded header descends to the first child', () => {
+    renderView();
+    const header = screen.getAllByRole('treeitem')[0];
+    expect(header.getAttribute('aria-expanded')).toBe('true');
+    header.focus();
+    fireEvent.keyDown(header, { key: 'ArrowRight' });
+    expect(document.activeElement?.getAttribute('role')).toBe('gridcell');
+  });
+
+  it('ArrowLeft on an already-collapsed header is a no-op (focus stays)', () => {
+    renderView();
+    const header = screen.getAllByRole('treeitem')[0];
+    fireEvent.keyDown(header, { key: 'ArrowLeft' }); // first collapse
+    const collapsed = screen.getAllByRole('treeitem')[0];
+    collapsed.focus();
+    fireEvent.keyDown(collapsed, { key: 'ArrowLeft' });
+    // Still collapsed; focus still on the header.
+    const after = screen.getAllByRole('treeitem')[0];
+    expect(after.getAttribute('aria-expanded')).toBe('false');
+    expect(document.activeElement?.id).toBe(collapsed.getAttribute('id'));
+  });
+
+  it('ArrowDown steps through consecutive headers when they are adjacent (empty groups collapsed)', () => {
+    renderView();
+    // Collapse first header so Row 0 (header) is followed directly by Row 1
+    // (the next header).
+    const headers = screen.getAllByRole('treeitem');
+    fireEvent.keyDown(headers[0], { key: 'ArrowLeft' });
+    const refreshed = screen.getAllByRole('treeitem');
+    refreshed[0].focus();
+    fireEvent.keyDown(refreshed[0], { key: 'ArrowDown' });
+    // Focus should move to the second header (treeitem), not a gridcell.
+    expect(document.activeElement?.getAttribute('role')).toBe('treeitem');
+    expect(document.activeElement).toBe(refreshed[1]);
+  });
+});

--- a/src/views/__tests__/AssetsView.test.jsx
+++ b/src/views/__tests__/AssetsView.test.jsx
@@ -199,14 +199,16 @@ describe('AssetsView — category hue', () => {
 });
 
 describe('AssetsView — grouping', () => {
-  it('renders group headers when groupBy is set', () => {
+  it('renders GroupHeader treeitems when groupBy is set', () => {
     renderAssets({ groupBy: 'category' });
-    expect(screen.getByRole('button', { name: /Collapse group training/i })).toBeInTheDocument();
+    const items = screen.getAllByRole('treeitem');
+    const labels = items.map(i => i.getAttribute('aria-label'));
+    expect(labels.some(l => l?.startsWith('category: training'))).toBe(true);
   });
 
   it('renders no group headers when groupBy is undefined', () => {
     renderAssets();
-    expect(screen.queryByRole('button', { name: /Collapse group/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole('treeitem')).not.toBeInTheDocument();
   });
 });
 

--- a/src/views/__tests__/AssetsView.toolbar.test.jsx
+++ b/src/views/__tests__/AssetsView.toolbar.test.jsx
@@ -1,0 +1,196 @@
+// @vitest-environment happy-dom
+/**
+ * AssetsView — on-page toolbar (ticket #134-10).
+ *
+ * The toolbar surfaces three controls without a ConfigPanel detour:
+ *   - "Group by" dropdown (asset fields + meta.* keys harvested from the
+ *     registry, plus "None"),
+ *   - "Sort by" dropdown (Registry order / Label / Group / Last event date),
+ *   - "Edit assets" button that deep-links to ConfigPanel's Assets tab.
+ *
+ * The toolbar only renders when there's something to control — either a
+ * registry is present (so Group/Sort make sense) or an onEditAssets callback
+ * was wired (so owners can jump to the registry). The legacy derived-row
+ * fallback keeps its minimal chrome.
+ */
+import { render, screen, fireEvent, within } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import '@testing-library/jest-dom';
+import React from 'react';
+
+import AssetsView from '../AssetsView.jsx';
+import { CalendarContext } from '../../core/CalendarContext.js';
+
+const currentDate = new Date(2026, 3, 1); // April 2026
+const evOn = (day) => new Date(2026, 3, day);
+
+function renderView(props = {}) {
+  return render(
+    <CalendarContext.Provider value={null}>
+      <AssetsView
+        currentDate={currentDate}
+        events={[]}
+        onEventClick={vi.fn()}
+        {...props}
+      />
+    </CalendarContext.Provider>,
+  );
+}
+
+describe('AssetsView toolbar — visibility', () => {
+  it('does not render the toolbar when no registry and no onEditAssets', () => {
+    renderView({
+      events: [{ id: 'e1', title: 'a', start: evOn(3), end: evOn(4), resource: 'X' }],
+    });
+    expect(screen.queryByRole('toolbar', { name: /Assets view controls/ })).not.toBeInTheDocument();
+  });
+
+  it('renders the toolbar when assets registry is provided', () => {
+    renderView({
+      assets: [{ id: 'a', label: 'Alpha', meta: {} }],
+      events: [],
+    });
+    expect(screen.getByRole('toolbar', { name: /Assets view controls/ })).toBeInTheDocument();
+  });
+
+  it('renders the toolbar when onEditAssets is provided even without a registry', () => {
+    renderView({ events: [], onEditAssets: vi.fn() });
+    expect(screen.getByRole('toolbar', { name: /Assets view controls/ })).toBeInTheDocument();
+  });
+});
+
+describe('AssetsView toolbar — Group by', () => {
+  it('includes "None", "Group", and one entry per distinct meta.* key', () => {
+    renderView({
+      assets: [
+        { id: 'a1', label: 'A1', meta: { sublabel: 'CJ3', region: 'W' } },
+        { id: 'a2', label: 'A2', meta: { sublabel: 'G5' } },
+      ],
+      events: [],
+    });
+    const select = screen.getByLabelText('Group by');
+    const values = within(select).getAllByRole('option').map(o => o.getAttribute('value'));
+    expect(values).toEqual(['', 'group', 'meta.region', 'meta.sublabel']);
+  });
+
+  it('calls onGroupByChange(null) when "None" is selected', () => {
+    const onGroupByChange = vi.fn();
+    renderView({
+      assets: [{ id: 'a', label: 'A', meta: {} }],
+      events: [],
+      groupBy: 'group',
+      onGroupByChange,
+    });
+    const select = screen.getByLabelText('Group by');
+    fireEvent.change(select, { target: { value: '' } });
+    expect(onGroupByChange).toHaveBeenCalledWith(null);
+  });
+
+  it('calls onGroupByChange("meta.region") when a meta option is chosen', () => {
+    const onGroupByChange = vi.fn();
+    renderView({
+      assets: [{ id: 'a', label: 'A', meta: { region: 'W' } }],
+      events: [],
+      onGroupByChange,
+    });
+    fireEvent.change(screen.getByLabelText('Group by'), { target: { value: 'meta.region' } });
+    expect(onGroupByChange).toHaveBeenCalledWith('meta.region');
+  });
+
+  it('reflects the current groupBy string as the selected value', () => {
+    renderView({
+      assets: [{ id: 'a', label: 'A', meta: { sublabel: 'x' } }],
+      events: [],
+      groupBy: 'meta.sublabel',
+      onGroupByChange: vi.fn(),
+    });
+    expect(screen.getByLabelText('Group by')).toHaveValue('meta.sublabel');
+  });
+
+  it('disables the Group by select when onGroupByChange is absent', () => {
+    renderView({
+      assets: [{ id: 'a', label: 'A', meta: {} }],
+      events: [],
+    });
+    expect(screen.getByLabelText('Group by')).toBeDisabled();
+  });
+});
+
+describe('AssetsView toolbar — Sort by', () => {
+  const assets = [
+    { id: 'c', label: 'Charlie', group: 'East', meta: {} },
+    { id: 'a', label: 'Alpha',   group: 'West', meta: {} },
+    { id: 'b', label: 'Bravo',   group: 'East', meta: {} },
+  ];
+
+  it('defaults to Registry order (declared order preserved)', () => {
+    renderView({ assets, events: [] });
+    const labels = screen.getAllByRole('rowheader').map(el => el.getAttribute('aria-label'));
+    expect(labels).toEqual(['Charlie', 'Alpha', 'Bravo']);
+  });
+
+  it('Label sort reorders rows alphabetically by display label', () => {
+    renderView({ assets, events: [] });
+    fireEvent.change(screen.getByLabelText('Sort by'), { target: { value: 'label' } });
+    const labels = screen.getAllByRole('rowheader').map(el => el.getAttribute('aria-label'));
+    expect(labels).toEqual(['Alpha', 'Bravo', 'Charlie']);
+  });
+
+  it('Group sort clusters by group then label within group', () => {
+    renderView({ assets, events: [] });
+    fireEvent.change(screen.getByLabelText('Sort by'), { target: { value: 'group' } });
+    const labels = screen.getAllByRole('rowheader').map(el => el.getAttribute('aria-label'));
+    // East: Bravo, Charlie; West: Alpha
+    expect(labels).toEqual(['Bravo', 'Charlie', 'Alpha']);
+  });
+
+  it('Last event date sort orders by most recent event end descending', () => {
+    renderView({
+      assets,
+      events: [
+        { id: 'e1', title: '1', start: evOn(3), end: evOn(3), resource: 'a' },
+        { id: 'e2', title: '2', start: evOn(10), end: evOn(10), resource: 'b' },
+        { id: 'e3', title: '3', start: evOn(20), end: evOn(20), resource: 'c' },
+      ],
+    });
+    fireEvent.change(screen.getByLabelText('Sort by'), { target: { value: 'lastEvent' } });
+    const labels = screen.getAllByRole('rowheader').map(el => el.getAttribute('aria-label'));
+    expect(labels).toEqual(['Charlie', 'Bravo', 'Alpha']);
+  });
+
+  it('disables Sort by when no registry is present', () => {
+    renderView({ events: [], onEditAssets: vi.fn() });
+    expect(screen.getByLabelText('Sort by')).toBeDisabled();
+  });
+});
+
+describe('AssetsView toolbar — Edit assets', () => {
+  it('renders the Edit assets button when onEditAssets is provided', () => {
+    const onEditAssets = vi.fn();
+    renderView({
+      assets: [{ id: 'a', label: 'A', meta: {} }],
+      events: [],
+      onEditAssets,
+    });
+    expect(screen.getByRole('button', { name: 'Edit assets' })).toBeInTheDocument();
+  });
+
+  it('fires the callback on click', () => {
+    const onEditAssets = vi.fn();
+    renderView({
+      assets: [{ id: 'a', label: 'A', meta: {} }],
+      events: [],
+      onEditAssets,
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Edit assets' }));
+    expect(onEditAssets).toHaveBeenCalledTimes(1);
+  });
+
+  it('hides the button when onEditAssets is absent', () => {
+    renderView({
+      assets: [{ id: 'a', label: 'A', meta: {} }],
+      events: [],
+    });
+    expect(screen.queryByRole('button', { name: 'Edit assets' })).not.toBeInTheDocument();
+  });
+});

--- a/src/views/__tests__/AuditDrawer.test.jsx
+++ b/src/views/__tests__/AuditDrawer.test.jsx
@@ -104,3 +104,66 @@ describe('AuditDrawer — close behaviour', () => {
     expect(onClose).not.toHaveBeenCalled();
   });
 });
+
+/**
+ * Inline approval actions (ticket #134-15): the drawer hosts the same
+ * ApprovalActionMenu as the pill caret, driven by config.approvals.rules.
+ */
+describe('AuditDrawer — inline approval actions', () => {
+  const approvalsConfig = {
+    enabled: true,
+    rules: {
+      denied: { allow: ['revoke'], prefix: 'Denied' },
+    },
+    labels: { revoke: 'Undo' },
+  };
+
+  it('renders action buttons when approvalsConfig + onAction are wired', () => {
+    render(
+      <AuditDrawer
+        event={deniedEvent}
+        onClose={vi.fn()}
+        approvalsConfig={approvalsConfig}
+        onAction={vi.fn()}
+      />,
+    );
+    expect(screen.getByRole('menuitem', { name: 'Undo' })).toBeInTheDocument();
+  });
+
+  it('omits actions when approvals.enabled=false', () => {
+    render(
+      <AuditDrawer
+        event={deniedEvent}
+        onClose={vi.fn()}
+        approvalsConfig={{ ...approvalsConfig, enabled: false }}
+        onAction={vi.fn()}
+      />,
+    );
+    expect(screen.queryByRole('menuitem')).not.toBeInTheDocument();
+  });
+
+  it('omits actions when onAction is missing', () => {
+    render(
+      <AuditDrawer
+        event={deniedEvent}
+        onClose={vi.fn()}
+        approvalsConfig={approvalsConfig}
+      />,
+    );
+    expect(screen.queryByRole('menuitem')).not.toBeInTheDocument();
+  });
+
+  it('clicking an action fires onAction with the action id', () => {
+    const onAction = vi.fn();
+    render(
+      <AuditDrawer
+        event={deniedEvent}
+        onClose={vi.fn()}
+        approvalsConfig={approvalsConfig}
+        onAction={onAction}
+      />,
+    );
+    fireEvent.click(screen.getByRole('menuitem', { name: 'Undo' }));
+    expect(onAction).toHaveBeenCalledWith('revoke');
+  });
+});

--- a/tests-e2e/calendar.assets-grouping.spec.ts
+++ b/tests-e2e/calendar.assets-grouping.spec.ts
@@ -69,8 +69,10 @@ test.describe('WorksCalendar Assets view', () => {
     await page.reload();
     await expect(page.getByTestId('works-calendar')).toBeVisible();
 
-    // ProfileBar chip for our seeded view should be visible.
-    const chip = page.getByRole('button', { name: /^Assets Day Zoom$/ });
+    // ProfileBar chip for our seeded view should be visible. The chip's
+    // accessible name is just the view.name — the 3-letter viewTag span is
+    // marked aria-hidden since it's a visual affordance, not content.
+    const chip = page.getByRole('button', { name: 'Assets Day Zoom' });
     await expect(chip).toBeVisible();
     await chip.click();
 

--- a/tests-e2e/calendar.assets-grouping.spec.ts
+++ b/tests-e2e/calendar.assets-grouping.spec.ts
@@ -1,0 +1,85 @@
+/**
+ * AssetsView — grouping + saved-view round-trip E2E (ticket #134-6).
+ *
+ * The demo loads with the schedule view; we flip to Assets, verify the
+ * grid paints its core affordances (rowheaders, zoom control), then drive
+ * a saved-view round-trip by seeding localStorage with a pinned Assets
+ * profile and clicking its chip. The round-trip spec is the one that
+ * ties ticket #134-2 (persist zoomLevel + collapsedGroups) back to the
+ * user-facing flow.
+ */
+import { test, expect } from '@playwright/test';
+
+const DEMO_CALENDAR_ID = 'ihc-oncall-demo';
+const SAVED_VIEWS_KEY = `wc-saved-views-${DEMO_CALENDAR_ID}`;
+
+test.describe('WorksCalendar Assets view', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.setViewportSize({ width: 1400, height: 900 });
+    await page.goto('/');
+    await expect(page.getByTestId('works-calendar')).toBeVisible();
+  });
+
+  test('renders the Assets grid with rowheaders and the zoom control', async ({ page }) => {
+    await page.getByRole('button', { name: /^Assets$/ }).click();
+    // The grid's aria-label includes "Assets timeline for <month>".
+    await expect(page.getByRole('grid', { name: /Assets timeline for / })).toBeVisible();
+    // At least one rowheader (employee resource) should be present.
+    const rowheaders = page.getByRole('rowheader');
+    await expect(rowheaders.first()).toBeVisible();
+    // Zoom control group with its four buttons.
+    await expect(page.getByRole('group', { name: /Zoom level/ })).toBeVisible();
+    await expect(page.getByRole('button', { name: /Zoom to Day/ })).toBeVisible();
+  });
+
+  test('clicking a zoom button toggles aria-pressed on the new zoom', async ({ page }) => {
+    await page.getByRole('button', { name: /^Assets$/ }).click();
+    const monthBtn = page.getByRole('button', { name: /Zoom to Month/ });
+    const dayBtn   = page.getByRole('button', { name: /Zoom to Day/ });
+    // Default zoom is month per AssetsView.
+    await expect(monthBtn).toHaveAttribute('aria-pressed', 'true');
+    await dayBtn.click();
+    await expect(dayBtn).toHaveAttribute('aria-pressed', 'true');
+    await expect(monthBtn).toHaveAttribute('aria-pressed', 'false');
+  });
+
+  test('saved view round-trip restores zoomLevel when its chip is applied', async ({ page }) => {
+    // Seed a saved view pinned to the Assets view with zoomLevel=day.
+    await page.evaluate(({ key }) => {
+      window.localStorage.setItem(key, JSON.stringify({
+        version: 3,
+        views: [
+          {
+            id: 'sv-assets-day',
+            name: 'Assets Day Zoom',
+            color: '#10b981',
+            filters: { categories: [], resources: [], search: '' },
+            view: 'assets',
+            groupBy: null,
+            sort: null,
+            showAllGroups: null,
+            zoomLevel: 'day',
+            collapsedGroups: [],
+            conditions: null,
+          },
+        ],
+      }));
+    }, { key: SAVED_VIEWS_KEY });
+
+    await page.reload();
+    await expect(page.getByTestId('works-calendar')).toBeVisible();
+
+    // ProfileBar chip for our seeded view should be visible.
+    const chip = page.getByRole('button', { name: /^Assets Day Zoom$/ });
+    await expect(chip).toBeVisible();
+    await chip.click();
+
+    // Applying the saved view switches to the Assets grid.
+    await expect(page.getByRole('grid', { name: /Assets timeline for / })).toBeVisible();
+    // And the pinned zoomLevel ('day') should be active.
+    await expect(page.getByRole('button', { name: /Zoom to Day/ })).toHaveAttribute(
+      'aria-pressed',
+      'true',
+    );
+  });
+});


### PR DESCRIPTION
Replaces the legacy row-based useGrouping/buildFieldAccessor with the TS
engine's buildGroupTree, walking the tree to emit virtualization-friendly
flatRows of {groupHeader, assetRow}. Group headers now use the shared
<GroupHeader> component so AssetsView has aria parity with AgendaView
(role=treeitem, aria-level, aria-expanded, aria-setsize/posinset,
aria-label=\"field: label, N events\"). Multi-level (2-deep) is supported
and an asset surfaces under each leaf group its events land in.

Adds controlled collapsedGroups + onCollapsedGroupsChange props so the
calendar can round-trip collapse state through saved views (ticket 2).

Ticket #134-1.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features

* **Assets View enhancements**: Configurable registry with toolbar-driven grouping, sorting, and zoom controls; keyboard navigation support.
* **Approval workflow system**: New approval actions, stages, and tiers with owner-configurable policies and action menus.
* **Conflict detection**: Scheduling conflict engine with hard/soft rules, overlap detection, and category restrictions.
* **Request form**: Schema-driven form for proposing new events with customizable fields.
* **Extended ConfigPanel**: New tabs for managing assets, approvals, conflicts, and request forms.
* **Saved view persistence**: Zoom level and collapsed group states now preserved across sessions.

## Tests

* Comprehensive integration and unit test coverage for approval workflows, conflict detection, grouping, and request forms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->