### PR TITLE
Fix shift coverage pill span and make covered shifts editable

### DIFF
--- a/src/WorksCalendar.tsx
+++ b/src/WorksCalendar.tsx
@@ -832,10 +832,43 @@ export const WorksCalendar = forwardRef<CalendarApi, WorksCalendarProps>(functio
     const eventId = resolveEventId(ev);
     if (!eventId) return;
     const normalizedCoveringEmployeeId = String(coveringEmployeeId ?? '');
-    if (!normalizedCoveringEmployeeId) return;
 
     const openShiftCandidates = findLinkedOpenShifts(expandedEvents, ev);
     const primaryOpenShift = openShiftCandidates[0] ?? null;
+    const mirroredCoverage = findLinkedMirroredCoverage(expandedEvents, ev);
+
+    if (!normalizedCoveringEmployeeId) {
+      const clearedMeta = {
+        ...(ev.meta ?? {}),
+        coveredBy: null,
+      };
+      applyEngineOp(
+        { type: 'update', id: eventId, patch: { meta: clearedMeta }, source: 'api' },
+        () => emitEventSave(eventId, ev, { meta: clearedMeta }),
+      );
+
+      if (primaryOpenShift) {
+        const openId = resolveEventId(primaryOpenShift);
+        if (openId) {
+          const openMeta = {
+            ...(primaryOpenShift.meta ?? {}),
+            coveredBy: null,
+            status: 'open',
+          };
+          applyEngineOp(
+            { type: 'update', id: openId, patch: { meta: openMeta }, source: 'api' },
+            () => emitEventSave(openId, primaryOpenShift, { meta: openMeta }),
+          );
+        }
+      }
+
+      mirroredCoverage.forEach((coverEv) => {
+        const coverId = resolveEventId(coverEv);
+        if (!coverId) return;
+        applyEngineOp({ type: 'delete', id: coverId, source: 'api' }, () => onEventDelete?.(coverId));
+      });
+      return;
+    }
 
     // 1. Mark the shift as covered
     const newMeta = buildCoverageMeta(ev, normalizedCoveringEmployeeId, resolveEventId(primaryOpenShift));
@@ -866,7 +899,6 @@ export const WorksCalendar = forwardRef<CalendarApi, WorksCalendarProps>(functio
       }
     }
 
-    const mirroredCoverage = findLinkedMirroredCoverage(expandedEvents, ev);
     mirroredCoverage.slice(1).forEach((duplicateEv) => {
       const duplicateId = resolveEventId(duplicateEv);
       if (!duplicateId) return;

--- a/src/__tests__/WorksCalendar.scheduleModel.integration.test.tsx
+++ b/src/__tests__/WorksCalendar.scheduleModel.integration.test.tsx
@@ -216,4 +216,30 @@ describe('WorksCalendar schedule model integration', () => {
       expect(String(shift.meta?.coveredBy ?? '')).toBe('emp-3');
     });
   }, 15000);
+
+  it('allows removing coverage after assignment from the covered status pill', async () => {
+    const apiRef = createRef<any>();
+    render(<WorksCalendar ref={apiRef} employees={employees} events={[baseShift]} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Schedule' }));
+    await requestPtoForAlex();
+    await assignCoverageTo(/^Bailey Chen — RN$/);
+
+    fireEvent.click(await screen.findByRole('button', { name: /Shift covered by Bailey Chen — click to edit coverage/i }));
+    fireEvent.click(await screen.findByRole('button', { name: /Remove coverage/i }));
+
+    await waitFor(() => {
+      const visible = apiRef.current.getVisibleEvents();
+      const shift = visible.find((ev) => String(ev.id) === 'shift-1');
+      expect(shift.meta?.coveredBy).toBeNull();
+
+      const openShift = getByKind(visible, 'open-shift')[0];
+      expect(openShift).toBeTruthy();
+      expect(openShift.meta?.coveredBy).toBeNull();
+      expect(openShift.meta?.status).toBe('open');
+
+      const coveringEvents = getByKind(visible, 'covering');
+      expect(coveringEvents).toHaveLength(0);
+    });
+  }, 15000);
 });

--- a/src/views/TimelineView.tsx
+++ b/src/views/TimelineView.tsx
@@ -94,6 +94,22 @@ function assignLanes(events, monthStart, monthEnd) {
   return { events: clipped, laneCount: Math.max(1, laneEnd.length) };
 }
 
