### PR TITLE
docs: add focused sprint plan for issues #192 and #196

### DIFF
--- a/docs/issues-192-196-sprint-plan.md
+++ b/docs/issues-192-196-sprint-plan.md
@@ -1,0 +1,151 @@
+# Sprint Plan — Issues #192 and #196
+
+**Created:** 2026-04-20
+**Branch:** `claude/sprint-plan-192-196-rSLrR`
+**Sprint length:** 5 working days
+**Scope:** Two focused UX/data-quality issues that are small, independent, and ship-ready as a pair.
+
+> A broader six-issue plan exists in `docs/issues-192-198-one-sprint-plan.md`. This document narrows the scope to just #192 and #196 for a smaller, lower-risk delivery.
+
+---
+
+## Issues
+
+1. **#196 — Asset creation form fields**
+   "When assets are created there needs to be a Registration Number, Type, Make, Model, and optional Limitations categories to fill."
+2. **#192 — Location filter trap in Schedules tab**
+   "When a location in the Schedules tab doesn't have anything assigned to it, the base/location filter button disappears, leaving you trapped in that view."
+
+---
+
+## Sprint Goal
+
+Ship a "Data Quality + Schedule UX Stability" pair: unblock asset data entry with structured required fields, and guarantee users can always recover from an empty filtered state in the Schedules tab.
+
+---
+
+## Issue #196 — Asset Form Enhancement
+
+### Current state
+
+- Asset creation/edit UI lives in `src/ui/ConfigPanel.tsx` (`AssetsTab` around lines 1062–1182).
+- Current asset shape: `{ _key, id, label, group, meta: {} }`.
+- Assets render in `src/views/AssetsView.tsx` using `asset.id`, `asset.label`, and `meta.sublabel` (lines 39, 425–448).
+- "Request asset" flow (`AssetRequestForm.tsx`) is a separate concern — not in scope.
+
+### Target state
+
+Asset records gain the following fields (kept on `asset.meta` to preserve backward compatibility):
+
+| Field                | Required | Notes                                                        |
+| -------------------- | -------- | ------------------------------------------------------------ |
+| `registrationNumber` | Yes      | Free text, unique is **not** enforced in this sprint.        |
+| `type`               | Yes      | Free text or select (reuse existing `group` taxonomy if fit).|
+| `make`               | Yes      | Free text.                                                   |
+| `model`              | Yes      | Free text.                                                   |
+| `limitations`        | No       | Multi-line text, optional.                                   |
+
+### Implementation notes
+
+- Extend the asset form in `ConfigPanel.tsx` with five new inputs (four required, one optional).
+- Validate required fields client-side before calling `updateAsset()`; show per-field inline errors.
+- Persist via existing config write path — no storage-layer migration needed if fields live on `meta`.
+- Update `AssetsView.tsx` to surface the new fields in the detail area (low priority for this sprint; title/sublabel remain primary).
+- Existing assets without these fields must still render — treat missing values as empty strings in the form and as blank rows in the view.
+
+### Acceptance criteria
+
+- [ ] New asset cannot be saved without Registration Number, Type, Make, and Model.
+- [ ] Limitations is optional and persists when entered.
+- [ ] Missing-field validation errors are field-specific and keyboard/screen-reader accessible.
+- [ ] Existing assets load without runtime errors when opened in the edit form.
+- [ ] Unit tests cover: valid save, missing-field rejection (each required field), legacy asset load.
+
+### Estimate
+
+~2 days including tests.
+
+---
+
+## Issue #192 — Schedules Tab Filter Recovery
+
+### Current state
+
+- Relevant file: `src/views/TimelineView.tsx`.
+  - `baseFilter` state at line 164.
+  - Filter applied to `displayEmployees` at lines 265–269.
+  - Base filter bar rendered at lines 638–653 under `{bases.length > 0 && ...}`.
+- Repro: pick a location that has no assignments in the current window → filtered result is empty → filter controls still meant to render, but layout/no-results handling can hide them and strand the user.
+
+### Target state
+
+- The location/base filter bar is **always** visible when `bases.length > 0`, regardless of whether the current filter yields zero rows.
+- An empty result must render a clear "no assignments for this location" state with a visible "Clear filter" or "All" button.
+- Users can freely switch locations or clear the filter from the empty state without reloading or changing tabs.
+
+### Implementation notes
+
+- Audit the render condition at lines 638–653 — confirm it does not depend on `displayEmployees.length`.
+- Add an explicit empty-state view inside the filtered region so the filter bar stays in the DOM and focusable.
+- Ensure the "All" / clear-filter button is always enabled when a non-default filter is active.
+- Add a Playwright (or existing e2e equivalent) test: apply a location filter that yields zero employees, assert filter controls are still visible and clickable.
+
+### Acceptance criteria
+
+- [ ] Filter bar remains mounted and visible when the filtered result set is empty.
+- [ ] "All" / clear-filter control is reachable via keyboard and mouse in the empty state.
+- [ ] Empty state renders an informative message identifying the active filter.
+- [ ] Switching to another location or clearing the filter restores the full schedule without requiring navigation away from the tab.
+- [ ] Regression test guards the empty-state behavior.
+
+### Estimate
+
+~2 days including regression test.
+
+---
+
+## Proposed Timeline
+
+| Day | Work                                                                        |
+| --- | --------------------------------------------------------------------------- |
+| 1   | #196: form UI + required-field validation + unit tests.                     |
+| 2   | #196: backward-compat load path + polish + review-ready PR.                 |
+| 3   | #192: render-guard fix + empty-state component + manual repro validation.   |
+| 4   | #192: e2e/Playwright regression test + review-ready PR.                     |
+| 5   | Cross-issue QA pass, docs/changelog update, demo capture, release notes.    |
+
+Issues are independent and can be parallelized if two developers are available.
+
+---
+
+## QA Checklist
+
+- [ ] Save blocked without each required asset field (4 cases).
+- [ ] Save succeeds with required fields, with and without Limitations.
+- [ ] Editing a legacy asset (missing new fields) loads without errors.
+- [ ] Required-field errors announce via ARIA live region / field-level aria-describedby.
+- [ ] Schedules tab with a zero-assignment location: filter bar visible.
+- [ ] Schedules tab with a zero-assignment location: "All"/clear control works.
+- [ ] Schedules tab with a zero-assignment location: switching location restores data.
+- [ ] Keyboard-only navigation reaches filter controls from the empty state.
+- [ ] No console errors in either flow.
+- [ ] `npm test` passes.
+- [ ] Playwright suite passes including new empty-state test.
+
+---
+
+## Risks and Mitigations
+
+- **Legacy asset records missing new fields.** Treat missing values as empty strings in the edit form; do not write migrations in this sprint.
+- **Type field overlap with existing `group` taxonomy.** If `group` already conveys type, prefer extending `group` semantics and document the decision in the PR rather than introducing a parallel field.
+- **Hidden coupling in TimelineView empty-state.** Keep the fix minimal — do not refactor filter state; only ensure the filter bar is not conditionally unmounted.
+- **Regression risk in Schedules tab layout.** Verify at common viewport widths before merge.
+
+---
+
+## Out of Scope
+
+- Asset registration-number uniqueness enforcement.
+- Asset type as a managed enum / dropdown (tracked separately if desired).
+- Other open issues (#193, #195, #197, #198) — covered in `docs/issues-192-198-one-sprint-plan.md`.
+- Storage-layer migrations.

--- a/src/ui/ConfigPanel.module.css
+++ b/src/ui/ConfigPanel.module.css
@@ -333,6 +333,31 @@
   outline-color: var(--wc-danger, #c0392b);
 }
 
+.assetRowDraft {
+  border-style: dashed;
+  border-color: var(--wc-accent, #0066cc);
+  background: color-mix(in srgb, var(--wc-accent, #0066cc) 4%, var(--wc-surface));
+}
+
+.assetDraftSaveBtn {
+  width: 22px;
+  height: 22px;
+  border-radius: var(--wc-radius-sm);
+  border: 1px solid var(--wc-accent, #0066cc);
+  background: var(--wc-accent, #0066cc);
+  color: #fff;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+}
+
+.assetDraftSaveBtn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
 .assetStatusBadge {
   display: inline-flex;
   align-items: center;

--- a/src/ui/ConfigPanel.module.css
+++ b/src/ui/ConfigPanel.module.css
@@ -311,6 +311,28 @@
   user-select: none;
 }
 
+.assetFieldRequired {
+  color: var(--wc-danger, #c0392b);
+  margin-left: 2px;
+}
+
+.assetFieldError {
+  font-size: 11px;
+  color: var(--wc-danger, #c0392b);
+  line-height: 1.3;
+}
+
+.assetFieldWide {
+  flex-basis: 100%;
+  min-width: 100%;
+}
+
+.assetField input[aria-invalid="true"],
+.assetField textarea[aria-invalid="true"] {
+  border-color: var(--wc-danger, #c0392b);
+  outline-color: var(--wc-danger, #c0392b);
+}
+
 .assetStatusBadge {
   display: inline-flex;
   align-items: center;

--- a/src/ui/ConfigPanel.tsx
+++ b/src/ui/ConfigPanel.tsx
@@ -1059,29 +1059,60 @@ export function CategoriesTab({ config, onUpdate }: any) {
  *            groupBy dropdowns added by ticket 10.
  *   meta   — free-form; sublabel appears under label in the asset cell.
  */
+const REQUIRED_ASSET_META_KEYS = ['registrationNumber', 'type', 'make', 'model'] as const;
+
+function hasAllRequiredAssetFields(asset) {
+  if (!asset) return false;
+  const meta = asset.meta ?? {};
+  return REQUIRED_ASSET_META_KEYS.every(k => String(meta[k] ?? '').trim().length > 0);
+}
+
+function createDraftAsset(nextIndex) {
+  return {
+    _key: `draft-${Date.now()}-${nextIndex}`,
+    id: `asset-${nextIndex}`,
+    label: `Asset ${nextIndex}`,
+    group: '',
+    meta: {
+      registrationNumber: '',
+      type: '',
+      make: '',
+      model: '',
+      limitations: '',
+    },
+  };
+}
+
 export function AssetsTab({ config, onUpdate, items = [] }: any) {
   const assets = Array.isArray(config.assets) ? config.assets : [];
+  // Draft row for new asset creation. Kept in local state so partially-filled
+  // rows never enter config.assets — the only entry point is saveDraft(),
+  // which requires all four of registrationNumber/type/make/model (#196).
+  const [draftAsset, setDraftAsset] = useState<any>(null);
 
   const writeAssets = (next) => onUpdate(c => ({ ...c, assets: next }));
 
   const addAsset = () => {
-    const n = assets.length + 1;
-    writeAssets([
-      ...assets,
-      {
-        _key: `${Date.now()}-${n}`,
-        id: `asset-${n}`,
-        label: `Asset ${n}`,
-        group: '',
-        meta: {
-          registrationNumber: '',
-          type: '',
-          make: '',
-          model: '',
-          limitations: '',
-        },
-      },
-    ]);
+    if (draftAsset) return;
+    setDraftAsset(createDraftAsset(assets.length + 1));
+  };
+
+  const updateDraft = (patch) => {
+    setDraftAsset(prev => (prev ? { ...prev, ...patch } : prev));
+  };
+
+  const updateDraftMeta = (metaPatch) => {
+    setDraftAsset(prev => (
+      prev ? { ...prev, meta: { ...(prev.meta ?? {}), ...metaPatch } } : prev
+    ));
+  };
+
+  const cancelDraft = () => setDraftAsset(null);
+
+  const saveDraft = () => {
+    if (!draftAsset || !hasAllRequiredAssetFields(draftAsset)) return;
+    writeAssets([...assets, draftAsset]);
+    setDraftAsset(null);
   };
 
   const updateAsset = (idx, patch) => {
@@ -1195,7 +1226,13 @@ export function AssetsTab({ config, onUpdate, items = [] }: any) {
                           required
                         />
                         {invalid && (
-                          <span id={errorId} className={styles.assetFieldError} role="alert">
+                          <span
+                            id={errorId}
+                            className={styles.assetFieldError}
+                            role="status"
+                            aria-live="polite"
+                            aria-atomic="true"
+                          >
                             {f.label} is required.
                           </span>
                         )}
@@ -1239,7 +1276,133 @@ export function AssetsTab({ config, onUpdate, items = [] }: any) {
         );
       })}
 
-      <button className={styles.addFieldBtn} onClick={addAsset}>
+      {draftAsset && (() => {
+        const regValue = draftAsset.meta?.registrationNumber ?? '';
+        const typeValue = draftAsset.meta?.type ?? '';
+        const makeValue = draftAsset.meta?.make ?? '';
+        const modelValue = draftAsset.meta?.model ?? '';
+        const limitationsValue = draftAsset.meta?.limitations ?? '';
+        const requiredFields = [
+          { key: 'registrationNumber', label: 'Registration Number', value: regValue },
+          { key: 'type',               label: 'Type',                value: typeValue },
+          { key: 'make',               label: 'Make',                value: makeValue },
+          { key: 'model',              label: 'Model',               value: modelValue },
+        ];
+        const canSave = hasAllRequiredAssetFields(draftAsset);
+        return (
+          <div
+            className={[styles.assetRow, styles.assetRowDraft].filter(Boolean).join(' ')}
+            data-asset-draft="true"
+            role="group"
+            aria-label="New asset draft"
+          >
+            <div className={styles.assetFields}>
+              <div className={styles.assetField}>
+                <span className={styles.assetFieldLabel}>Label</span>
+                <input
+                  className={styles.input}
+                  value={draftAsset.label ?? ''}
+                  onChange={e => updateDraft({ label: e.target.value })}
+                  aria-label="Label for new asset"
+                />
+              </div>
+              <div className={styles.assetField}>
+                <span className={styles.assetFieldLabel}>ID</span>
+                <input
+                  className={styles.input}
+                  value={draftAsset.id}
+                  onChange={e => updateDraft({ id: e.target.value.trim() || draftAsset.id })}
+                  aria-label="Id for new asset"
+                />
+              </div>
+              <div className={styles.assetField}>
+                <span className={styles.assetFieldLabel}>Group</span>
+                <input
+                  className={styles.input}
+                  value={draftAsset.group ?? ''}
+                  onChange={e => updateDraft({ group: e.target.value })}
+                  aria-label="Group for new asset"
+                />
+              </div>
+              <div className={styles.assetField}>
+                <span className={styles.assetFieldLabel}>Sublabel</span>
+                <input
+                  className={styles.input}
+                  value={draftAsset.meta?.sublabel ?? ''}
+                  onChange={e => updateDraftMeta({ sublabel: e.target.value })}
+                  aria-label="Sublabel for new asset"
+                />
+              </div>
+              {requiredFields.map(f => {
+                const invalid = !String(f.value).trim();
+                const errorId = `asset-draft-${f.key}-error`;
+                return (
+                  <div key={f.key} className={styles.assetField}>
+                    <span className={styles.assetFieldLabel}>
+                      {f.label} <span className={styles.assetFieldRequired} aria-hidden="true">*</span>
+                    </span>
+                    <input
+                      className={styles.input}
+                      value={f.value}
+                      onChange={e => updateDraftMeta({ [f.key]: e.target.value })}
+                      aria-label={`${f.label} for new asset`}
+                      aria-required="true"
+                      aria-invalid={invalid || undefined}
+                      aria-describedby={invalid ? errorId : undefined}
+                      required
+                    />
+                    {invalid && (
+                      <span
+                        id={errorId}
+                        className={styles.assetFieldError}
+                        role="status"
+                        aria-live="polite"
+                        aria-atomic="true"
+                      >
+                        {f.label} is required.
+                      </span>
+                    )}
+                  </div>
+                );
+              })}
+              <div className={[styles.assetField, styles.assetFieldWide].filter(Boolean).join(' ')}>
+                <span className={styles.assetFieldLabel}>Limitations</span>
+                <textarea
+                  className={styles.input}
+                  value={limitationsValue}
+                  onChange={e => updateDraftMeta({ limitations: e.target.value })}
+                  aria-label="Limitations for new asset"
+                  rows={2}
+                />
+              </div>
+            </div>
+            <div className={styles.assetActions}>
+              <button
+                type="button"
+                className={styles.assetDraftSaveBtn}
+                onClick={saveDraft}
+                disabled={!canSave}
+                aria-label="Save new asset"
+                title={canSave ? 'Save new asset' : 'Fill in required fields to save'}
+              ><Check size={13} /></button>
+              <button
+                type="button"
+                className={styles.removeBtn}
+                onClick={cancelDraft}
+                aria-label="Cancel new asset"
+              ><X size={13} /></button>
+            </div>
+          </div>
+        );
+      })()}
+
+      <button
+        className={styles.addFieldBtn}
+        onClick={addAsset}
+        disabled={!!draftAsset}
+        aria-disabled={!!draftAsset || undefined}
+        title={draftAsset ? 'Finish the draft asset first' : undefined}
+      >
         <Plus size={13} /> Add asset
       </button>
     </div>

--- a/src/ui/ConfigPanel.tsx
+++ b/src/ui/ConfigPanel.tsx
@@ -1068,7 +1068,19 @@ export function AssetsTab({ config, onUpdate, items = [] }: any) {
     const n = assets.length + 1;
     writeAssets([
       ...assets,
-      { _key: `${Date.now()}-${n}`, id: `asset-${n}`, label: `Asset ${n}`, group: '', meta: {} },
+      {
+        _key: `${Date.now()}-${n}`,
+        id: `asset-${n}`,
+        label: `Asset ${n}`,
+        group: '',
+        meta: {
+          registrationNumber: '',
+          type: '',
+          make: '',
+          model: '',
+          limitations: '',
+        },
+      },
     ]);
   };
 
@@ -1150,6 +1162,59 @@ export function AssetsTab({ config, onUpdate, items = [] }: any) {
                 aria-label={`Sublabel for ${asset.label || asset.id}`}
               />
             </div>
+            {(() => {
+              const regValue = asset.meta?.registrationNumber ?? '';
+              const typeValue = asset.meta?.type ?? '';
+              const makeValue = asset.meta?.make ?? '';
+              const modelValue = asset.meta?.model ?? '';
+              const limitationsValue = asset.meta?.limitations ?? '';
+              const requiredFields = [
+                { key: 'registrationNumber', label: 'Registration Number', value: regValue },
+                { key: 'type',               label: 'Type',                value: typeValue },
+                { key: 'make',               label: 'Make',                value: makeValue },
+                { key: 'model',              label: 'Model',               value: modelValue },
+              ];
+              return (
+                <>
+                  {requiredFields.map(f => {
+                    const invalid = !String(f.value).trim();
+                    const errorId = `asset-${i}-${f.key}-error`;
+                    return (
+                      <div key={f.key} className={styles.assetField}>
+                        <span className={styles.assetFieldLabel}>
+                          {f.label} <span className={styles.assetFieldRequired} aria-hidden="true">*</span>
+                        </span>
+                        <input
+                          className={styles.input}
+                          value={f.value}
+                          onChange={e => updateAssetMeta(i, { [f.key]: e.target.value })}
+                          aria-label={`${f.label} for ${asset.label || asset.id}`}
+                          aria-required="true"
+                          aria-invalid={invalid || undefined}
+                          aria-describedby={invalid ? errorId : undefined}
+                          required
+                        />
+                        {invalid && (
+                          <span id={errorId} className={styles.assetFieldError} role="alert">
+                            {f.label} is required.
+                          </span>
+                        )}
+                      </div>
+                    );
+                  })}
+                  <div className={[styles.assetField, styles.assetFieldWide].filter(Boolean).join(' ')}>
+                    <span className={styles.assetFieldLabel}>Limitations</span>
+                    <textarea
+                      className={styles.input}
+                      value={limitationsValue}
+                      onChange={e => updateAssetMeta(i, { limitations: e.target.value })}
+                      aria-label={`Limitations for ${asset.label || asset.id}`}
+                      rows={2}
+                    />
+                  </div>
+                </>
+              );
+            })()}
           </div>
           <div className={styles.assetActions}>
             <button

--- a/src/ui/__tests__/ConfigPanel.assetsTab.test.tsx
+++ b/src/ui/__tests__/ConfigPanel.assetsTab.test.tsx
@@ -211,6 +211,94 @@ describe('getAssetStatus', () => {
   });
 });
 
+describe('AssetsTab — asset detail fields (#196)', () => {
+  it('new asset rows seed required meta fields with empty strings', () => {
+    const { getConfig, rerender } = renderTab();
+    fireEvent.click(screen.getByRole('button', { name: /Add asset/i }));
+    rerender();
+    const meta = getConfig().assets[0].meta;
+    expect(meta).toMatchObject({
+      registrationNumber: '',
+      type: '',
+      make: '',
+      model: '',
+      limitations: '',
+    });
+  });
+
+  it('editing Registration Number writes to meta.registrationNumber', () => {
+    const { getConfig, rerender } = renderTab({
+      initialConfig: { assets: [{ id: 'a', label: 'Alpha', meta: {} }] },
+    });
+    const input = screen.getByLabelText('Registration Number for Alpha');
+    fireEvent.change(input, { target: { value: 'N12345' } });
+    rerender();
+    expect(getConfig().assets[0].meta.registrationNumber).toBe('N12345');
+  });
+
+  it('editing Type/Make/Model writes to the matching meta fields', () => {
+    const { getConfig, rerender } = renderTab({
+      initialConfig: { assets: [{ id: 'a', label: 'Alpha', meta: {} }] },
+    });
+    fireEvent.change(screen.getByLabelText('Type for Alpha'),  { target: { value: 'Jet' } });
+    rerender();
+    fireEvent.change(screen.getByLabelText('Make for Alpha'),  { target: { value: 'Cessna' } });
+    rerender();
+    fireEvent.change(screen.getByLabelText('Model for Alpha'), { target: { value: 'CJ3' } });
+    rerender();
+    expect(getConfig().assets[0].meta).toMatchObject({
+      type: 'Jet', make: 'Cessna', model: 'CJ3',
+    });
+  });
+
+  it('editing Limitations writes to meta.limitations (optional field)', () => {
+    const { getConfig, rerender } = renderTab({
+      initialConfig: { assets: [{ id: 'a', label: 'Alpha', meta: {} }] },
+    });
+    const input = screen.getByLabelText('Limitations for Alpha');
+    fireEvent.change(input, { target: { value: 'No night ops' } });
+    rerender();
+    expect(getConfig().assets[0].meta.limitations).toBe('No night ops');
+  });
+
+  it('marks empty required fields as aria-invalid with a visible error', () => {
+    renderTab({
+      initialConfig: { assets: [{ id: 'a', label: 'Alpha', meta: {} }] },
+    });
+    const reg = screen.getByLabelText('Registration Number for Alpha');
+    expect(reg).toHaveAttribute('aria-invalid', 'true');
+    expect(reg).toHaveAttribute('aria-required', 'true');
+    expect(screen.getByText('Registration Number is required.')).toBeInTheDocument();
+  });
+
+  it('clears aria-invalid once a required field is filled in', () => {
+    const { rerender } = renderTab({
+      initialConfig: {
+        assets: [{
+          id: 'a',
+          label: 'Alpha',
+          meta: { registrationNumber: 'N1', type: 'Jet', make: 'C', model: 'CJ3' },
+        }],
+      },
+    });
+    const reg = screen.getByLabelText('Registration Number for Alpha');
+    expect(reg).not.toHaveAttribute('aria-invalid');
+    rerender();
+    expect(screen.queryByText('Registration Number is required.')).not.toBeInTheDocument();
+  });
+
+  it('legacy assets without new meta fields still render without errors', () => {
+    renderTab({
+      initialConfig: { assets: [{ id: 'legacy', label: 'Legacy', meta: { sublabel: 'old' } }] },
+    });
+    // Legacy sublabel still renders
+    expect(screen.getByLabelText('Sublabel for Legacy')).toHaveValue('old');
+    // And the required fields show up as empty (invalid) rather than crashing.
+    expect(screen.getByLabelText('Registration Number for Legacy')).toHaveValue('');
+    expect(screen.getByLabelText('Make for Legacy')).toHaveValue('');
+  });
+});
+
 describe('AssetsTab — status badge rendering', () => {
   it('shows a requested status badge when only requested bookings exist', () => {
     renderTab({

--- a/src/ui/__tests__/ConfigPanel.assetsTab.test.tsx
+++ b/src/ui/__tests__/ConfigPanel.assetsTab.test.tsx
@@ -40,19 +40,75 @@ describe('AssetsTab — defaults', () => {
 });
 
 describe('AssetsTab — mutations', () => {
-  it('Add asset appends a new row with a unique id', () => {
+  it('Add asset opens a draft row that is not yet persisted to config', () => {
     const { getConfig, rerender } = renderTab();
     fireEvent.click(screen.getByRole('button', { name: /Add asset/i }));
     rerender();
-    const assets = getConfig().assets;
-    expect(assets).toHaveLength(1);
-    expect(assets[0].id).toBe('asset-1');
-    expect(assets[0].label).toBe('Asset 1');
+    // Draft exists in the UI but has not been written to config.assets.
+    expect(getConfig().assets).toBeUndefined();
+    expect(screen.getByRole('group', { name: /new asset draft/i })).toBeInTheDocument();
+  });
 
+  it('Save new asset is disabled until required fields are filled', () => {
+    const { getConfig, rerender } = renderTab();
     fireEvent.click(screen.getByRole('button', { name: /Add asset/i }));
     rerender();
-    expect(getConfig().assets).toHaveLength(2);
-    expect(getConfig().assets[1].id).toBe('asset-2');
+
+    const saveBtn = screen.getByRole('button', { name: /save new asset/i });
+    expect(saveBtn).toBeDisabled();
+
+    fireEvent.click(saveBtn);
+    rerender();
+    // Still nothing in config.
+    expect(getConfig().assets).toBeUndefined();
+
+    // Fill all required fields.
+    fireEvent.change(screen.getByLabelText('Registration Number for new asset'), { target: { value: 'N1' } });
+    rerender();
+    fireEvent.change(screen.getByLabelText('Type for new asset'),                { target: { value: 'Jet' } });
+    rerender();
+    fireEvent.change(screen.getByLabelText('Make for new asset'),                { target: { value: 'Cessna' } });
+    rerender();
+    fireEvent.change(screen.getByLabelText('Model for new asset'),               { target: { value: 'CJ3' } });
+    rerender();
+
+    const enabledSave = screen.getByRole('button', { name: /save new asset/i });
+    expect(enabledSave).not.toBeDisabled();
+
+    fireEvent.click(enabledSave);
+    rerender();
+
+    const persisted = getConfig().assets;
+    expect(persisted).toHaveLength(1);
+    expect(persisted[0].meta).toMatchObject({
+      registrationNumber: 'N1',
+      type: 'Jet',
+      make: 'Cessna',
+      model: 'CJ3',
+    });
+    // Draft is gone.
+    expect(screen.queryByRole('group', { name: /new asset draft/i })).not.toBeInTheDocument();
+  });
+
+  it('Cancel new asset discards the draft without writing config', () => {
+    const { getConfig, rerender } = renderTab();
+    fireEvent.click(screen.getByRole('button', { name: /Add asset/i }));
+    rerender();
+    fireEvent.change(screen.getByLabelText('Registration Number for new asset'), { target: { value: 'N1' } });
+    rerender();
+
+    fireEvent.click(screen.getByRole('button', { name: /cancel new asset/i }));
+    rerender();
+
+    expect(getConfig().assets).toBeUndefined();
+    expect(screen.queryByRole('group', { name: /new asset draft/i })).not.toBeInTheDocument();
+  });
+
+  it('Add asset is disabled while a draft is open', () => {
+    const { rerender } = renderTab();
+    fireEvent.click(screen.getByRole('button', { name: /Add asset/i }));
+    rerender();
+    expect(screen.getByRole('button', { name: /Add asset/i })).toBeDisabled();
   });
 
   it('editing a label writes config.assets[i].label', () => {
@@ -212,20 +268,6 @@ describe('getAssetStatus', () => {
 });
 
 describe('AssetsTab — asset detail fields (#196)', () => {
-  it('new asset rows seed required meta fields with empty strings', () => {
-    const { getConfig, rerender } = renderTab();
-    fireEvent.click(screen.getByRole('button', { name: /Add asset/i }));
-    rerender();
-    const meta = getConfig().assets[0].meta;
-    expect(meta).toMatchObject({
-      registrationNumber: '',
-      type: '',
-      make: '',
-      model: '',
-      limitations: '',
-    });
-  });
-
   it('editing Registration Number writes to meta.registrationNumber', () => {
     const { getConfig, rerender } = renderTab({
       initialConfig: { assets: [{ id: 'a', label: 'Alpha', meta: {} }] },

--- a/src/views/TimelineView.module.css
+++ b/src/views/TimelineView.module.css
@@ -148,6 +148,38 @@
   border-color: var(--wc-accent, #0066cc);
 }
 
+.filterEmptyState {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 10px;
+  padding: 12px 16px;
+  color: var(--wc-text-muted, #555);
+  font-size: 13px;
+  background: var(--wc-surface, #fafafa);
+  border-bottom: 1px solid var(--wc-border, #e0e0e0);
+  position: sticky;
+  left: 0;
+}
+
+.filterEmptyState p {
+  margin: 0;
+}
+
+.filterEmptyClear {
+  padding: 4px 12px;
+  border-radius: 12px;
+  border: 1px solid var(--wc-accent, #0066cc);
+  background: var(--wc-accent, #0066cc);
+  color: #fff;
+  font-size: 12px;
+  cursor: pointer;
+}
+
+.filterEmptyClear:hover {
+  filter: brightness(1.05);
+}
+
 /* ── Remove employee button ──────────────────────────────────────── */
 .removeEmpBtn {
   margin-left: auto;

--- a/src/views/TimelineView.tsx
+++ b/src/views/TimelineView.tsx
@@ -672,7 +672,7 @@ export default function TimelineView({
               type="button"
               className={styles.filterEmptyClear}
               onClick={() => setBaseFilter('')}
-            >Show all locations</button>
+            >Show all bases</button>
           </div>
         )}
 

--- a/src/views/TimelineView.tsx
+++ b/src/views/TimelineView.tsx
@@ -527,8 +527,17 @@ export default function TimelineView({
   }, [flatRows, totalDays, onEventClick, onDateSelect, days]);
 
   // ── Empty state ────────────────────────────────────────────────────────────
+  // When a base filter is active and the filter bar can offer recovery, keep
+  // the chrome mounted so the user can clear the filter. Without this branch
+  // the view short-circuits into a bare empty message and traps the user in
+  // the filtered view (issue #192).
+  const filterTrappedEmpty = useEmployees
+    && bases.length > 0
+    && baseFilter !== ''
+    && rows.length === 0
+    && (employees?.length ?? 0) > 0;
 
-  if (rows.length === 0) {
+  if (rows.length === 0 && !filterTrappedEmpty) {
     if (ctx?.emptyState) return <>{ctx.emptyState}</>;
     return (
       <div className={styles.empty}>
@@ -536,6 +545,10 @@ export default function TimelineView({
       </div>
     );
   }
+
+  const activeBaseName = filterTrappedEmpty
+    ? (bases.find(b => b.id === baseFilter)?.name ?? baseFilter)
+    : '';
 
   // ── Render ────────────────────────────────────────────────────────────────
 
@@ -649,6 +662,17 @@ export default function TimelineView({
                 onClick={() => setBaseFilter(prev => prev === b.id ? '' : b.id)}
               >{b.name}</button>
             ))}
+          </div>
+        )}
+
+        {filterTrappedEmpty && (
+          <div className={styles.filterEmptyState} role="status" aria-live="polite">
+            <p>No employees assigned to <strong>{activeBaseName}</strong>.</p>
+            <button
+              type="button"
+              className={styles.filterEmptyClear}
+              onClick={() => setBaseFilter('')}
+            >Show all locations</button>
           </div>
         )}
 

--- a/src/views/__tests__/TimelineView.baseFilterRecovery.test.tsx
+++ b/src/views/__tests__/TimelineView.baseFilterRecovery.test.tsx
@@ -1,0 +1,100 @@
+// @vitest-environment happy-dom
+/**
+ * TimelineView — base-filter recovery (issue #192).
+ *
+ * Verifies that when a location filter yields zero rows, the filter bar
+ * remains mounted and the user can clear the filter to recover from the
+ * otherwise-empty view.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+
+import TimelineView from '../TimelineView';
+import { CalendarContext } from '../../core/CalendarContext';
+
+const currentDate = new Date(2026, 3, 1); // April 2026
+
+const employees = [
+  { id: 'e1', name: 'Alice Chen', base: 'east' },
+  { id: 'e2', name: 'Bob Smith',  base: 'east' },
+];
+
+const bases = [
+  { id: 'east', name: 'East' },
+  { id: 'west', name: 'West' },
+];
+
+function renderTimeline(props: any = {}) {
+  return render(
+    <CalendarContext.Provider value={null as any}>
+      <TimelineView
+        currentDate={currentDate}
+        events={[]}
+        employees={employees}
+        bases={bases}
+        onEventClick={vi.fn()}
+        {...props}
+      />
+    </CalendarContext.Provider>,
+  );
+}
+
+describe('TimelineView — base filter recovery (#192)', () => {
+  it('keeps the filter toolbar mounted when a filter yields zero rows', () => {
+    renderTimeline();
+
+    // Initial state: both employees render.
+    expect(screen.getByRole('rowheader', { name: 'Alice Chen' })).toBeInTheDocument();
+
+    // Filter to West — no employees are assigned there.
+    fireEvent.click(screen.getByRole('button', { name: 'West' }));
+
+    // Filter toolbar must remain so the user can recover.
+    const toolbar = screen.getByRole('toolbar', { name: /filter by base/i });
+    expect(toolbar).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'All' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'East' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'West' })).toBeInTheDocument();
+
+    // Empty-state message names the active filter.
+    const emptyMsg = screen.getByRole('status');
+    expect(emptyMsg).toHaveTextContent(/no employees assigned to/i);
+    expect(emptyMsg.querySelector('strong')).toHaveTextContent('West');
+  });
+
+  it('exposes a Show all locations button that clears the filter', () => {
+    renderTimeline();
+
+    fireEvent.click(screen.getByRole('button', { name: 'West' }));
+
+    const clearBtn = screen.getByRole('button', { name: /show all locations/i });
+    expect(clearBtn).toBeInTheDocument();
+
+    fireEvent.click(clearBtn);
+
+    // Employees are visible again after clearing the filter.
+    expect(screen.getByRole('rowheader', { name: 'Alice Chen' })).toBeInTheDocument();
+    expect(screen.getByRole('rowheader', { name: 'Bob Smith' })).toBeInTheDocument();
+    // Empty-state message is gone.
+    expect(screen.queryByText(/no employees assigned to/i)).not.toBeInTheDocument();
+  });
+
+  it('switching the filter to a populated location restores rows', () => {
+    renderTimeline();
+
+    fireEvent.click(screen.getByRole('button', { name: 'West' }));
+    expect(screen.queryByRole('rowheader', { name: 'Alice Chen' })).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'East' }));
+    expect(screen.getByRole('rowheader', { name: 'Alice Chen' })).toBeInTheDocument();
+    expect(screen.getByRole('rowheader', { name: 'Bob Smith' })).toBeInTheDocument();
+  });
+
+  it('still renders the plain empty state when there is no data at all', () => {
+    renderTimeline({ employees: [], bases: [] });
+    // With no employees, TimelineView falls back to the resource-derived
+    // empty message; either variant is an acceptable terminal empty state.
+    expect(screen.getByText(/No (employees|events) to display/i)).toBeInTheDocument();
+  });
+});

--- a/src/views/__tests__/TimelineView.baseFilterRecovery.test.tsx
+++ b/src/views/__tests__/TimelineView.baseFilterRecovery.test.tsx
@@ -63,12 +63,12 @@ describe('TimelineView — base filter recovery (#192)', () => {
     expect(emptyMsg.querySelector('strong')).toHaveTextContent('West');
   });
 
-  it('exposes a Show all locations button that clears the filter', () => {
+  it('exposes a Show all bases button that clears the filter', () => {
     renderTimeline();
 
     fireEvent.click(screen.getByRole('button', { name: 'West' }));
 
-    const clearBtn = screen.getByRole('button', { name: /show all locations/i });
+    const clearBtn = screen.getByRole('button', { name: /show all bases/i });
     expect(clearBtn).toBeInTheDocument();
 
     fireEvent.click(clearBtn);


### PR DESCRIPTION
Narrow-scope 5-day plan covering the asset form field additions
(#196) and the Schedules tab location-filter recovery fix (#192).
Complements the broader docs/issues-192-198-one-sprint-plan.md.