### PR TITLE
Add Request Asset button + AssetRequestForm modal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,16 @@ live in day-to-day.
 - **Create-shift fallback** — Schedule view date-select now routes to the
   generic `EventForm` when the dropped cell isn't a configured employee,
   instead of silently dropping the interaction.
+- **`assetRequestCategories` prop** on `<WorksCalendar>` (optional).
+  When provided alongside an `assets` registry, AssetsView renders a
+  primary "Request Asset" toolbar button that opens a focused modal
+  (`AssetRequestForm`). Submissions route through the normal
+  `onEventSave` path with `meta.approvalStage = { stage: 'requested' }`,
+  so the existing approvals state machine handles the rest
+  (approve / deny / finalize / escalate to higher). Categories are
+  constrained to the host-configured ids — the demo ships
+  `['maintenance', 'pr', 'training', 'aircraft-movement']` with a new
+  Aircraft Movement category.
 - **`strictAssetFiltering` prop** on `<WorksCalendar>` (default `false`).
   When `true` and an `assets` registry is provided, AssetsView keeps
   only events whose `resource` matches a registered asset id — drops

--- a/demo/App.jsx
+++ b/demo/App.jsx
@@ -183,6 +183,8 @@ const UNIFIED_CATEGORIES = [
   { id: 'PTO',      label: 'PTO',        color: '#10b981' },
   // Fleet (from DEFAULT_CATEGORIES, spread here so both sets share the palette)
   ...DEFAULT_CATEGORIES,
+  // Demo-only: asset movement requests route through the approvals workflow.
+  { id: 'aircraft-movement', label: 'Aircraft Movement', color: '#06b6d4' },
 ];
 
 const UNIFIED_CATEGORIES_CONFIG = {
@@ -411,6 +413,7 @@ function App() {
             employees={employees}
             assets={AIRCRAFT_RESOURCES}
             strictAssetFiltering={true}
+            assetRequestCategories={['maintenance', 'pr', 'training', 'aircraft-movement']}
             onEmployeeAdd={handleEmployeeAdd}
             onEmployeeDelete={handleEmployeeDelete}
             calendarId={DEMO_CALENDAR_ID}

--- a/src/WorksCalendar.tsx
+++ b/src/WorksCalendar.tsx
@@ -44,6 +44,7 @@ import KeyboardHelpOverlay   from './ui/KeyboardHelpOverlay.jsx';
 import { useKeyboardShortcuts } from './hooks/useKeyboardShortcuts.js';
 import ConfigPanel            from './ui/ConfigPanel.jsx';
 import EventForm              from './ui/EventForm.jsx';
+import AssetRequestForm       from './ui/AssetRequestForm.jsx';
 import ImportZone             from './ui/ImportZone.jsx';
 import ScheduleTemplateDialog from './ui/ScheduleTemplateDialog.jsx';
 import AvailabilityForm        from './ui/AvailabilityForm.jsx';
@@ -156,6 +157,7 @@ export type WorksCalendarProps = {
   categoriesConfig?: Record<string, unknown>;
   assets?: { id: string; label: string; group?: string; meta?: Record<string, unknown> }[];
   strictAssetFiltering?: boolean;
+  assetRequestCategories?: string[];
   onConflictCheck?: (...args: unknown[]) => Promise<unknown>;
   onApprovalAction?: (...args: unknown[]) => void | Promise<void>;
   renderAssetLocation?: (...args: unknown[]) => ReactNode;
@@ -302,6 +304,7 @@ export const WorksCalendar = forwardRef<CalendarApi, WorksCalendarProps>(functio
     categoriesConfig,
     assets,
     strictAssetFiltering,
+    assetRequestCategories,
     onConflictCheck,
     onApprovalAction,
     renderAssetLocation,
@@ -544,6 +547,25 @@ export const WorksCalendar = forwardRef<CalendarApi, WorksCalendarProps>(functio
     () => categories.filter(c => !SCHEDULE_ONLY_CATS.has(c)),
     [categories],
   );
+
+  // Resolve asset-request category ids → {id, label} pairs by looking up the
+  // host's configured categories. Falls back to using the id as the label so
+  // the modal never renders a blank dropdown.
+  const resolvedAssetRequestCategories = useMemo(() => {
+    if (!Array.isArray(assetRequestCategories) || assetRequestCategories.length === 0) return [];
+    const cfg = categoriesConfig ?? ownerCfg.config?.categoriesConfig;
+    const defs = Array.isArray(cfg?.categories) ? cfg.categories : [];
+    const byId = new Map(defs.map(d => [d.id, d]));
+    return assetRequestCategories.map(id => {
+      const def = byId.get(id);
+      return { id, label: def?.label ?? id, color: def?.color };
+    });
+  }, [assetRequestCategories, categoriesConfig, ownerCfg.config?.categoriesConfig]);
+
+  const canRequestAsset =
+    resolvedAssetRequestCategories.length > 0 &&
+    Array.isArray(effectiveAssets) &&
+    effectiveAssets.length > 0;
   const resources     = useMemo(() => getResources(expandedEvents),  [expandedEvents]);
   const filteredEvents = useMemo(
     () => applyFilters(expandedEvents, cal.filters, schema),
@@ -610,6 +632,7 @@ export const WorksCalendar = forwardRef<CalendarApi, WorksCalendarProps>(functio
   // ── Local UI state ───────────────────────────────────────────────────────
   const [selectedEvent,  setSelectedEvent]  = useState(null);
   const [formEvent,        setFormEvent]        = useState(null);
+  const [assetRequestOpen, setAssetRequestOpen] = useState(false);
   const [importOpen,       setImportOpen]       = useState(false);
   const [scheduleOpen,     setScheduleOpen]     = useState(false);
   // { emp: { id, name, role? }, kind: 'pto' | 'unavailable' | 'availability', start?: Date, initialEvent?: object | null }
@@ -1064,6 +1087,7 @@ export const WorksCalendar = forwardRef<CalendarApi, WorksCalendarProps>(functio
           status:     rawEv.status     ?? 'confirmed',
           rrule:      rawEv.rrule      ?? null,
           exdates:    rawEv.exdates    ?? [],
+          meta:       rawEv.meta       ?? {},
         },
         source: 'form',
       };
@@ -1687,6 +1711,7 @@ export const WorksCalendar = forwardRef<CalendarApi, WorksCalendarProps>(functio
                   locationProvider={effectiveLocationProvider}
                   renderAssetLocation={renderAssetLocation}
                   onEditAssets={ownerCfg.isOwner ? () => ownerCfg.openConfigToTab('assets') : undefined}
+                  onRequestAsset={canRequestAsset ? () => setAssetRequestOpen(true) : undefined}
                   approvalsConfig={ownerCfg.config?.approvals}
                   onApprovalAction={onApprovalAction}
                 />
@@ -1724,6 +1749,20 @@ export const WorksCalendar = forwardRef<CalendarApi, WorksCalendarProps>(functio
             onClose={() => setFormEvent(null)}
             permissions={perms}
             onAddCategory={perms.canManageOptions ? eventOptions.addCategory : undefined}
+          />
+        )}
+
+        {/* ── Asset request form ── */}
+        {assetRequestOpen && canRequestAsset && perms.canAddEvent && (
+          <AssetRequestForm
+            assets={effectiveAssets}
+            categories={resolvedAssetRequestCategories}
+            initialStart={cal.currentDate}
+            onSubmit={(payload) => {
+              handleEventSave(payload);
+              setAssetRequestOpen(false);
+            }}
+            onClose={() => setAssetRequestOpen(false)}
           />
         )}
 

--- a/src/ui/AssetRequestForm.jsx
+++ b/src/ui/AssetRequestForm.jsx
@@ -1,0 +1,191 @@
+/**
+ * AssetRequestForm — focused modal for submitting an asset request that
+ * enters the approvals state machine at stage `requested`.
+ *
+ * The host opts into this flow by passing `assetRequestCategories` (an
+ * ordered array of category ids) on <WorksCalendar>. When present AND an
+ * `assets` registry is provided, AssetsView renders a "Request Asset"
+ * button that opens this modal. Submission routes through the same
+ * `onEventSave` path as EventForm; the only difference is that the event
+ * ships with `meta.approvalStage = { stage: 'requested', updatedAt }`.
+ */
+import { useMemo, useState } from 'react';
+import { X } from 'lucide-react';
+import { useFocusTrap } from '../hooks/useFocusTrap.js';
+import styles from './EventForm.module.css';
+
+function toLocalInput(date) {
+  const pad = (n) => String(n).padStart(2, '0');
+  return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}T${pad(date.getHours())}:${pad(date.getMinutes())}`;
+}
+
+function fromLocalInput(value) {
+  // Interpret as local time (same convention as EventForm's fromDatetimeLocal).
+  const [datePart, timePart] = value.split('T');
+  const [y, m, d] = datePart.split('-').map(Number);
+  const [hh, mm] = (timePart || '00:00').split(':').map(Number);
+  return new Date(y, m - 1, d, hh, mm, 0, 0);
+}
+
+export default function AssetRequestForm({
+  assets,
+  categories,
+  initialStart,
+  initialAssetId,
+  onSubmit,
+  onClose,
+}) {
+  const trapRef = useFocusTrap(onClose);
+
+  const start = initialStart instanceof Date ? initialStart : new Date();
+  const defaultEnd = new Date(start.getTime() + 60 * 60 * 1000);
+
+  const [assetId,  setAssetId]  = useState(initialAssetId || assets[0]?.id || '');
+  const [category, setCategory] = useState(categories[0]?.id || '');
+  const [title,    setTitle]    = useState('');
+  const [startStr, setStartStr] = useState(toLocalInput(start));
+  const [endStr,   setEndStr]   = useState(toLocalInput(defaultEnd));
+  const [notes,    setNotes]    = useState('');
+  const [errors,   setErrors]   = useState({});
+
+  const assetOptions = useMemo(
+    () => assets.map(a => ({ value: a.id, label: a.label || a.id })),
+    [assets],
+  );
+
+  function validate() {
+    const e = {};
+    if (!title.trim())      e.title    = 'Title is required';
+    if (!assetId)           e.assetId  = 'Select an asset';
+    if (!category)          e.category = 'Select a category';
+    if (!startStr)          e.start    = 'Start is required';
+    if (!endStr)            e.end      = 'End is required';
+    if (startStr && endStr && fromLocalInput(endStr) <= fromLocalInput(startStr)) {
+      e.end = 'End must be after start';
+    }
+    setErrors(e);
+    return Object.keys(e).length === 0;
+  }
+
+  function handleSubmit(e) {
+    e.preventDefault();
+    if (!validate()) return;
+    const now = new Date().toISOString();
+    onSubmit({
+      title:    title.trim(),
+      start:    fromLocalInput(startStr),
+      end:      fromLocalInput(endStr),
+      allDay:   false,
+      category,
+      resource: assetId,
+      meta: {
+        ...(notes.trim() ? { notes: notes.trim() } : {}),
+        approvalStage: { stage: 'requested', updatedAt: now },
+      },
+    });
+  }
+
+  return (
+    <div className={styles.overlay} onClick={e => e.target === e.currentTarget && onClose()}>
+      <div
+        className={styles.modal}
+        ref={trapRef}
+        role="dialog"
+        aria-modal="true"
+        aria-label="Request asset"
+      >
+        <div className={styles.header}>
+          <h2 className={styles.title}>Request Asset</h2>
+          <button className={styles.closeBtn} onClick={onClose} aria-label="Close"><X size={18} /></button>
+        </div>
+        <form className={styles.form} onSubmit={handleSubmit} noValidate>
+          <div className={styles.field}>
+            <label className={styles.label} htmlFor="ar-title">Title <span className={styles.req}>*</span></label>
+            <input
+              id="ar-title"
+              className={[styles.input, errors.title && styles.inputError].filter(Boolean).join(' ')}
+              value={title}
+              onChange={e => setTitle(e.target.value)}
+              placeholder="e.g. A-check, VIP charter, CRM training"
+              autoFocus
+            />
+            {errors.title && <span className={styles.error}>{errors.title}</span>}
+          </div>
+
+          <div className={styles.row2}>
+            <div className={styles.field}>
+              <label className={styles.label} htmlFor="ar-asset">Asset <span className={styles.req}>*</span></label>
+              <select
+                id="ar-asset"
+                className={styles.select}
+                value={assetId}
+                onChange={e => setAssetId(e.target.value)}
+              >
+                {assetOptions.map(o => <option key={o.value} value={o.value}>{o.label}</option>)}
+              </select>
+              {errors.assetId && <span className={styles.error}>{errors.assetId}</span>}
+            </div>
+            <div className={styles.field}>
+              <label className={styles.label} htmlFor="ar-category">Category <span className={styles.req}>*</span></label>
+              <select
+                id="ar-category"
+                className={styles.select}
+                value={category}
+                onChange={e => setCategory(e.target.value)}
+              >
+                {categories.map(c => (
+                  <option key={c.id} value={c.id}>{c.label || c.id}</option>
+                ))}
+              </select>
+              {errors.category && <span className={styles.error}>{errors.category}</span>}
+            </div>
+          </div>
+
+          <div className={styles.row2}>
+            <div className={styles.field}>
+              <label className={styles.label} htmlFor="ar-start">Start <span className={styles.req}>*</span></label>
+              <input
+                id="ar-start"
+                type="datetime-local"
+                className={[styles.input, errors.start && styles.inputError].filter(Boolean).join(' ')}
+                value={startStr}
+                onChange={e => setStartStr(e.target.value)}
+              />
+              {errors.start && <span className={styles.error}>{errors.start}</span>}
+            </div>
+            <div className={styles.field}>
+              <label className={styles.label} htmlFor="ar-end">End <span className={styles.req}>*</span></label>
+              <input
+                id="ar-end"
+                type="datetime-local"
+                className={[styles.input, errors.end && styles.inputError].filter(Boolean).join(' ')}
+                value={endStr}
+                onChange={e => setEndStr(e.target.value)}
+              />
+              {errors.end && <span className={styles.error}>{errors.end}</span>}
+            </div>
+          </div>
+
+          <div className={styles.field}>
+            <label className={styles.label} htmlFor="ar-notes">Notes</label>
+            <textarea
+              id="ar-notes"
+              className={styles.textarea}
+              value={notes}
+              onChange={e => setNotes(e.target.value)}
+              placeholder="Optional — context for the approver"
+              rows={3}
+            />
+          </div>
+
+          <div className={styles.actions}>
+            <div className={styles.actionRight}>
+              <button type="button" className={styles.btnCancel} onClick={onClose}>Cancel</button>
+              <button type="submit" className={styles.btnSave}>Submit Request</button>
+            </div>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/src/ui/__tests__/AssetRequestForm.test.jsx
+++ b/src/ui/__tests__/AssetRequestForm.test.jsx
@@ -1,0 +1,117 @@
+// @vitest-environment happy-dom
+/**
+ * AssetRequestForm — submits a new event at approvalStage=requested so the
+ * existing approvals state machine handles the rest.
+ */
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import '@testing-library/jest-dom';
+import React from 'react';
+
+import AssetRequestForm from '../AssetRequestForm.jsx';
+
+const assets = [
+  { id: 'n100aa', label: 'N100AA', meta: { sublabel: 'CJ3' } },
+  { id: 'n200bb', label: 'N200BB', meta: { sublabel: 'Phenom' } },
+];
+
+const categories = [
+  { id: 'maintenance',       label: 'Maintenance' },
+  { id: 'pr',                label: 'PR' },
+  { id: 'training',          label: 'Training' },
+  { id: 'aircraft-movement', label: 'Aircraft Movement' },
+];
+
+function renderForm(props = {}) {
+  return render(
+    <AssetRequestForm
+      assets={assets}
+      categories={categories}
+      onSubmit={vi.fn()}
+      onClose={vi.fn()}
+      {...props}
+    />,
+  );
+}
+
+describe('AssetRequestForm', () => {
+  it('renders the restricted category list (no other categories leak in)', () => {
+    renderForm();
+    const select = screen.getByLabelText(/Category/);
+    const optionLabels = Array.from(select.querySelectorAll('option')).map(o => o.textContent);
+    expect(optionLabels).toEqual(['Maintenance', 'PR', 'Training', 'Aircraft Movement']);
+  });
+
+  it('renders the asset registry as dropdown options', () => {
+    renderForm();
+    const select = screen.getByLabelText(/Asset/);
+    const optionLabels = Array.from(select.querySelectorAll('option')).map(o => o.textContent);
+    expect(optionLabels).toEqual(['N100AA', 'N200BB']);
+  });
+
+  it('validates required fields before submit', () => {
+    const onSubmit = vi.fn();
+    renderForm({ onSubmit });
+    fireEvent.click(screen.getByRole('button', { name: 'Submit Request' }));
+    expect(onSubmit).not.toHaveBeenCalled();
+    expect(screen.getByText('Title is required')).toBeInTheDocument();
+  });
+
+  it('submits a payload with approvalStage=requested', () => {
+    const onSubmit = vi.fn();
+    renderForm({ onSubmit });
+    fireEvent.change(screen.getByLabelText(/Title/),    { target: { value: 'A-check' } });
+    fireEvent.change(screen.getByLabelText(/Asset/),    { target: { value: 'n200bb' } });
+    fireEvent.change(screen.getByLabelText(/Category/), { target: { value: 'maintenance' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Submit Request' }));
+
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+    const payload = onSubmit.mock.calls[0][0];
+    expect(payload.title).toBe('A-check');
+    expect(payload.resource).toBe('n200bb');
+    expect(payload.category).toBe('maintenance');
+    expect(payload.meta.approvalStage.stage).toBe('requested');
+    expect(typeof payload.meta.approvalStage.updatedAt).toBe('string');
+    expect(payload.start).toBeInstanceOf(Date);
+    expect(payload.end).toBeInstanceOf(Date);
+    expect(payload.end.getTime()).toBeGreaterThan(payload.start.getTime());
+  });
+
+  it('rejects end-before-start', () => {
+    const onSubmit = vi.fn();
+    renderForm({ onSubmit });
+    fireEvent.change(screen.getByLabelText(/Title/), { target: { value: 'bad window' } });
+    fireEvent.change(screen.getByLabelText(/Start/), { target: { value: '2026-05-01T12:00' } });
+    fireEvent.change(screen.getByLabelText(/End/),   { target: { value: '2026-05-01T10:00' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Submit Request' }));
+    expect(onSubmit).not.toHaveBeenCalled();
+    expect(screen.getByText('End must be after start')).toBeInTheDocument();
+  });
+
+  it('pre-fills the asset when initialAssetId is provided', () => {
+    renderForm({ initialAssetId: 'n200bb' });
+    expect(screen.getByLabelText(/Asset/).value).toBe('n200bb');
+  });
+
+  it('includes notes in meta when provided', () => {
+    const onSubmit = vi.fn();
+    renderForm({ onSubmit });
+    fireEvent.change(screen.getByLabelText(/Title/),    { target: { value: 'Ferry flight' } });
+    fireEvent.change(screen.getByLabelText(/Category/), { target: { value: 'aircraft-movement' } });
+    fireEvent.change(screen.getByLabelText(/Notes/),    { target: { value: 'KPHX → KBOS repositioning' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Submit Request' }));
+
+    const payload = onSubmit.mock.calls[0][0];
+    expect(payload.meta.notes).toBe('KPHX → KBOS repositioning');
+    expect(payload.meta.approvalStage.stage).toBe('requested');
+  });
+
+  it('omits notes from meta when the field is blank', () => {
+    const onSubmit = vi.fn();
+    renderForm({ onSubmit });
+    fireEvent.change(screen.getByLabelText(/Title/), { target: { value: 'training' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Submit Request' }));
+    const payload = onSubmit.mock.calls[0][0];
+    expect(payload.meta).not.toHaveProperty('notes');
+  });
+});

--- a/src/views/AssetsView.jsx
+++ b/src/views/AssetsView.jsx
@@ -182,6 +182,7 @@ export default function AssetsView({
   onCollapsedGroupsChange,
   assets,
   onEditAssets,
+  onRequestAsset,
   approvalsConfig,
   onApprovalAction,
   resolveResourceLabel,
@@ -400,7 +401,7 @@ export default function AssetsView({
   }, [assetRegistry]);
 
   const currentGroupByValue = typeof groupBy === 'string' ? groupBy : '';
-  const showToolbar = Boolean(assetRegistry) || Boolean(onEditAssets);
+  const showToolbar = Boolean(assetRegistry) || Boolean(onEditAssets) || Boolean(onRequestAsset);
 
   // ── Live locations (via LocationProvider) ──────────────────────────────────
   const locations = useResourceLocations(resourceList, locationProvider);
@@ -725,6 +726,16 @@ export default function AssetsView({
         </select>
       </div>
       <div className={styles.toolbarSpacer} />
+      {onRequestAsset && (
+        <button
+          type="button"
+          className={styles.toolbarBtnPrimary}
+          onClick={onRequestAsset}
+          aria-label="Request asset"
+        >
+          Request Asset
+        </button>
+      )}
       {onEditAssets && (
         <button
           type="button"

--- a/src/views/AssetsView.module.css
+++ b/src/views/AssetsView.module.css
@@ -71,6 +71,26 @@
   cursor: not-allowed;
 }
 
+.toolbarBtnPrimary {
+  font: inherit;
+  padding: 4px 12px;
+  border: 1px solid var(--wc-accent);
+  border-radius: 4px;
+  background: var(--wc-accent);
+  color: #fff;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.toolbarBtnPrimary:hover:not(:disabled) {
+  filter: brightness(1.08);
+}
+
+.toolbarBtnPrimary:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
 .inner {
   display: flex;
   flex-direction: column;

--- a/src/views/__tests__/AssetsView.requestAsset.test.jsx
+++ b/src/views/__tests__/AssetsView.requestAsset.test.jsx
@@ -1,0 +1,66 @@
+// @vitest-environment happy-dom
+/**
+ * AssetsView — "Request Asset" button.
+ *
+ * When the host passes `onRequestAsset`, AssetsView renders a primary
+ * toolbar button that invokes the callback. The button is absent when the
+ * callback is omitted (default opt-out behavior).
+ */
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import '@testing-library/jest-dom';
+import React from 'react';
+
+import AssetsView from '../AssetsView.jsx';
+import { CalendarContext } from '../../core/CalendarContext.js';
+
+const currentDate = new Date(2026, 3, 1);
+
+function renderView(props = {}) {
+  return render(
+    <CalendarContext.Provider value={null}>
+      <AssetsView
+        currentDate={currentDate}
+        events={[]}
+        onEventClick={vi.fn()}
+        assets={[{ id: 'n100aa', label: 'N100AA', meta: {} }]}
+        {...props}
+      />
+    </CalendarContext.Provider>,
+  );
+}
+
+describe('AssetsView — Request Asset button', () => {
+  it('renders when onRequestAsset is provided', () => {
+    renderView({ onRequestAsset: vi.fn() });
+    expect(screen.getByRole('button', { name: 'Request asset' })).toBeInTheDocument();
+  });
+
+  it('invokes the callback on click', () => {
+    const onRequestAsset = vi.fn();
+    renderView({ onRequestAsset });
+    fireEvent.click(screen.getByRole('button', { name: 'Request asset' }));
+    expect(onRequestAsset).toHaveBeenCalledTimes(1);
+  });
+
+  it('is hidden when onRequestAsset is omitted', () => {
+    renderView();
+    expect(screen.queryByRole('button', { name: 'Request asset' })).not.toBeInTheDocument();
+  });
+
+  it('shows the toolbar (so the button is reachable) even with no registry', () => {
+    // Edge case: host passes onRequestAsset without an assets registry. Button
+    // should still render so the host doesn't silently drop the flow.
+    render(
+      <CalendarContext.Provider value={null}>
+        <AssetsView
+          currentDate={currentDate}
+          events={[]}
+          onEventClick={vi.fn()}
+          onRequestAsset={vi.fn()}
+        />
+      </CalendarContext.Provider>,
+    );
+    expect(screen.getByRole('button', { name: 'Request asset' })).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
Hosts opt in via a new assetRequestCategories prop on <WorksCalendar> (e.g. ['maintenance', 'pr', 'training', 'aircraft-movement']). When provided alongside an assets registry, AssetsView renders a primary "Request Asset" toolbar button that opens a focused modal. Submissions route through the normal onEventSave path with meta.approvalStage = { stage: 'requested' }, so the existing approvals state machine picks up the new request without any extra wiring.

Demo adds an Aircraft Movement category and enables the four-category request list so the feature is discoverable on GitHub Pages.

Also fixes a meta-passthrough gap on the create engine op — meta now flows into the engine state for newly-created events, which is required for approvalStage to survive the round-trip but also benefits any host that attaches meta via EventForm.