### PR TITLE
Add persistedFields to VIEW_SCOPES + captureSavedViewFields helper

### DIFF
--- a/src/WorksCalendar.tsx
+++ b/src/WorksCalendar.tsx
@@ -38,7 +38,7 @@ import { applyFilters, getCategories, getResources } from './filters/filterEngin
 import { DEFAULT_FILTER_SCHEMA, buildDefaultFilterSchema, makeResourceResolver, viewScopedSchema, type FilterField } from './filters/filterSchema';
 import { SCHEDULE_WORKFLOW_CATEGORIES } from './core/scheduleModel';
 import { useTabScopedEvents } from './hooks/useTabScopedEvents';
-import type { ViewId } from './core/viewScope';
+import { captureSavedViewFields, type ViewId } from './core/viewScope';
 import { buildActiveFilterPills, buildFilterSummary, hasActiveFilters } from './filters/filterState';
 import FilterBar              from './ui/FilterBar';
 import ProfileBar             from './ui/ProfileBar';
@@ -1775,6 +1775,15 @@ export const WorksCalendar = forwardRef<CalendarApi, WorksCalendarProps>(functio
     showAllGroups: activeShowAllGroups,
   };
 
+  const savedViewCaptureCtx = {
+    groupBy:         activeGroupBy,
+    sort:            activeSort,
+    showAllGroups:   activeShowAllGroups,
+    zoomLevel:       activeAssetsZoom,
+    collapsedGroups: activeAssetsCollapsed,
+    selectedBaseIds,
+  };
+
   if (shouldShowSetup) {
     return (
       <CalendarErrorBoundary>
@@ -1915,9 +1924,9 @@ export const WorksCalendar = forwardRef<CalendarApi, WorksCalendarProps>(functio
               activeId:    savedViewActiveId,
               isDirty:     savedViewDirty,
               applyView:   handleApplyView,
-              saveView:    (name, opts) => savedViews.saveView(name, cal.filters, { view: cal.view, groupBy: activeGroupBy, sort: activeSort, showAllGroups: activeShowAllGroups, zoomLevel: activeAssetsZoom, collapsedGroups: activeAssetsCollapsed, selectedBaseIds, ...opts }),
+              saveView:    (name, opts) => savedViews.saveView(name, cal.filters, { view: cal.view, ...captureSavedViewFields(cal.view, savedViewCaptureCtx), ...opts }),
               updateView:  savedViews.updateView,
-              resaveView:  (id) => savedViews.resaveView(id, cal.filters, cal.view, activeGroupBy, { sort: activeSort, showAllGroups: activeShowAllGroups, zoomLevel: activeAssetsZoom, collapsedGroups: activeAssetsCollapsed, selectedBaseIds }),
+              resaveView:  (id) => savedViews.resaveView(id, cal.filters, cal.view, activeGroupBy, captureSavedViewFields(cal.view, savedViewCaptureCtx)),
               deleteView:  handleDeleteView,
               toggleStripVisibility: savedViews.toggleStripVisibility,
               clearFilters: cal.clearFilters,
@@ -1940,9 +1949,9 @@ export const WorksCalendar = forwardRef<CalendarApi, WorksCalendarProps>(functio
               hasActiveFilters={hasActiveFilters(cal.filters, schema)}
               onApply={handleApplyView}
               onAdd={({ name, color }) =>
-                savedViews.saveView(name, cal.filters, { color, view: cal.view, groupBy: activeGroupBy, sort: activeSort, showAllGroups: activeShowAllGroups, zoomLevel: activeAssetsZoom, collapsedGroups: activeAssetsCollapsed, selectedBaseIds })
+                savedViews.saveView(name, cal.filters, { color, view: cal.view, ...captureSavedViewFields(cal.view, savedViewCaptureCtx) })
               }
-              onResave={(id) => savedViews.resaveView(id, cal.filters, cal.view, activeGroupBy, { sort: activeSort, showAllGroups: activeShowAllGroups, zoomLevel: activeAssetsZoom, collapsedGroups: activeAssetsCollapsed, selectedBaseIds })}
+              onResave={(id) => savedViews.resaveView(id, cal.filters, cal.view, activeGroupBy, captureSavedViewFields(cal.view, savedViewCaptureCtx))}
               onUpdate={savedViews.updateView}
               onDelete={handleDeleteView}
               onToggleVisibility={savedViews.toggleStripVisibility}

--- a/src/core/__tests__/viewScope.test.ts
+++ b/src/core/__tests__/viewScope.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect } from 'vitest';
+import {
+  VIEW_SCOPES,
+  captureSavedViewFields,
+  type SavedViewCaptureCtx,
+} from '../viewScope';
+
+const FULL_CTX: SavedViewCaptureCtx = {
+  groupBy:         'role',
+  sort:            [{ field: 'title', direction: 'asc' }],
+  showAllGroups:   true,
+  zoomLevel:       'week',
+  collapsedGroups: new Set(['a']),
+  selectedBaseIds: ['base-1'],
+};
+
+describe('captureSavedViewFields', () => {
+  it('returns an empty object for views without persistedFields', () => {
+    expect(captureSavedViewFields('month', FULL_CTX)).toEqual({});
+    expect(captureSavedViewFields('week',  FULL_CTX)).toEqual({});
+    expect(captureSavedViewFields('day',   FULL_CTX)).toEqual({});
+  });
+
+  it('picks only the fields declared on agenda scope', () => {
+    expect(captureSavedViewFields('agenda', FULL_CTX)).toEqual({
+      groupBy:       'role',
+      sort:          FULL_CTX.sort,
+      showAllGroups: true,
+    });
+  });
+
+  it('picks only the fields declared on schedule scope', () => {
+    expect(captureSavedViewFields('schedule', FULL_CTX)).toEqual({
+      groupBy: 'role',
+      sort:    FULL_CTX.sort,
+    });
+  });
+
+  it('picks only selectedBaseIds on base scope', () => {
+    expect(captureSavedViewFields('base', FULL_CTX)).toEqual({
+      selectedBaseIds: ['base-1'],
+    });
+  });
+
+  it('picks the assets-specific fields on assets scope', () => {
+    expect(captureSavedViewFields('assets', FULL_CTX)).toEqual({
+      groupBy:         'role',
+      sort:            FULL_CTX.sort,
+      zoomLevel:       'week',
+      collapsedGroups: FULL_CTX.collapsedGroups,
+    });
+  });
+
+  it('drops undefined entries', () => {
+    expect(
+      captureSavedViewFields('assets', {
+        groupBy:         undefined,
+        sort:            FULL_CTX.sort,
+        zoomLevel:       undefined,
+        collapsedGroups: FULL_CTX.collapsedGroups,
+      }),
+    ).toEqual({
+      sort:            FULL_CTX.sort,
+      collapsedGroups: FULL_CTX.collapsedGroups,
+    });
+  });
+
+  it('preserves null (distinct from undefined) so callers can clear state', () => {
+    expect(captureSavedViewFields('agenda', { groupBy: null, sort: null, showAllGroups: false }))
+      .toEqual({ groupBy: null, sort: null, showAllGroups: false });
+  });
+
+  it('falls back to the month scope (empty) for unknown view ids', () => {
+    expect(captureSavedViewFields('nope', FULL_CTX)).toEqual({});
+  });
+
+  it('registry lists each field exactly once per view', () => {
+    for (const scope of Object.values(VIEW_SCOPES)) {
+      const fields = scope.persistedFields ?? [];
+      expect(new Set(fields).size).toBe(fields.length);
+    }
+  });
+});

--- a/src/core/viewScope.ts
+++ b/src/core/viewScope.ts
@@ -17,10 +17,33 @@ export type ViewScopeContext = {
   selectedBaseIds: string[];
 };
 
+/**
+ * Saved-view fields owned by an individual view. Each view declares which of
+ * these it contributes to a saved view; `captureSavedViewFields` picks only
+ * those keys off a context object at save time.
+ */
+export type SavedViewCaptureField =
+  | 'groupBy'
+  | 'sort'
+  | 'showAllGroups'
+  | 'zoomLevel'
+  | 'collapsedGroups'
+  | 'selectedBaseIds';
+
+export type SavedViewCaptureCtx = Partial<Record<SavedViewCaptureField, unknown>>;
+
 export interface ViewScope {
   id: ViewId;
   includes(ev: any, ctx: ViewScopeContext): boolean;
   seedCategoryOptions?: readonly string[];
+  /**
+   * Which saved-view fields this view owns. `captureSavedViewFields` reads
+   * these keys off a live-state ctx at save time. Omit (or leave empty) for
+   * views that only contribute `filters` + `view`. Sanitization still runs
+   * inside `useSavedViews`, so this is a pass-through whitelist, not a
+   * validator.
+   */
+  persistedFields?: readonly SavedViewCaptureField[];
 }
 
 function includesForBase(ev: any, ctx: ViewScopeContext): boolean {
@@ -48,16 +71,47 @@ export const VIEW_SCOPES: Record<ViewId, ViewScope> = Object.freeze({
   month:    { id: 'month',    includes: ev => !isScheduleWorkflowEvent(ev) },
   week:     { id: 'week',     includes: ev => !isScheduleWorkflowEvent(ev) },
   day:      { id: 'day',      includes: ev => !isScheduleWorkflowEvent(ev) },
-  agenda:   { id: 'agenda',   includes: ev => !isScheduleWorkflowEvent(ev) },
+  agenda: {
+    id: 'agenda',
+    includes: ev => !isScheduleWorkflowEvent(ev),
+    persistedFields: ['groupBy', 'sort', 'showAllGroups'],
+  },
   schedule: {
     id: 'schedule',
     includes: ev => isScheduleWorkflowEvent(ev),
     seedCategoryOptions: SCHEDULE_TAB_CATEGORY_SEEDS,
+    persistedFields: ['groupBy', 'sort'],
   },
-  base:     { id: 'base',     includes: includesForBase },
-  assets:   { id: 'assets',   includes: () => true },
+  base: {
+    id: 'base',
+    includes: includesForBase,
+    persistedFields: ['selectedBaseIds'],
+  },
+  assets: {
+    id: 'assets',
+    includes: () => true,
+    persistedFields: ['groupBy', 'sort', 'zoomLevel', 'collapsedGroups'],
+  },
 });
 
 export function getViewScope(view: string): ViewScope {
   return (VIEW_SCOPES as any)[view] ?? VIEW_SCOPES.month;
+}
+
+/**
+ * Pick only the saved-view fields the active view owns out of `ctx`.
+ * Undefined entries are dropped; everything else is passed through verbatim
+ * for `useSavedViews` to sanitize. Safe to spread into `saveView`/`resaveView`.
+ */
+export function captureSavedViewFields(
+  view: string,
+  ctx: SavedViewCaptureCtx,
+): SavedViewCaptureCtx {
+  const fields = getViewScope(view).persistedFields;
+  if (!fields || fields.length === 0) return {};
+  const out: SavedViewCaptureCtx = {};
+  for (const f of fields) {
+    if (ctx[f] !== undefined) out[f] = ctx[f];
+  }
+  return out;
 }


### PR DESCRIPTION
Each view now declares which saved-view fields it owns (groupBy, sort, showAllGroups, zoomLevel, collapsedGroups, selectedBaseIds) on its VIEW_SCOPES entry. captureSavedViewFields(viewId, ctx) picks only those keys off a live-state context, replacing the grab-bag spread at the four saveView/resaveView call sites in WorksCalendar so month/week/day saves no longer accidentally snapshot unrelated tab state.

Sanitization still happens in useSavedViews; this is a tab-scoped whitelist, not a new engine abstraction.

https://claude.ai/code/session_01XjU8Hz7S8Ar82Ug7wxo5os