### PR TITLE
Open Filters/Groups/Views sidebar by default, auto-apply demo SW updates, and improve sidebar labels

### DIFF
--- a/demo/App.tsx
+++ b/demo/App.tsx
@@ -1,5 +1,5 @@
 // @ts-nocheck — demo fixture, re-typed after Phase 2 d.ts regeneration
-import { StrictMode, useState, useCallback, useMemo } from 'react';
+import { StrictMode, useState, useCallback, useMemo, useEffect } from 'react';
 import { createRoot } from 'react-dom/client';
 import { registerSW } from 'virtual:pwa-register';
 import {
@@ -429,6 +429,15 @@ function App() {
     })
   );
 
+  // Keep the public demo on the latest bundle automatically so feature
+  // updates (like the unified Filter/Group/Views sidebar) are visible
+  // without requiring users to notice and click the update toast.
+  useEffect(() => {
+    if (!needsRefresh) return;
+    void updateSW(true);
+    setNeedsRefresh(false);
+  }, [needsRefresh, updateSW]);
+
   const log = (msg) => setEventLog(prev => [`[${new Date().toLocaleTimeString()}] ${msg}`, ...prev].slice(0, 8));
 
   // When the owner saves config (e.g. changes preferred theme in Settings > Setup),
@@ -523,6 +532,7 @@ function App() {
             onEventClick={ev => log(`Clicked: ${ev.title}`)}
             theme={theme}
             showAddButton={true}
+            defaultOrganizeOpen={true}
             categoriesConfig={UNIFIED_CATEGORIES_CONFIG}
             locationProvider={assetLocationProvider}
           />

--- a/src/WorksCalendar.tsx
+++ b/src/WorksCalendar.tsx
@@ -159,6 +159,8 @@ export type WorksCalendarProps = {
   renderToolbar?: (api: CalendarApi) => ReactNode;
   renderFilterBar?: (...args: unknown[]) => ReactNode;
   renderSavedViewsBar?: (...args: unknown[]) => ReactNode;
+  /** Open the Filter/Group/Views sidebar on initial render. */
+  defaultOrganizeOpen?: boolean;
   emptyState?: ReactNode;
   filterSchema?: FilterField[];
   showAddButton?: boolean;
@@ -379,6 +381,7 @@ export const WorksCalendar = forwardRef<CalendarApi, WorksCalendarProps>(functio
     renderToolbar,
     renderFilterBar,
     renderSavedViewsBar,
+    defaultOrganizeOpen = false,
     emptyState,
 
     // ── Filter schema (pass a custom FilterField[] to extend or replace defaults) ──
@@ -574,7 +577,7 @@ export const WorksCalendar = forwardRef<CalendarApi, WorksCalendarProps>(functio
   useEffect(() => setActiveShowAllGroups(!!showAllGroups), [showAllGroups]);
 
   // ── FilterGroupSidebar state ──
-  const [sidebarOpen, setSidebarOpen] = useState(false);
+  const [sidebarOpen, setSidebarOpen] = useState(defaultOrganizeOpen);
 
   // Derive GroupLevel[] from activeGroupBy for the sidebar's GroupsPanel
   const sidebarGroupLevels = useMemo<GroupLevel[]>(() => {

--- a/src/ui/FilterGroupSidebar.tsx
+++ b/src/ui/FilterGroupSidebar.tsx
@@ -167,7 +167,7 @@ export default function FilterGroupSidebar({
         <div className={styles.header}>
           <h2 className={styles.headerTitle}>
             <SlidersHorizontal size={15} style={{ marginRight: 6, verticalAlign: 'middle' }} />
-            Organize
+            Filters, Groups & Views
           </h2>
           <button
             className={styles.closeBtn}
@@ -286,12 +286,12 @@ export function SidebarToggleButton({
     <button
       className={[styles.toggleBtn, isOpen && styles.active].filter(Boolean).join(' ')}
       onClick={onClick}
-      aria-label={isOpen ? 'Close organize sidebar' : 'Open organize sidebar'}
+      aria-label={isOpen ? 'Close filters, groups, and views sidebar' : 'Open filters, groups, and views sidebar'}
       aria-expanded={isOpen}
-      title="Filters, grouping & saved views"
+      title="Filters, groups, and saved views"
     >
       <SlidersHorizontal size={15} />
-      <span>Organize</span>
+      <span>Filters / Groups</span>
       {totalActive > 0 && (
         <span className={styles.badge}>{totalActive}</span>
       )}


### PR DESCRIPTION
### Motivation

- Make the demo showcase feature updates by opening the Filter/Group/Views sidebar by default and auto-applying service worker updates so visitors see new UI changes without manual interaction.
- Expose a `WorksCalendar` prop to allow hosts to control the initial sidebar state programmatically.
- Improve clarity of sidebar labels and accessibility strings to better describe the content (filters, groups and saved views).

### Description

- Add a new prop `defaultOrganizeOpen?: boolean` to the `WorksCalendarProps` type and wire it into the component so the sidebar initial state is `useState(defaultOrganizeOpen)` with a default of `false`.
- Update the demo `App` to set `defaultOrganizeOpen={true}` and add a `useEffect` that automatically calls `updateSW(true)` when `needsRefresh` becomes true, then clears the flag to apply the latest bundle without user interaction.
- Rename sidebar header text from "Organize" to "Filters, Groups & Views" and update the `SidebarToggleButton`'s `aria-label`, `title`, and visible label to be more descriptive.
- Import `useEffect` in the demo and ensure the demo keeps the public sample synced with the latest service-worker bundle.

### Testing

- Ran TypeScript type-check with `tsc --noEmit` and it completed successfully.
- Ran the project's unit test suite with `npm test` and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e58adc5554832ca886833e556667cd)