### PR TITLE
Fix recurring event edit save for numeric resources

### DIFF
--- a/src/hooks/useEventDraftState.ts
+++ b/src/hooks/useEventDraftState.ts
@@ -66,7 +66,7 @@ export function useEventDraftState(event, categories, config) {
       end:      toDatetimeLocal(endDate),
       allDay:   event?.allDay   ?? false,
       category: event?.category ?? categories[0] ?? '',
-      resource: event?.resource ?? '',
+      resource: event?.resource == null ? '' : String(event.resource),
       color:    event?.color    ?? '',
       meta:     event?.meta     ?? {},
     };
@@ -124,7 +124,7 @@ export function useEventDraftState(event, categories, config) {
       };
       if (template.defaults.title) next.title = template.defaults.title;
       if (template.defaults.category) next.category = template.defaults.category;
-      if (template.defaults.resource) next.resource = template.defaults.resource;
+      if (template.defaults.resource) next.resource = String(template.defaults.resource);
       if (template.defaults.color) next.color = template.defaults.color;
       if (typeof template.defaults.allDay === 'boolean') next.allDay = template.defaults.allDay;
       if (startDate && Number.isFinite(template.defaults.durationMinutes)) {

--- a/src/ui/EventForm.tsx
+++ b/src/ui/EventForm.tsx
@@ -23,6 +23,7 @@ export default function EventForm({ event, config, categories, onSave, onDelete,
   function handleSubmit(e) {
     e.preventDefault();
     if (!draft.validate()) return;
+    const normalizedResource = draft.values.resource == null ? '' : String(draft.values.resource);
     onSave({
       ...(event || {}),
       title:    draft.values.title.trim(),
@@ -30,7 +31,7 @@ export default function EventForm({ event, config, categories, onSave, onDelete,
       end:      fromDatetimeLocal(draft.values.end),
       allDay:   draft.values.allDay,
       category: draft.values.category || null,
-      resource: draft.values.resource.trim() || null,
+      resource: normalizedResource.trim() || null,
       color:    draft.values.color || undefined,
       meta:     draft.values.meta,
       rrule:    draft.buildRRule(),

--- a/src/ui/__tests__/EventForm.regression.test.tsx
+++ b/src/ui/__tests__/EventForm.regression.test.tsx
@@ -157,4 +157,24 @@ describe('EventForm end-to-end regression', () => {
     expect(screen.getByRole('alertdialog')).toBeInTheDocument();
     expect(onDelete).not.toHaveBeenCalled();
   });
+
+  it('allows saving an edited event when resource is numeric', () => {
+    const onSave = vi.fn();
+    render(
+      <EventForm
+        event={{ id: 'real-2', title: 'On-Call Shift', start: START, end: END, resource: 1, rrule: 'FREQ=WEEKLY;BYDAY=WE' }}
+        config={{ eventFields: {} }}
+        categories={[]}
+        onSave={onSave}
+        onDelete={vi.fn()}
+        onClose={vi.fn()}
+        permissions={{}}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Save Changes' }));
+
+    expect(onSave).toHaveBeenCalledOnce();
+    expect(onSave.mock.calls[0][0].resource).toBe('1');
+  });
 });


### PR DESCRIPTION
### Motivation
- Editing some recurring events could throw `TypeError` on save because `resource` was sometimes a non-string (e.g. `1`) and the form called `.trim()` on it. This prevents saving edits to recurring schedules.

### Description
- Normalize `resource` when hydrating the draft state so initial `resource` values are strings by changing the initializer in `useEventDraftState` to `event?.resource == null ? '' : String(event.resource)` (`src/hooks/useEventDraftState.ts`).
- Normalize `resource` when applying templates by coercing `template.defaults.resource` to `String(...)` (`src/hooks/useEventDraftState.ts`).
- Guard submit serialization in the form by coercing `draft.values.resource` to a string before calling `.trim()` in `EventForm` (`src/ui/EventForm.tsx`).
- Add a regression test that renders an edit modal for a recurring event whose `resource` is numeric and asserts `Save Changes` succeeds and `resource` is serialized as a string (`src/ui/__tests__/EventForm.regression.test.tsx`).

### Testing
- Ran `npm test -- src/ui/__tests__/EventForm.regression.test.tsx` and the test file passed with `1 passed` test file and `9 passed` tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e4e6b73188832c933f124e53e91bb1)