### PR TITLE
Self-heal stale PWA cache on demo boot

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -38,6 +38,34 @@
 </head>
 <body>
   <div id="root"></div>
+  <script>
+    // Self-heal for stale PWA cache. On iOS Safari and other browsers, an
+    // old service worker can keep serving a cached index.html that points
+    // at JS hashes no longer on the origin, producing a blank page. If the
+    // React root hasn't mounted within 8s, unregister SWs + clear caches
+    // and reload exactly once (guarded by sessionStorage).
+    (function () {
+      var KEY = 'wc-sw-recovered';
+      if (sessionStorage.getItem(KEY)) return;
+      setTimeout(function () {
+        var root = document.getElementById('root');
+        if (root && root.childElementCount > 0) return;
+        sessionStorage.setItem(KEY, '1');
+        var steps = [];
+        if (navigator.serviceWorker && navigator.serviceWorker.getRegistrations) {
+          steps.push(navigator.serviceWorker.getRegistrations()
+            .then(function (rs) { return Promise.all(rs.map(function (r) { return r.unregister(); })); })
+            .catch(function () {}));
+        }
+        if (window.caches && caches.keys) {
+          steps.push(caches.keys()
+            .then(function (ks) { return Promise.all(ks.map(function (k) { return caches.delete(k); })); })
+            .catch(function () {}));
+        }
+        Promise.all(steps).finally(function () { location.reload(); });
+      }, 8000);
+    })();
+  </script>
   <script type="module" src="./App.jsx"></script>
 </body>
 </html>


### PR DESCRIPTION
iOS Safari (and sometimes other browsers) can keep serving a cached index.html that references JS asset hashes the origin no longer has, leaving the page blank. Add an inline boot guard: if the React root hasn't mounted within 8s, unregister service workers, clear Cache Storage, and reload once (sessionStorage-guarded so we never loop).

This fixes the blank-page symptom that appears after a deploy when an old service worker is still live.