### PR TITLE
Add borders to pills across calendar views

### DIFF
--- a/src/ui/FilterBar.module.css
+++ b/src/ui/FilterBar.module.css
@@ -132,6 +132,7 @@
   background: var(--wc-accent);
   color: #fff;
   border-radius: 100px;
+  border: 1px solid color-mix(in srgb, var(--wc-accent) 70%, #000);
   font-size: 11px;
   font-weight: 500;
 }

--- a/src/views/AssetsView.module.css
+++ b/src/views/AssetsView.module.css
@@ -426,7 +426,7 @@
   border-radius: 5px;
   background: var(--ev-color, var(--wc-accent));
   color: #fff;
-  border: none;
+  border: 1px solid color-mix(in srgb, var(--ev-color, var(--wc-accent)) 65%, #000);
   cursor: pointer;
   text-align: left;
   overflow: hidden;

--- a/src/views/MonthView.module.css
+++ b/src/views/MonthView.module.css
@@ -95,7 +95,7 @@
   font-size: 11px;
   font-weight: 500;
   border-radius: var(--wc-radius-sm);
-  border: none;
+  border: 1px solid color-mix(in srgb, var(--ev-color, var(--wc-accent)) 65%, #000);
   cursor: pointer;
   white-space: nowrap;
   overflow: hidden;
@@ -227,7 +227,7 @@
   font-size: calc(11px * var(--wc-font-scale, 1));
   font-weight: 500;
   text-align: left;
-  border: none;
+  border: 1px solid color-mix(in srgb, var(--ev-color, var(--wc-accent)) 65%, #000);
   cursor: pointer;
   white-space: nowrap;
   overflow: hidden;

--- a/src/views/ScheduleView.module.css
+++ b/src/views/ScheduleView.module.css
@@ -103,7 +103,7 @@
   font-size: 11px;
   font-weight: 500;
   text-align: left;
-  border: none;
+  border: 1px solid color-mix(in srgb, var(--ev-color, var(--wc-accent)) 65%, #000);
   cursor: pointer;
   white-space: nowrap;
   overflow: hidden;
@@ -140,7 +140,7 @@
   color: #fff;
   font-size: 13px;
   font-weight: 500;
-  border: none;
+  border: 1px solid color-mix(in srgb, var(--ev-color, var(--wc-accent)) 65%, #000);
   cursor: pointer;
   text-align: left;
   transition: opacity 0.1s;

--- a/src/views/TimelineView.module.css
+++ b/src/views/TimelineView.module.css
@@ -369,7 +369,7 @@
   border-radius: 5px;
   background: var(--ev-color, var(--wc-accent));
   color: #fff;
-  border: none;
+  border: 1px solid color-mix(in srgb, var(--ev-color, var(--wc-accent)) 65%, #000);
   cursor: pointer;
   text-align: left;
   overflow: hidden;
@@ -568,7 +568,7 @@
   font-weight: 600;
   overflow: hidden;
   white-space: nowrap;
-  border: none;
+  border: 1px solid color-mix(in srgb, currentColor 30%, #000);
   text-align: left;
   z-index: 4;
   box-sizing: border-box;


### PR DESCRIPTION
### Motivation
- Improve visual distinguishability of pill-like UI elements so event/filter chips read as separate pieces against varied backgrounds and adjacent items. 
- Enforce a consistent pill treatment across calendar surfaces (month, schedule, timeline, assets, and filter bar) without changing behavior.

### Description
- Added a 1px contrasting border to month view `.`spanBar` and `.eventPill` elements to visually separate span bars and month pills (`src/views/MonthView.module.css`).
- Applied the same 1px border to schedule view `.`eventPill` and fallback `.`simpleEvent` items for consistent pill rendering (`src/views/ScheduleView.module.css`).
- Added a 1px border to assets view `.`event` pills and timeline `.`event` bars to match the pill visual language (`src/views/AssetsView.module.css`, `src/views/TimelineView.module.css`).
- Added a thin border to timeline coverage pills and to active filter pills so all chip-style UI follows the same bordered style (`src/views/TimelineView.module.css`, `src/ui/FilterBar.module.css`).

### Testing
- Ran the unit/interaction test suite for the AssetsView-related specs with `npm run test -- src/views/__tests__/AssetsView.test.jsx src/views/__tests__/AssetsView.approvalActions.test.jsx src/views/__tests__/AuditDrawer.test.jsx`.
- The test run completed successfully with 3 test files and 55 tests passing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e3ede40ec0832ca90df35ae282fecd)