### PR TITLE
Team & Assets: add phone/type metadata, asset status badges, and WeekView compact titles

### DIFF
--- a/src/ui/ConfigPanel.tsx
+++ b/src/ui/ConfigPanel.tsx
@@ -373,6 +373,9 @@ export function TeamTab({ config, onUpdate, onEmployeeAdd, onEmployeeDelete }: a
 
   // ── Pending new member ──────────────────────────────────────────────────────
   const [pendingName, setPendingName] = useState('');
+  const [pendingPhone, setPendingPhone] = useState('');
+  const [pendingRole, setPendingRole] = useState('');
+  const [pendingBase, setPendingBase] = useState('');
   const [isAdding,    setIsAdding]    = useState(false);
   const pendingInputRef = useRef(null);
 
@@ -428,17 +431,35 @@ export function TeamTab({ config, onUpdate, onEmployeeAdd, onEmployeeDelete }: a
   // ── Member helpers ──────────────────────────────────────────────────────────
   const commitPending = () => {
     const trimmed = pendingName.trim();
-    if (!trimmed) { setIsAdding(false); setPendingName(''); return; }
+    const trimmedPhone = pendingPhone.trim();
+    if (!trimmed) { setIsAdding(false); setPendingName(''); setPendingPhone(''); setPendingRole(''); setPendingBase(''); return; }
+    if (!trimmedPhone) return;
+    if (roles.length > 0 && !pendingRole) return;
+    if (bases.length > 0 && !pendingBase) return;
     const nextId = Math.max(0, ...teamMembers.map((member) => Number(member.id) || 0)) + 1;
-    const newMember = { id: nextId, name: trimmed, color: '#8b5cf6', avatar: null };
+    const newMember = {
+      id: nextId,
+      name: trimmed,
+      phone: trimmedPhone,
+      role: pendingRole || undefined,
+      base: pendingBase || undefined,
+      color: '#8b5cf6',
+      avatar: null,
+    };
     updateMembers([...teamMembers, newMember]);
     onEmployeeAdd?.(newMember);
     setPendingName('');
+    setPendingPhone('');
+    setPendingRole('');
+    setPendingBase('');
     setIsAdding(false);
   };
 
   const cancelPending = () => {
     setPendingName('');
+    setPendingPhone('');
+    setPendingRole('');
+    setPendingBase('');
     setIsAdding(false);
   };
 
@@ -559,6 +580,13 @@ export function TeamTab({ config, onUpdate, onEmployeeAdd, onEmployeeDelete }: a
             </button>
           </div>
           <div className={styles.memberMeta}>
+            <input
+              className={styles.input}
+              value={member.phone ?? ''}
+              onChange={e => updateMember(member.id, { phone: e.target.value })}
+              placeholder="Phone"
+              aria-label="Phone"
+            />
             <select
               className={styles.select}
               value={member.role ?? ''}
@@ -591,22 +619,57 @@ export function TeamTab({ config, onUpdate, onEmployeeAdd, onEmployeeDelete }: a
               </div>
             </div>
           </div>
-          <input
-            ref={pendingInputRef}
-            className={styles.input}
-            value={pendingName}
-            onChange={(e) => setPendingName(e.target.value)}
-            onKeyDown={(e) => {
-              if (e.key === 'Enter') { e.preventDefault(); commitPending(); }
-              if (e.key === 'Escape') { e.preventDefault(); cancelPending(); }
-            }}
-            onBlur={commitPending}
-            placeholder="Employee name"
-          />
+          <div style={{ flex: 1, display: 'grid', gap: 8 }}>
+            <input
+              ref={pendingInputRef}
+              className={styles.input}
+              value={pendingName}
+              onChange={(e) => setPendingName(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter') { e.preventDefault(); commitPending(); }
+                if (e.key === 'Escape') { e.preventDefault(); cancelPending(); }
+              }}
+              placeholder="Employee name"
+            />
+            <input
+              className={styles.input}
+              value={pendingPhone}
+              onChange={(e) => setPendingPhone(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter') { e.preventDefault(); commitPending(); }
+                if (e.key === 'Escape') { e.preventDefault(); cancelPending(); }
+              }}
+              placeholder="Phone number"
+              aria-label="Phone number"
+            />
+            <div className={styles.memberMeta}>
+              <select
+                className={styles.select}
+                value={pendingRole}
+                onChange={e => setPendingRole(e.target.value)}
+                aria-label="Pending role"
+              >
+                <option value="">{roles.length > 0 ? '— select role —' : '— no roles configured —'}</option>
+                {roles.map(r => <option key={r} value={r}>{r}</option>)}
+              </select>
+              {bases.length > 0 && (
+                <select
+                  className={styles.select}
+                  value={pendingBase}
+                  onChange={e => setPendingBase(e.target.value)}
+                  aria-label="Pending base"
+                >
+                  <option value="">— select base —</option>
+                  {bases.map(b => <option key={b.id} value={b.id}>{b.name}</option>)}
+                </select>
+              )}
+            </div>
+          </div>
           <button
             className={styles.removeBtn}
             onMouseDown={(e) => e.preventDefault()}
             onClick={commitPending}
+            disabled={!pendingName.trim() || !pendingPhone.trim() || (roles.length > 0 && !pendingRole) || (bases.length > 0 && !pendingBase)}
             aria-label="Add employee"
           >
             <Check size={13} />
@@ -1028,12 +1091,12 @@ export function AssetsTab({ config, onUpdate }: any) {
         <div key={asset._key ?? i} className={styles.assetRow} data-asset-id={asset.id}>
           <div className={styles.assetFields}>
             <div className={styles.assetField}>
-              <span className={styles.assetFieldLabel}>Label</span>
+              <span className={styles.assetFieldLabel}>Registration</span>
               <input
                 className={styles.input}
                 value={asset.label ?? ''}
                 onChange={e => updateAsset(i, { label: e.target.value })}
-                aria-label={`Label for ${asset.id}`}
+                aria-label={`Registration for ${asset.id}`}
               />
             </div>
             <div className={styles.assetField}>
@@ -1061,6 +1124,42 @@ export function AssetsTab({ config, onUpdate }: any) {
                 value={asset.meta?.sublabel ?? ''}
                 onChange={e => updateAssetMeta(i, { sublabel: e.target.value })}
                 aria-label={`Sublabel for ${asset.label || asset.id}`}
+              />
+            </div>
+            <div className={styles.assetField}>
+              <span className={styles.assetFieldLabel}>Type</span>
+              <input
+                className={styles.input}
+                value={asset.meta?.type ?? ''}
+                onChange={e => updateAssetMeta(i, { type: e.target.value })}
+                aria-label={`Type for ${asset.label || asset.id}`}
+              />
+            </div>
+            <div className={styles.assetField}>
+              <span className={styles.assetFieldLabel}>Make</span>
+              <input
+                className={styles.input}
+                value={asset.meta?.make ?? ''}
+                onChange={e => updateAssetMeta(i, { make: e.target.value })}
+                aria-label={`Make for ${asset.label || asset.id}`}
+              />
+            </div>
+            <div className={styles.assetField}>
+              <span className={styles.assetFieldLabel}>Model</span>
+              <input
+                className={styles.input}
+                value={asset.meta?.model ?? ''}
+                onChange={e => updateAssetMeta(i, { model: e.target.value })}
+                aria-label={`Model for ${asset.label || asset.id}`}
+              />
+            </div>
+            <div className={styles.assetField}>
+              <span className={styles.assetFieldLabel}>Limitations (optional)</span>
+              <input
+                className={styles.input}
+                value={asset.meta?.limitations ?? ''}
+                onChange={e => updateAssetMeta(i, { limitations: e.target.value })}
+                aria-label={`Limitations for ${asset.label || asset.id}`}
               />
             </div>
           </div>

--- a/src/ui/__tests__/ConfigPanel.assetsTab.test.tsx
+++ b/src/ui/__tests__/ConfigPanel.assetsTab.test.tsx
@@ -54,11 +54,11 @@ describe('AssetsTab — mutations', () => {
     expect(getConfig().assets[1].id).toBe('asset-2');
   });
 
-  it('editing a label writes config.assets[i].label', () => {
+  it('editing registration writes config.assets[i].label', () => {
     const { getConfig, rerender } = renderTab({
       initialConfig: { assets: [{ id: 'n100aa', label: 'N100AA', meta: {} }] },
     });
-    const input = screen.getByLabelText('Label for n100aa');
+    const input = screen.getByLabelText('Registration for n100aa');
     fireEvent.change(input, { target: { value: 'Alpha 1' } });
     rerender();
     expect(getConfig().assets[0].label).toBe('Alpha 1');

--- a/src/ui/__tests__/ConfigPanel.teamTab.test.tsx
+++ b/src/ui/__tests__/ConfigPanel.teamTab.test.tsx
@@ -32,15 +32,16 @@ function renderTab({ initialMembers = [], onUpdate, onEmployeeAdd, onEmployeeDel
 }
 
 describe('TeamTab bidirectional sync (issue #101)', () => {
-  it('committing a new employee (with name) patches config.team.members', () => {
+  it('committing a new employee patches config.team.members', () => {
     const { update, getConfig } = renderTab();
     fireEvent.click(screen.getByRole('button', { name: /Add employee/ }));
     const input = screen.getByPlaceholderText('Employee name');
     fireEvent.change(input, { target: { value: 'Nora' } });
+    fireEvent.change(screen.getByPlaceholderText('Phone number'), { target: { value: '555-0100' } });
     fireEvent.keyDown(input, { key: 'Enter' });
     expect(update).toHaveBeenCalledTimes(1);
     expect(getConfig().team.members).toHaveLength(1);
-    expect(getConfig().team.members[0]).toMatchObject({ id: 1, name: 'Nora' });
+    expect(getConfig().team.members[0]).toMatchObject({ id: 1, name: 'Nora', phone: '555-0100' });
   });
 
   it('committing a new employee emits onEmployeeAdd upstream', () => {
@@ -48,16 +49,16 @@ describe('TeamTab bidirectional sync (issue #101)', () => {
     fireEvent.click(screen.getByRole('button', { name: /Add employee/ }));
     const input = screen.getByPlaceholderText('Employee name');
     fireEvent.change(input, { target: { value: 'Nora' } });
+    fireEvent.change(screen.getByPlaceholderText('Phone number'), { target: { value: '555-0100' } });
     fireEvent.keyDown(input, { key: 'Enter' });
     expect(add).toHaveBeenCalledTimes(1);
-    expect(add.mock.calls[0][0]).toMatchObject({ id: 1, name: 'Nora' });
+    expect(add.mock.calls[0][0]).toMatchObject({ id: 1, name: 'Nora', phone: '555-0100' });
   });
 
-  it('blank name does not add a member (prevents ghost rows in schedule)', () => {
+  it('blank name or phone does not add a member (prevents ghost rows in schedule)', () => {
     const { update, add, getConfig } = renderTab();
     fireEvent.click(screen.getByRole('button', { name: /Add employee/ }));
     const input = screen.getByPlaceholderText('Employee name');
-    // Submitting without typing should cancel — no add.
     fireEvent.keyDown(input, { key: 'Enter' });
     expect(update).not.toHaveBeenCalled();
     expect(add).not.toHaveBeenCalled();
@@ -83,8 +84,8 @@ describe('TeamTab bidirectional sync (issue #101)', () => {
     fireEvent.click(screen.getByRole('button', { name: /Add employee/ }));
     const input = screen.getByPlaceholderText('Employee name');
     fireEvent.change(input, { target: { value: 'Nora' } });
+    fireEvent.change(screen.getByPlaceholderText('Phone number'), { target: { value: '555-0100' } });
     fireEvent.keyDown(input, { key: 'Enter' });
-    // If we got here without throwing, the test passes.
     expect(true).toBe(true);
   });
 
@@ -103,11 +104,11 @@ describe('TeamTab bidirectional sync (issue #101)', () => {
       initialMembers: [{ id: 5, name: 'Existing', color: '#111', avatar: null }],
     });
     fireEvent.click(screen.getByRole('button', { name: /Add employee/ }));
-    // The pending input is the newly-added one (empty value); filter it out.
     const inputs = screen.getAllByPlaceholderText('Employee name');
     const pending = inputs.find(el => (el as HTMLInputElement).value === '');
-    fireEvent.change(pending, { target: { value: 'Nora' } });
-    fireEvent.keyDown(pending, { key: 'Enter' });
+    fireEvent.change(pending!, { target: { value: 'Nora' } });
+    fireEvent.change(screen.getByPlaceholderText('Phone number'), { target: { value: '555-0100' } });
+    fireEvent.keyDown(pending!, { key: 'Enter' });
     expect(getConfig().team.members.map(m => m.id)).toEqual([5, 6]);
   });
 });

--- a/src/views/AssetsView.module.css
+++ b/src/views/AssetsView.module.css
@@ -296,6 +296,31 @@
   flex: 1 1 auto;
 }
 
+.assetStatusBadge {
+  align-self: flex-start;
+  padding: 1px 6px;
+  border-radius: 999px;
+  font-size: 10px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.assetStatusAssigned {
+  background: color-mix(in srgb, var(--wc-accent) 25%, transparent);
+  color: var(--wc-accent-ink, #0b3d7a);
+}
+
+.assetStatusAvailable {
+  background: color-mix(in srgb, #16a34a 20%, transparent);
+  color: #166534;
+}
+
+.assetStatusRequested {
+  background: color-mix(in srgb, #f59e0b 22%, transparent);
+  color: #92400e;
+}
+
 .assetRegistration {
   font-size: calc(14px * var(--wc-font-scale, 1));
   font-weight: 700;

--- a/src/views/AssetsView.tsx
+++ b/src/views/AssetsView.tsx
@@ -162,6 +162,15 @@ function approvalPrefix(stage) {
   return null;
 }
 
+function getAssetStatus(rowEvents, now) {
+  const nowTs = now.getTime();
+  const hasAssignedNow = rowEvents.some(ev => new Date(ev.start).getTime() <= nowTs && new Date(ev.end).getTime() >= nowTs);
+  if (hasAssignedNow) return 'assigned';
+  const hasRequested = rowEvents.some(ev => getApprovalStage(ev) === 'requested');
+  if (hasRequested) return 'requested';
+  return 'available';
+}
+
 // ─── Component ───────────────────────────────────────────────────────────────
 
 export default function AssetsView({
@@ -885,6 +894,7 @@ export default function AssetsView({
             const displayLabel = label ?? resource;
             const topOffset = rowOffsets[rowIdx];
             const locationData = locations.get(resource) ?? null;
+            const assetStatus = getAssetStatus(rowEvents, new Date());
 
             return (
               <div
@@ -914,6 +924,11 @@ export default function AssetsView({
                     {sublabel && (
                       <span className={styles.assetSublabel}>{sublabel}</span>
                     )}
+                    <span
+                      className={[styles.assetStatusBadge, styles[`assetStatus${assetStatus[0].toUpperCase()}${assetStatus.slice(1)}`]].join(' ')}
+                    >
+                      {assetStatus}
+                    </span>
                   </div>
                   <div
                     className={styles.locationBanner}

--- a/src/views/WeekView.tsx
+++ b/src/views/WeekView.tsx
@@ -286,6 +286,8 @@ export default function WeekView({
     const pctWidth = (1 / numCols) * 100;
     const statusClass = ev.status === 'cancelled' ? styles.cancelled
       : ev.status === 'tentative' ? styles.tentative : '';
+    const eventDurationMinutes = Math.max(1, Math.round((new Date(ev.end).getTime() - new Date(ev.start).getTime()) / 60000));
+    const isCompactEvent = eventDurationMinutes <= 60;
     const ariaLabel = `${ev.title}, ${format(ev.start, 'h:mm a')} to ${format(ev.end, 'h:mm a')}${ev.category ? `, ${ev.category}` : ''}${ev.status && ev.status !== 'confirmed' ? `, ${ev.status}` : ''}`;
     const display   = ev.meta?._display ?? {};
 
@@ -316,10 +318,13 @@ export default function WeekView({
           aria-hidden="true" />
         {inner ?? (
           <>
-            <span className={styles.evTitle} style={{ fontWeight: display.bold ? '700' : undefined }}>Title: {ev.title}</span>
-            <span className={styles.evTime}>Start: {format(ev.start, 'h:mm a')}</span>
-            <span className={styles.evTime}>End: {format(ev.end, 'h:mm a')}</span>
-            <span className={styles.evMeta}>Resource: {pillResource(ev)}</span>
+            <span className={styles.evTitle} style={{ fontWeight: display.bold ? '700' : undefined }}>{ev.title}</span>
+            {!isCompactEvent && (
+              <>
+                <span className={styles.evTime}>{format(ev.start, 'h:mm a')} - {format(ev.end, 'h:mm a')}</span>
+                <span className={styles.evMeta}>{pillResource(ev)}</span>
+              </>
+            )}
           </>
         )}
         <div className={styles.resizeHandle}


### PR DESCRIPTION
### Motivation
- Reduce friction in owner setup flows by surfacing key metadata when creating employees and assets and preventing ghost/partial entries.  
- Improve timeline readability for short events by prioritizing title text in tight vertical space.  
- Surface asset availability at-a-glance in the Assets view so owners can quickly see rows that are `assigned`, `requested`, or `available`.  
- No external skills were used for this change set.

### Description
- Team setup: extended the Team tab add-flow to capture `phone` (required), plus optional `role`/`base` when configured, and exposed an editable `phone` input for existing members; added client-side validation and updated the pending/new-member UI grid layout (`src/ui/ConfigPanel.tsx`).  
- Assets setup: renamed the label UI to a registration-first UX and added editable metadata fields `type`, `make`, `model`, and `limitations` while keeping `group` and `sublabel`; preserved write/update helpers (`src/ui/ConfigPanel.tsx`).  
- Assets view: added `getAssetStatus` logic and a small status badge rendered per asset row (`assigned` / `requested` / `available`) plus CSS classes to style each state (`src/views/AssetsView.tsx`, `src/views/AssetsView.module.css`).  
- Week view: improved compact-event rendering so events <= 60 minutes show the title prominently and omit secondary lines to avoid truncation (`src/views/WeekView.tsx`).  
- Tests updated to reflect the new registration label and the required phone field in the Team add flow (`src/ui/__tests__/ConfigPanel.assetsTab.test.tsx`, `src/ui/__tests__/ConfigPanel.teamTab.test.tsx`).

### Testing
- Ran `npm test -- src/ui/__tests__/ConfigPanel.assetsTab.test.tsx src/ui/__tests__/ConfigPanel.teamTab.test.tsx`; the first run surfaced failing assertions which were addressed and the final run completed with all tests passing.  
- Ran `npm run type-check` (`tsc --noEmit`) and it completed successfully.  
- The focused test-suite and type-check were green at the end of verification.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e58838eb74832c801cd21a634f94e4)