+function getInclusiveDayEnd(endDate) {
+  const end = endDate instanceof Date ? endDate : new Date(endDate);
+  if (Number.isNaN(end.getTime())) return startOfDay(new Date());
+  // Built schedule bars treat end-at-midnight as exclusive, so coverage pills
+  // should follow the same visual span.
+  if (
+    end.getHours() === 0
+    && end.getMinutes() === 0
+    && end.getSeconds() === 0
+    && end.getMilliseconds() === 0
+  ) {
+    return addDays(startOfDay(end), -1);
+  }
+  return startOfDay(end);
+}
+
 // ─── Component ───────────────────────────────────────────────────────────────
 
 export default function TimelineView({
@@ -992,8 +1008,7 @@ export default function TimelineView({
                       const reqStart = ev.meta?.requestStart ? new Date(ev.meta.requestStart) : ev.start;
                       const reqEnd   = ev.meta?.requestEnd   ? new Date(ev.meta.requestEnd)   : ev.end;
                       const pillDayStart = differenceInCalendarDays(max([startOfDay(reqStart), monthStart]), monthStart);
-                      // reqEnd is exclusive [start, end), so subtract 1 day to get the last included day
-                      const pillDayEnd   = differenceInCalendarDays(min([addDays(startOfDay(reqEnd), -1), monthEnd]), monthStart);
+                      const pillDayEnd   = differenceInCalendarDays(min([getInclusiveDayEnd(reqEnd), monthEnd]), monthStart);
                       const left  = pillDayStart * DAY_W + 2;
                       const width = Math.max(DAY_W - 4, (pillDayEnd - pillDayStart + 1) * DAY_W - 4);
                       const top   = baseH + 3;
@@ -1005,14 +1020,20 @@ export default function TimelineView({
 
                       if (isCovered) {
                         return (
-                          <div
+                          <button
                             key={`sp-${ev.id}`}
                             className={[styles.coveragePill, styles.coveragePillCovered].join(' ')}
                             style={{ left, top, width, height: COVERAGE_PILL_H }}
+                            onClick={e => {
+                              e.stopPropagation();
+                              const rect = e.currentTarget.getBoundingClientRect();
+                              setCoverMenu(prev => prev?.ev?.id === ev.id ? null : { ev, rect });
+                            }}
                             title={`Shift covered by ${coveredByName}`}
+                            aria-label={`Shift covered by ${coveredByName} — click to edit coverage`}
                           >
                             ✓ Shift covered by {coveredByName}
-                          </div>
+                          </button>
                         );
                       }
                       return (
@@ -1109,7 +1130,17 @@ export default function TimelineView({
           className={styles.coverPopover}
           style={{ top: coverMenu.rect.bottom + 4, left: coverMenu.rect.left }}
         >
-          <p className={styles.coverPopoverTitle}>Who will cover this shift?</p>
+          <p className={styles.coverPopoverTitle}>
+            {coverMenu.ev?.meta?.coveredBy ? 'Edit shift coverage' : 'Who will cover this shift?'}
+          </p>
+          {coverMenu.ev?.meta?.coveredBy && (
+            <button
+              className={styles.coverEmpBtn}
+              onClick={() => { onCoverageAssign?.(coverMenu.ev, null); setCoverMenu(null); }}
+            >
+              ✕ Remove coverage (mark shift as available)
+            </button>
+          )}
           {employees.filter(e => e.id !== (coverMenu.ev.resource ?? '')).length === 0 ? (
             <p className={styles.coverPopoverEmpty}>No other employees available.</p>
           ) : (


### PR DESCRIPTION
### Motivation
- Align coverage-pill rendering with built-schedule semantics so shift-available/covered pills span the correct days (midnight end-times treated as exclusive). 
- Allow post-assignment editing and removal of coverage so a user can change, edit, or delete coverage after it has been assigned and keep behaviour consistent with built schedule logic.

### Description
- Added `getInclusiveDayEnd` helper and used it when computing coverage pill day-end so midnight `end` timestamps are treated as exclusive and non-midnight ends are treated inclusive, fixing the off-by-one span. (`src/views/TimelineView.tsx`).
- Made the covered status pill interactive (changed to a `button`) and wired it to open the coverage popover so assigned coverage can be edited via the same UI as unassigned shifts. (`src/views/TimelineView.tsx`).
- Updated coverage popover text and added a `✕ Remove coverage` action to let users revert a covered shift back to available/open. (`src/views/TimelineView.tsx`).
- Extended `handleCoverageAssign` to accept a `null` covering employee, which clears `coveredBy` on the shift, resets the linked open-shift `status` to `open`, and deletes mirrored covering events so coverage can be cleared or reassigned. (`src/WorksCalendar.tsx`).
- Added an integration test that exercises clearing coverage from the covered pill and verifies the shift, open-shift, and mirrored covering records update as expected. (`src/__tests__/WorksCalendar.scheduleModel.integration.test.tsx`).

### Testing
- Ran the integration spec: `npm test -- src/__tests__/WorksCalendar.scheduleModel.integration.test.tsx`, which completed and reported the test file passed (all tests in that file passed).
- Ran type checks: `npm run type-check` (`tsc --noEmit`), which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e4e551079c832c8d0e239e5b53b9b5)