### PR TITLE
demo: auto-apply service worker updates for latest UI

### DIFF
--- a/demo/App.tsx
+++ b/demo/App.tsx
@@ -1,5 +1,5 @@
 // @ts-nocheck — demo fixture, re-typed after Phase 2 d.ts regeneration
-import { StrictMode, useState, useCallback, useMemo } from 'react';
+import { StrictMode, useState, useCallback, useMemo, useEffect } from 'react';
 import { createRoot } from 'react-dom/client';
 import { registerSW } from 'virtual:pwa-register';
 import {
@@ -428,6 +428,15 @@ function App() {
       onOfflineReady() { console.info('[PWA] App ready to work offline.'); },
     })
   );
+
+  // Keep the public demo on the latest bundle automatically so feature
+  // updates (like the unified Filter/Group/Views sidebar) are visible
+  // without requiring users to notice and click the update toast.
+  useEffect(() => {
+    if (!needsRefresh) return;
+    void updateSW(true);
+    setNeedsRefresh(false);
+  }, [needsRefresh, updateSW]);
 
   const log = (msg) => setEventLog(prev => [`[${new Date().toLocaleTimeString()}] ${msg}`, ...prev].slice(0, 8));
 


### PR DESCRIPTION
### Motivation
- The hosted demo could stay on an older cached bundle due to the PWA service worker, hiding recent UI updates (for example the unified Filter/Group/Views sidebar from the referenced change). The goal is to ensure the demo shows the latest UI without requiring a manual toast click.

### Description
- Import `useEffect` and add an auto-refresh effect in `demo/App.tsx` that calls `updateSW(true)` when `onNeedRefresh` triggers so the demo activates the new service worker automatically.
- The change is confined to `demo/App.tsx` and preserves the existing update toast as a fallback UX.

### Testing
- Ran `npm run build:demo` which completed successfully and produced a new `dist-demo` build.
- Attempted the Playwright screenshot e2e tests but they failed because Playwright browsers are not installed in this environment (`npx playwright install` required).
- Running the repository test runner (`vitest`) with the e2e filter reported no matching unit test files in the configured include patterns.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e58adc5554832ca886833e556667cd)