### PR TITLE
docs: park Vue + Angular multi-framework support in roadmap

### DIFF
--- a/docs/Roadmap.md
+++ b/docs/Roadmap.md
@@ -1,6 +1,6 @@
 # WorksCalendar Roadmap
 
-_Last updated: 2026-04-15_
+_Last updated: 2026-04-20_
 
 ## Next release targets
 
@@ -16,6 +16,38 @@ _Last updated: 2026-04-15_
 4. **Quality and trust**
    - Keep release notes current per tag.
    - Continue visual QA and example parity checks.
+
+## Future / exploratory
+
+_Items parked until the core engine API stabilizes. Not scheduled._
+
+### Multi-framework support (Vue + Angular)
+
+Goal: make WorksCalendar usable outside React without forking the codebase.
+Deferred because the engine and public API are still evolving; locking down a
+framework-agnostic contract now would slow iteration.
+
+Prerequisites before this work can start:
+
+- Core engine (`src/core/engine/`) API considered stable enough to version.
+- Public `src/api/v1/` surface reviewed for leaks from the React layer.
+- Visual regression baseline (Playwright screenshots) in place for the React
+  views so adapter work can be validated against known-good output.
+
+High-level approach when picked up:
+
+1. Extract `@workscalendar/core` as a standalone published package containing
+   the engine, sync managers, and adapters. React package consumes it.
+2. Build `@workscalendar/vue` adapter first (cheapest port, composables map
+   cleanly to the subscribe/dispatch pattern).
+3. Build `@workscalendar/angular` adapter second (unlocks enterprise; adds
+   DI and RxJS wrapping overhead).
+4. Svelte deferred further — revisit if community demand or a paying
+   customer surfaces.
+
+Rough effort estimate (for planning only): ~3 weeks Vue, ~4–5 weeks Angular,
+single engineer. Biggest risk is React feature velocity dropping during the
+core extraction phase.
 
 ## Triaging and issue labels
 


### PR DESCRIPTION
Core engine and public API are still evolving, so framework adapter
work is deferred until the contract stabilizes. Captures prerequisites,
phased approach, and rough effort estimate for future planning.

https://claude.ai/code/session_01AJfb3X2gvVCgNF4CESp1ZQ