### PR TITLE
Make saved-view pencil open Smart View editor when edit handler exists

### DIFF
--- a/src/ui/ProfileBar.tsx
+++ b/src/ui/ProfileBar.tsx
@@ -139,6 +139,7 @@ function ViewChip({ savedView, schema, isActive, isDirty, isManaging, onApply, o
   // hidden-button querySelector / focus-order trap that previously kept
   // the DOM button present even when invisible.
   const showPencil = isHovered || isActive || isManaging;
+  const shouldOpenEditorDirectly = typeof onEditConditions === 'function';
 
   const viewIcon = savedView.view ? VIEW_ICON_MAP[savedView.view] : null;
 
@@ -181,8 +182,16 @@ function ViewChip({ savedView, schema, isActive, isDirty, isManaging, onApply, o
         <button
           type="button"
           className={styles.manageBtn}
-          onClick={e => { e.stopPropagation(); onManageToggle(); }}
-          aria-label="Manage saved view"
+          onClick={e => {
+            e.stopPropagation();
+            if (shouldOpenEditorDirectly) {
+              onEditConditions();
+              return;
+            }
+            onManageToggle();
+          }}
+          aria-label={shouldOpenEditorDirectly ? 'Edit saved view' : 'Manage saved view'}
+          title={shouldOpenEditorDirectly ? 'Edit this saved view' : 'Manage this saved view'}
         >
           <Pencil size={10} />
         </button>
@@ -364,5 +373,4 @@ function SaveForm({ onSave, onCancel }: any) {
     </div>
   );
 }
-
 

--- a/src/ui/__tests__/ProfileBar.manageButton.test.tsx
+++ b/src/ui/__tests__/ProfileBar.manageButton.test.tsx
@@ -1,0 +1,56 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import ProfileBar from '../ProfileBar';
+
+const BASE_VIEW = {
+  id: 'view-1',
+  name: 'Sarah\'s Week',
+  filters: {},
+  color: '#3b82f6',
+};
+
+function renderBar(extraProps: any = {}) {
+  const onApply = vi.fn();
+  const onAdd = vi.fn();
+  const onResave = vi.fn();
+  const onUpdate = vi.fn();
+  const onDelete = vi.fn();
+
+  render(
+    <ProfileBar
+      views={[BASE_VIEW]}
+      activeId={BASE_VIEW.id}
+      isDirty={false}
+      onApply={onApply}
+      onAdd={onAdd}
+      onResave={onResave}
+      onUpdate={onUpdate}
+      onDelete={onDelete}
+      {...extraProps}
+    />
+  );
+
+  return { onApply, onAdd, onResave, onUpdate, onDelete };
+}
+
+describe('ProfileBar manage pencil behavior', () => {
+  it('opens manage menu when no edit handler is provided', () => {
+    renderBar();
+
+    fireEvent.click(screen.getByLabelText('Manage saved view'));
+
+    expect(screen.getByText('Rename')).toBeInTheDocument();
+    expect(screen.getByText('Update with current filters')).toBeInTheDocument();
+  });
+
+  it('opens Smart View editor directly when edit handler is provided', () => {
+    const onEditConditions = vi.fn();
+    renderBar({ onEditConditions });
+
+    fireEvent.click(screen.getByLabelText('Edit saved view'));
+
+    expect(onEditConditions).toHaveBeenCalledTimes(1);
+    expect(onEditConditions).toHaveBeenCalledWith(BASE_VIEW.id);
+    expect(screen.queryByText('Rename')).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
### Motivation
- Users reported that clicking the pencil on saved-view pills did not take them to the full Smart View editor to modify or delete views. 
- When an `onEditConditions` handler is available (owner/config mode), the preferred behavior is to route the pencil click to the Smart Views editor instead of only toggling the inline manage popover.

### Description
- Detects presence of an `onEditConditions` handler in `ViewChip` and, when present, invokes it on pencil click instead of toggling the inline manage panel by calling `onEditConditions()`; otherwise preserves the existing `onManageToggle()` flow (`src/ui/ProfileBar.tsx`).
- Adds contextual accessibility attributes and a `title` on the pencil button to reflect the two modes (`Edit saved view` / `Manage saved view`).
- Adds unit tests exercising both flows in `src/ui/__tests__/ProfileBar.manageButton.test.tsx` to assert the manage panel opens when no handler is provided and the editor callback is invoked when one is provided.

### Testing
- Ran the focused unit tests with `npm test -- src/ui/__tests__/ProfileBar.manageButton.test.tsx src/ui/__tests__/ConfigPanel.smartViews.test.tsx`, and both test files passed (2 test files, 10 tests total all passing).
- Also ran the existing `ConfigPanel.smartViews` test individually earlier and it passed (1 test file, 8 tests passing).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e4eb15f6d4832ca4e8904b42543beb)