### PR TITLE
Fix coverage pill spanning to match PTO request windows

### DIFF
--- a/src/WorksCalendar.tsx
+++ b/src/WorksCalendar.tsx
@@ -1038,12 +1038,21 @@ export const WorksCalendar = forwardRef<CalendarApi, WorksCalendarProps>(functio
       applyEngineOp({ type: 'delete', id: duplicateId, source: 'api' }, () => onEventDelete?.(duplicateId));
     });
 
-    // 3. Create or update the mirrored on-call event on the covering employee's row
+    // 3. Create or update the mirrored on-call event on the covering employee's row.
+    //    Clamp the mirrored event to the PTO request window (meta.requestStart/End)
+    //    when available, so the coverage bar only spans the days actually needing
+    //    coverage — not the entire underlying shift.
     const onCallCat = ownerCfg.config?.onCallCategory ?? 'on-call';
+    const shiftStart = ev.start instanceof Date ? ev.start : new Date(ev.start);
+    const shiftEnd   = ev.end   instanceof Date ? ev.end   : new Date(ev.end);
+    const requestStart = ev.meta?.requestStart ? new Date(ev.meta.requestStart) : shiftStart;
+    const requestEnd   = ev.meta?.requestEnd   ? new Date(ev.meta.requestEnd)   : shiftEnd;
+    const mirrorStart = requestStart > shiftStart ? requestStart : shiftStart;
+    const mirrorEnd   = requestEnd   < shiftEnd   ? requestEnd   : shiftEnd;
     const mirroredPatch = {
       title:    `Covering: ${ev.title ?? 'Shift'}`,
-      start:    ev.start instanceof Date ? ev.start : new Date(ev.start),
-      end:      ev.end   instanceof Date ? ev.end   : new Date(ev.end),
+      start:    mirrorStart,
+      end:      mirrorEnd,
       category: onCallCat,
       resource: normalizedCoveringEmployeeId,
       meta: {

--- a/src/views/TimelineView.tsx
+++ b/src/views/TimelineView.tsx
@@ -30,6 +30,7 @@ import EmployeeActionCard from '../ui/EmployeeActionCard';
 import styles from './TimelineView.module.css';
 import { buildGroupTree } from '../hooks/useGrouping.ts';
 import { useTouchDnd } from '../hooks/useTouchDnd';
+import { normalizeScheduleKind, SCHEDULE_KINDS } from '../core/scheduleModel';
 
 // ─── Layout constants ─────────────────────────────────────────────────────────
 
@@ -94,20 +95,16 @@ function assignLanes(events, monthStart, monthEnd) {
   return { events: clipped, laneCount: Math.max(1, laneEnd.length) };
 }
 
-function getInclusiveDayEnd(endDate) {
-  const end = endDate instanceof Date ? endDate : new Date(endDate);
-  if (Number.isNaN(end.getTime())) return startOfDay(new Date());
-  // Built schedule bars treat end-at-midnight as exclusive, so coverage pills
-  // should follow the same visual span.
-  if (
-    end.getHours() === 0
-    && end.getMinutes() === 0
-    && end.getSeconds() === 0
-    && end.getMilliseconds() === 0
-  ) {
-    return addDays(startOfDay(end), -1);
-  }
-  return startOfDay(end);
+// Matches any event that represents a shift or on-call bar, whether it was
+// tagged via category (legacy seed events) or via meta.kind / meta.onCall
+// (events created by ScheduleEditorForm or mirrored coverage).  Used so the
+// shift-status pills render for user-created shifts, not just seeded ones.
+function isShiftOrOnCallLikeEvent(ev, onCallCategory) {
+  const kind = normalizeScheduleKind(ev?.meta?.kind ?? ev?.kind);
+  return ev?.category === onCallCategory
+    || ev?.meta?.onCall === true
+    || kind === SCHEDULE_KINDS.SHIFT
+    || kind === SCHEDULE_KINDS.ON_CALL;
 }
 
 // ─── Component ───────────────────────────────────────────────────────────────
@@ -290,13 +287,18 @@ export default function TimelineView({
     const coveringMap = new Map(); // empId → [{ ev, origEmpName, _dayStart, _dayEnd }]
     if (useEmployees) {
       events.forEach(ev => {
-        const isOnCallEv = ev.category === onCallCategory || ev.meta?.onCall === true;
-        if (!isOnCallEv || !ev.meta?.shiftStatus || !ev.meta?.coveredBy) return;
+        if (!isShiftOrOnCallLikeEvent(ev, onCallCategory)) return;
+        if (!ev.meta?.shiftStatus || !ev.meta?.coveredBy) return;
         const coverId = String(ev.meta.coveredBy);
         if (!coveringMap.has(coverId)) coveringMap.set(coverId, []);
-        const origEmp = displayEmployees.find(e => e.id === (ev.resource ?? ''));
-        const clampedStart = max([startOfDay(ev.start), monthStart]);
-        const clampedEnd   = min([startOfDay(ev.end),   monthEnd]);
+        const origEmp = displayEmployees.find(e => String(e.id) === String(ev.resource ?? ''));
+        // Clamp to the PTO request window (meta.requestStart/End) so the
+        // "covering for" pill only spans the days actually needing coverage,
+        // not the entire underlying shift.
+        const reqStart = ev.meta?.requestStart ? new Date(ev.meta.requestStart) : ev.start;
+        const reqEnd   = ev.meta?.requestEnd   ? new Date(ev.meta.requestEnd)   : ev.end;
+        const clampedStart = max([startOfDay(reqStart), monthStart]);
+        const clampedEnd   = min([startOfDay(reqEnd),   monthEnd]);
         if (clampedStart > clampedEnd) return;
         const ds = differenceInCalendarDays(clampedStart, monthStart);
         const de = differenceInCalendarDays(clampedEnd,   monthStart);
@@ -311,12 +313,12 @@ export default function TimelineView({
 
     if (useEmployees) {
       return displayEmployees.map((emp, idx) => {
-        const eventsForRow = events.filter(e => (e.resource ?? '') === emp.id);
+        const eventsForRow = events.filter(e => String(e.resource ?? '') === String(emp.id));
         const { events: laned, laneCount } = assignLanes(eventsForRow, monthStart, monthEnd);
 
-        const coveringPills  = coveringMap.get(emp.id) ?? [];
+        const coveringPills  = coveringMap.get(String(emp.id)) ?? [];
         const hasStatusPills = laned.some(ev =>
-          (ev.category === onCallCategory || ev.meta?.onCall === true) && !!ev.meta?.shiftStatus
+          isShiftOrOnCallLikeEvent(ev, onCallCategory) && !!ev.meta?.shiftStatus
         );
 
         const baseH = Math.max(
@@ -1003,18 +1005,20 @@ export default function TimelineView({
 
                   {/* ── Shift coverage status pills (below event lanes) ── */}
                   {rowEvents
-                    .filter(ev => (ev.category === onCallCategory || ev.meta?.onCall === true) && ev.meta?.shiftStatus)
+                    .filter(ev => isShiftOrOnCallLikeEvent(ev, onCallCategory) && ev.meta?.shiftStatus)
                     .map(ev => {
                       const reqStart = ev.meta?.requestStart ? new Date(ev.meta.requestStart) : ev.start;
                       const reqEnd   = ev.meta?.requestEnd   ? new Date(ev.meta.requestEnd)   : ev.end;
+                      // Use startOfDay (matches assignLanes) so this pill spans the same
+                      // day range as the PTO/unavailable event pill it mirrors.
                       const pillDayStart = differenceInCalendarDays(max([startOfDay(reqStart), monthStart]), monthStart);
-                      const pillDayEnd   = differenceInCalendarDays(min([getInclusiveDayEnd(reqEnd), monthEnd]), monthStart);
+                      const pillDayEnd   = differenceInCalendarDays(min([startOfDay(reqEnd), monthEnd]), monthStart);
                       const left  = pillDayStart * DAY_W + 2;
                       const width = Math.max(DAY_W - 4, (pillDayEnd - pillDayStart + 1) * DAY_W - 4);
                       const top   = baseH + 3;
                       const isCovered = !!ev.meta?.coveredBy;
                       const coveredByEmp = isCovered
-                        ? employees.find(e => e.id === String(ev.meta.coveredBy))
+                        ? employees.find(e => String(e.id) === String(ev.meta.coveredBy))
                         : null;
                       const coveredByName = coveredByEmp?.name ?? 'Someone';
 


### PR DESCRIPTION
## Summary
This PR fixes the coverage pill rendering logic to properly span only the days covered by a PTO/unavailability request, rather than the entire underlying shift. It also improves event matching to recognize shifts created via the ScheduleEditorForm in addition to legacy seeded events.

## Key Changes

- **Replaced `getInclusiveDayEnd()` with `isShiftOrOnCallLikeEvent()`**: The old function attempted to handle end-of-day edge cases but was only used in one place. The new helper function properly identifies shift and on-call events regardless of how they were created (legacy category, meta.kind, or meta.onCall flag), making the shift-status pills render for all user-created shifts.

- **Clamped coverage pills to PTO request windows**: Modified the covering map calculation in TimelineView to use `meta.requestStart` and `meta.requestEnd` when available, ensuring coverage pills only span the days actually needing coverage rather than the entire shift duration.

- **Updated mirrored event creation in WorksCalendar**: When creating the mirrored on-call event on the covering employee's row, the event is now clamped to the PTO request window, so the coverage bar visually matches the actual coverage period.

- **Improved type safety**: Added explicit string conversions when comparing employee IDs to handle potential type mismatches between string and numeric IDs.

- **Clarified pill day calculation**: Replaced `getInclusiveDayEnd(reqEnd)` with `startOfDay(reqEnd)` in the shift status pill rendering, with added comments explaining that this matches the behavior of `assignLanes()` for consistent visual spanning.

## Implementation Details

- The `isShiftOrOnCallLikeEvent()` helper checks multiple conditions: legacy `category` field, `meta.onCall` flag, and normalized `meta.kind` values (SHIFT or ON_CALL).
- Coverage pills now respect the PTO request window boundaries, falling back to the full shift dates if request boundaries aren't specified.
- String conversions ensure employee ID comparisons work correctly regardless of whether IDs are stored as strings or numbers in the data model.

https://claude.ai/code/session_01CdGdcvZ4jjP5wT4NZJUaWc