### PR TITLE
Fix asset settings: stable keys, visible field labels, button layout

### DIFF
--- a/src/ui/ConfigPanel.jsx
+++ b/src/ui/ConfigPanel.jsx
@@ -976,7 +976,7 @@ export function AssetsTab({ config, onUpdate }) {
     const n = assets.length + 1;
     writeAssets([
       ...assets,
-      { id: `asset-${n}`, label: `Asset ${n}`, group: '', meta: {} },
+      { _key: `${Date.now()}-${n}`, id: `asset-${n}`, label: `Asset ${n}`, group: '', meta: {} },
     ]);
   };
 
@@ -1010,52 +1010,64 @@ export function AssetsTab({ config, onUpdate }) {
       </p>
 
       {assets.map((asset, i) => (
-        <div key={asset.id + ':' + i} className={styles.fieldRow} data-asset-id={asset.id}>
-          <input
-            className={styles.input}
-            value={asset.label ?? ''}
-            onChange={e => updateAsset(i, { label: e.target.value })}
-            placeholder="Label"
-            aria-label={`Label for ${asset.id}`}
-          />
-          <input
-            className={styles.input}
-            value={asset.id}
-            onChange={e => updateAsset(i, { id: e.target.value.trim() || asset.id })}
-            placeholder="id"
-            aria-label={`Id for ${asset.label || asset.id}`}
-          />
-          <input
-            className={styles.input}
-            value={asset.group ?? ''}
-            onChange={e => updateAsset(i, { group: e.target.value })}
-            placeholder="Group"
-            aria-label={`Group for ${asset.label || asset.id}`}
-          />
-          <input
-            className={styles.input}
-            value={asset.meta?.sublabel ?? ''}
-            onChange={e => updateAssetMeta(i, { sublabel: e.target.value })}
-            placeholder="Sublabel"
-            aria-label={`Sublabel for ${asset.label || asset.id}`}
-          />
-          <button
-            className={styles.removeBtn}
-            onClick={() => moveAsset(i, -1)}
-            disabled={i === 0}
-            aria-label={`Move ${asset.label || asset.id} up`}
-          ><ArrowUp size={13} /></button>
-          <button
-            className={styles.removeBtn}
-            onClick={() => moveAsset(i, 1)}
-            disabled={i === assets.length - 1}
-            aria-label={`Move ${asset.label || asset.id} down`}
-          ><ArrowDown size={13} /></button>
-          <button
-            className={styles.removeBtn}
-            onClick={() => removeAsset(i)}
-            aria-label={`Remove ${asset.label || asset.id}`}
-          ><Trash2 size={13} /></button>
+        <div key={asset._key ?? i} className={styles.assetRow} data-asset-id={asset.id}>
+          <div className={styles.assetFields}>
+            <div className={styles.assetField}>
+              <span className={styles.assetFieldLabel}>Label</span>
+              <input
+                className={styles.input}
+                value={asset.label ?? ''}
+                onChange={e => updateAsset(i, { label: e.target.value })}
+                aria-label={`Label for ${asset.id}`}
+              />
+            </div>
+            <div className={styles.assetField}>
+              <span className={styles.assetFieldLabel}>ID</span>
+              <input
+                className={styles.input}
+                value={asset.id}
+                onChange={e => updateAsset(i, { id: e.target.value.trim() || asset.id })}
+                aria-label={`Id for ${asset.label || asset.id}`}
+              />
+            </div>
+            <div className={styles.assetField}>
+              <span className={styles.assetFieldLabel}>Group</span>
+              <input
+                className={styles.input}
+                value={asset.group ?? ''}
+                onChange={e => updateAsset(i, { group: e.target.value })}
+                aria-label={`Group for ${asset.label || asset.id}`}
+              />
+            </div>
+            <div className={styles.assetField}>
+              <span className={styles.assetFieldLabel}>Sublabel</span>
+              <input
+                className={styles.input}
+                value={asset.meta?.sublabel ?? ''}
+                onChange={e => updateAssetMeta(i, { sublabel: e.target.value })}
+                aria-label={`Sublabel for ${asset.label || asset.id}`}
+              />
+            </div>
+          </div>
+          <div className={styles.assetActions}>
+            <button
+              className={styles.removeBtn}
+              onClick={() => moveAsset(i, -1)}
+              disabled={i === 0}
+              aria-label={`Move ${asset.label || asset.id} up`}
+            ><ArrowUp size={13} /></button>
+            <button
+              className={styles.removeBtn}
+              onClick={() => moveAsset(i, 1)}
+              disabled={i === assets.length - 1}
+              aria-label={`Move ${asset.label || asset.id} down`}
+            ><ArrowDown size={13} /></button>
+            <button
+              className={styles.removeBtn}
+              onClick={() => removeAsset(i)}
+              aria-label={`Remove ${asset.label || asset.id}`}
+            ><Trash2 size={13} /></button>
+          </div>
         </div>
       ))}
 

--- a/src/ui/ConfigPanel.module.css
+++ b/src/ui/ConfigPanel.module.css
@@ -274,6 +274,55 @@
   border: 1px solid var(--wc-border);
 }
 
+.assetRow {
+  display: flex;
+  gap: 8px;
+  align-items: flex-end;
+  padding: 8px;
+  background: var(--wc-surface);
+  border-radius: var(--wc-radius-sm);
+  border: 1px solid var(--wc-border);
+}
+
+.assetFields {
+  display: flex;
+  flex: 1;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.assetField {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+  flex: 1;
+  min-width: 90px;
+}
+
+.assetField .input {
+  width: 100%;
+  box-sizing: border-box;
+}
+
+.assetFieldLabel {
+  font-size: 11px;
+  font-weight: 500;
+  color: var(--wc-text-muted);
+  user-select: none;
+}
+
+.assetActions {
+  display: flex;
+  gap: 2px;
+  align-items: center;
+  flex-shrink: 0;
+  padding-bottom: 2px;
+}
+
+.assetActions .removeBtn {
+  margin-left: 0;
+}
+
 .reqLabel {
   display: flex;
   align-items: center;
@@ -590,6 +639,15 @@
 
   .fieldRow {
     flex-direction: column;
+  }
+
+  .assetRow {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .assetActions {
+    justify-content: flex-end;
   }
 
   .themeGrid {


### PR DESCRIPTION
- Add _key to newly created assets so the row key never changes when the
  user edits the ID field; previously the key derived from asset.id caused
  React to unmount/remount the whole row on every keystroke, losing focus
- Replace unlabeled plain inputs with labelled field pairs (Label / ID /
  Group / Sublabel) so users know what each box is for
- Group action buttons in a dedicated assetActions flex container so
  margin-left:auto on removeBtn no longer scatters them across the row

https://claude.ai/code/session_016pMXaHYabFShR2T892HiyS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized the assets management interface with improved grouping of form fields and action controls for better usability.

* **Style**
  * Enhanced mobile responsiveness with optimized vertical layout and spacing for smaller screens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->