### PR TITLE
feat: opt-in interactive setup landing page for first-time owners

### DIFF
--- a/demo/App.tsx
+++ b/demo/App.tsx
@@ -400,6 +400,7 @@ function App() {
             calendarId={DEMO_CALENDAR_ID}
             ownerPassword="demo1234"
             initialView="schedule"
+            showSetupLanding
             onConfigSave={handleConfigSave}
             notes={notes}
             onNoteSave={handleNoteSave}

--- a/src/WorksCalendar.tsx
+++ b/src/WorksCalendar.tsx
@@ -33,6 +33,7 @@ import { fromLegacyEvents }   from './core/engine/adapters/fromLegacyEvents.ts';
 import { occurrenceToLegacy, toLegacyEvent } from './core/engine/adapters/toLegacyEvents.ts';
 import { validateOperation } from './core/engine/validation/validateOperation.ts';
 import RecurringScopeDialog   from './ui/RecurringScopeDialog';
+import SetupLanding, { type SetupLandingResult, type SetupRecipeId } from './ui/SetupLanding';
 import { applyFilters, getCategories, getResources } from './filters/filterEngine';
 import { DEFAULT_FILTER_SCHEMA, buildDefaultFilterSchema, makeResourceResolver, type FilterField } from './filters/filterSchema';
 import { buildActiveFilterPills, buildFilterSummary } from './filters/filterState';
@@ -155,6 +156,16 @@ export type WorksCalendarProps = {
   emptyState?: ReactNode;
   filterSchema?: FilterField[];
   showAddButton?: boolean;
+  /**
+   * Opt-in interactive setup landing page. When true, first-time owners
+   * (those with `config.setup.completed === false`) see a full-page
+   * guided walkthrough before the calendar renders — with a prominent
+   * "Skip setup guide" button for owners who already know the product.
+   *
+   * Defaults to false so hosts and test fixtures keep their current
+   * behavior. Turn it on from the host app to enable the guided flow.
+   */
+  showSetupLanding?: boolean;
   initialView?: CalendarView;
   weekStartDay?: 0 | 1;
   groupBy?: GroupByInput;
@@ -201,6 +212,72 @@ const DEFAULT_SCHEDULE_INSTANTIATION_LIMITS = {
   previewMax: 200,
   createMax: 200,
 };
+
+/**
+ * Translate a SetupLanding recipe id into a real Saved View payload.
+ * These are the "plain-language starting points" the landing page offers
+ * owners who don't want to build filters by hand. Returns null if the id
+ * isn't recognised so future additions fail soft.
+ */
+function buildRecipeSavedView(
+  id: SetupRecipeId,
+  weekStartsOn: 0 | 1 | 2 | 3 | 4 | 5 | 6,
+): { name: string; filters: Record<string, unknown>; view: string | null; groupBy: GroupByInput | null } | null {
+  const emptyFilters = {
+    categories: new Set<string>(),
+    resources:  new Set<string>(),
+    sources:    new Set<string>(),
+    search:     '',
+    dateRange:  null as null | { start: string; end: string },
+  };
+
+  switch (id) {
+    case 'everything':
+      return { name: 'Show everything', filters: { ...emptyFilters }, view: null, groupBy: null };
+
+    case 'by-person':
+      return {
+        name:    'Group by person',
+        filters: { ...emptyFilters },
+        view:    'schedule',
+        groupBy: 'resource',
+      };
+
+    case 'by-type':
+      return {
+        name:    'Group by type',
+        filters: { ...emptyFilters },
+        view:    null,
+        groupBy: 'category',
+      };
+
+    case 'on-call':
+      return {
+        name:    'On-call only',
+        filters: { ...emptyFilters, categories: new Set(['on-call']) },
+        view:    null,
+        groupBy: null,
+      };
+
+    case 'this-week': {
+      const now      = new Date();
+      const weekStart = startOfWeek(now, { weekStartsOn });
+      const weekEnd   = endOfWeek(now, { weekStartsOn });
+      return {
+        name: 'This week only',
+        filters: {
+          ...emptyFilters,
+          dateRange: { start: weekStart.toISOString(), end: weekEnd.toISOString() },
+        },
+        view:    'week',
+        groupBy: null,
+      };
+    }
+
+    default:
+      return null;
+  }
+}
 let exportToExcelFn = null;
 
 async function exportVisibleEvents(events) {
@@ -296,6 +373,7 @@ export const WorksCalendar = forwardRef<CalendarApi, WorksCalendarProps>(functio
 
     // ── UI toggles ──
     showAddButton           = false,
+    showSetupLanding        = false,
 
     // ── Initial view (overrides saved config on first render) ──
     initialView,
@@ -410,6 +488,61 @@ export const WorksCalendar = forwardRef<CalendarApi, WorksCalendarProps>(functio
   const [savedViewDirty,    setSavedViewDirty]    = useState(false);
   const skipDirtyRef = useRef(false);
   const savedViews = useSavedViews(calendarId);
+
+  // ── Setup landing gate ──────────────────────────────────────────────────
+  // Shown before the calendar for first-time owners until they finish or
+  // skip the guide. The landing persists its decision via setup.completed;
+  // this session flag is just for "show on demand" re-opens later.
+  const [setupDismissed, setSetupDismissed] = useState(false);
+  const setupCompleted  = !!ownerCfg.config?.setup?.completed;
+  const shouldShowSetup = showSetupLanding && !setupCompleted && !setupDismissed;
+
+  const handleSetupSkip = useCallback(() => {
+    ownerCfg.updateConfig(prev => ({
+      ...prev,
+      setup: { ...(prev.setup ?? {}), completed: true },
+    }));
+    setSetupDismissed(true);
+  }, [ownerCfg.updateConfig]);
+
+  const handleSetupFinish = useCallback((result: SetupLandingResult) => {
+    // 1) Persist title / theme / default view / team / setup.completed.
+    ownerCfg.updateConfig(prev => ({
+      ...prev,
+      title: result.calendarName,
+      setup: {
+        ...(prev.setup ?? {}),
+        completed: true,
+        preferredTheme: result.theme,
+      },
+      display: {
+        ...(prev.display ?? {}),
+        defaultView: result.defaultView,
+      },
+      team: {
+        ...(prev.team ?? {}),
+        members: [
+          ...((prev.team?.members ?? []) as Array<{ id: unknown }>)
+            .filter(m => !result.teamMembers.some(r => String(r.id) === String(m.id))),
+          ...result.teamMembers,
+        ],
+      },
+    }));
+
+    // 2) Save each chosen recipe as a Smart View so it shows up in the
+    //    views bar. Recipes map to real filter + groupBy state; the owner
+    //    can edit or delete any of them later.
+    for (const recipeId of result.recipes) {
+      const recipe = buildRecipeSavedView(recipeId, weekStartDay);
+      if (!recipe) continue;
+      savedViews.saveView(recipe.name, recipe.filters, {
+        view: recipe.view,
+        groupBy: recipe.groupBy,
+      });
+    }
+
+    setSetupDismissed(true);
+  }, [ownerCfg.updateConfig, savedViews, weekStartDay]);
 
   // ── Active groupBy / sort (controlled by props; overridden when a saved view is applied) ──
   const [activeGroupBy, setActiveGroupBy] = useState<GroupByInput | null>(groupBy ?? null);
@@ -1546,6 +1679,26 @@ export const WorksCalendar = forwardRef<CalendarApi, WorksCalendarProps>(functio
     sort:          activeSort,
     showAllGroups: activeShowAllGroups,
   };
+
+  if (shouldShowSetup) {
+    return (
+      <CalendarErrorBoundary>
+        <div
+          className={styles.root}
+          data-wc-theme={effectiveTheme}
+          data-testid="works-calendar-setup"
+          style={customThemeVars as React.CSSProperties}
+        >
+          <SetupLanding
+            onSkip={handleSetupSkip}
+            onFinish={handleSetupFinish}
+            initialName={ownerCfg.config?.title}
+            initialTheme={ownerCfg.config?.setup?.preferredTheme ?? effectiveTheme}
+          />
+        </div>
+      </CalendarErrorBoundary>
+    );
+  }
 
   return (
     <CalendarErrorBoundary>

--- a/src/ui/SetupLanding.module.css
+++ b/src/ui/SetupLanding.module.css
@@ -1,0 +1,458 @@
+/* SetupLanding.module.css — full-page guided setup. */
+
+.landing {
+  position: absolute;
+  inset: 0;
+  background: var(--wc-bg, #ffffff);
+  color: var(--wc-text, #0f172a);
+  display: flex;
+  align-items: stretch;
+  justify-content: center;
+  overflow-y: auto;
+  z-index: 100;
+  animation: wcSetupFade 0.2s ease;
+}
+
+@keyframes wcSetupFade {
+  from { opacity: 0; }
+  to   { opacity: 1; }
+}
+
+/* ── Welcome hero ──────────────────────────────────────────────────────── */
+
+.hero {
+  max-width: 640px;
+  margin: auto;
+  padding: 48px 24px;
+  text-align: center;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 16px;
+}
+
+.heroIcon {
+  width: 72px;
+  height: 72px;
+  border-radius: 50%;
+  background: color-mix(in srgb, var(--wc-accent, #3b82f6) 15%, transparent);
+  color: var(--wc-accent, #3b82f6);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.heroTitle {
+  font-size: clamp(24px, 4vw, 34px);
+  font-weight: 800;
+  line-height: 1.15;
+  margin: 0;
+  color: var(--wc-text, #0f172a);
+}
+
+.heroLead {
+  font-size: 16px;
+  line-height: 1.55;
+  margin: 0;
+  color: var(--wc-text-muted, #475569);
+  max-width: 520px;
+}
+
+.heroBullets {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 10px;
+  width: 100%;
+  margin-top: 8px;
+}
+
+.heroBullet {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 12px;
+  background: var(--wc-surface, #f8fafc);
+  border: 1px solid var(--wc-border, #e2e8f0);
+  border-radius: 10px;
+  font-size: 13px;
+  color: var(--wc-text, #0f172a);
+  text-align: left;
+}
+
+.heroActions {
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
+  justify-content: center;
+  margin-top: 8px;
+}
+
+.heroFine {
+  font-size: 12px;
+  color: var(--wc-text-muted, #64748b);
+  margin: 0;
+  max-width: 440px;
+}
+
+/* ── Shell & steps ─────────────────────────────────────────────────────── */
+
+.shell {
+  width: 100%;
+  max-width: 720px;
+  margin: 0 auto;
+  padding: 24px 20px 40px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.topBar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  font-size: 13px;
+}
+
+.brand {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-weight: 700;
+  color: var(--wc-accent, #3b82f6);
+}
+
+.stepPill {
+  font-size: 11px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--wc-text-muted, #475569);
+  background: var(--wc-surface, #f1f5f9);
+  border-radius: 999px;
+  padding: 4px 10px;
+}
+
+.skipTextBtn {
+  background: transparent;
+  border: none;
+  color: var(--wc-text-muted, #64748b);
+  font-size: 12px;
+  cursor: pointer;
+  padding: 4px 6px;
+  border-radius: 6px;
+  text-decoration: underline;
+}
+
+.skipTextBtn:hover {
+  color: var(--wc-text, #0f172a);
+}
+
+.progressTrack {
+  height: 6px;
+  background: var(--wc-surface, #f1f5f9);
+  border-radius: 999px;
+  overflow: hidden;
+}
+
+.progressFill {
+  height: 100%;
+  background: var(--wc-accent, #3b82f6);
+  border-radius: inherit;
+  transition: width 0.25s ease;
+}
+
+.body {
+  background: var(--wc-surface, #ffffff);
+  border: 1px solid var(--wc-border, #e2e8f0);
+  border-radius: 16px;
+  padding: 28px;
+  box-shadow: 0 4px 24px rgba(15, 23, 42, 0.05);
+}
+
+.step {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.stepTitle {
+  font-size: 22px;
+  font-weight: 800;
+  line-height: 1.25;
+  margin: 0;
+  color: var(--wc-text, #0f172a);
+}
+
+.stepPlain {
+  font-size: 15px;
+  line-height: 1.6;
+  color: var(--wc-text-muted, #475569);
+  margin: 0;
+}
+
+.stepTip {
+  font-size: 12px;
+  color: var(--wc-text-muted, #64748b);
+  background: color-mix(in srgb, var(--wc-accent, #3b82f6) 8%, transparent);
+  border: 1px dashed color-mix(in srgb, var(--wc-accent, #3b82f6) 40%, transparent);
+  border-radius: 8px;
+  padding: 8px 10px;
+  margin: 0;
+}
+
+/* ── Fields ────────────────────────────────────────────────────────────── */
+
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.fieldLabel {
+  font-size: 12px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--wc-text-muted, #64748b);
+}
+
+.input {
+  width: 100%;
+  box-sizing: border-box;
+  font-size: 15px;
+  padding: 10px 12px;
+  border: 1px solid var(--wc-border, #cbd5e1);
+  border-radius: 8px;
+  background: var(--wc-bg, #ffffff);
+  color: var(--wc-text, #0f172a);
+  outline: none;
+  transition: border-color 0.12s ease, box-shadow 0.12s ease;
+}
+
+.input:focus-visible {
+  border-color: var(--wc-accent, #3b82f6);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--wc-accent, #3b82f6) 20%, transparent);
+}
+
+/* ── Theme grid ────────────────────────────────────────────────────────── */
+
+.themeGrid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));
+  gap: 12px;
+}
+
+.themeCard,
+.viewCard,
+.recipeCard {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 12px;
+  border: 2px solid var(--wc-border, #e2e8f0);
+  border-radius: 12px;
+  background: var(--wc-bg, #ffffff);
+  cursor: pointer;
+  text-align: left;
+  transition: border-color 0.12s ease, transform 0.12s ease, box-shadow 0.12s ease;
+  font: inherit;
+  color: inherit;
+}
+
+.themeCard:hover,
+.viewCard:hover,
+.recipeCard:hover {
+  border-color: color-mix(in srgb, var(--wc-accent, #3b82f6) 60%, var(--wc-border, #e2e8f0));
+  transform: translateY(-1px);
+}
+
+.cardSelected {
+  border-color: var(--wc-accent, #3b82f6) !important;
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--wc-accent, #3b82f6) 22%, transparent);
+}
+
+.themeMeta,
+.viewMeta,
+.recipeMeta {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.themeLabel,
+.viewLabel,
+.recipeTitle {
+  font-size: 14px;
+  font-weight: 700;
+  flex: 1;
+}
+
+.themeBadge {
+  font-size: 9px;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  padding: 2px 6px;
+  border-radius: 999px;
+  background: #334155;
+  color: #e2e8f0;
+}
+
+.themeBlurb,
+.viewBlurb,
+.recipePlain {
+  font-size: 12px;
+  color: var(--wc-text-muted, #475569);
+  line-height: 1.4;
+}
+
+.recipeExample {
+  font-size: 11px;
+  color: var(--wc-text-muted, #64748b);
+  font-style: italic;
+  line-height: 1.4;
+}
+
+.selectedMark {
+  color: var(--wc-accent, #3b82f6);
+  display: inline-flex;
+  align-items: center;
+}
+
+/* ── View grid ─────────────────────────────────────────────────────────── */
+
+.viewGrid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
+  gap: 12px;
+}
+
+/* ── Team ──────────────────────────────────────────────────────────────── */
+
+.teamIllustrationRow {
+  max-width: 320px;
+  margin: 4px 0 4px;
+}
+
+.teamList {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.teamRow {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.dot {
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.rowRemoveBtn {
+  background: transparent;
+  border: 1px solid var(--wc-border, #cbd5e1);
+  color: var(--wc-text-muted, #64748b);
+  border-radius: 6px;
+  padding: 6px 10px;
+  font-size: 12px;
+  cursor: pointer;
+}
+
+.rowRemoveBtn:hover {
+  border-color: #ef4444;
+  color: #ef4444;
+}
+
+.secondaryBtn {
+  align-self: flex-start;
+  background: transparent;
+  border: 1px dashed var(--wc-border, #cbd5e1);
+  color: var(--wc-text, #0f172a);
+  padding: 8px 12px;
+  border-radius: 8px;
+  cursor: pointer;
+  font-size: 13px;
+  font-weight: 600;
+}
+
+.secondaryBtn:hover {
+  border-color: var(--wc-accent, #3b82f6);
+  color: var(--wc-accent, #3b82f6);
+}
+
+/* ── Recipes ───────────────────────────────────────────────────────────── */
+
+.recipeGrid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+  gap: 12px;
+}
+
+/* ── Footer / buttons ──────────────────────────────────────────────────── */
+
+.footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.primaryBtn,
+.skipBtn,
+.backBtn {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 10px 16px;
+  border-radius: 8px;
+  border: 1px solid transparent;
+  font-size: 14px;
+  font-weight: 700;
+  cursor: pointer;
+  transition: background 0.12s ease, border-color 0.12s ease, color 0.12s ease;
+  font-family: inherit;
+}
+
+.primaryBtn {
+  background: var(--wc-accent, #3b82f6);
+  color: #ffffff;
+  border-color: var(--wc-accent, #3b82f6);
+}
+
+.primaryBtn:hover {
+  filter: brightness(1.08);
+}
+
+.skipBtn {
+  background: var(--wc-surface, #f1f5f9);
+  color: var(--wc-text, #0f172a);
+  border-color: var(--wc-border, #cbd5e1);
+}
+
+.skipBtn:hover {
+  border-color: var(--wc-accent, #3b82f6);
+  color: var(--wc-accent, #3b82f6);
+}
+
+.backBtn {
+  background: transparent;
+  color: var(--wc-text-muted, #64748b);
+}
+
+.backBtn:hover:not(:disabled) {
+  color: var(--wc-text, #0f172a);
+}
+
+.backBtn:disabled {
+  opacity: 0.35;
+  cursor: default;
+}

--- a/src/ui/SetupLanding.tsx
+++ b/src/ui/SetupLanding.tsx
@@ -1,0 +1,476 @@
+/**
+ * SetupLanding — full-page guided setup shown before the calendar loads.
+ *
+ * Rendered by WorksCalendar when `config.setup.completed === false` and the
+ * host hasn't opted out via `showSetupLanding={false}`. Every step uses
+ * plain-language copy and an inline SVG illustration so non-technical owners
+ * understand what each option does without needing docs.
+ *
+ * Escape hatch: a prominent "Skip setup guide" button marks setup complete
+ * and drops the owner straight into the calendar with default config.
+ */
+import { useState } from 'react';
+import { ChevronRight, ChevronLeft, Check, Sparkles, Rocket, Users, Palette, LayoutGrid, Wand2 } from 'lucide-react';
+import { THEMES } from '../styles/themes';
+import styles from './SetupLanding.module.css';
+import {
+  IllustrationTheme,
+  IllustrationView,
+  IllustrationTeam,
+  IllustrationRecipe,
+} from './SetupLandingIllustrations';
+
+/* ────────────────────────────────────────────────────────────────────────── */
+/*  Types                                                                     */
+/* ────────────────────────────────────────────────────────────────────────── */
+
+export type SetupRecipeId =
+  | 'everything'
+  | 'by-person'
+  | 'by-type'
+  | 'on-call'
+  | 'this-week';
+
+export type SetupLandingResult = {
+  calendarName: string;
+  theme: string;
+  defaultView: 'month' | 'week' | 'day' | 'agenda' | 'schedule';
+  teamMembers: Array<{ id: string; name: string; color: string }>;
+  recipes: SetupRecipeId[];
+};
+
+export type SetupLandingProps = {
+  /** Called when owner finishes the guide. Host persists the result. */
+  onFinish: (result: SetupLandingResult) => void;
+  /** Called when owner skips the guide. Host marks setup.completed=true. */
+  onSkip: () => void;
+  /** Initial calendar name (from config.title). */
+  initialName?: string;
+  /** Initial theme (from config.setup.preferredTheme). */
+  initialTheme?: string;
+};
+
+/* ────────────────────────────────────────────────────────────────────────── */
+/*  Constants                                                                 */
+/* ────────────────────────────────────────────────────────────────────────── */
+
+const TOTAL_STEPS = 5;
+
+const VIEW_CHOICES: Array<{
+  id: SetupLandingResult['defaultView'];
+  label: string;
+  plain: string;
+}> = [
+  { id: 'month',    label: 'Month',    plain: 'See one whole month at a time, like a paper calendar.' },
+  { id: 'week',     label: 'Week',     plain: 'See seven days side by side with start and end times.' },
+  { id: 'day',      label: 'Day',      plain: 'Zoom in on a single day, hour by hour.' },
+  { id: 'agenda',   label: 'List',     plain: 'A simple list of what is coming up next.' },
+  { id: 'schedule', label: 'Schedule', plain: 'One row per person. Great for shifts and coverage.' },
+];
+
+const RECIPE_CHOICES: Array<{
+  id: SetupRecipeId;
+  title: string;
+  plain: string;
+  example: string;
+}> = [
+  {
+    id: 'everything',
+    title: 'Show everything',
+    plain: 'Every event, all together. A good place to start.',
+    example: 'Nothing is hidden. You can add filters later.',
+  },
+  {
+    id: 'by-person',
+    title: 'Group by person',
+    plain: 'Put each person\u2019s events in their own row.',
+    example: 'You can see at a glance who is busy and who is free.',
+  },
+  {
+    id: 'by-type',
+    title: 'Group by type',
+    plain: 'Put all the same kinds of events together.',
+    example: 'Meetings with meetings, time off with time off.',
+  },
+  {
+    id: 'on-call',
+    title: 'On-call only',
+    plain: 'Hide everything that is not an on-call shift.',
+    example: 'Useful when you only care about who is covering.',
+  },
+  {
+    id: 'this-week',
+    title: 'This week only',
+    plain: 'Hide events that are not happening this week.',
+    example: 'Cuts out the noise so today stays on top.',
+  },
+];
+
+const STARTER_TEAM = [
+  { id: 't1', name: '',  color: '#3b82f6' },
+  { id: 't2', name: '',  color: '#ef4444' },
+  { id: 't3', name: '',  color: '#10b981' },
+];
+
+/* ────────────────────────────────────────────────────────────────────────── */
+/*  Component                                                                 */
+/* ────────────────────────────────────────────────────────────────────────── */
+
+export default function SetupLanding({
+  onFinish,
+  onSkip,
+  initialName = 'My Calendar',
+  initialTheme = 'corporate',
+}: SetupLandingProps) {
+  // Step 0 is the welcome screen. Steps 1..TOTAL_STEPS are the form.
+  const [step, setStep] = useState(0);
+  const [calendarName, setCalendarName] = useState(initialName);
+  const [theme, setTheme] = useState(initialTheme);
+  const [defaultView, setDefaultView] = useState<SetupLandingResult['defaultView']>('month');
+  const [team, setTeam] = useState(STARTER_TEAM);
+  const [recipes, setRecipes] = useState<SetupRecipeId[]>(['everything']);
+
+  const next = () => setStep(s => Math.min(TOTAL_STEPS, s + 1));
+  const back = () => setStep(s => Math.max(0, s - 1));
+
+  const toggleRecipe = (id: SetupRecipeId) => {
+    setRecipes(prev => prev.includes(id) ? prev.filter(r => r !== id) : [...prev, id]);
+  };
+
+  const handleFinish = () => {
+    onFinish({
+      calendarName: calendarName.trim() || 'My Calendar',
+      theme,
+      defaultView,
+      teamMembers: team
+        .filter(m => m.name.trim())
+        .map(m => ({ id: m.id, name: m.name.trim(), color: m.color })),
+      recipes,
+    });
+  };
+
+  /* ── Welcome ─────────────────────────────────────────────────────────── */
+  if (step === 0) {
+    return (
+      <div className={styles.landing} data-wc-theme={theme} role="region" aria-label="Calendar setup">
+        <div className={styles.hero}>
+          <div className={styles.heroIcon}><Rocket size={40} aria-hidden="true" /></div>
+          <h1 className={styles.heroTitle}>Let’s set up your calendar</h1>
+          <p className={styles.heroLead}>
+            Answer a few easy questions and we’ll pick good settings for you.
+            No tech words. No guessing. You can change anything later.
+          </p>
+
+          <div className={styles.heroBullets}>
+            <div className={styles.heroBullet}><Palette size={16} aria-hidden="true" /> Pick how it looks</div>
+            <div className={styles.heroBullet}><LayoutGrid size={16} aria-hidden="true" /> Pick what you see first</div>
+            <div className={styles.heroBullet}><Users size={16} aria-hidden="true" /> Add your team</div>
+            <div className={styles.heroBullet}><Wand2 size={16} aria-hidden="true" /> Make a smart view</div>
+          </div>
+
+          <div className={styles.heroActions}>
+            <button className={styles.primaryBtn} onClick={() => setStep(1)} type="button">
+              <Sparkles size={16} aria-hidden="true" /> Start setup guide
+            </button>
+            <button className={styles.skipBtn} onClick={onSkip} type="button">
+              Skip setup guide
+            </button>
+          </div>
+          <p className={styles.heroFine}>
+            Skip if you already know how this calendar works. You can open setup again from the settings gear.
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  /* ── Steps ───────────────────────────────────────────────────────────── */
+  return (
+    <div className={styles.landing} data-wc-theme={theme} role="region" aria-label="Calendar setup">
+      <div className={styles.shell}>
+        <header className={styles.topBar}>
+          <span className={styles.brand}><Sparkles size={14} aria-hidden="true" /> Calendar setup</span>
+          <span className={styles.stepPill}>Step {step} of {TOTAL_STEPS}</span>
+          <button className={styles.skipTextBtn} onClick={onSkip} type="button">
+            Skip setup guide
+          </button>
+        </header>
+
+        <div className={styles.progressTrack} role="progressbar" aria-valuenow={step} aria-valuemin={1} aria-valuemax={TOTAL_STEPS}>
+          <div className={styles.progressFill} style={{ width: `${(step / TOTAL_STEPS) * 100}%` }} />
+        </div>
+
+        <main className={styles.body}>
+          {step === 1 && (
+            <StepName name={calendarName} onChange={setCalendarName} />
+          )}
+          {step === 2 && (
+            <StepTheme current={theme} onChange={setTheme} />
+          )}
+          {step === 3 && (
+            <StepView current={defaultView} onChange={setDefaultView} />
+          )}
+          {step === 4 && (
+            <StepTeam team={team} onChange={setTeam} />
+          )}
+          {step === 5 && (
+            <StepRecipes selected={recipes} onToggle={toggleRecipe} />
+          )}
+        </main>
+
+        <footer className={styles.footer}>
+          <button
+            className={styles.backBtn}
+            onClick={back}
+            type="button"
+            disabled={step === 1}
+          >
+            <ChevronLeft size={15} aria-hidden="true" /> Back
+          </button>
+
+          {step < TOTAL_STEPS ? (
+            <button className={styles.primaryBtn} onClick={next} type="button">
+              Next <ChevronRight size={15} aria-hidden="true" />
+            </button>
+          ) : (
+            <button className={styles.primaryBtn} onClick={handleFinish} type="button">
+              <Check size={15} aria-hidden="true" /> I’m done
+            </button>
+          )}
+        </footer>
+      </div>
+    </div>
+  );
+}
+
+/* ────────────────────────────────────────────────────────────────────────── */
+/*  Steps                                                                     */
+/* ────────────────────────────────────────────────────────────────────────── */
+
+function StepName({ name, onChange }: { name: string; onChange: (v: string) => void }) {
+  return (
+    <section className={styles.step}>
+      <h2 className={styles.stepTitle}>What should we call your calendar?</h2>
+      <p className={styles.stepPlain}>
+        Pick a name your team will know. It shows up at the top of the page.
+        Something like <em>“Team Calendar”</em> or <em>“Kitchen Schedule”</em> works great.
+      </p>
+      <label className={styles.field}>
+        <span className={styles.fieldLabel}>Calendar name</span>
+        <input
+          className={styles.input}
+          type="text"
+          value={name}
+          onChange={e => onChange(e.target.value)}
+          maxLength={64}
+          placeholder="My Calendar"
+          autoFocus
+        />
+      </label>
+      <p className={styles.stepTip}>
+        Tip: Don’t worry — you can rename it any time from the settings gear.
+      </p>
+    </section>
+  );
+}
+
+function StepTheme({ current, onChange }: { current: string; onChange: (id: string) => void }) {
+  return (
+    <section className={styles.step}>
+      <h2 className={styles.stepTitle}>How should it look?</h2>
+      <p className={styles.stepPlain}>
+        Pick a look that feels right for your team. You are only picking colors here.
+        You can switch any time.
+      </p>
+
+      <div className={styles.themeGrid}>
+        {THEMES.map(t => {
+          const selected = current === t.id;
+          return (
+            <button
+              key={t.id}
+              type="button"
+              onClick={() => onChange(t.id)}
+              className={[styles.themeCard, selected && styles.cardSelected].filter(Boolean).join(' ')}
+              aria-pressed={selected}
+              title={t.description}
+            >
+              <IllustrationTheme
+                bg={t.preview.bg}
+                surface={t.preview.surface}
+                accent={t.preview.accent}
+                text={t.preview.text}
+                border={t.preview.border}
+              />
+              <div className={styles.themeMeta}>
+                <span className={styles.themeLabel}>{t.label}</span>
+                {t.dark && <span className={styles.themeBadge}>dark</span>}
+                {selected && <span className={styles.selectedMark}><Check size={12} aria-hidden="true" /></span>}
+              </div>
+              <span className={styles.themeBlurb}>{simpleBlurb(t.description)}</span>
+            </button>
+          );
+        })}
+      </div>
+    </section>
+  );
+}
+
+function StepView({
+  current,
+  onChange,
+}: {
+  current: SetupLandingResult['defaultView'];
+  onChange: (v: SetupLandingResult['defaultView']) => void;
+}) {
+  return (
+    <section className={styles.step}>
+      <h2 className={styles.stepTitle}>What should you see first?</h2>
+      <p className={styles.stepPlain}>
+        This is the view your calendar opens to. You can switch views any time with the buttons up top.
+      </p>
+
+      <div className={styles.viewGrid}>
+        {VIEW_CHOICES.map(v => {
+          const selected = current === v.id;
+          return (
+            <button
+              key={v.id}
+              type="button"
+              onClick={() => onChange(v.id)}
+              className={[styles.viewCard, selected && styles.cardSelected].filter(Boolean).join(' ')}
+              aria-pressed={selected}
+            >
+              <IllustrationView kind={v.id} />
+              <div className={styles.viewMeta}>
+                <span className={styles.viewLabel}>{v.label}</span>
+                {selected && <span className={styles.selectedMark}><Check size={12} aria-hidden="true" /></span>}
+              </div>
+              <span className={styles.viewBlurb}>{v.plain}</span>
+            </button>
+          );
+        })}
+      </div>
+    </section>
+  );
+}
+
+function StepTeam({
+  team,
+  onChange,
+}: {
+  team: typeof STARTER_TEAM;
+  onChange: (next: typeof STARTER_TEAM) => void;
+}) {
+  const update = (id: string, name: string) => {
+    onChange(team.map(m => (m.id === id ? { ...m, name } : m)));
+  };
+  const add = () => {
+    const colors = ['#8b5cf6', '#f59e0b', '#06b6d4', '#ec4899', '#14b8a6'];
+    const nextColor = colors[team.length % colors.length];
+    onChange([...team, { id: `t${Date.now()}`, name: '', color: nextColor }]);
+  };
+  const remove = (id: string) => {
+    onChange(team.filter(m => m.id !== id));
+  };
+
+  return (
+    <section className={styles.step}>
+      <h2 className={styles.stepTitle}>Who is on your team?</h2>
+      <p className={styles.stepPlain}>
+        Add the people who show up on your calendar. Just first names are fine.
+        Leave a row blank to skip that person. You can add, rename, or remove people later.
+      </p>
+
+      <div className={styles.teamIllustrationRow}>
+        <IllustrationTeam members={team.filter(m => m.name.trim()).slice(0, 4)} />
+      </div>
+
+      <ul className={styles.teamList}>
+        {team.map(m => (
+          <li key={m.id} className={styles.teamRow}>
+            <span className={styles.dot} style={{ background: m.color }} aria-hidden="true" />
+            <input
+              className={styles.input}
+              type="text"
+              value={m.name}
+              onChange={e => update(m.id, e.target.value)}
+              maxLength={40}
+              placeholder="Type a name…"
+            />
+            {team.length > 1 && (
+              <button
+                className={styles.rowRemoveBtn}
+                type="button"
+                onClick={() => remove(m.id)}
+                aria-label={`Remove ${m.name || 'this person'}`}
+              >
+                Remove
+              </button>
+            )}
+          </li>
+        ))}
+      </ul>
+
+      <button className={styles.secondaryBtn} type="button" onClick={add}>
+        + Add another person
+      </button>
+    </section>
+  );
+}
+
+function StepRecipes({
+  selected,
+  onToggle,
+}: {
+  selected: SetupRecipeId[];
+  onToggle: (id: SetupRecipeId) => void;
+}) {
+  return (
+    <section className={styles.step}>
+      <h2 className={styles.stepTitle}>Pick a smart view or two</h2>
+      <p className={styles.stepPlain}>
+        A smart view is a saved way to look at your calendar. We made some for you.
+        Tap any box to turn it on. You can always add more, or make your own, later.
+      </p>
+
+      <div className={styles.recipeGrid}>
+        {RECIPE_CHOICES.map(r => {
+          const isOn = selected.includes(r.id);
+          return (
+            <button
+              key={r.id}
+              type="button"
+              onClick={() => onToggle(r.id)}
+              className={[styles.recipeCard, isOn && styles.cardSelected].filter(Boolean).join(' ')}
+              aria-pressed={isOn}
+            >
+              <IllustrationRecipe kind={r.id} />
+              <div className={styles.recipeMeta}>
+                <span className={styles.recipeTitle}>{r.title}</span>
+                {isOn && <span className={styles.selectedMark}><Check size={12} aria-hidden="true" /></span>}
+              </div>
+              <span className={styles.recipePlain}>{r.plain}</span>
+              <span className={styles.recipeExample}>{r.example}</span>
+            </button>
+          );
+        })}
+      </div>
+
+      <p className={styles.stepTip}>
+        Not sure? Leave <strong>Show everything</strong> on. You can add more views later from the views bar.
+      </p>
+    </section>
+  );
+}
+
+/* ────────────────────────────────────────────────────────────────────────── */
+/*  Utilities                                                                 */
+/* ────────────────────────────────────────────────────────────────────────── */
+
+/** Strip jargon words from theme descriptions so 5th-graders get the gist. */
+function simpleBlurb(desc: string): string {
+  // Keep only the first sentence, it's usually the friendliest.
+  const firstSentence = desc.split(/[.!?]/)[0]?.trim() ?? desc;
+  return firstSentence.length > 60 ? firstSentence.slice(0, 57) + '\u2026' : firstSentence;
+}

--- a/src/ui/SetupLandingIllustrations.tsx
+++ b/src/ui/SetupLandingIllustrations.tsx
@@ -1,0 +1,345 @@
+/**
+ * SetupLandingIllustrations — inline SVG diagrams for the setup landing page.
+ *
+ * Kept in a dedicated file so the main SetupLanding component stays focused
+ * on the form. Every illustration is a pure function of its props and ships
+ * no binary assets, so the bundle stays tiny and the diagrams stay in sync
+ * with the design system.
+ */
+import type { CSSProperties } from 'react';
+import type { SetupRecipeId } from './SetupLanding';
+
+/* ────────────────────────────────────────────────────────────────────────── */
+/*  Theme preview                                                             */
+/* ────────────────────────────────────────────────────────────────────────── */
+
+export type IllustrationThemeProps = {
+  bg: string;
+  surface: string;
+  accent: string;
+  text: string;
+  border: string;
+};
+
+/** Miniature calendar surface painted in the theme's five preview colors. */
+export function IllustrationTheme({ bg, surface, accent, text, border }: IllustrationThemeProps) {
+  return (
+    <svg viewBox="0 0 120 72" role="img" aria-label="Theme preview" style={svgStyle}>
+      <rect x="0" y="0" width="120" height="72" rx="6" fill={bg} stroke={border} />
+      <rect x="6" y="6" width="108" height="10" rx="2" fill={surface} stroke={border} />
+      <rect x="9" y="9" width="18" height="4" rx="1" fill={accent} />
+      <rect x="6" y="20" width="108" height="46" rx="2" fill={surface} stroke={border} />
+      {/* mini event pills */}
+      <rect x="10" y="25" width="28" height="6" rx="2" fill={accent} opacity="0.85" />
+      <rect x="42" y="25" width="20" height="6" rx="2" fill={text} opacity="0.22" />
+      <rect x="10" y="35" width="18" height="6" rx="2" fill={text} opacity="0.22" />
+      <rect x="32" y="35" width="30" height="6" rx="2" fill={accent} opacity="0.65" />
+      <rect x="66" y="35" width="22" height="6" rx="2" fill={text} opacity="0.22" />
+      <rect x="10" y="45" width="40" height="6" rx="2" fill={accent} opacity="0.85" />
+      <rect x="54" y="45" width="24" height="6" rx="2" fill={text} opacity="0.22" />
+      <rect x="10" y="55" width="16" height="6" rx="2" fill={text} opacity="0.22" />
+      <rect x="30" y="55" width="36" height="6" rx="2" fill={accent} opacity="0.5" />
+    </svg>
+  );
+}
+
+/* ────────────────────────────────────────────────────────────────────────── */
+/*  View preview                                                              */
+/* ────────────────────────────────────────────────────────────────────────── */
+
+export type IllustrationViewKind = 'month' | 'week' | 'day' | 'agenda' | 'schedule';
+
+/** Wireframe showing the shape of each starting view. */
+export function IllustrationView({ kind }: { kind: IllustrationViewKind }) {
+  const pill = 'var(--wc-accent, #3b82f6)';
+  const ink = 'var(--wc-text, #0f172a)';
+  const soft = 'var(--wc-border, #cbd5e1)';
+  const bg = 'var(--wc-surface, #f8fafc)';
+
+  return (
+    <svg viewBox="0 0 140 84" role="img" aria-label={`${kind} view preview`} style={svgStyle}>
+      <rect x="0" y="0" width="140" height="84" rx="6" fill={bg} stroke={soft} />
+      {kind === 'month' && <MonthWireframe ink={ink} soft={soft} pill={pill} />}
+      {kind === 'week' && <WeekWireframe ink={ink} soft={soft} pill={pill} />}
+      {kind === 'day' && <DayWireframe ink={ink} soft={soft} pill={pill} />}
+      {kind === 'agenda' && <AgendaWireframe ink={ink} soft={soft} pill={pill} />}
+      {kind === 'schedule' && <ScheduleWireframe ink={ink} soft={soft} pill={pill} />}
+    </svg>
+  );
+}
+
+function MonthWireframe({ ink, soft, pill }: { ink: string; soft: string; pill: string }) {
+  const cells = [] as JSX.Element[];
+  for (let r = 0; r < 4; r++) {
+    for (let c = 0; c < 7; c++) {
+      const x = 6 + c * 18.5;
+      const y = 10 + r * 16;
+      cells.push(<rect key={`${r}-${c}`} x={x} y={y} width={18} height={16} fill="none" stroke={soft} />);
+    }
+  }
+  return (
+    <g>
+      {cells}
+      <rect x="8" y="14" width="10" height="2" fill={ink} opacity="0.4" />
+      <rect x="8" y="18" width="14" height="3" rx="1" fill={pill} opacity="0.85" />
+      <rect x="45" y="30" width="14" height="3" rx="1" fill={pill} opacity="0.6" />
+      <rect x="82" y="46" width="14" height="3" rx="1" fill={pill} opacity="0.85" />
+    </g>
+  );
+}
+
+function WeekWireframe({ ink, soft, pill }: { ink: string; soft: string; pill: string }) {
+  const days = [] as JSX.Element[];
+  for (let c = 0; c < 7; c++) {
+    const x = 6 + c * 18.5;
+    days.push(<line key={c} x1={x} y1={10} x2={x} y2={76} stroke={soft} />);
+  }
+  return (
+    <g>
+      {days}
+      <line x1="6" y1="10" x2="134" y2="10" stroke={soft} />
+      <rect x="9" y="18" width="14" height="18" rx="2" fill={pill} opacity="0.75" />
+      <rect x="46" y="30" width="14" height="14" rx="2" fill={pill} opacity="0.55" />
+      <rect x="102" y="44" width="14" height="22" rx="2" fill={pill} opacity="0.85" />
+    </g>
+  );
+}
+
+function DayWireframe({ ink, soft, pill }: { ink: string; soft: string; pill: string }) {
+  return (
+    <g>
+      {[0, 1, 2, 3, 4, 5].map(i => (
+        <line key={i} x1="20" y1={12 + i * 12} x2="132" y2={12 + i * 12} stroke={soft} />
+      ))}
+      {[0, 1, 2, 3, 4, 5].map(i => (
+        <rect key={`t${i}`} x="6" y={10 + i * 12} width="10" height="2" fill={ink} opacity="0.4" />
+      ))}
+      <rect x="22" y="16" width="106" height="12" rx="2" fill={pill} opacity="0.85" />
+      <rect x="22" y="42" width="78" height="10" rx="2" fill={pill} opacity="0.55" />
+      <rect x="22" y="58" width="56" height="14" rx="2" fill={pill} opacity="0.75" />
+    </g>
+  );
+}
+
+function AgendaWireframe({ ink, soft, pill }: { ink: string; soft: string; pill: string }) {
+  return (
+    <g>
+      {[0, 1, 2, 3].map(i => (
+        <g key={i}>
+          <rect x="6" y={10 + i * 18} width="128" height="14" rx="3" fill="none" stroke={soft} />
+          <rect x="10" y={14 + i * 18} width="4" height="6" rx="1" fill={pill} opacity="0.9" />
+          <rect x="18" y={14 + i * 18} width="64" height="2" fill={ink} opacity="0.55" />
+          <rect x="18" y={18 + i * 18} width="40" height="2" fill={ink} opacity="0.3" />
+        </g>
+      ))}
+    </g>
+  );
+}
+
+function ScheduleWireframe({ ink, soft, pill }: { ink: string; soft: string; pill: string }) {
+  return (
+    <g>
+      {[0, 1, 2, 3].map(i => (
+        <g key={i}>
+          <rect x="6" y={12 + i * 16} width="24" height="14" rx="2" fill={ink} opacity="0.08" />
+          <circle cx="14" cy={19 + i * 16} r="3" fill={pill} opacity={0.4 + i * 0.15} />
+          <rect x="34" y={14 + i * 16} width="100" height="10" rx="2" fill="none" stroke={soft} />
+          <rect x={36 + i * 14} y={16 + i * 16} width={24 + i * 8} height="6" rx="1" fill={pill} opacity="0.85" />
+        </g>
+      ))}
+    </g>
+  );
+}
+
+/* ────────────────────────────────────────────────────────────────────────── */
+/*  Team preview                                                              */
+/* ────────────────────────────────────────────────────────────────────────── */
+
+export type IllustrationTeamMember = { id: string; name: string; color: string };
+
+/** Row of avatar bubbles — fills with placeholders if the team is thin. */
+export function IllustrationTeam({ members }: { members: IllustrationTeamMember[] }) {
+  const placeholderColors = ['#94a3b8', '#94a3b8', '#94a3b8', '#94a3b8'];
+  const filled = members.slice(0, 4);
+  const placeholders = placeholderColors.slice(0, Math.max(0, 3 - filled.length));
+
+  const bubbles = [
+    ...filled.map((m, i) => ({ key: m.id, color: m.color, letter: firstLetter(m.name), x: 12 + i * 30 })),
+    ...placeholders.map((color, i) => ({
+      key: `ph-${i}`,
+      color,
+      letter: '?',
+      x: 12 + (filled.length + i) * 30,
+    })),
+  ];
+
+  return (
+    <svg viewBox="0 0 140 48" role="img" aria-label="Team preview" style={svgStyle}>
+      {bubbles.map(b => (
+        <g key={b.key}>
+          <circle cx={b.x + 12} cy="24" r="14" fill={b.color} opacity={b.letter === '?' ? 0.35 : 1} />
+          <text
+            x={b.x + 12}
+            y="28"
+            textAnchor="middle"
+            fontSize="13"
+            fontWeight="700"
+            fill="#ffffff"
+            fontFamily="system-ui, sans-serif"
+          >
+            {b.letter}
+          </text>
+        </g>
+      ))}
+    </svg>
+  );
+}
+
+function firstLetter(name: string): string {
+  const trimmed = name.trim();
+  return trimmed ? trimmed[0].toUpperCase() : '?';
+}
+
+/* ────────────────────────────────────────────────────────────────────────── */
+/*  Smart-view recipe previews                                                */
+/* ────────────────────────────────────────────────────────────────────────── */
+
+/** Tiny diagram of what each recipe does with the events. */
+export function IllustrationRecipe({ kind }: { kind: SetupRecipeId }) {
+  return (
+    <svg viewBox="0 0 140 72" role="img" aria-label={`${kind} recipe preview`} style={svgStyle}>
+      <rect x="0" y="0" width="140" height="72" rx="6" fill="var(--wc-surface, #f8fafc)" stroke="var(--wc-border, #cbd5e1)" />
+      {kind === 'everything' && <RecipeEverything />}
+      {kind === 'by-person' && <RecipeByPerson />}
+      {kind === 'by-type' && <RecipeByType />}
+      {kind === 'on-call' && <RecipeOnCall />}
+      {kind === 'this-week' && <RecipeThisWeek />}
+    </svg>
+  );
+}
+
+const pillColors = ['#3b82f6', '#ef4444', '#10b981', '#f59e0b', '#8b5cf6', '#06b6d4'];
+
+function RecipeEverything() {
+  // A messy jumble of every color — the "firehose" default.
+  const pills = [
+    { x: 8, y: 12, w: 40, c: 0 },
+    { x: 52, y: 12, w: 22, c: 1 },
+    { x: 78, y: 12, w: 30, c: 2 },
+    { x: 8, y: 24, w: 26, c: 3 },
+    { x: 38, y: 24, w: 46, c: 4 },
+    { x: 88, y: 24, w: 20, c: 5 },
+    { x: 8, y: 36, w: 32, c: 1 },
+    { x: 44, y: 36, w: 24, c: 2 },
+    { x: 72, y: 36, w: 36, c: 0 },
+    { x: 8, y: 48, w: 48, c: 4 },
+    { x: 60, y: 48, w: 20, c: 5 },
+    { x: 84, y: 48, w: 28, c: 3 },
+  ];
+  return (
+    <g>
+      {pills.map((p, i) => (
+        <rect key={i} x={p.x} y={p.y} width={p.w} height="6" rx="2" fill={pillColors[p.c]} opacity="0.85" />
+      ))}
+    </g>
+  );
+}
+
+function RecipeByPerson() {
+  // Three labelled rows, one per person.
+  const rows = [
+    { y: 10, color: '#3b82f6', letter: 'S', pills: [{ x: 40, w: 30 }, { x: 74, w: 22 }] },
+    { y: 30, color: '#ef4444', letter: 'M', pills: [{ x: 40, w: 48 }] },
+    { y: 50, color: '#10b981', letter: 'A', pills: [{ x: 40, w: 22 }, { x: 66, w: 18 }, { x: 88, w: 26 }] },
+  ];
+  return (
+    <g>
+      {rows.map((r, i) => (
+        <g key={i}>
+          <circle cx="18" cy={r.y + 7} r="7" fill={r.color} />
+          <text x="18" y={r.y + 10} textAnchor="middle" fontSize="8" fontWeight="700" fill="#fff" fontFamily="system-ui">{r.letter}</text>
+          <line x1="32" y1={r.y + 7} x2="134" y2={r.y + 7} stroke="var(--wc-border, #cbd5e1)" />
+          {r.pills.map((p, j) => (
+            <rect key={j} x={p.x} y={r.y + 3} width={p.w} height="8" rx="2" fill={r.color} opacity="0.85" />
+          ))}
+        </g>
+      ))}
+    </g>
+  );
+}
+
+function RecipeByType() {
+  // Three labelled type stacks.
+  const groups = [
+    { y: 8,  label: 'Meetings',  color: '#3b82f6', count: 3 },
+    { y: 28, label: 'On-call',   color: '#ef4444', count: 2 },
+    { y: 48, label: 'Time off',  color: '#10b981', count: 4 },
+  ];
+  return (
+    <g>
+      {groups.map((g, i) => (
+        <g key={i}>
+          <rect x="6" y={g.y} width="50" height="14" rx="3" fill={g.color} opacity="0.18" />
+          <text x="10" y={g.y + 10} fontSize="8" fontWeight="700" fill={g.color} fontFamily="system-ui">{g.label}</text>
+          {Array.from({ length: g.count }).map((_, j) => (
+            <rect key={j} x={62 + j * 18} y={g.y + 3} width="14" height="8" rx="2" fill={g.color} opacity="0.85" />
+          ))}
+        </g>
+      ))}
+    </g>
+  );
+}
+
+function RecipeOnCall() {
+  // Only red (on-call) pills survive; others are faded out as "hidden".
+  return (
+    <g>
+      <rect x="8"  y="12" width="40" height="6" rx="2" fill="#94a3b8" opacity="0.25" />
+      <rect x="52" y="12" width="26" height="6" rx="2" fill="#ef4444" />
+      <rect x="82" y="12" width="30" height="6" rx="2" fill="#94a3b8" opacity="0.25" />
+      <rect x="8"  y="26" width="46" height="6" rx="2" fill="#ef4444" />
+      <rect x="58" y="26" width="26" height="6" rx="2" fill="#94a3b8" opacity="0.25" />
+      <rect x="8"  y="40" width="30" height="6" rx="2" fill="#94a3b8" opacity="0.25" />
+      <rect x="42" y="40" width="34" height="6" rx="2" fill="#ef4444" />
+      <rect x="8"  y="54" width="56" height="6" rx="2" fill="#ef4444" />
+      <text x="122" y="32" fontSize="8" fontWeight="700" fill="#ef4444" fontFamily="system-ui" textAnchor="end">only red</text>
+    </g>
+  );
+}
+
+function RecipeThisWeek() {
+  // Seven-day strip highlighting this week.
+  const days = [] as JSX.Element[];
+  for (let i = 0; i < 7; i++) {
+    const x = 6 + i * 18.5;
+    const highlighted = i >= 2 && i <= 4;
+    days.push(
+      <g key={i}>
+        <rect x={x} y="14" width="18" height="44" rx="2" fill={highlighted ? 'var(--wc-accent, #3b82f6)' : 'var(--wc-border, #cbd5e1)'} opacity={highlighted ? 0.2 : 0.3} />
+        {highlighted && (
+          <>
+            <rect x={x + 2} y="22" width="14" height="4" rx="1" fill="var(--wc-accent, #3b82f6)" />
+            <rect x={x + 2} y="30" width="12" height="4" rx="1" fill="var(--wc-accent, #3b82f6)" opacity="0.7" />
+          </>
+        )}
+      </g>,
+    );
+  }
+  return (
+    <g>
+      {days}
+      <text x="70" y="10" fontSize="8" fontWeight="700" fill="var(--wc-text, #0f172a)" fontFamily="system-ui" textAnchor="middle">this week</text>
+    </g>
+  );
+}
+
+/* ────────────────────────────────────────────────────────────────────────── */
+/*  Shared                                                                    */
+/* ────────────────────────────────────────────────────────────────────────── */
+
+const svgStyle: CSSProperties = {
+  width: '100%',
+  height: 'auto',
+  display: 'block',
+  borderRadius: 6,
+};


### PR DESCRIPTION
Adds a full-page guided setup experience that renders before the calendar when the host opts in via `showSetupLanding`. Every step is written at a 5th-grade reading level with inline SVG diagrams — no binary assets — so non-technical owners can see what each option does without leaving the page.

- Five steps: name, look (theme), starting view, team, smart-view recipes
- Inline SVG illustrations for themes, views, team, and each recipe
- Five plain-language recipes translate to real filter + groupBy state and save as Smart Views (everything, by-person, by-type, on-call, this-week)
- Prominent "Skip setup guide" button on every step for owners who already know the product; skip marks setup.completed so they aren't re-prompted
- Opt-in: defaults to false so existing hosts and tests are unchanged
- Demo turns the flag on to showcase the feature

https://claude.ai/code/session_01FdiFtxnmaqULB4ZAhRCeAX