### PR TITLE
Improve week view pill content visibility on desktop

### DIFF
--- a/src/views/WeekView.jsx
+++ b/src/views/WeekView.jsx
@@ -12,8 +12,8 @@ import { useDrag } from '../hooks/useDrag.js';
 import { useFocusTrap } from '../hooks/useFocusTrap.js';
 import styles from './WeekView.module.css';
 
-const SPAN_H    = 22;
-const SPAN_GAP  = 2;
+const SPAN_H    = 34;
+const SPAN_GAP  = 3;
 const MAX_SPANS = 4;
 const GUTTER_W  = 56;
 
@@ -263,6 +263,15 @@ export default function WeekView({
 
   // ── Renderers ─────────────────────────────────────────────────────────────
 
+
+  function formatPillDate(date) {
+    return format(date, 'M/d h:mma');
+  }
+
+  function pillResource(ev) {
+    return ev.resource || 'Unassigned';
+  }
+
   function renderTimedEvent(ev) {
     const isDimmed = drag.draggedId === ev.id;
     const color    = resolveColor(ev, ctx?.colorRules);
@@ -306,8 +315,10 @@ export default function WeekView({
           aria-hidden="true" />
         {inner ?? (
           <>
-            <span className={styles.evTitle} style={{ fontWeight: display.bold ? '700' : undefined }}>{ev.title}</span>
-            <span className={styles.evTime}>{format(ev.start, 'h:mm a')}</span>
+            <span className={styles.evTitle} style={{ fontWeight: display.bold ? '700' : undefined }}>Title: {ev.title}</span>
+            <span className={styles.evTime}>Start: {format(ev.start, 'h:mm a')}</span>
+            <span className={styles.evTime}>End: {format(ev.end, 'h:mm a')}</span>
+            <span className={styles.evMeta}>Resource: {pillResource(ev)}</span>
           </>
         )}
         <div className={styles.resizeHandle}
@@ -389,7 +400,10 @@ export default function WeekView({
                 const statusClass = ev.status === 'cancelled' ? styles.cancelled
                   : ev.status === 'tentative' ? styles.tentative : '';
                 const isDimmedBar = allDayGhost?.ev?.id === ev.id;
-                const ariaLabel = `${ev.title}${ev.category ? `, ${ev.category}` : ''}${continuesBefore ? ', continues from previous week' : ''}${continuesAfter ? ', continues next week' : ''}${ev.status && ev.status !== 'confirmed' ? `, ${ev.status}` : ''}`;
+                const startLabel = formatPillDate(ev.start);
+                const endLabel = formatPillDate(ev.end);
+                const resourceLabel = pillResource(ev);
+                const ariaLabel = `${ev.title}, start ${startLabel}, end ${endLabel}, resource ${resourceLabel}${ev.category ? `, ${ev.category}` : ''}${continuesBefore ? ', continues from previous week' : ''}${continuesAfter ? ', continues next week' : ''}${ev.status && ev.status !== 'confirmed' ? `, ${ev.status}` : ''}`;
                 return (
                   <button key={ev.id}
                     className={[
@@ -411,7 +425,12 @@ export default function WeekView({
                     onClick={() => !isDimmedBar && onEventClick?.(ev)}
                     onPointerDown={e => startAllDayBarDrag(ev, e, startCol, endCol)}
                   >
-                    {!continuesBefore && ev.title}
+                    <span className={styles.allDayTitleLine}>Title: {ev.title}</span>
+                    <span className={styles.allDayMetaLine}>
+                      <span>Start: {startLabel}</span>
+                      <span>End: {endLabel}</span>
+                      <span>Resource: {resourceLabel}</span>
+                    </span>
                   </button>
                 );
               })}

--- a/src/views/WeekView.module.css
+++ b/src/views/WeekView.module.css
@@ -73,8 +73,9 @@
 .allDaySpan {
   position: absolute;
   display: flex;
-  align-items: center;
-  padding: 0 7px;
+  align-items: flex-start;
+  justify-content: center;
+  padding: 3px 7px;
   border-radius: var(--wc-radius-sm);
   background: var(--ev-color, var(--wc-accent));
   color: #fff;
@@ -82,9 +83,7 @@
   font-weight: 500;
   border: none;
   cursor: pointer;
-  white-space: nowrap;
   overflow: hidden;
-  text-overflow: ellipsis;
   box-sizing: border-box;
   transition: filter 0.1s;
   z-index: 2;
@@ -95,6 +94,30 @@
 .allDaySpan.continuesAfter  { border-top-right-radius: 0; border-bottom-right-radius: 0; padding-right: 3px; }
 .allDaySpan.tentative { opacity: 0.65; background-image: repeating-linear-gradient(45deg, transparent, transparent 3px, rgba(255,255,255,.25) 3px, rgba(255,255,255,.25) 6px); }
 .allDaySpan.cancelled { opacity: 0.45; text-decoration: line-through; }
+
+
+.allDayTitleLine {
+  font-size: 10px;
+  font-weight: 700;
+  line-height: 1.2;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.allDayMetaLine {
+  display: flex;
+  gap: 8px;
+  font-size: 9px;
+  line-height: 1.2;
+  white-space: nowrap;
+  overflow: hidden;
+}
+
+.allDayMetaLine > span {
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
 
 /* Overflow button wrapper — sits at bottom-right of the all-day grid */
 .allDayMoreWrapper {
@@ -311,7 +334,8 @@
   overflow: hidden;
   text-overflow: ellipsis;
 }
-.evTime { font-size: 10px; opacity: 0.85; }
+.evTime { font-size: 10px; opacity: 0.9; line-height: 1.2; }
+.evMeta { font-size: 10px; opacity: 0.9; line-height: 1.2; }
 
 /* ── Resize handles ── */
 .resizeHandle {
@@ -392,6 +416,16 @@
   .headerRow, .grid { grid-template-columns: 44px repeat(7, minmax(80px, 1fr)); }
   .allDayRow { grid-template-columns: 44px 1fr; }
   .dayAbbr { font-size: 10px; }
+  .allDaySpan {
+    align-items: center;
+    padding: 0 7px;
+  }
+  .allDayMetaLine { display: none; }
+  .allDayTitleLine {
+    font-size: 11px;
+    font-weight: 500;
+  }
+  .evMeta { display: none; }
 }
 
 @media (max-width: 480px) {


### PR DESCRIPTION
### Motivation
- Fix truncated pill text in Week view so desktop pills surface the full `Title`, `Start`, `End` and `Resource` information. 
- Preserve compact/mobile behavior while making desktop pills readable and accessible. 
- Give all-day lanes more vertical room so additional metadata fits without clipping.

### Description
- Increased all-day lane sizing by changing `SPAN_H` and `SPAN_GAP` in `src/views/WeekView.jsx` to provide more vertical space. 
- Added helper render utilities `formatPillDate` and `pillResource` in `src/views/WeekView.jsx` and updated ARIA labels to include start/end/resource metadata. 
- Updated default timed event rendering in `src/views/WeekView.jsx` to show labeled `Title`, `Start`, `End`, and `Resource` fields when no custom `renderEvent` is provided, and expanded all-day pill markup to include the same fields. 
- Adjusted styles in `src/views/WeekView.module.css`: changed `.allDaySpan` padding/alignment, added `.allDayTitleLine`, `.allDayMetaLine` and `.evMeta` rules, tuned `.evTime`/`.evMeta` spacing, and added responsive rules to hide extra metadata on smaller screens so mobile remains compact.

### Testing
- Ran the focused unit test file with `npm test -- --run src/views/__tests__/WeekDayView.offHoursClipping.test.jsx`, and all tests passed (`1` test file, `8` tests passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e3f065748c832cad17a5211b8eab05)