### PR TITLE
Fix recurring event edit to show series repeat cadence

### DIFF
--- a/demo/regression-bugs.jsx
+++ b/demo/regression-bugs.jsx
@@ -79,6 +79,16 @@ function App() {
       resource: 'emp-alpha',
       color: '#0ea5e9',
     },
+    {
+      id: 'recurring-pen-1',
+      title: 'Repeating Pencil Test',
+      start: at(today, 0, 10, 0).toISOString(),
+      end: at(today, 0, 11, 0).toISOString(),
+      category: 'Meeting',
+      resource: 'emp-alpha',
+      color: '#10b981',
+      rrule: 'FREQ=WEEKLY;BYDAY=' + ['SU','MO','TU','WE','TH','FR','SA'][today.getDay()],
+    },
   ]), [today]);
 
   const [events, setEvents] = useState(initialEvents);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "works-calendar",
-  "version": "0.1.0",
+  "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "works-calendar",
-      "version": "0.1.0",
+      "version": "0.4.0",
       "license": "MIT",
       "dependencies": {
         "date-fns": "^3.6.0",

--- a/src/WorksCalendar.tsx
+++ b/src/WorksCalendar.tsx
@@ -1351,7 +1351,16 @@ export const WorksCalendar = forwardRef<CalendarApi, WorksCalendarProps>(functio
 
   const handleEditFromHoverCard = useCallback((ev) => {
     setSelectedEvent(null);
-    setFormEvent(ev._raw ?? ev);
+    let formEv = ev._raw ?? ev;
+    // Recurring occurrences carry rrule:null — look up the series master so the
+    // EventForm shows the correct repeat cadence and preserves it on save.
+    if (ev._recurring && ev._eventId) {
+      const master = engineRef.current?.state?.events?.get(ev._eventId);
+      if (master?.rrule) {
+        formEv = { ...formEv, rrule: master.rrule };
+      }
+    }
+    setFormEvent(formEv);
   }, []);
 
   /** Save quick display customizations from InlineEventEditor. */

--- a/tests-e2e/calendar.regressions.spec.ts
+++ b/tests-e2e/calendar.regressions.spec.ts
@@ -90,4 +90,24 @@ test.describe('WorksCalendar targeted regressions', () => {
     await expect(editor).toBeVisible();
     await expect(editor.getByPlaceholder('Event title')).toHaveValue('Edit Pen Fixture');
   });
+
+  test('edit pen on a recurring event shows the series repeat cadence, not "Does not repeat"', async ({ page }) => {
+    await page.setViewportSize({ width: 1280, height: 900 });
+    await page.goto('/regression-bugs.html');
+
+    await page.getByRole('button', { name: /Repeating Pencil Test/i }).first().click();
+
+    const dialog = page.getByRole('dialog', { name: /Event details: Repeating Pencil Test/i });
+    await expect(dialog).toBeVisible();
+
+    await dialog.getByRole('button', { name: /Edit event/i }).click();
+
+    const editor = page.getByRole('dialog', { name: /Edit event/i });
+    await expect(editor).toBeVisible();
+    await expect(editor.getByPlaceholder('Event title')).toHaveValue('Repeating Pencil Test');
+
+    // The Repeat dropdown must NOT show "Does not repeat" — the series RRULE should be loaded.
+    const repeatSelect = editor.getByLabel(/^Repeat$/i);
+    await expect(repeatSelect).not.toHaveValue('none');
+  });
 });


### PR DESCRIPTION
## Summary
Fixed an issue where editing a recurring event occurrence from the hover card would incorrectly show "Does not repeat" instead of displaying the series' repeat cadence.

## Key Changes
- **WorksCalendar.tsx**: Updated `handleEditFromHoverCard` to detect recurring event occurrences and look up the series master event to retrieve the correct `rrule`. This ensures the EventForm displays and preserves the actual repeat cadence when editing.
- **regression-bugs.jsx**: Added a test fixture event ("Repeating Pencil Test") with a weekly recurrence rule to support regression testing.
- **calendar.regressions.spec.ts**: Added a new e2e test that verifies editing a recurring event occurrence shows the series repeat cadence rather than "Does not repeat".

## Implementation Details
When a user edits a recurring event occurrence, the occurrence object carries `rrule: null`. The fix checks if the event is a recurring occurrence (`ev._recurring && ev._eventId`) and retrieves the series master event from the engine state to extract its `rrule`. This master rule is then merged into the form event object before opening the editor, ensuring the correct repeat settings are displayed and saved.

https://claude.ai/code/session_01KNPQsje7BCvLNvpTLhC7fK