### PR TITLE
fix(demo): proactively probe for SW updates so stale caches don't hide new UI

### DIFF
--- a/demo/App.tsx
+++ b/demo/App.tsx
@@ -428,6 +428,20 @@ function App() {
     registerSW({
       onNeedRefresh() { setNeedsRefresh(true); },
       onOfflineReady() { console.info('[PWA] App ready to work offline.'); },
+      // Probe for a new bundle on registration and whenever the tab regains
+      // focus. Without this, a visitor with a stale SW would only pick up
+      // new bundles on the next fresh navigation. Combined with the
+      // onNeedRefresh auto-apply below this means a user who already had
+      // the pre-sidebar build cached will get bumped to the latest UI
+      // (e.g. the unified Filter/Group/Views sidebar) within seconds of
+      // re-opening the demo tab.
+      onRegisteredSW(_swUrl, r) {
+        if (!r) return;
+        void r.update();
+        const check = () => { if (!document.hidden) void r.update(); };
+        window.addEventListener('focus', check);
+        document.addEventListener('visibilitychange', check);
+      },
     })
   );
 


### PR DESCRIPTION
The unified Filter/Group/Views sidebar from 015fc95 ships in the bundle but
visitors with a pre-sidebar service worker were only getting the new build
on a subsequent fresh navigation — vite-plugin-pwa's default registerSW
only probes for updates at registration time, so onNeedRefresh (and the
auto-apply effect from PR #201) never fired during a normal session.

Add an explicit r.update() at registration + on focus/visibilitychange so
a returning visitor picks up the new bundle within seconds of opening the
tab, at which point the existing auto-apply effect reloads them onto the
latest UI.

https://claude.ai/code/session_01GFyvMerugbymkHf9ueQ4MW