### PR TITLE
Update links for transfer to workscalendar

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 WorksCalendar is an embeddable React calendar focused on **real scheduling workflows** (team coverage, PTO handling, saved filtered views) instead of a single static calendar screen.
 
+**Website:** [workscalendar.com](https://workscalendar.com) · **Repository:** [github.com/workscalendar/calendarthatworks](https://github.com/workscalendar/calendarthatworks)
+
 ## Highlights
 
 - Multiple calendar modes: month, week, day, agenda, schedule, timeline

--- a/docs/GROUPING_SPRINT_EXECUTIVE_SUMMARY.md
+++ b/docs/GROUPING_SPRINT_EXECUTIVE_SUMMARY.md
@@ -263,7 +263,7 @@ The calendar is a valuable product. Let's build grouping features properly, not 
 
 ## Delivery Update — 2026-04 Sprint
 
-**Tracking issue:** [#134 — Sprint: Close the Grouping Plan A gap](https://github.com/natehorst240-sketch/calendarthatworks/issues/134)
+**Tracking issue:** [#134 — Sprint: Close the Grouping Plan A gap](https://github.com/workscalendar/calendarthatworks/issues/134)
 
 The original 5-day "infinite grouping" ambition was correctly flagged above as
 infeasible. Work landed in two phases instead, with a strict owner-config-first

--- a/docs/Setup.md
+++ b/docs/Setup.md
@@ -806,4 +806,4 @@ Not sure which combination fits you? Start here.
 - [Schedule workflow](./ScheduleWorkflow.md) — PTO → uncovered → coverage details.
 - [Roadmap](./Roadmap.md) — what's coming.
 
-Stuck? Open an issue: https://github.com/natehorst240-sketch/CalendarThatWorks/issues
+Stuck? Open an issue: https://github.com/workscalendar/calendarthatworks/issues

--- a/package.json
+++ b/package.json
@@ -29,11 +29,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/natehorst240-sketch/CalendarThatWorks.git"
+    "url": "git+https://github.com/workscalendar/calendarthatworks.git"
   },
-  "homepage": "https://github.com/natehorst240-sketch/CalendarThatWorks#readme",
+  "homepage": "https://workscalendar.com",
   "bugs": {
-    "url": "https://github.com/natehorst240-sketch/CalendarThatWorks/issues"
+    "url": "https://github.com/workscalendar/calendarthatworks/issues"
   },
   "scripts": {
     "test": "vitest run",


### PR DESCRIPTION
Point README, docs, and package.json repository/homepage/bugs fields at the new workscalendar/calendarthatworks GitHub org and the workscalendar.com landing page.

https://claude.ai/code/session_01XjU8Hz7S8Ar82Ug7wxo5os