### PR TITLE
Store and use request dates for shift coverage indicators

### DIFF
--- a/src/WorksCalendar.tsx
+++ b/src/WorksCalendar.tsx
@@ -1006,9 +1006,11 @@ export const WorksCalendar = forwardRef<CalendarApi, WorksCalendarProps>(functio
         // Mark the original shift as needing coverage
         const updatedMeta = {
           ...(shiftEv.meta ?? {}),
-          shiftStatus: availEv.kind,   // 'pto' | 'unavailable'
-          openShiftId: openShift.id,
-          coveredBy:   null,
+          shiftStatus:  availEv.kind,   // 'pto' | 'unavailable'
+          openShiftId:  openShift.id,
+          coveredBy:    null,
+          requestStart: availEv.start instanceof Date ? availEv.start.toISOString() : String(availEv.start),
+          requestEnd:   availEv.end   instanceof Date ? availEv.end.toISOString()   : String(availEv.end),
         };
         applyEngineOp(
           { type: 'update', id: shiftId, patch: { meta: updatedMeta }, source: 'api' },

--- a/src/views/TimelineView.jsx
+++ b/src/views/TimelineView.jsx
@@ -928,7 +928,8 @@ export default function TimelineView({
                       const reqStart = ev.meta?.requestStart ? new Date(ev.meta.requestStart) : ev.start;
                       const reqEnd   = ev.meta?.requestEnd   ? new Date(ev.meta.requestEnd)   : ev.end;
                       const pillDayStart = differenceInCalendarDays(max([startOfDay(reqStart), monthStart]), monthStart);
-                      const pillDayEnd   = differenceInCalendarDays(min([startOfDay(reqEnd),   monthEnd]),   monthStart);
+                      // reqEnd is exclusive [start, end), so subtract 1 day to get the last included day
+                      const pillDayEnd   = differenceInCalendarDays(min([addDays(startOfDay(reqEnd), -1), monthEnd]), monthStart);
                       const left  = pillDayStart * DAY_W + 2;
                       const width = Math.max(DAY_W - 4, (pillDayEnd - pillDayStart + 1) * DAY_W - 4);
                       const top   = baseH + 3;

--- a/src/views/TimelineView.jsx
+++ b/src/views/TimelineView.jsx
@@ -925,8 +925,12 @@ export default function TimelineView({
                   {rowEvents
                     .filter(ev => (ev.category === onCallCategory || ev.meta?.onCall === true) && ev.meta?.shiftStatus)
                     .map(ev => {
-                      const left  = ev._dayStart * DAY_W + 2;
-                      const width = Math.max(DAY_W - 4, (ev._dayEnd - ev._dayStart + 1) * DAY_W - 4);
+                      const reqStart = ev.meta?.requestStart ? new Date(ev.meta.requestStart) : ev.start;
+                      const reqEnd   = ev.meta?.requestEnd   ? new Date(ev.meta.requestEnd)   : ev.end;
+                      const pillDayStart = differenceInCalendarDays(max([startOfDay(reqStart), monthStart]), monthStart);
+                      const pillDayEnd   = differenceInCalendarDays(min([startOfDay(reqEnd),   monthEnd]),   monthStart);
+                      const left  = pillDayStart * DAY_W + 2;
+                      const width = Math.max(DAY_W - 4, (pillDayEnd - pillDayStart + 1) * DAY_W - 4);
                       const top   = baseH + 3;
                       const isCovered = !!ev.meta?.coveredBy;
                       const coveredByEmp = isCovered


### PR DESCRIPTION
## Summary
This PR updates the shift coverage workflow to store the original availability request dates and use them for positioning coverage indicator pills in the timeline view, rather than using the shift's own dates.

## Key Changes
- **WorksCalendar.tsx**: When marking a shift as needing coverage, now stores `requestStart` and `requestEnd` timestamps from the availability event in the shift's metadata
- **TimelineView.jsx**: Updated the coverage indicator pill positioning logic to:
  - Retrieve the stored request dates from shift metadata
  - Fall back to the shift's own dates if request dates aren't available
  - Calculate pill position and width based on the request date range instead of the shift date range
  - Properly clamp the pill dates to the current month boundaries

## Implementation Details
- Request dates are stored as ISO strings in the shift metadata for persistence
- The timeline view converts these ISO strings back to Date objects for calculation
- Uses existing date utility functions (`differenceInCalendarDays`, `max`, `min`, `startOfDay`) to compute accurate pill positioning
- Maintains backward compatibility by falling back to shift dates when request metadata is unavailable

https://claude.ai/code/session_019qMSHLorWKgvdZewTFZ3z9