### PR TITLE
Preserve series identity and RRULE when saving recurring edits

### DIFF
--- a/src/WorksCalendar.tsx
+++ b/src/WorksCalendar.tsx
@@ -1259,9 +1259,17 @@ export const WorksCalendar = forwardRef<CalendarApi, WorksCalendarProps>(functio
   const handleEventSave = useCallback((rawEv) => {
     const newStart = rawEv.start instanceof Date ? rawEv.start : new Date(rawEv.start);
     const newEnd   = rawEv.end   instanceof Date ? rawEv.end   : new Date(rawEv.end);
-    // _eventId is present on occurrences from the engine; fall back to id for
-    // legacy shapes passed directly (e.g. from the EventForm).
-    const eventId  = rawEv._eventId ?? (rawEv.id ? String(rawEv.id) : null);
+    // Expanded recurring occurrences from the engine carry _eventId.
+    // Legacy recurring shapes may only carry _seriesId.
+    const recurringMasterId = rawEv._eventId ?? rawEv._seriesId ?? null;
+    // Fallback to id for non-recurring/legacy event shapes from the EventForm.
+    const eventId  = recurringMasterId ?? (rawEv.id ? String(rawEv.id) : null);
+
+    // Defensive RRULE preservation: if a recurring edit payload arrives with a
+    // missing RRULE (e.g. an occurrence shape that lost series fields), keep
+    // the series master cadence instead of accidentally stripping recurrence.
+    const existingMaster = recurringMasterId ? engineRef.current?.state?.events?.get(String(recurringMasterId)) : null;
+    const resolvedRrule = rawEv.rrule ?? existingMaster?.rrule ?? null;
 
     if (!eventId) {
       // New event — no scope picker needed.
@@ -1278,7 +1286,7 @@ export const WorksCalendar = forwardRef<CalendarApi, WorksCalendarProps>(functio
           category:   rawEv.category   ?? null,
           color:      rawEv.color      ?? null,
           status:     rawEv.status     ?? 'confirmed',
-          rrule:      rawEv.rrule      ?? null,
+          rrule:      resolvedRrule,
           exdates:    rawEv.exdates    ?? [],
           meta:       rawEv.meta       ?? {},
         },
@@ -1307,7 +1315,7 @@ export const WorksCalendar = forwardRef<CalendarApi, WorksCalendarProps>(functio
           category:   rawEv.category   ?? null,
           color:      rawEv.color      ?? null,
           status:     rawEv.status     ?? 'confirmed',
-          rrule:      rawEv.rrule      ?? null,
+          rrule:      resolvedRrule,
         },
         source: 'form',
       }),


### PR DESCRIPTION
### Motivation
- Editing a recurring occurrence could send an incomplete payload (missing series pointer and/or `rrule`) which caused the master series to be updated with a null RRULE and effectively remove the recurrence for the entire schedule.
- The change prevents accidental stripping of recurrence and ensures updates target the canonical series master when appropriate.

### Description
- Resolve the canonical recurring master id from either `_eventId` (engine occurrences) or legacy `_seriesId` and fall back to `id` for non-recurring shapes by computing `recurringMasterId` and `eventId` in `handleEventSave` in `src/WorksCalendar.tsx`.
- Add defensive RRULE preservation by computing `resolvedRrule = rawEv.rrule ?? existingMaster?.rrule ?? null` so missing `rrule` in a form payload does not clear the series cadence.
- Use `resolvedRrule` in both create and update operation payloads produced by the EventForm handler so recurrence is preserved consistently.
- Minor clarifying comments added to document the behavior for engine vs legacy shapes.

### Testing
- Ran the targeted regression tests `npm test -- src/__tests__/WorksCalendar.recurringScopedEdit.test.tsx`, which completed successfully (`1 file, 2 tests passed`).
- Ran static type checks via `npm run type-check` (`tsc --noEmit`) which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e4f187908c832c897c2ba32a520ab7)