### PR TITLE
Fix EventForm save crash when resource is non-string

### DIFF
--- a/src/ui/EventForm.tsx
+++ b/src/ui/EventForm.tsx
@@ -23,6 +23,9 @@ export default function EventForm({ event, config, categories, onSave, onDelete,
   function handleSubmit(e) {
     e.preventDefault();
     if (!draft.validate()) return;
+    const normalizedResource = typeof draft.values.resource === 'string'
+      ? draft.values.resource.trim()
+      : String(draft.values.resource ?? '').trim();
     onSave({
       ...(event || {}),
       title:    draft.values.title.trim(),
@@ -30,7 +33,7 @@ export default function EventForm({ event, config, categories, onSave, onDelete,
       end:      fromDatetimeLocal(draft.values.end),
       allDay:   draft.values.allDay,
       category: draft.values.category || null,
-      resource: draft.values.resource.trim() || null,
+      resource: normalizedResource || null,
       color:    draft.values.color || undefined,
       meta:     draft.values.meta,
       rrule:    draft.buildRRule(),

--- a/src/ui/__tests__/EventForm.recurrence.test.tsx
+++ b/src/ui/__tests__/EventForm.recurrence.test.tsx
@@ -64,4 +64,17 @@ describe('EventForm recurrence controls', () => {
       templateVersion: 1,
     });
   });
+
+  it('normalizes non-string resource values before save', () => {
+    const { onSave } = renderForm({
+      event: {
+        resource: { id: 'A1' },
+      },
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Add Event' }));
+
+    expect(onSave).toHaveBeenCalledTimes(1);
+    expect(onSave.mock.calls[0][0].resource).toBe('[object Object]');
+  });
 });


### PR DESCRIPTION
### Motivation
- Prevent a runtime crash when submitting the Event form if `draft.values.resource` is not a string (e.g. an object), which caused a `trim is not a function` error during save.

### Description
- Normalize `draft.values.resource` in `src/ui/EventForm.tsx` before calling `trim`, producing `resource: normalizedResource || null` so non-strings are safely coerced to a string and empty values become `null`.
- Add a regression test in `src/ui/__tests__/EventForm.recurrence.test.tsx` that submits an object-valued `resource` and asserts the form saves with the normalized value.

### Testing
- Ran `npm run test -- src/ui/__tests__/EventForm.recurrence.test.tsx`, and the test file passed (3 tests passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e4e7c29930832caed9d7bd69dcb077)