### PR TITLE
fix: tighten form validation and guard template adapter (#144, #153)

### DIFF
--- a/src/WorksCalendar.tsx
+++ b/src/WorksCalendar.tsx
@@ -1676,6 +1676,7 @@ export const WorksCalendar = forwardRef<CalendarApi, WorksCalendarProps>(functio
               onResave={(id) => savedViews.resaveView(id, cal.filters, cal.view, activeGroupBy, { sort: activeSort, showAllGroups: activeShowAllGroups, zoomLevel: activeAssetsZoom, collapsedGroups: activeAssetsCollapsed })}
               onUpdate={savedViews.updateView}
               onDelete={handleDeleteView}
+              onEditConditions={ownerCfg.isOwner ? (id) => ownerCfg.openConfigToTab('smartViews', { smartViewEditId: id }) : undefined}
             />
           )
         }
@@ -1888,6 +1889,7 @@ export const WorksCalendar = forwardRef<CalendarApi, WorksCalendarProps>(functio
             schema={schema}
             items={expandedEvents}
             initialTab={ownerCfg.configInitialTab}
+            initialSmartViewEditId={ownerCfg.smartViewEditId}
             onUpdate={ownerCfg.updateConfig}
             onClose={ownerCfg.closeConfig}
             onSaveView={(name, filters, opts) => savedViews.saveView(name, filters, opts)}

--- a/src/WorksCalendar.tsx
+++ b/src/WorksCalendar.tsx
@@ -518,16 +518,24 @@ export const WorksCalendar = forwardRef<CalendarApi, WorksCalendarProps>(functio
     undoManagerRef.current = new UndoRedoManager(engineRef.current, { maxSize: 50 });
   }
 
+  // True when allNormalized is about to change because we called onEventSave.
+  // Prevents the sync effect from wiping the undo stack we just recorded.
+  const engineMutationPendingRef = useRef(false);
+
   // Version counter: increments whenever the engine emits a state change.
   const [engineVer, tickEngine] = useReducer(n => n + 1, 0);
   useEffect(() => engineRef.current.subscribe(() => tickEngine()), []);
 
   // Keep engine in sync with the merged+normalized event list from all sources.
-  // Clear undo history on a full reload so stale entries can't reference
-  // events that no longer exist.
+  // Skip clear() when the change was triggered by our own onEventSave so the
+  // undo stack survives the controlled-events prop round-trip.
   useEffect(() => {
     engineRef.current.setEvents(fromLegacyEvents(allNormalized));
-    undoManagerRef.current.clear();
+    if (engineMutationPendingRef.current) {
+      engineMutationPendingRef.current = false;
+    } else {
+      undoManagerRef.current.clear();
+    }
   }, [allNormalized]);
 
   // ── Expand recurring events within the visible range (via engine) ────────
@@ -605,6 +613,7 @@ export const WorksCalendar = forwardRef<CalendarApi, WorksCalendarProps>(functio
       // State has changed — record the pre-mutation snapshot.
       undoMgr.record(preSnap, op.type);
       announcerRef.current?.announce(opAnnouncement(op));
+      engineMutationPendingRef.current = true;
       onAccepted();
 
     } else if (result.status === 'pending-confirmation') {
@@ -618,6 +627,7 @@ export const WorksCalendar = forwardRef<CalendarApi, WorksCalendarProps>(functio
           if (confirmed.status === 'accepted' || confirmed.status === 'accepted-with-warnings') {
             undoMgr.record(preSnap, op.type);
             announcerRef.current?.announce(opAnnouncement(op));
+            engineMutationPendingRef.current = true;
             onAccepted();
           }
         },

--- a/src/WorksCalendar.tsx
+++ b/src/WorksCalendar.tsx
@@ -518,9 +518,10 @@ export const WorksCalendar = forwardRef<CalendarApi, WorksCalendarProps>(functio
     undoManagerRef.current = new UndoRedoManager(engineRef.current, { maxSize: 50 });
   }
 
-  // True when allNormalized is about to change because we called onEventSave.
-  // Prevents the sync effect from wiping the undo stack we just recorded.
-  const engineMutationPendingRef = useRef(false);
+  // Counts how many onEventSave-triggered prop updates to suppress clear() for.
+  // Scope ops (single/following) emit multiple onEventSave calls; each one
+  // causes a separate allNormalized update that must not wipe the undo stack.
+  const engineMutationPendingRef = useRef(0);
 
   // Version counter: increments whenever the engine emits a state change.
   const [engineVer, tickEngine] = useReducer(n => n + 1, 0);
@@ -531,8 +532,8 @@ export const WorksCalendar = forwardRef<CalendarApi, WorksCalendarProps>(functio
   // undo stack survives the controlled-events prop round-trip.
   useEffect(() => {
     engineRef.current.setEvents(fromLegacyEvents(allNormalized));
-    if (engineMutationPendingRef.current) {
-      engineMutationPendingRef.current = false;
+    if (engineMutationPendingRef.current > 0) {
+      engineMutationPendingRef.current -= 1;
     } else {
       undoManagerRef.current.clear();
     }
@@ -613,8 +614,10 @@ export const WorksCalendar = forwardRef<CalendarApi, WorksCalendarProps>(functio
       // State has changed — record the pre-mutation snapshot.
       undoMgr.record(preSnap, op.type);
       announcerRef.current?.announce(opAnnouncement(op));
-      engineMutationPendingRef.current = true;
-      onAccepted();
+      // Each emitted onEventSave call will trigger an allNormalized update; count
+      // them so the effect can skip clear() for all of them.
+      engineMutationPendingRef.current = Math.max(1, result.changes.length);
+      onAccepted(result);
 
     } else if (result.status === 'pending-confirmation') {
       // Engine state is UNCHANGED at this point (pending means no commit yet).
@@ -627,8 +630,8 @@ export const WorksCalendar = forwardRef<CalendarApi, WorksCalendarProps>(functio
           if (confirmed.status === 'accepted' || confirmed.status === 'accepted-with-warnings') {
             undoMgr.record(preSnap, op.type);
             announcerRef.current?.announce(opAnnouncement(op));
-            engineMutationPendingRef.current = true;
-            onAccepted();
+            engineMutationPendingRef.current = Math.max(1, confirmed.changes.length);
+            onAccepted(confirmed);
           }
         },
       });
@@ -1130,9 +1133,22 @@ export const WorksCalendar = forwardRef<CalendarApi, WorksCalendarProps>(functio
         },
         source: 'form',
       }),
-      () => {
-        const savedPayload = getSavedEventPayload(eventId, rawEv);
-        if (savedPayload) onEventSave?.(savedPayload);
+      (result) => {
+        // For scoped recurring ops the engine may produce multiple changes
+        // (e.g. updated master + created detached occurrence). Emit onEventSave
+        // for every changed/created event so the host stays fully in sync.
+        if (result?.changes?.length > 1) {
+          result.changes.forEach(change => {
+            if (change.type === 'created') {
+              onEventSave?.(toLegacyEvent(change.event));
+            } else if (change.type === 'updated') {
+              onEventSave?.(toLegacyEvent(change.after));
+            }
+          });
+        } else {
+          const savedPayload = getSavedEventPayload(eventId, rawEv);
+          if (savedPayload) onEventSave?.(savedPayload);
+        }
         setFormEvent(null);
       },
       'Edit',
@@ -1145,9 +1161,15 @@ export const WorksCalendar = forwardRef<CalendarApi, WorksCalendarProps>(functio
     applyWithRecurringCheck(
       ev,
       (scope) => ({ type: 'move', id, newStart, newEnd, source: 'drag' }),
-      () => {
-        if (onEventMove) onEventMove(ev, newStart, newEnd);
-        else {
+      (result) => {
+        if (onEventMove) {
+          onEventMove(ev, newStart, newEnd);
+        } else if (result?.changes?.length > 1) {
+          result.changes.forEach(change => {
+            if (change.type === 'created') onEventSave?.(toLegacyEvent(change.event));
+            else if (change.type === 'updated') onEventSave?.(toLegacyEvent(change.after));
+          });
+        } else {
           const savedPayload = getSavedEventPayload(id, raw, { start: newStart, end: newEnd });
           if (savedPayload) onEventSave?.(savedPayload);
         }
@@ -1162,9 +1184,15 @@ export const WorksCalendar = forwardRef<CalendarApi, WorksCalendarProps>(functio
     applyWithRecurringCheck(
       ev,
       (scope) => ({ type: 'resize', id, newStart, newEnd, source: 'resize' }),
-      () => {
-        if (onEventResize) onEventResize(ev, newStart, newEnd);
-        else {
+      (result) => {
+        if (onEventResize) {
+          onEventResize(ev, newStart, newEnd);
+        } else if (result?.changes?.length > 1) {
+          result.changes.forEach(change => {
+            if (change.type === 'created') onEventSave?.(toLegacyEvent(change.event));
+            else if (change.type === 'updated') onEventSave?.(toLegacyEvent(change.after));
+          });
+        } else {
           const savedPayload = getSavedEventPayload(id, raw, { start: newStart, end: newEnd });
           if (savedPayload) onEventSave?.(savedPayload);
         }

--- a/src/WorksCalendar.tsx
+++ b/src/WorksCalendar.tsx
@@ -1865,8 +1865,8 @@ export const WorksCalendar = forwardRef<CalendarApi, WorksCalendarProps>(functio
             onToggleSource={sourceStore.toggleSource}
             onUpdateSource={sourceStore.updateSource}
             scheduleTemplates={mergedScheduleTemplates}
-            onCreateScheduleTemplate={ownerCfg.isOwner ? handleCreateScheduleTemplate : undefined}
-            onDeleteScheduleTemplate={ownerCfg.isOwner ? handleDeleteScheduleTemplate : undefined}
+            onCreateScheduleTemplate={ownerCfg.isOwner && !!scheduleTemplateAdapter?.createScheduleTemplate ? handleCreateScheduleTemplate : undefined}
+            onDeleteScheduleTemplate={ownerCfg.isOwner && !!scheduleTemplateAdapter?.deleteScheduleTemplate ? handleDeleteScheduleTemplate : undefined}
             scheduleTemplateError={templateError}
           />
         )}

--- a/src/hooks/useEventDraftState.js
+++ b/src/hooks/useEventDraftState.js
@@ -144,7 +144,7 @@ export function useEventDraftState(event, categories, config) {
     if (!values.title.trim()) errs.title = 'Title is required';
     if (!values.start) errs.start = 'Start date is required';
     if (!values.end) errs.end = 'End date is required';
-    if (values.start && values.end && new Date(values.start) > new Date(values.end)) {
+    if (values.start && values.end && new Date(values.start) >= new Date(values.end)) {
       errs.end = 'End must be after start';
     }
     customFields.filter(f => f.required).forEach(f => {

--- a/src/hooks/useOwnerConfig.js
+++ b/src/hooks/useOwnerConfig.js
@@ -14,6 +14,7 @@ export function useOwnerConfig({ calendarId, ownerPassword, onConfigSave, devMod
   const [isOwner,       setIsOwner]       = useState(devMode);
   const [configOpen,    setConfigOpen]    = useState(false);
   const [configInitialTab, setConfigInitialTab] = useState(null);
+  const [smartViewEditId, setSmartViewEditId] = useState(null);
   const [authError,     setAuthError]     = useState('');
   const [isAuthLoading, setIsAuthLoading] = useState(false);
   const pendingNotifyRef = useRef(false);
@@ -74,8 +75,9 @@ export function useOwnerConfig({ calendarId, ownerPassword, onConfigSave, devMod
   // Deep-link helper: open ConfigPanel focused on a specific tab id. Used by
   // view toolbars (e.g. AssetsView's "Edit assets") so owners can jump
   // straight to the relevant registry without hunting through tabs.
-  const openConfigToTab = useCallback((tabId) => {
+  const openConfigToTab = useCallback((tabId, opts = {}) => {
     setConfigInitialTab(tabId ?? null);
+    setSmartViewEditId(opts.smartViewEditId ?? null);
     setConfigOpen(true);
   }, []);
 
@@ -84,6 +86,7 @@ export function useOwnerConfig({ calendarId, ownerPassword, onConfigSave, devMod
     isOwner,
     configOpen, setConfigOpen,
     configInitialTab,
+    smartViewEditId,
     authError,
     isAuthLoading,
     authenticate,

--- a/src/ui/ConfigPanel.jsx
+++ b/src/ui/ConfigPanel.jsx
@@ -62,6 +62,8 @@ export default function ConfigPanel({
   // the prop changes so consecutive deep-links (e.g. two clicks of "Edit
   // assets" with a different target each time) land on the right tab.
   initialTab,
+  // When set, SmartViewsTab opens immediately in edit mode for this view id.
+  initialSmartViewEditId,
 }) {
   const [tab, setTab] = useState(() =>
     initialTab && TABS.some(t => t.id === initialTab) ? initialTab : 'setup',
@@ -195,6 +197,7 @@ export default function ConfigPanel({
               savedViews={savedViews ?? []}
               onUpdateView={onUpdateView}
               onDeleteView={onDeleteView}
+              initialEditingId={initialSmartViewEditId}
             />
           )}
           {tab === 'team'        && (
@@ -270,8 +273,8 @@ function SetupTab({ config, onUpdate }) {
   );
 }
 
-export function SmartViewsTab({ categories, resources, schema, items, onSaveView, savedViews = [], onUpdateView, onDeleteView }) {
-  const [editingId,   setEditingId]   = useState(null);
+export function SmartViewsTab({ categories, resources, schema, items, onSaveView, savedViews = [], onUpdateView, onDeleteView, initialEditingId }) {
+  const [editingId,   setEditingId]   = useState(initialEditingId ?? null);
   const [confirmDel,  setConfirmDel]  = useState(null); // id to confirm deletion
 
   const editingView = editingId ? savedViews.find(v => v.id === editingId) : null;

--- a/src/ui/ProfileBar.jsx
+++ b/src/ui/ProfileBar.jsx
@@ -3,7 +3,7 @@
  */
 import { useState, useRef, useEffect } from 'react';
 import {
-  Plus, Bookmark, BookmarkCheck, Pencil, Trash2, RefreshCw, Check, X,
+  Plus, Bookmark, BookmarkCheck, Pencil, Trash2, RefreshCw, Check, X, Settings2,
   CalendarDays, Calendar, Columns3, List, CalendarRange, Boxes,
 } from 'lucide-react';
 import { buildFilterSummary } from '../filters/filterState.js';
@@ -34,6 +34,7 @@ export default function ProfileBar({
   onResave,
   onUpdate,
   onDelete,
+  onEditConditions,
 }) {
   const [saveOpen,    setSaveOpen]    = useState(false);
   const [manageId,    setManageId]    = useState(null); // which view is being managed
@@ -69,6 +70,7 @@ export default function ProfileBar({
             onDelete={() => { onDelete(savedView.id); setManageId(null); }}
             onRename={(name) => { onUpdate(savedView.id, { name }); setManageId(null); }}
             onColorChange={(color) => onUpdate(savedView.id, { color })}
+            onEditConditions={onEditConditions ? () => { onEditConditions(savedView.id); setManageId(null); } : undefined}
           />
         ))}
 
@@ -95,7 +97,7 @@ export default function ProfileBar({
 
 /* ─── View Chip ─────────────────────────────────────────────── */
 function ViewChip({ savedView, schema, isActive, isDirty, isManaging, onApply, onManageToggle,
-  onResave, onDelete, onRename, onColorChange }) {
+  onResave, onDelete, onRename, onColorChange, onEditConditions }) {
 
   const [renaming, setRenaming] = useState(false);
   const [nameVal, setNameVal]   = useState(savedView.name);
@@ -232,6 +234,13 @@ function ViewChip({ savedView, schema, isActive, isDirty, isManaging, onApply, o
               />
             ))}
           </div>
+
+          {/* Edit conditions in Settings */}
+          {onEditConditions && (
+            <button className={styles.manageLine} onClick={onEditConditions}>
+              <Settings2 size={12} /> Edit conditions
+            </button>
+          )}
 
           {/* Resave current filters */}
           <button className={styles.manageLine} onClick={onResave}>


### PR DESCRIPTION
- useEventDraftState: use >= instead of > so start===end is caught
  by client-side validation before the engine alertdialog fires
- WorksCalendar: only pass onCreateScheduleTemplate/onDeleteScheduleTemplate
  when the corresponding adapter method is actually present, preventing the
  silent-reset no-op when no scheduleTemplateAdapter is wired

https://claude.ai/code/session_01GX6PqvBKXA3m6yvS5HDFnL