### PR TITLE
Redesign saved-views header: dropdown, customize panel, clear filters

### DIFF
--- a/src/WorksCalendar.tsx
+++ b/src/WorksCalendar.tsx
@@ -36,7 +36,7 @@ import RecurringScopeDialog   from './ui/RecurringScopeDialog';
 import SetupLanding, { type SetupLandingResult, type SetupRecipeId } from './ui/SetupLanding';
 import { applyFilters, getCategories, getResources } from './filters/filterEngine';
 import { DEFAULT_FILTER_SCHEMA, buildDefaultFilterSchema, makeResourceResolver, type FilterField } from './filters/filterSchema';
-import { buildActiveFilterPills, buildFilterSummary } from './filters/filterState';
+import { buildActiveFilterPills, buildFilterSummary, hasActiveFilters } from './filters/filterState';
 import FilterBar              from './ui/FilterBar';
 import ProfileBar             from './ui/ProfileBar';
 import HoverCard              from './ui/HoverCard';
@@ -1865,6 +1865,9 @@ export const WorksCalendar = forwardRef<CalendarApi, WorksCalendarProps>(functio
               updateView:  savedViews.updateView,
               resaveView:  (id) => savedViews.resaveView(id, cal.filters, cal.view, activeGroupBy, { sort: activeSort, showAllGroups: activeShowAllGroups, zoomLevel: activeAssetsZoom, collapsedGroups: activeAssetsCollapsed }),
               deleteView:  handleDeleteView,
+              toggleStripVisibility: savedViews.toggleStripVisibility,
+              clearFilters: cal.clearFilters,
+              hasActiveFilters: hasActiveFilters(cal.filters, schema),
               currentFilters: cal.filters,
               currentView:    cal.view,
               schema,
@@ -1876,6 +1879,7 @@ export const WorksCalendar = forwardRef<CalendarApi, WorksCalendarProps>(functio
               activeId={savedViewActiveId}
               isDirty={savedViewDirty}
               schema={schema}
+              hasActiveFilters={hasActiveFilters(cal.filters, schema)}
               onApply={handleApplyView}
               onAdd={({ name, color, pinView }) =>
                 savedViews.saveView(name, cal.filters, { color, view: pinView ? cal.view : null, groupBy: activeGroupBy, sort: activeSort, showAllGroups: activeShowAllGroups, zoomLevel: activeAssetsZoom, collapsedGroups: activeAssetsCollapsed })
@@ -1883,6 +1887,8 @@ export const WorksCalendar = forwardRef<CalendarApi, WorksCalendarProps>(functio
               onResave={(id) => savedViews.resaveView(id, cal.filters, cal.view, activeGroupBy, { sort: activeSort, showAllGroups: activeShowAllGroups, zoomLevel: activeAssetsZoom, collapsedGroups: activeAssetsCollapsed })}
               onUpdate={savedViews.updateView}
               onDelete={handleDeleteView}
+              onToggleVisibility={savedViews.toggleStripVisibility}
+              onClearFilters={cal.clearFilters}
               onEditConditions={ownerCfg.isOwner ? (id) => ownerCfg.openConfigToTab('smartViews', { smartViewEditId: id }) : undefined}
             />
           )

--- a/src/__tests__/WorksCalendar.scheduleWorkflow.test.tsx
+++ b/src/__tests__/WorksCalendar.scheduleWorkflow.test.tsx
@@ -50,7 +50,7 @@ describe('WorksCalendar schedule workflow entry points', () => {
     expect(await screen.findByRole('dialog', { name: 'Request PTO for Alex Rivera' })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Save PTO Request' })).toBeInTheDocument();
     expect(screen.queryByRole('combobox', { name: 'Type' })).not.toBeInTheDocument();
-  });
+  }, 15000);
 
   it('opens unavailable-focused form when Mark Unavailable is selected', async () => {
     render(<WorksCalendar events={[]} employees={employees} />);
@@ -62,7 +62,7 @@ describe('WorksCalendar schedule workflow entry points', () => {
     expect(await screen.findByRole('dialog', { name: 'Mark Unavailable for Alex Rivera' })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Save Unavailable Time' })).toBeInTheDocument();
     expect(screen.queryByRole('combobox', { name: 'Type' })).not.toBeInTheDocument();
-  });
+  }, 15000);
 
   it('opens availability-focused edit form when Edit Availability is selected', async () => {
     render(
@@ -90,5 +90,5 @@ describe('WorksCalendar schedule workflow entry points', () => {
     expect(screen.getByDisplayValue('Clinic Hours')).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Save Availability Changes' })).toBeInTheDocument();
     expect(screen.queryByRole('combobox', { name: 'Type' })).not.toBeInTheDocument();
-  });
+  }, 15000);
 });

--- a/src/filters/filterState.ts
+++ b/src/filters/filterState.ts
@@ -37,6 +37,15 @@ export function clearFilterValue(field) {
   }
 }
 
+/**
+ * Return true when at least one schema field has a non-empty value in `filters`.
+ * Mirrors the derivation used in FilterBar so the saved-views header can share it.
+ */
+export function hasActiveFilters(filters, schema: any[] = DEFAULT_FILTER_SCHEMA) {
+  if (!filters) return false;
+  return schema.some(field => !isEmptyFilterValue(filters[field.key]));
+}
+
 // ── Initial state ─────────────────────────────────────────────────────────────
 
 /**

--- a/src/hooks/__tests__/useSavedViews.test.ts
+++ b/src/hooks/__tests__/useSavedViews.test.ts
@@ -197,7 +197,7 @@ describe('useSavedViews', () => {
       });
     });
     const stored = JSON.parse(localStorage.getItem(`wc-saved-views-${CAL_ID}`));
-    expect(stored.version).toBe(3);
+    expect(stored.version).toBe(4);
     expect(stored.views).toHaveLength(1);
     expect(stored.views[0].name).toBe('Persisted');
   });
@@ -669,7 +669,7 @@ describe('useSavedViews — storage v2 → v3 migration', () => {
       result.current.saveView('New One', EMPTY_FILTERS);
     });
     const stored = JSON.parse(localStorage.getItem(`wc-saved-views-${CAL_ID}`));
-    expect(stored.version).toBe(3);
+    expect(stored.version).toBe(4);
     expect(stored.views).toHaveLength(2);
   });
 
@@ -869,5 +869,67 @@ describe('useSavedViews — resaveView collapsedGroups persistence', () => {
       });
     });
     expect(result.current.views[0].collapsedGroups).toBeNull();
+  });
+});
+
+// ── hiddenFromStrip + toggleStripVisibility ───────────────────────────────────
+
+describe('useSavedViews — hiddenFromStrip strip visibility', () => {
+  it('saveView defaults hiddenFromStrip to false so new views appear in the strip', () => {
+    const { result } = renderHook(() => useSavedViews(CAL_ID));
+    act(() => {
+      result.current.saveView('Visible', EMPTY_FILTERS);
+    });
+    expect(result.current.views[0].hiddenFromStrip).toBe(false);
+  });
+
+  it('toggleStripVisibility flips hiddenFromStrip on and off', () => {
+    const { result } = renderHook(() => useSavedViews(CAL_ID));
+    act(() => {
+      result.current.saveView('Toggle', EMPTY_FILTERS);
+    });
+    const id = result.current.views[0].id;
+
+    act(() => { result.current.toggleStripVisibility(id); });
+    expect(result.current.views[0].hiddenFromStrip).toBe(true);
+
+    act(() => { result.current.toggleStripVisibility(id); });
+    expect(result.current.views[0].hiddenFromStrip).toBe(false);
+  });
+
+  it('updateView can set hiddenFromStrip directly via patch', () => {
+    const { result } = renderHook(() => useSavedViews(CAL_ID));
+    act(() => {
+      result.current.saveView('Direct', EMPTY_FILTERS);
+    });
+    const id = result.current.views[0].id;
+    act(() => { result.current.updateView(id, { hiddenFromStrip: true }); });
+    expect(result.current.views[0].hiddenFromStrip).toBe(true);
+  });
+
+  it('hiddenFromStrip survives localStorage round-trip', () => {
+    const { result } = renderHook(() => useSavedViews(CAL_ID));
+    act(() => {
+      result.current.saveView('Persist hidden', EMPTY_FILTERS);
+    });
+    const id = result.current.views[0].id;
+    act(() => { result.current.toggleStripVisibility(id); });
+
+    const { result: result2 } = renderHook(() => useSavedViews(CAL_ID));
+    expect(result2.current.views[0].hiddenFromStrip).toBe(true);
+  });
+
+  it('v2/v3 payloads migrate with hiddenFromStrip = false (existing views remain visible)', () => {
+    localStorage.setItem(`wc-saved-views-${CAL_ID}`, JSON.stringify({
+      version: 3,
+      views: [{
+        id: 'v-old',
+        name: 'Old',
+        createdAt: new Date().toISOString(),
+        filters: { categories: [], resources: [], sources: [], search: '', dateRange: null },
+      }],
+    }));
+    const { result } = renderHook(() => useSavedViews(CAL_ID));
+    expect(result.current.views[0].hiddenFromStrip).toBe(false);
   });
 });

--- a/src/hooks/__tests__/useSavedViews.test.ts
+++ b/src/hooks/__tests__/useSavedViews.test.ts
@@ -612,9 +612,9 @@ describe('useSavedViews — collapsedGroups + showAllGroups', () => {
   });
 });
 
-// ── v2 → v3 migration ─────────────────────────────────────────────────────────
+// ── v2 → v4 migration ─────────────────────────────────────────────────────────
 
-describe('useSavedViews — storage v2 → v3 migration', () => {
+describe('useSavedViews — storage v2 → v4 migration', () => {
   it('loads v2 payloads without dropping entries', () => {
     const v2 = {
       version: 2,

--- a/src/hooks/useSavedViews.ts
+++ b/src/hooks/useSavedViews.ts
@@ -118,8 +118,9 @@ function migrateSavedViewsPayload(payload, calendarId) {
       && payload.version >= MIN_READABLE_VERSION
       && payload.version <= STORAGE_VERSION
     ) {
-      // v2 and v3 share the same on-disk shape; normalizeSavedView fills in
-      // new fields (sort, collapsedGroups, showAllGroups) as null on load.
+      // v2–v4 share a compatible on-disk shape; normalizeSavedView fills in
+      // fields added in later versions (sort, collapsedGroups, showAllGroups,
+      // hiddenFromStrip) when loading older payloads.
       return normalizeViews(payload.views);
     }
 

--- a/src/hooks/useSavedViews.ts
+++ b/src/hooks/useSavedViews.ts
@@ -16,7 +16,7 @@ import { useState, useEffect, useCallback } from 'react';
 import { createId } from '../core/createId';
 
 function viewsKey(calendarId) { return `wc-saved-views-${calendarId}`; }
-const STORAGE_VERSION = 3;
+const STORAGE_VERSION = 4;
 const MIN_READABLE_VERSION = 2;
 
 const ASSETS_ZOOM_LEVELS = new Set(['day', 'week', 'month', 'quarter']);
@@ -96,6 +96,7 @@ function normalizeSavedView(view) {
     zoomLevel:       sanitizeZoomLevel(view.zoomLevel),
     collapsedGroups: sanitizeCollapsedGroups(view.collapsedGroups),
     showAllGroups:   typeof view.showAllGroups === 'boolean' ? view.showAllGroups : null,
+    hiddenFromStrip: view.hiddenFromStrip === true,
     filters:         view.filters,
   };
 }
@@ -288,6 +289,7 @@ export function useSavedViews(calendarId) {
       zoomLevel:       sanitizeZoomLevel(zoomLevel),
       collapsedGroups: sanitizeCollapsedGroups(collapsedGroups),
       showAllGroups:   typeof showAllGroups === 'boolean' ? showAllGroups : null,
+      hiddenFromStrip: false,
       filters:         serializeFilters(filters),
     };
     setViews(prev => [...prev, savedView]);
@@ -331,5 +333,11 @@ export function useSavedViews(calendarId) {
     setViews(prev => prev.filter(v => v.id !== id));
   }, []);
 
-  return { views, saveView, updateView, resaveView, deleteView };
+  const toggleStripVisibility = useCallback((id) => {
+    setViews(prev => prev.map(v =>
+      v.id === id ? { ...v, hiddenFromStrip: !v.hiddenFromStrip } : v
+    ));
+  }, []);
+
+  return { views, saveView, updateView, resaveView, deleteView, toggleStripVisibility };
 }

--- a/src/ui/ClearFiltersButton.tsx
+++ b/src/ui/ClearFiltersButton.tsx
@@ -1,0 +1,27 @@
+/**
+ * ClearFiltersButton — resets every filter back to its default value.
+ * Disabled when no filters are currently active.
+ */
+import { FilterX } from 'lucide-react';
+import styles from './ProfileBar.module.css';
+
+export default function ClearFiltersButton({
+  hasActiveFilters,
+  onClear,
+}: {
+  hasActiveFilters: boolean;
+  onClear: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      className={styles.headerBtn}
+      onClick={onClear}
+      disabled={!hasActiveFilters}
+      title={hasActiveFilters ? 'Clear all filters' : 'No filters to clear'}
+    >
+      <FilterX size={13} />
+      <span>Clear all filters</span>
+    </button>
+  );
+}

--- a/src/ui/CustomizeQuickViewsPanel.tsx
+++ b/src/ui/CustomizeQuickViewsPanel.tsx
@@ -110,6 +110,17 @@ function CustomizeRow({
   const isHidden = !!view.hiddenFromStrip;
   const color = view.color ?? '#64748b';
 
+  function commitRename() {
+    const trimmed = nameVal.trim();
+    if (!trimmed) {
+      setNameVal(view.name);
+      setRenaming(false);
+      return;
+    }
+    if (trimmed !== view.name) onRename(view.id, trimmed);
+    setRenaming(false);
+  }
+
   return (
     <li className={styles.customizeRow} style={{ '--chip-color': color } as React.CSSProperties}>
       <div className={styles.customizeHeader}>
@@ -120,7 +131,7 @@ function CustomizeRow({
               value={nameVal}
               onChange={e => setNameVal(e.target.value)}
               onKeyDown={e => {
-                if (e.key === 'Enter') { onRename(view.id, nameVal); setRenaming(false); }
+                if (e.key === 'Enter') { commitRename(); }
                 if (e.key === 'Escape') { setNameVal(view.name); setRenaming(false); }
               }}
               autoFocus
@@ -128,7 +139,7 @@ function CustomizeRow({
             <button
               type="button"
               className={styles.iconBtn}
-              onClick={() => { onRename(view.id, nameVal); setRenaming(false); }}
+              onClick={commitRename}
               aria-label="Confirm rename"
             >
               <Check size={13} />

--- a/src/ui/CustomizeQuickViewsPanel.tsx
+++ b/src/ui/CustomizeQuickViewsPanel.tsx
@@ -1,0 +1,233 @@
+/**
+ * CustomizeQuickViewsPanel — popover where saved views are organized.
+ *
+ * Moves the rename / color / delete / resave / edit-conditions affordances
+ * that previously lived behind the pencil button on each chip into a single
+ * surface. Also exposes a visibility toggle so users can pick which views
+ * appear as chips in the ProfileBar strip.
+ */
+import { useEffect, useRef, useState } from 'react';
+import {
+  Settings, Pencil, Trash2, RefreshCw, Check, X,
+  Eye, EyeOff, Settings2, ChevronDown,
+} from 'lucide-react';
+import styles from './ProfileBar.module.css';
+
+const PROFILE_COLORS = [
+  '#3b82f6', '#10b981', '#f59e0b', '#ef4444',
+  '#8b5cf6', '#ec4899', '#06b6d4', '#f97316',
+];
+
+export default function CustomizeQuickViewsPanel({
+  views,
+  onRename,
+  onColorChange,
+  onResave,
+  onDelete,
+  onToggleVisibility,
+  onEditConditions,
+}: any) {
+  const [open, setOpen] = useState(false);
+  const rootRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    function handleClick(e: MouseEvent) {
+      if (rootRef.current && !rootRef.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    }
+    function handleKey(e: KeyboardEvent) {
+      if (e.key === 'Escape') setOpen(false);
+    }
+    document.addEventListener('mousedown', handleClick);
+    document.addEventListener('keydown', handleKey);
+    return () => {
+      document.removeEventListener('mousedown', handleClick);
+      document.removeEventListener('keydown', handleKey);
+    };
+  }, [open]);
+
+  return (
+    <div ref={rootRef} className={styles.headerControl}>
+      <button
+        type="button"
+        className={styles.headerBtn}
+        onClick={() => setOpen(v => !v)}
+        aria-haspopup="dialog"
+        aria-expanded={open}
+        disabled={views.length === 0}
+        title={views.length === 0 ? 'Save a view first to customize' : 'Customize quick views'}
+      >
+        <Settings size={13} />
+        <span>Customize Quick Views</span>
+        <ChevronDown size={13} aria-hidden="true" />
+      </button>
+
+      {open && (
+        <div
+          className={`${styles.dropdownPanel} ${styles.customizePanel}`}
+          role="dialog"
+          aria-label="Customize quick views"
+        >
+          {views.length === 0 ? (
+            <p className={styles.dropdownEmpty}>No saved views yet.</p>
+          ) : (
+            <ul className={styles.customizeList}>
+              {views.map((view: any) => (
+                <CustomizeRow
+                  key={view.id}
+                  view={view}
+                  onRename={onRename}
+                  onColorChange={onColorChange}
+                  onResave={onResave}
+                  onDelete={onDelete}
+                  onToggleVisibility={onToggleVisibility}
+                  onEditConditions={onEditConditions}
+                />
+              ))}
+            </ul>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function CustomizeRow({
+  view,
+  onRename,
+  onColorChange,
+  onResave,
+  onDelete,
+  onToggleVisibility,
+  onEditConditions,
+}: any) {
+  const [renaming, setRenaming] = useState(false);
+  const [nameVal, setNameVal] = useState(view.name);
+  const [confirmDelete, setConfirmDelete] = useState(false);
+
+  const isHidden = !!view.hiddenFromStrip;
+  const color = view.color ?? '#64748b';
+
+  return (
+    <li className={styles.customizeRow} style={{ '--chip-color': color } as React.CSSProperties}>
+      <div className={styles.customizeHeader}>
+        {renaming ? (
+          <div className={styles.renameRow}>
+            <input
+              className={styles.renameInput}
+              value={nameVal}
+              onChange={e => setNameVal(e.target.value)}
+              onKeyDown={e => {
+                if (e.key === 'Enter') { onRename(view.id, nameVal); setRenaming(false); }
+                if (e.key === 'Escape') { setNameVal(view.name); setRenaming(false); }
+              }}
+              autoFocus
+            />
+            <button
+              type="button"
+              className={styles.iconBtn}
+              onClick={() => { onRename(view.id, nameVal); setRenaming(false); }}
+              aria-label="Confirm rename"
+            >
+              <Check size={13} />
+            </button>
+            <button
+              type="button"
+              className={styles.iconBtn}
+              onClick={() => { setNameVal(view.name); setRenaming(false); }}
+              aria-label="Cancel rename"
+            >
+              <X size={13} />
+            </button>
+          </div>
+        ) : (
+          <div className={styles.customizeNameRow}>
+            <span className={styles.customizeColorDot} style={{ background: color }} aria-hidden="true" />
+            <span className={styles.customizeName}>{view.name}</span>
+            <button
+              type="button"
+              className={styles.iconBtn}
+              onClick={() => setRenaming(true)}
+              aria-label={`Rename ${view.name}`}
+            >
+              <Pencil size={12} />
+            </button>
+          </div>
+        )}
+      </div>
+
+      <div className={styles.colorRow}>
+        {PROFILE_COLORS.map(c => (
+          <button
+            key={c}
+            type="button"
+            className={[styles.colorDot, view.color === c && styles.colorDotActive].filter(Boolean).join(' ')}
+            style={{ background: c }}
+            onClick={() => onColorChange(view.id, c)}
+            aria-label={`Set color ${c} for ${view.name}`}
+          />
+        ))}
+      </div>
+
+      <div className={styles.customizeActions}>
+        <button
+          type="button"
+          className={styles.manageLine}
+          onClick={() => onToggleVisibility(view.id)}
+        >
+          {isHidden ? <Eye size={12} /> : <EyeOff size={12} />}
+          {isHidden ? 'Show in quick views' : 'Hide from quick views'}
+        </button>
+
+        <button
+          type="button"
+          className={styles.manageLine}
+          onClick={() => onResave(view.id)}
+        >
+          <RefreshCw size={12} /> Update with current filters
+        </button>
+
+        {onEditConditions && (
+          <button
+            type="button"
+            className={styles.manageLine}
+            onClick={() => onEditConditions(view.id)}
+          >
+            <Settings2 size={12} /> Edit conditions
+          </button>
+        )}
+
+        {confirmDelete ? (
+          <div className={styles.confirmRow} role="alertdialog" aria-label="Confirm delete">
+            <span className={styles.confirmText}>Delete saved view?</span>
+            <button
+              type="button"
+              className={[styles.confirmBtn, styles.confirmYes].join(' ')}
+              onClick={() => { onDelete(view.id); setConfirmDelete(false); }}
+              autoFocus
+            >
+              Yes, delete
+            </button>
+            <button
+              type="button"
+              className={styles.confirmBtn}
+              onClick={() => setConfirmDelete(false)}
+            >
+              Cancel
+            </button>
+          </div>
+        ) : (
+          <button
+            type="button"
+            className={[styles.manageLine, styles.danger].join(' ')}
+            onClick={() => setConfirmDelete(true)}
+          >
+            <Trash2 size={12} /> Delete saved view
+          </button>
+        )}
+      </div>
+    </li>
+  );
+}

--- a/src/ui/FilterBar.tsx
+++ b/src/ui/FilterBar.tsx
@@ -4,7 +4,7 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { Search, X, ChevronDown } from 'lucide-react';
 import { DEFAULT_FILTER_SCHEMA } from '../filters/filterSchema';
-import { isEmptyFilterValue, buildActiveFilterPills, clearFilterValue } from '../filters/filterState';
+import { buildActiveFilterPills, clearFilterValue, hasActiveFilters as computeHasActiveFilters } from '../filters/filterState';
 import styles from './FilterBar.module.css';
 
 function formatDateInput(date) {
@@ -95,7 +95,7 @@ export default function FilterBar({
     ...(groupLabels ?? {}),
   };
 
-  const hasActiveFilters = schema.some(field => !isEmptyFilterValue(filters[field.key]));
+  const hasActiveFilters = computeHasActiveFilters(filters, schema);
   const activePills = buildActiveFilterPills(filters, schema);
 
   function selectedCountForGroup(groupKey) {

--- a/src/ui/ProfileBar.module.css
+++ b/src/ui/ProfileBar.module.css
@@ -1,25 +1,3 @@
-/* ─── Collapsed state (no profiles yet) ─────────────────────── */
-.collapsed {
-  padding: 4px 12px;
-  border-bottom: 1px solid var(--wc-border);
-  background: var(--wc-bg);
-}
-
-.saveHint {
-  display: flex;
-  align-items: center;
-  gap: 6px;
-  background: none;
-  border: none;
-  cursor: pointer;
-  font-size: 12px;
-  color: var(--wc-text-faint);
-  padding: 4px 0;
-  font-family: inherit;
-  transition: color 0.15s;
-}
-.saveHint:hover { color: var(--wc-accent); }
-
 /* ─── Main bar ───────────────────────────────────────────────── */
 .bar {
   display: flex;
@@ -28,11 +6,64 @@
   background: var(--wc-surface);
 }
 
+/* Top row: All views ▾ | Customize | Clear all filters | + Save view */
+.headerRow {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 12px;
+  flex-wrap: wrap;
+}
+
+.headerControl {
+  position: relative;
+  flex-shrink: 0;
+}
+
+.headerBtn {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  padding: 5px 10px;
+  border-radius: var(--wc-radius-sm);
+  border: 1px solid var(--wc-border);
+  background: var(--wc-bg);
+  color: var(--wc-text-muted);
+  font-size: 12px;
+  font-weight: 500;
+  font-family: inherit;
+  cursor: pointer;
+  transition: background 0.15s, border-color 0.15s, color 0.15s;
+}
+.headerBtn:not(:disabled):hover {
+  border-color: var(--wc-accent);
+  color: var(--wc-accent);
+}
+.headerBtn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.headerBtnBadge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 20px;
+  height: 16px;
+  padding: 0 5px;
+  border-radius: 8px;
+  background: var(--wc-surface-2);
+  color: var(--wc-text-muted);
+  font-size: 10px;
+  font-weight: 600;
+}
+
+/* Chip strip (only visible views) */
 .strip {
   display: flex;
   align-items: center;
   gap: 4px;
-  padding: 6px 12px;
+  padding: 0 12px 6px;
   overflow-x: auto;
   scrollbar-width: none;
   -ms-overflow-style: none;
@@ -93,8 +124,8 @@
   border-style: dashed;
 }
 
-/* When no pencil sibling exists, the chip alone takes the full pill shape. */
-.chipWrap:not(:hover):not(.chipWrapActive) .chip {
+/* Chip takes the full pill shape (no pencil sibling in the redesign). */
+.chip {
   padding-right: 10px;
   border-radius: 100px;
 }
@@ -133,29 +164,8 @@
   opacity: 0.7;
 }
 
-/* Manage toggle (pencil icon — sibling of .chip inside .chipWrap).
-   The component mounts this only when the chip is hovered, active, or
-   actively being managed, so no CSS visibility gate is needed. */
-.manageBtn {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  padding: 0 8px 0 4px;
-  min-width: 22px;
-  border: none;
-  background: transparent;
-  border-radius: 0 100px 100px 0;
-  cursor: pointer;
-  opacity: 0.8;
-  color: inherit;
-  flex-shrink: 0;
-  font-family: inherit;
-}
-.manageBtn:hover { opacity: 1; }
-.chipWrapActive .manageBtn { color: #fff; }
-
-/* ─── Manage panel (popover below chip) ──────────────────────── */
-.managePanel {
+/* ─── Dropdown / customize popover ────────────────────────────── */
+.dropdownPanel {
   position: absolute;
   top: calc(100% + 6px);
   left: 0;
@@ -164,70 +174,175 @@
   border: 1px solid var(--wc-border);
   border-radius: var(--wc-radius);
   box-shadow: var(--wc-shadow);
-  min-width: 240px;
-  max-width: 320px;
-  padding: 10px;
+  min-width: 260px;
+  max-width: 360px;
+  max-height: 420px;
+  overflow-y: auto;
+  padding: 6px;
   display: flex;
   flex-direction: column;
-  gap: 4px;
   animation: pop 0.12s ease;
+}
+
+.customizePanel {
+  min-width: 320px;
+  max-width: 420px;
+}
+
+.dropdownEmpty {
+  margin: 0;
+  padding: 12px;
+  font-size: 12px;
+  color: var(--wc-text-faint);
+  font-style: italic;
+  text-align: center;
+}
+
+.dropdownList {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.dropdownRow {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  border-radius: var(--wc-radius-sm);
+  transition: background 0.1s;
+}
+.dropdownRow:hover {
+  background: var(--wc-surface);
+}
+
+.dropdownVisibilityBtn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  border: none;
+  background: transparent;
+  border-radius: var(--wc-radius-sm);
+  color: var(--wc-text-muted);
+  cursor: pointer;
+  flex-shrink: 0;
+}
+.dropdownVisibilityBtn:hover {
+  background: var(--wc-surface-2);
+  color: var(--wc-text);
+}
+.dropdownVisibilityBtn[aria-pressed="false"] {
+  color: var(--wc-text-faint);
+  opacity: 0.6;
+}
+
+.dropdownApplyBtn {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 5px 8px;
+  border: none;
+  background: transparent;
+  border-radius: var(--wc-radius-sm);
+  font-family: inherit;
+  font-size: 12px;
+  color: var(--wc-text);
+  cursor: pointer;
+  text-align: left;
+  min-width: 0;
+}
+.dropdownApplyBtn:hover {
+  background: var(--wc-surface-2);
+}
+
+.dropdownColorDot {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.dropdownIcon { flex-shrink: 0; opacity: 0.75; }
+
+.dropdownName {
+  flex: 1;
+  min-width: 0;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.dropdownViewIcon {
+  flex-shrink: 0;
+  opacity: 0.6;
+}
+
+/* Customize panel — one row per view */
+.customizeList {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.customizeRow {
+  padding: 8px;
+  border: 1px solid var(--wc-border);
+  border-radius: var(--wc-radius-sm);
+  background: var(--wc-bg);
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.customizeHeader {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.customizeNameRow {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex: 1;
+  min-width: 0;
+}
+
+.customizeColorDot {
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.customizeName {
+  flex: 1;
+  min-width: 0;
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--wc-text);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.customizeActions {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
 }
 
 @keyframes pop {
   from { opacity: 0; transform: translateY(-4px) scale(0.97); }
   to   { opacity: 1; transform: translateY(0)   scale(1); }
-}
-
-.summaryBlock {
-  margin-bottom: 4px;
-  padding-bottom: 8px;
-  border-bottom: 1px solid var(--wc-border);
-}
-
-.summary {
-  display: flex;
-  flex-direction: column;
-  gap: 4px;
-}
-
-.summaryNone {
-  font-size: 12px;
-  color: var(--wc-text-faint);
-  margin: 0;
-  font-style: italic;
-}
-
-.summaryRow {
-  display: flex;
-  align-items: flex-start;
-  gap: 8px;
-  font-size: 11px;
-}
-
-.summaryLabel {
-  color: var(--wc-text-faint);
-  font-weight: 600;
-  text-transform: uppercase;
-  letter-spacing: 0.05em;
-  flex-shrink: 0;
-  padding-top: 1px;
-  min-width: 70px;
-}
-
-.summaryTags {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 3px;
-}
-
-.tag {
-  display: inline-block;
-  padding: 1px 6px;
-  border-radius: 4px;
-  background: var(--wc-surface-2);
-  color: var(--wc-text-muted);
-  font-size: 11px;
-  white-space: nowrap;
 }
 
 /* Manage action rows */
@@ -455,10 +570,24 @@
 
 /* ─── Responsive ─────────────────────────────────────────────── */
 @media (max-width: 480px) {
-  .managePanel {
+  .dropdownPanel {
     left: auto;
     right: 0;
-    min-width: 200px;
+    min-width: 220px;
+    max-width: calc(100vw - 24px);
+  }
+
+  .customizePanel {
+    min-width: 240px;
+  }
+
+  .headerRow {
+    gap: 4px;
+    padding: 6px 10px;
+  }
+
+  .headerBtn span {
+    display: none;
   }
 
   .saveForm {

--- a/src/ui/ProfileBar.module.css
+++ b/src/ui/ProfileBar.module.css
@@ -97,8 +97,8 @@
   display: flex;
   align-items: center;
   gap: 5px;
-  padding: 4px 6px 4px 8px;
-  border-radius: 100px 0 0 100px;
+  padding: 4px 10px 4px 8px;
+  border-radius: 100px;
   font-size: 12px;
   font-weight: 500;
   font-family: inherit;
@@ -122,12 +122,6 @@
    chip is out-of-sync with the live filters. */
 .chipWrapDirty {
   border-style: dashed;
-}
-
-/* Chip takes the full pill shape (no pencil sibling in the redesign). */
-.chip {
-  padding-right: 10px;
-  border-radius: 100px;
 }
 
 .chipIcon { flex-shrink: 0; opacity: 0.8; }

--- a/src/ui/ProfileBar.tsx
+++ b/src/ui/ProfileBar.tsx
@@ -1,13 +1,23 @@
 /**
- * ProfileBar.jsx — Saved-view chips with add/rename/delete/resave.
+ * ProfileBar — Saved-view header with quick-view chip strip and organizing controls.
+ *
+ * Layout:
+ *   [All views ▾] [Customize Quick Views ▾] [Clear all filters] [+ Save view]
+ *   [chip] [chip] [chip] ...   (only views where !hiddenFromStrip)
+ *
+ * Applying a saved view and seeing the "unsaved" dirty indicator still work
+ * the same way. Renaming / recoloring / deleting / resaving now live in the
+ * CustomizeQuickViewsPanel rather than behind a pencil button on each chip.
  */
 import { useState, useRef, useEffect } from 'react';
 import {
-  Plus, Bookmark, BookmarkCheck, Pencil, Trash2, RefreshCw, Check, X, Settings2,
+  Plus, Bookmark, BookmarkCheck,
   CalendarDays, Calendar, Columns3, List, CalendarRange, Boxes,
 } from 'lucide-react';
-import { buildFilterSummary } from '../filters/filterState';
 import { DEFAULT_FILTER_SCHEMA } from '../filters/filterSchema';
+import ViewsDropdown from './ViewsDropdown';
+import CustomizeQuickViewsPanel from './CustomizeQuickViewsPanel';
+import ClearFiltersButton from './ClearFiltersButton';
 import styles from './ProfileBar.module.css';
 
 const PROFILE_COLORS = [
@@ -29,65 +39,73 @@ export default function ProfileBar({
   activeId,
   isDirty,
   schema = DEFAULT_FILTER_SCHEMA,
+  hasActiveFilters = false,
   onApply,
   onAdd,
   onResave,
   onUpdate,
   onDelete,
+  onToggleVisibility,
+  onClearFilters,
   onEditConditions,
 }: any) {
-  const [saveOpen,    setSaveOpen]    = useState(false);
-  const [manageId,    setManageId]    = useState(null); // which view is being managed
-  const scrollRef = useRef(null);
+  const [saveOpen, setSaveOpen] = useState(false);
 
-  if (views.length === 0 && !saveOpen) {
-    // Collapsed state — just a small "Save view" prompt
-    return (
-      <div className={styles.collapsed}>
-        <button className={styles.saveHint} onClick={() => setSaveOpen(true)}>
-          <Bookmark size={13} />
-          Save current view…
-        </button>
-      </div>
-    );
-  }
+  const visibleViews = views.filter((v: any) => !v.hiddenFromStrip);
 
   return (
     <div className={styles.bar}>
-      {/* View chip strip */}
-      <div className={styles.strip} ref={scrollRef}>
-        {views.map(savedView => (
-          <ViewChip
-            key={savedView.id}
-            savedView={savedView}
-            schema={schema}
-            isActive={savedView.id === activeId}
-            isDirty={isDirty && savedView.id === activeId}
-            isManaging={manageId === savedView.id}
-            onApply={() => { onApply(savedView); setManageId(null); setSaveOpen(false); }}
-            onManageToggle={() => setManageId(prev => prev === savedView.id ? null : savedView.id)}
-            onResave={() => { onResave(savedView.id); setManageId(null); }}
-            onDelete={() => { onDelete(savedView.id); setManageId(null); }}
-            onRename={(name) => { onUpdate(savedView.id, { name }); setManageId(null); }}
-            onColorChange={(color) => onUpdate(savedView.id, { color })}
-            onEditConditions={onEditConditions ? () => { onEditConditions(savedView.id); setManageId(null); } : undefined}
-          />
-        ))}
+      <div className={styles.headerRow}>
+        <ViewsDropdown
+          views={views}
+          activeId={activeId}
+          onApply={(sv: any) => { onApply(sv); setSaveOpen(false); }}
+          onToggleVisibility={onToggleVisibility}
+        />
 
-        {/* Add button (inline in strip when views exist) */}
-        {!saveOpen && (
-          <button className={styles.addChip} onClick={() => { setSaveOpen(true); setManageId(null); }}
-            title="Save current filters as a new saved view">
-            <Plus size={13} />
-            Save view
-          </button>
-        )}
+        <CustomizeQuickViewsPanel
+          views={views}
+          onRename={(id: string, name: string) => onUpdate(id, { name })}
+          onColorChange={(id: string, color: string) => onUpdate(id, { color })}
+          onResave={(id: string) => onResave(id)}
+          onDelete={(id: string) => onDelete(id)}
+          onToggleVisibility={onToggleVisibility}
+          onEditConditions={onEditConditions}
+        />
+
+        <ClearFiltersButton
+          hasActiveFilters={hasActiveFilters}
+          onClear={onClearFilters}
+        />
+
+        <button
+          type="button"
+          className={styles.addChip}
+          onClick={() => setSaveOpen(v => !v)}
+          title="Save current filters as a new saved view"
+        >
+          <Plus size={13} />
+          Save view
+        </button>
       </div>
 
-      {/* Save form */}
+      {visibleViews.length > 0 && (
+        <div className={styles.strip}>
+          {visibleViews.map((savedView: any) => (
+            <ViewChip
+              key={savedView.id}
+              savedView={savedView}
+              isActive={savedView.id === activeId}
+              isDirty={isDirty && savedView.id === activeId}
+              onApply={() => { onApply(savedView); setSaveOpen(false); }}
+            />
+          ))}
+        </div>
+      )}
+
       {saveOpen && (
         <SaveForm
-          onSave={(opts) => { onAdd(opts); setSaveOpen(false); }}
+          onSave={(opts: any) => { onAdd(opts); setSaveOpen(false); }}
           onCancel={() => setSaveOpen(false)}
         />
       )}
@@ -96,37 +114,9 @@ export default function ProfileBar({
 }
 
 /* ─── View Chip ─────────────────────────────────────────────── */
-function ViewChip({ savedView, schema, isActive, isDirty, isManaging, onApply, onManageToggle,
-  onResave, onDelete, onRename, onColorChange, onEditConditions }) {
-
-  const [renaming, setRenaming] = useState(false);
-  const [nameVal, setNameVal]   = useState(savedView.name);
-  const [isHovered, setIsHovered] = useState(false);
-  const [confirmDelete, setConfirmDelete] = useState(false);
-  const chipRef = useRef(null);
-
-  // Close manage panel on outside click
-  useEffect(() => {
-    if (!isManaging) return;
-    function handler(e) {
-      if (chipRef.current && !chipRef.current.contains(e.target)) {
-        onManageToggle();
-      }
-    }
-    document.addEventListener('mousedown', handler);
-    return () => document.removeEventListener('mousedown', handler);
-  }, [isManaging, onManageToggle]);
-
-  // Reset confirm-delete when manage panel closes
-  useEffect(() => { if (!isManaging) setConfirmDelete(false); }, [isManaging]);
-
+function ViewChip({ savedView, isActive, isDirty, onApply }: any) {
   const color = savedView.color ?? '#64748b';
-
-  // Build a summary string for the tooltip using schema-driven formatting
-  const summaryItems = buildFilterSummary(savedView.filters, schema);
-  const summaryParts = summaryItems.map(item => `${item.label}: ${item.displayValues.join(', ')}`);
-  if (savedView.view) summaryParts.push(`View: ${savedView.view}`);
-  const summary = summaryParts.length ? summaryParts.join(' \u00b7 ') : 'No filters applied';
+  const viewIcon = savedView.view ? VIEW_ICON_MAP[savedView.view] : null;
 
   const chipClass = [styles.chip, isDirty && styles.dirty].filter(Boolean).join(' ');
   const wrapClass = [
@@ -135,26 +125,12 @@ function ViewChip({ savedView, schema, isActive, isDirty, isManaging, onApply, o
     isDirty && styles.chipWrapDirty,
   ].filter(Boolean).join(' ');
 
-  // Pencil is mounted only when its visual is meaningful — fixes the
-  // hidden-button querySelector / focus-order trap that previously kept
-  // the DOM button present even when invisible.
-  const showPencil = isHovered || isActive || isManaging;
-
-  const viewIcon = savedView.view ? VIEW_ICON_MAP[savedView.view] : null;
-
   return (
     <div
-      ref={chipRef}
       className={wrapClass}
       style={{ '--chip-color': color } as React.CSSProperties}
-      onMouseEnter={() => setIsHovered(true)}
-      onMouseLeave={() => setIsHovered(false)}
     >
-      <button
-        className={chipClass}
-        onClick={onApply}
-        title={summary}
-      >
+      <button className={chipClass} onClick={onApply} title={savedView.name}>
         {isActive
           ? <BookmarkCheck size={12} className={styles.chipIcon} />
           : <Bookmark size={12} className={styles.chipIcon} />
@@ -174,139 +150,6 @@ function ViewChip({ savedView, schema, isActive, isDirty, isManaging, onApply, o
           />
         )}
       </button>
-
-      {/* Manage toggle (pencil) — only mounted when chip is hovered/active/managing
-          so screen readers and keyboard users don't traverse a hidden button. */}
-      {showPencil && (
-        <button
-          type="button"
-          className={styles.manageBtn}
-          onClick={e => { e.stopPropagation(); onManageToggle(); }}
-          aria-label="Manage saved view"
-        >
-          <Pencil size={10} />
-        </button>
-      )}
-
-      {/* Manage panel */}
-      {isManaging && (
-        <div className={styles.managePanel}>
-          {/* Filter summary */}
-          <div className={styles.summaryBlock}>
-            <FilterSummary savedView={savedView} schema={schema} />
-          </div>
-
-          {/* Rename */}
-          {renaming ? (
-            <div className={styles.renameRow}>
-              <input
-                className={styles.renameInput}
-                value={nameVal}
-                onChange={e => setNameVal(e.target.value)}
-                onKeyDown={e => {
-                  if (e.key === 'Enter') { onRename(nameVal); setRenaming(false); }
-                  if (e.key === 'Escape') { setNameVal(savedView.name); setRenaming(false); }
-                }}
-                autoFocus
-              />
-              <button className={styles.iconBtn} onClick={() => { onRename(nameVal); setRenaming(false); }}>
-                <Check size={13} />
-              </button>
-              <button className={styles.iconBtn} onClick={() => { setNameVal(savedView.name); setRenaming(false); }}>
-                <X size={13} />
-              </button>
-            </div>
-          ) : (
-            <button className={styles.manageLine} onClick={() => setRenaming(true)}>
-              <Pencil size={12} /> Rename
-            </button>
-          )}
-
-          {/* Color picker */}
-          <div className={styles.colorRow}>
-            {PROFILE_COLORS.map(c => (
-              <button
-                key={c}
-                className={[styles.colorDot, savedView.color === c && styles.colorDotActive].filter(Boolean).join(' ')}
-                style={{ background: c }}
-                onClick={() => onColorChange(c)}
-                aria-label={`Set color ${c}`}
-              />
-            ))}
-          </div>
-
-          {/* Edit conditions in Settings */}
-          {onEditConditions && (
-            <button className={styles.manageLine} onClick={onEditConditions}>
-              <Settings2 size={12} /> Edit conditions
-            </button>
-          )}
-
-          {/* Resave current filters */}
-          <button className={styles.manageLine} onClick={onResave}>
-            <RefreshCw size={12} /> Update with current filters
-          </button>
-
-          {/* Delete with two-step inline confirm */}
-          {confirmDelete ? (
-            <div className={styles.confirmRow} role="alertdialog" aria-label="Confirm delete">
-              <span className={styles.confirmText}>Delete saved view?</span>
-              <button
-                className={[styles.confirmBtn, styles.confirmYes].join(' ')}
-                onClick={onDelete}
-                autoFocus
-              >
-                Yes, delete
-              </button>
-              <button
-                className={styles.confirmBtn}
-                onClick={() => setConfirmDelete(false)}
-              >
-                Cancel
-              </button>
-            </div>
-          ) : (
-            <button
-              className={[styles.manageLine, styles.danger].join(' ')}
-              onClick={() => setConfirmDelete(true)}
-            >
-              <Trash2 size={12} /> Delete saved view
-            </button>
-          )}
-        </div>
-      )}
-    </div>
-  );
-}
-
-/* ─── Filter Summary (inside manage panel) ─────────────────────── */
-function FilterSummary({ savedView, schema }: any) {
-  const summaryItems = buildFilterSummary(savedView.filters, schema);
-
-  if (summaryItems.length === 0 && !savedView.view) {
-    return <p className={styles.summaryNone}>No filters — matches all events</p>;
-  }
-
-  return (
-    <div className={styles.summary}>
-      {summaryItems.map(item => (
-        <div key={item.key} className={styles.summaryRow}>
-          <span className={styles.summaryLabel}>{item.label}</span>
-          <span className={styles.summaryTags}>
-            {item.displayValues.map((dv, i) => (
-              <span key={`${item.key}-${i}`} className={styles.tag}>{dv}</span>
-            ))}
-          </span>
-        </div>
-      ))}
-      {savedView.view && (
-        <div className={styles.summaryRow}>
-          <span className={styles.summaryLabel}>Pinned view</span>
-          <span className={styles.summaryTags}>
-            <span className={styles.tag}>{savedView.view}</span>
-          </span>
-        </div>
-      )}
     </div>
   );
 }
@@ -316,7 +159,7 @@ function SaveForm({ onSave, onCancel }: any) {
   const [name,     setName]     = useState('');
   const [color,    setColor]    = useState(PROFILE_COLORS[0]);
   const [pinView,  setPinView]  = useState(false);
-  const inputRef = useRef(null);
+  const inputRef = useRef<HTMLInputElement>(null);
 
   useEffect(() => { inputRef.current?.focus(); }, []);
 
@@ -337,11 +180,11 @@ function SaveForm({ onSave, onCancel }: any) {
         placeholder="View name, e.g. Agusta Inspections…"
       />
 
-      {/* Color row */}
       <div className={styles.colorRow}>
         {PROFILE_COLORS.map(c => (
           <button
             key={c}
+            type="button"
             className={[styles.colorDot, color === c && styles.colorDotActive].filter(Boolean).join(' ')}
             style={{ background: c }}
             onClick={() => setColor(c)}
@@ -356,13 +199,11 @@ function SaveForm({ onSave, onCancel }: any) {
       </label>
 
       <div className={styles.saveActions}>
-        <button className={styles.btnSave} onClick={handleSave} disabled={!name.trim()}>
+        <button type="button" className={styles.btnSave} onClick={handleSave} disabled={!name.trim()}>
           Save view
         </button>
-        <button className={styles.btnCancel} onClick={onCancel}>Cancel</button>
+        <button type="button" className={styles.btnCancel} onClick={onCancel}>Cancel</button>
       </div>
     </div>
   );
 }
-
-

--- a/src/ui/ViewsDropdown.tsx
+++ b/src/ui/ViewsDropdown.tsx
@@ -1,0 +1,125 @@
+/**
+ * ViewsDropdown — "All Views ▾" popover listing every saved view.
+ *
+ * Each row has:
+ *   - a visibility checkbox that toggles whether the view appears as a chip
+ *     in the ProfileBar strip
+ *   - a clickable name that applies the view's filters
+ */
+import { useEffect, useRef, useState } from 'react';
+import {
+  BookmarkCheck, Bookmark, Eye, EyeOff, ChevronDown,
+  CalendarDays, Calendar, Columns3, List, CalendarRange, Boxes,
+} from 'lucide-react';
+import styles from './ProfileBar.module.css';
+
+const VIEW_ICON_MAP = {
+  month:    CalendarDays,
+  week:     Columns3,
+  day:      Calendar,
+  agenda:   List,
+  schedule: CalendarRange,
+  assets:   Boxes,
+};
+
+export default function ViewsDropdown({
+  views,
+  activeId,
+  onApply,
+  onToggleVisibility,
+}: any) {
+  const [open, setOpen] = useState(false);
+  const rootRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    function handleClick(e: MouseEvent) {
+      if (rootRef.current && !rootRef.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    }
+    function handleKey(e: KeyboardEvent) {
+      if (e.key === 'Escape') setOpen(false);
+    }
+    document.addEventListener('mousedown', handleClick);
+    document.addEventListener('keydown', handleKey);
+    return () => {
+      document.removeEventListener('mousedown', handleClick);
+      document.removeEventListener('keydown', handleKey);
+    };
+  }, [open]);
+
+  const hiddenCount = views.filter((v: any) => v.hiddenFromStrip).length;
+
+  return (
+    <div ref={rootRef} className={styles.headerControl}>
+      <button
+        type="button"
+        className={styles.headerBtn}
+        onClick={() => setOpen(v => !v)}
+        aria-haspopup="menu"
+        aria-expanded={open}
+      >
+        <Bookmark size={13} />
+        <span>All views</span>
+        {hiddenCount > 0 && (
+          <span className={styles.headerBtnBadge}>{views.length - hiddenCount}/{views.length}</span>
+        )}
+        <ChevronDown size={13} aria-hidden="true" />
+      </button>
+
+      {open && (
+        <div className={styles.dropdownPanel} role="menu" aria-label="All saved views">
+          {views.length === 0 ? (
+            <p className={styles.dropdownEmpty}>
+              No saved views yet — click Save view to create one.
+            </p>
+          ) : (
+            <ul className={styles.dropdownList}>
+              {views.map((view: any) => {
+                const ViewIcon = view.view ? VIEW_ICON_MAP[view.view] : null;
+                const isActive = view.id === activeId;
+                const isHidden = !!view.hiddenFromStrip;
+                const color = view.color ?? '#64748b';
+                return (
+                  <li key={view.id} className={styles.dropdownRow}>
+                    <button
+                      type="button"
+                      className={styles.dropdownVisibilityBtn}
+                      onClick={() => onToggleVisibility(view.id)}
+                      aria-pressed={!isHidden}
+                      title={isHidden ? 'Show in quick views' : 'Hide from quick views'}
+                    >
+                      {isHidden ? <EyeOff size={14} /> : <Eye size={14} />}
+                    </button>
+                    <button
+                      type="button"
+                      className={styles.dropdownApplyBtn}
+                      onClick={() => {
+                        onApply(view);
+                        setOpen(false);
+                      }}
+                      role="menuitem"
+                    >
+                      <span
+                        className={styles.dropdownColorDot}
+                        style={{ background: color }}
+                        aria-hidden="true"
+                      />
+                      {isActive
+                        ? <BookmarkCheck size={12} className={styles.dropdownIcon} />
+                        : <Bookmark size={12} className={styles.dropdownIcon} />
+                      }
+                      <span className={styles.dropdownName}>{view.name}</span>
+                      {ViewIcon && <ViewIcon size={11} className={styles.dropdownViewIcon} aria-hidden="true" />}
+                    </button>
+                  </li>
+                );
+              })}
+            </ul>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/ui/ViewsDropdown.tsx
+++ b/src/ui/ViewsDropdown.tsx
@@ -88,6 +88,7 @@ export default function ViewsDropdown({
                       className={styles.dropdownVisibilityBtn}
                       onClick={() => onToggleVisibility(view.id)}
                       aria-pressed={!isHidden}
+                      aria-label={isHidden ? `Show ${view.name} in quick views` : `Hide ${view.name} from quick views`}
                       title={isHidden ? 'Show in quick views' : 'Hide from quick views'}
                     >
                       {isHidden ? <EyeOff size={14} /> : <Eye size={14} />}

--- a/src/ui/__tests__/ProfileBar.redesign.test.tsx
+++ b/src/ui/__tests__/ProfileBar.redesign.test.tsx
@@ -94,9 +94,7 @@ describe('ProfileBar — All Views dropdown', () => {
     const { props } = renderBar();
     fireEvent.click(screen.getByRole('button', { name: /All views/i }));
     const menu = screen.getByRole('menu', { name: /All saved views/i });
-    // The visibility toggle is the button whose aria-pressed state reflects visibility.
-    const toggles = within(menu).getAllByRole('button', { pressed: true });
-    fireEvent.click(toggles[0]);
+    fireEvent.click(within(menu).getByRole('button', { name: /Hide Work Week from quick views/i }));
     expect(props.onToggleVisibility).toHaveBeenCalledWith(VIEW_VISIBLE.id);
   });
 

--- a/src/ui/__tests__/ProfileBar.redesign.test.tsx
+++ b/src/ui/__tests__/ProfileBar.redesign.test.tsx
@@ -1,0 +1,190 @@
+// @vitest-environment happy-dom
+/**
+ * ProfileBar redesign — locks in the header-row behaviour introduced when
+ * the inline pencil / manage-panel flow was replaced with three explicit
+ * controls:
+ *
+ *   [All views ▾]  [Customize Quick Views ▾]  [Clear all filters]  [+ Save view]
+ *
+ * and the chip strip now only shows views where `!hiddenFromStrip`.
+ */
+import { render, screen, fireEvent, within } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import '@testing-library/jest-dom';
+
+import ProfileBar from '../ProfileBar';
+
+const VIEW_VISIBLE = {
+  id: 'v-vis',
+  name: 'Work Week',
+  createdAt: new Date().toISOString(),
+  color: '#3b82f6',
+  view: 'week',
+  filters: { categories: [], resources: [], sources: [], search: '', dateRange: null },
+  hiddenFromStrip: false,
+};
+
+const VIEW_HIDDEN = {
+  id: 'v-hid',
+  name: 'Archive',
+  createdAt: new Date().toISOString(),
+  color: '#10b981',
+  view: null,
+  filters: { categories: [], resources: [], sources: [], search: '', dateRange: null },
+  hiddenFromStrip: true,
+};
+
+function renderBar(overrides: any = {}) {
+  const props = {
+    views: [VIEW_VISIBLE, VIEW_HIDDEN],
+    activeId: null,
+    isDirty: false,
+    hasActiveFilters: false,
+    onApply: vi.fn(),
+    onAdd: vi.fn(),
+    onResave: vi.fn(),
+    onUpdate: vi.fn(),
+    onDelete: vi.fn(),
+    onToggleVisibility: vi.fn(),
+    onClearFilters: vi.fn(),
+    ...overrides,
+  };
+  const utils = render(<ProfileBar {...props} />);
+  return { ...utils, props };
+}
+
+describe('ProfileBar — chip strip filters by hiddenFromStrip', () => {
+  it('renders only views where hiddenFromStrip is falsy as chips', () => {
+    renderBar();
+    // Visible view's chip is rendered as a button with its name
+    const visibleChip = screen.getByRole('button', { name: /Work Week/ });
+    expect(visibleChip).toBeInTheDocument();
+    // Hidden view has no chip in the strip
+    expect(screen.queryByRole('button', { name: /^Archive$/ })).toBeNull();
+  });
+
+  it('omits the chip strip entirely when every view is hidden', () => {
+    const { container } = renderBar({
+      views: [{ ...VIEW_VISIBLE, hiddenFromStrip: true }, VIEW_HIDDEN],
+    });
+    // Header controls still render; no visible chip name present
+    expect(screen.queryByRole('button', { name: /^Work Week$/ })).toBeNull();
+    // Strip CSS-module class starts with 'strip' — sanity-check via container
+    expect(container.querySelector('[class*="strip"]')).toBeNull();
+  });
+});
+
+describe('ProfileBar — All Views dropdown', () => {
+  it('lists every view (visible + hidden) once opened', () => {
+    renderBar();
+    fireEvent.click(screen.getByRole('button', { name: /All views/i }));
+    const menu = screen.getByRole('menu', { name: /All saved views/i });
+    expect(within(menu).getByRole('menuitem', { name: /Work Week/ })).toBeInTheDocument();
+    expect(within(menu).getByRole('menuitem', { name: /Archive/ })).toBeInTheDocument();
+  });
+
+  it('clicking a row fires onApply with the saved view', () => {
+    const { props } = renderBar();
+    fireEvent.click(screen.getByRole('button', { name: /All views/i }));
+    fireEvent.click(screen.getByRole('menuitem', { name: /Archive/ }));
+    expect(props.onApply).toHaveBeenCalledWith(VIEW_HIDDEN);
+  });
+
+  it('clicking the visibility toggle fires onToggleVisibility with the view id', () => {
+    const { props } = renderBar();
+    fireEvent.click(screen.getByRole('button', { name: /All views/i }));
+    const menu = screen.getByRole('menu', { name: /All saved views/i });
+    // The visibility toggle is the button whose aria-pressed state reflects visibility.
+    const toggles = within(menu).getAllByRole('button', { pressed: true });
+    fireEvent.click(toggles[0]);
+    expect(props.onToggleVisibility).toHaveBeenCalledWith(VIEW_VISIBLE.id);
+  });
+
+  it('shows an empty-state message when no views exist', () => {
+    renderBar({ views: [] });
+    fireEvent.click(screen.getByRole('button', { name: /All views/i }));
+    expect(screen.getByText(/No saved views yet/i)).toBeInTheDocument();
+  });
+});
+
+describe('ProfileBar — Customize Quick Views', () => {
+  it('disables the trigger when no views exist', () => {
+    renderBar({ views: [] });
+    const btn = screen.getByRole('button', { name: /Customize Quick Views/i });
+    expect(btn).toBeDisabled();
+  });
+
+  it('exposes rename, color, resave, visibility-toggle, and delete for each view', () => {
+    const { props } = renderBar();
+    fireEvent.click(screen.getByRole('button', { name: /Customize Quick Views/i }));
+
+    // Rename — click pencil, change value, commit
+    const renameBtn = screen.getByRole('button', { name: /Rename Work Week/i });
+    fireEvent.click(renameBtn);
+    const input = screen.getByDisplayValue('Work Week');
+    fireEvent.change(input, { target: { value: 'Renamed' } });
+    fireEvent.click(screen.getByRole('button', { name: /Confirm rename/i }));
+    expect(props.onUpdate).toHaveBeenCalledWith(VIEW_VISIBLE.id, { name: 'Renamed' });
+
+    // Color — click a color dot for the visible view
+    const colorButtons = screen.getAllByRole('button', { name: /Set color #10b981 for Work Week/i });
+    fireEvent.click(colorButtons[0]);
+    expect(props.onUpdate).toHaveBeenCalledWith(VIEW_VISIBLE.id, { color: '#10b981' });
+
+    // Resave
+    fireEvent.click(screen.getAllByRole('button', { name: /Update with current filters/i })[0]);
+    expect(props.onResave).toHaveBeenCalledWith(VIEW_VISIBLE.id);
+
+    // Toggle visibility from the customize panel
+    fireEvent.click(screen.getAllByRole('button', { name: /Hide from quick views/i })[0]);
+    expect(props.onToggleVisibility).toHaveBeenCalledWith(VIEW_VISIBLE.id);
+
+    // Delete — two-step confirm
+    fireEvent.click(screen.getAllByRole('button', { name: /Delete saved view/i })[0]);
+    fireEvent.click(screen.getByRole('button', { name: /Yes, delete/i }));
+    expect(props.onDelete).toHaveBeenCalledWith(VIEW_VISIBLE.id);
+  });
+
+  it('shows the Edit conditions action only when the prop is passed', () => {
+    const onEditConditions = vi.fn();
+    renderBar({ onEditConditions });
+    fireEvent.click(screen.getByRole('button', { name: /Customize Quick Views/i }));
+    const editConditions = screen.getAllByRole('button', { name: /Edit conditions/i });
+    fireEvent.click(editConditions[0]);
+    expect(onEditConditions).toHaveBeenCalledWith(VIEW_VISIBLE.id);
+  });
+});
+
+describe('ProfileBar — Clear all filters', () => {
+  it('is disabled when hasActiveFilters is false', () => {
+    renderBar({ hasActiveFilters: false });
+    const btn = screen.getByRole('button', { name: /Clear all filters/i });
+    expect(btn).toBeDisabled();
+  });
+
+  it('fires onClearFilters when clicked', () => {
+    const { props } = renderBar({ hasActiveFilters: true });
+    fireEvent.click(screen.getByRole('button', { name: /Clear all filters/i }));
+    expect(props.onClearFilters).toHaveBeenCalled();
+  });
+});
+
+describe('ProfileBar — Save view form', () => {
+  it('toggles open when the + Save view button is clicked', () => {
+    renderBar();
+    expect(screen.queryByPlaceholderText(/View name/i)).toBeNull();
+    fireEvent.click(screen.getByRole('button', { name: /Save view/i }));
+    expect(screen.getByPlaceholderText(/View name/i)).toBeInTheDocument();
+  });
+
+  it('submits the new-view payload when Save view is clicked', () => {
+    const { props } = renderBar();
+    fireEvent.click(screen.getByRole('button', { name: /Save view/i }));
+    const input = screen.getByPlaceholderText(/View name/i);
+    fireEvent.change(input, { target: { value: 'New Saved' } });
+    // Both the header "+ Save view" and the form submit share the same accessible name;
+    // submit via Enter to disambiguate.
+    fireEvent.keyDown(input, { key: 'Enter' });
+    expect(props.onAdd).toHaveBeenCalledWith(expect.objectContaining({ name: 'New Saved' }));
+  });
+});


### PR DESCRIPTION
Replace the inline pencil/manage-panel flow in ProfileBar with three explicit header controls: "All views" dropdown with visibility toggles, "Customize Quick Views" panel that owns rename/color/delete/resave, and a "Clear all filters" button. The chip strip now only shows views where !hiddenFromStrip. Adds hiddenFromStrip persistence (v3 -> v4), a toggleStripVisibility hook method, and a shared hasActiveFilters helper.

https://claude.ai/code/session_01CdGdcvZ4jjP5wT4NZJUaWc

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a "Clear all filters" button for quick filter reset.
  * Saved views can now be toggled to show/hide from the quick views strip.
  * Introduced "Customize Quick Views" panel for managing saved views (rename, recolor, resave, delete).
  * Added "All views" dropdown to browse and apply all saved views with visibility controls.

* **Refactor**
  * Redesigned ProfileBar layout with improved header controls and organization.

* **Tests**
  * Added comprehensive test suite for ProfileBar redesign validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->