### PR TITLE
Simplify AssetsView to fixed day-scale Gantt and auto-center current date

### DIFF
--- a/src/views/AssetsView.tsx
+++ b/src/views/AssetsView.tsx
@@ -285,7 +285,10 @@ export default function AssetsView({
   }, []);
 
   // Keep the current day in view for the gantt timeline by centering the
-  // selected date whenever the month/day scale changes.
+  // selected date whenever the month/day scale changes. Depend on a stable
+  // primitive (ISO string) so we don't re-run on every render due to a new
+  // monthStart Date object reference.
+  const monthStartKey = monthStart.toISOString();
   useEffect(() => {
     const wrap = wrapRef.current;
     if (!wrap) return;
@@ -293,10 +296,14 @@ export default function AssetsView({
       Math.max(differenceInCalendarDays(startOfDay(currentDate), monthStart), 0),
       Math.max(totalDays - 1, 0),
     );
-    const dayCenter = (todayIdx + 0.5) * pxPerDay;
-    const targetLeft = Math.max(dayCenter - wrap.clientWidth / 2, 0);
+    // Day columns start after the sticky NAME_W column, so center within
+    // the visible-days region (clientWidth - NAME_W), not the whole viewport.
+    const dayCenter = NAME_W + (todayIdx + 0.5) * pxPerDay;
+    const visibleDaysWidth = Math.max(wrap.clientWidth - NAME_W, 0);
+    const targetLeft = Math.max(dayCenter - NAME_W - visibleDaysWidth / 2, 0);
     wrap.scrollLeft = targetLeft;
-  }, [currentDate, monthStart, totalDays, pxPerDay]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [currentDate, monthStartKey, totalDays, pxPerDay]);
 
   // ── Row source ──
   // When `assets` is provided (first-class registry from owner config),

--- a/src/views/AssetsView.tsx
+++ b/src/views/AssetsView.tsx
@@ -8,7 +8,7 @@
  *   - Rows derived from event.resource (one row per distinct asset).
  *   - Horizontal pill bars sized by duration and laid out with
  *     first-fit lane packing (shared algorithm with TimelineView).
- *   - Pxpday scales with zoomLevel (day=80, week=30, month=10, quarter=4).
+ *   - Assets timeline always renders in day-scale gantt mode.
  *   - Sticky left asset column: registration + sublabel + banner slot.
  *     Location banner is a placeholder in Sprint 2; Sprint 3 wires the
  *     real LocationProvider.
@@ -44,9 +44,7 @@ const OVERSCAN_ROWS = 3;
 
 // Zoom level → pixels per day. Sprint 2 keeps the visible range = current
 // month; later sprints may expand the range at coarser zooms.
-const ZOOM_PX_PER_DAY = { day: 80, week: 30, month: 10, quarter: 4 };
-const ZOOM_LABELS     = { day: 'Day', week: 'Week', month: 'Month', quarter: 'Quarter' };
-const ZOOM_ORDER      = ['day', 'week', 'month', 'quarter'];
+const DAY_PX_PER_DAY = 80;
 
 const APPROVAL_STAGES = new Set([
   'requested', 'approved', 'finalized', 'pending_higher', 'denied',
@@ -174,8 +172,6 @@ export default function AssetsView({
   groupBy,
   onGroupByChange,
   categoriesConfig,
-  zoomLevel = 'month',
-  onZoomChange,
   locationProvider,
   renderAssetLocation,
   collapsedGroups: collapsedGroupsProp,
@@ -242,14 +238,8 @@ export default function AssetsView({
     drawerOpenerRef.current = null;
   }, [announce]);
 
-  const handleZoomChange = useCallback((next) => {
-    if (!onZoomChange) return;
-    onZoomChange(next);
-    announce(`Zoom: ${ZOOM_LABELS[next] ?? next}`);
-  }, [onZoomChange, announce]);
-
-  const activeZoom = ZOOM_PX_PER_DAY[zoomLevel] ? zoomLevel : 'month';
-  const pxPerDay   = ZOOM_PX_PER_DAY[activeZoom];
+  const activeZoom = 'day';
+  const pxPerDay   = DAY_PX_PER_DAY;
 
   const monthStart = startOfMonth(currentDate);
   const monthEnd   = endOfMonth(currentDate);
@@ -293,6 +283,20 @@ export default function AssetsView({
       ro?.disconnect();
     };
   }, []);
+
+  // Keep the current day in view for the gantt timeline by centering the
+  // selected date whenever the month/day scale changes.
+  useEffect(() => {
+    const wrap = wrapRef.current;
+    if (!wrap) return;
+    const todayIdx = Math.min(
+      Math.max(differenceInCalendarDays(startOfDay(currentDate), monthStart), 0),
+      Math.max(totalDays - 1, 0),
+    );
+    const dayCenter = (todayIdx + 0.5) * pxPerDay;
+    const targetLeft = Math.max(dayCenter - wrap.clientWidth / 2, 0);
+    wrap.scrollLeft = targetLeft;
+  }, [currentDate, monthStart, totalDays, pxPerDay]);
 
   // ── Row source ──
   // When `assets` is provided (first-class registry from owner config),
@@ -794,24 +798,6 @@ export default function AssetsView({
             <span className={styles.cornerTitle}>
               {format(currentDate, 'MMM yyyy')}
             </span>
-            <div className={styles.zoomControl} role="group" aria-label="Zoom level">
-              {ZOOM_ORDER.map(z => (
-                <button
-                  key={z}
-                  type="button"
-                  className={[
-                    styles.zoomBtn,
-                    z === activeZoom && styles.zoomBtnActive,
-                  ].filter(Boolean).join(' ')}
-                  aria-pressed={z === activeZoom}
-                  aria-label={`Zoom to ${ZOOM_LABELS[z]}`}
-                  onClick={() => handleZoomChange(z)}
-                  disabled={!onZoomChange}
-                >
-                  {ZOOM_LABELS[z][0]}
-                </button>
-              ))}
-            </div>
           </div>
           <div
             className={styles.dayHeads}

--- a/src/views/__tests__/AssetsView.test.tsx
+++ b/src/views/__tests__/AssetsView.test.tsx
@@ -89,36 +89,16 @@ describe('AssetsView — rows & rendering', () => {
   });
 });
 
-describe('AssetsView — zoom control', () => {
-  it('renders four zoom buttons with Month as the default active', () => {
+describe('AssetsView — gantt day view', () => {
+  it('does not render zoom buttons', () => {
     renderAssets();
-    expect(screen.getByRole('button', { name: 'Zoom to Day' })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'Zoom to Week' })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'Zoom to Month' })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'Zoom to Quarter' })).toBeInTheDocument();
-
-    expect(screen.getByRole('button', { name: 'Zoom to Month' }))
-      .toHaveAttribute('aria-pressed', 'true');
-    expect(screen.getByRole('button', { name: 'Zoom to Day' }))
-      .toHaveAttribute('aria-pressed', 'false');
+    expect(screen.queryByRole('group', { name: /zoom level/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /zoom to/i })).not.toBeInTheDocument();
   });
 
-  it('calls onZoomChange with the clicked zoom id', () => {
-    const onZoomChange = vi.fn();
-    renderAssets({ zoomLevel: 'month', onZoomChange });
-    fireEvent.click(screen.getByRole('button', { name: 'Zoom to Week' }));
-    expect(onZoomChange).toHaveBeenCalledWith('week');
-  });
-
-  it('disables zoom buttons when onZoomChange is absent', () => {
-    renderAssets({ onZoomChange: undefined });
-    expect(screen.getByRole('button', { name: 'Zoom to Day' })).toBeDisabled();
-  });
-
-  it('respects the passed-in zoomLevel', () => {
-    renderAssets({ zoomLevel: 'day', onZoomChange: vi.fn() });
-    expect(screen.getByRole('button', { name: 'Zoom to Day' }))
-      .toHaveAttribute('aria-pressed', 'true');
+  it('renders the timeline in day zoom mode', () => {
+    const { container } = renderAssets();
+    expect(container.querySelector('[data-zoom="day"]')).toBeTruthy();
   });
 });
 
@@ -298,8 +278,8 @@ describe('AssetsView — keyboard navigation', () => {
   it('calls onDateSelect on Enter when the cell is empty', () => {
     const onDateSelect = vi.fn();
     renderAssets({ onDateSelect });
-    // April 20 = day index 19, no event on N121AB
-    const cell = document.querySelector('[data-cell="0-19"]') as HTMLElement;
+    // Day index 0 has no event on N121AB and is always visible.
+    const cell = document.querySelector('[data-cell="0-0"]') as HTMLElement;
     cell.focus();
     fireEvent.keyDown(cell, { key: 'Enter' });
     expect(onDateSelect).toHaveBeenCalled();
@@ -316,13 +296,6 @@ describe('AssetsView — a11y', () => {
     const announcer = screen.getByTestId('assets-announcer');
     expect(announcer).toHaveAttribute('role', 'status');
     expect(announcer).toHaveAttribute('aria-live', 'polite');
-  });
-
-  it('announces zoom changes', () => {
-    const onZoomChange = vi.fn();
-    renderAssets({ zoomLevel: 'month', onZoomChange });
-    fireEvent.click(screen.getByRole('button', { name: 'Zoom to Week' }));
-    expect(screen.getByTestId('assets-announcer').textContent).toMatch(/Zoom: Week/);
   });
 
   it('announces when audit drawer opens and closes', () => {

--- a/tests-e2e/calendar.assets-grouping.spec.ts
+++ b/tests-e2e/calendar.assets-grouping.spec.ts
@@ -2,11 +2,9 @@
  * AssetsView — grouping + saved-view round-trip E2E (ticket #134-6).
  *
  * The demo loads with the schedule view; we flip to Assets, verify the
- * grid paints its core affordances (rowheaders, zoom control), then drive
- * a saved-view round-trip by seeding localStorage with a pinned Assets
- * profile and clicking its chip. The round-trip spec is the one that
- * ties ticket #134-2 (persist zoomLevel + collapsedGroups) back to the
- * user-facing flow.
+ * grid paints its core affordances (rowheaders, fixed day gantt), then
+ * drives a saved-view round-trip by seeding localStorage with a pinned
+ * Assets profile and clicking its chip.
  */
 import { test, expect } from '@playwright/test';
 
@@ -20,30 +18,26 @@ test.describe('WorksCalendar Assets view', () => {
     await expect(page.getByTestId('works-calendar')).toBeVisible();
   });
 
-  test('renders the Assets grid with rowheaders and the zoom control', async ({ page }) => {
+  test('renders the Assets grid with rowheaders in fixed day gantt mode', async ({ page }) => {
     await page.getByRole('button', { name: /^Assets$/ }).click();
     // The grid's aria-label includes "Assets timeline for <month>".
     await expect(page.getByRole('grid', { name: /Assets timeline for / })).toBeVisible();
     // At least one rowheader (employee resource) should be present.
     const rowheaders = page.getByRole('rowheader');
     await expect(rowheaders.first()).toBeVisible();
-    // Zoom control group with its four buttons.
-    await expect(page.getByRole('group', { name: /Zoom level/ })).toBeVisible();
-    await expect(page.getByRole('button', { name: /Zoom to Day/ })).toBeVisible();
+    // Assets no longer exposes zoom controls; it should always render in day mode.
+    await expect(page.getByRole('group', { name: /Zoom level/ })).toHaveCount(0);
+    await expect(page.getByRole('button', { name: /Zoom to / })).toHaveCount(0);
+    await expect(page.locator('[data-zoom="day"]').first()).toBeVisible();
   });
 
-  test('clicking a zoom button toggles aria-pressed on the new zoom', async ({ page }) => {
+  test('assets timeline does not render interactive zoom buttons', async ({ page }) => {
     await page.getByRole('button', { name: /^Assets$/ }).click();
-    const monthBtn = page.getByRole('button', { name: /Zoom to Month/ });
-    const dayBtn   = page.getByRole('button', { name: /Zoom to Day/ });
-    // Default zoom is month per AssetsView.
-    await expect(monthBtn).toHaveAttribute('aria-pressed', 'true');
-    await dayBtn.click();
-    await expect(dayBtn).toHaveAttribute('aria-pressed', 'true');
-    await expect(monthBtn).toHaveAttribute('aria-pressed', 'false');
+    await expect(page.getByRole('button', { name: /Zoom to / })).toHaveCount(0);
+    await expect(page.locator('[data-zoom="day"]').first()).toBeVisible();
   });
 
-  test('saved view round-trip restores zoomLevel when its chip is applied', async ({ page }) => {
+  test('saved view round-trip still opens Assets even with legacy zoomLevel', async ({ page }) => {
     // Seed a saved view pinned to the Assets view with zoomLevel=day.
     await page.evaluate(({ key }) => {
       window.localStorage.setItem(key, JSON.stringify({
@@ -78,10 +72,8 @@ test.describe('WorksCalendar Assets view', () => {
 
     // Applying the saved view switches to the Assets grid.
     await expect(page.getByRole('grid', { name: /Assets timeline for / })).toBeVisible();
-    // And the pinned zoomLevel ('day') should be active.
-    await expect(page.getByRole('button', { name: /Zoom to Day/ })).toHaveAttribute(
-      'aria-pressed',
-      'true',
-    );
+    // Legacy zoomLevel is ignored; Assets always renders day-scale.
+    await expect(page.getByRole('button', { name: /Zoom to / })).toHaveCount(0);
+    await expect(page.locator('[data-zoom="day"]').first()).toBeVisible();
   });
 });


### PR DESCRIPTION
### Motivation
- The Assets (Gantt) timeline should always render in a day-scale gantt mode and not expose week/month/quarter zoom controls in the header.
- Auto-centering the timeline on the current date improves discoverability and places the current day in the viewport by default.
- Simplify UI and reduce state/props surface related to zooming.

### Description
- Force day-scale rendering by replacing multi-zoom constants with `DAY_PX_PER_DAY` and setting the active zoom to `'day'` in `src/views/AssetsView.tsx`.
- Remove the header zoom control UI and any `onZoomChange` / zoom-handling logic from `src/views/AssetsView.tsx` so zoom buttons (D/W/M/Q) are no longer rendered.
- Add a `useEffect` that centers the horizontal scroll around the `currentDate` by computing the day index and setting `wrapRef.scrollLeft` in `src/views/AssetsView.tsx`.
- Update unit tests in `src/views/__tests__/AssetsView.test.tsx` to reflect the fixed day-scale behavior and remove zoom-specific assertions; adjust one keyboard test to select a reliably visible empty cell.

### Testing
- Ran the AssetsView unit tests with `npm test -- src/views/__tests__/AssetsView.test.tsx` and observed all tests pass (`29/29` passed).
- No additional automated test suites were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e4eddab274832cbf77b014182c6816)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Assets timeline zoom controls have been removed. The timeline now displays at a fixed day-level scale instead of supporting day, week, month, or quarter zoom options.
  * Timeline automatically centers on the current day, keeping your view aligned with today's date as you navigate assets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->