### PR TITLE
Sprint 1 hardening — start with approval transition reducer (#209)

### DIFF
--- a/src/core/__tests__/conflictEngine.test.ts
+++ b/src/core/__tests__/conflictEngine.test.ts
@@ -16,6 +16,7 @@ import {
 } from '../conflictEngine';
 import type { EngineResource } from '../engine/schema/resourceSchema';
 import { makeAssignment, type Assignment } from '../engine/schema/assignmentSchema';
+import type { CategoryDef } from '../../types/assets';
 
 const day = (d: number, h = 9, m = 0) => new Date(2026, 3, d, h, m);
 
@@ -492,5 +493,193 @@ describe('conflictEngine — outside-business-hours rule', () => {
     const resources = withHours({ days: [1, 2, 3, 4, 5], start: '09:00', end: '17:00' });
     const result = evaluateConflicts({ proposed, events: [], rules: [rule], resources });
     expect(result.violations).toEqual([]);
+  });
+});
+
+describe('conflictEngine — policy-violation rule (#213)', () => {
+  const rule: ConflictRule = { id: 'pol', type: 'policy-violation' };
+
+  const categoryMap = (policy: CategoryDef['policy']): Map<string, CategoryDef> =>
+    new Map([[
+      'flight',
+      { id: 'flight', label: 'Flight', color: '#000', policy } as CategoryDef,
+    ]]);
+
+  it('skips silently when the category has no policy', () => {
+    const categories = categoryMap(undefined);
+    const result = evaluateConflicts({
+      proposed: base, events: [], rules: [rule], categories,
+      now: day(10, 0),
+    });
+    expect(result.violations).toEqual([]);
+  });
+
+  it('skips silently when categories map is not provided', () => {
+    const result = evaluateConflicts({
+      proposed: base, events: [], rules: [rule], now: day(10, 0),
+    });
+    expect(result.violations).toEqual([]);
+  });
+
+  it('flags min-lead-time violation as hard', () => {
+    const categories = categoryMap({ minLeadTimeMinutes: 120 });
+    // "now" is 30 min before the event start — lead is only 30 min.
+    const result = evaluateConflicts({
+      proposed: base, events: [], rules: [rule], categories,
+      now: day(10, 8, 30),
+    });
+    expect(result.allowed).toBe(false);
+    expect(result.violations).toHaveLength(1);
+    expect(result.violations[0].details).toMatchObject({
+      type: 'policy-violation',
+      check: 'min-lead-time',
+      requiredMinutes: 120,
+    });
+  });
+
+  it('passes min-lead-time when lead is exactly the required minutes', () => {
+    const categories = categoryMap({ minLeadTimeMinutes: 60 });
+    const result = evaluateConflicts({
+      proposed: base, events: [], rules: [rule], categories,
+      now: day(10, 8, 0),
+    });
+    expect(result.violations).toEqual([]);
+  });
+
+  it('flags max-duration when event exceeds the cap', () => {
+    // base event is 2h (9–11); cap is 60 min.
+    const categories = categoryMap({ maxDurationMinutes: 60 });
+    const result = evaluateConflicts({
+      proposed: base, events: [], rules: [rule], categories,
+      now: day(10, 0),
+    });
+    expect(result.violations).toHaveLength(1);
+    expect(result.violations[0].details).toMatchObject({
+      type: 'policy-violation',
+      check: 'max-duration',
+      maxMinutes: 60,
+    });
+  });
+
+  it('ignores max-duration set to 0 (disabled)', () => {
+    const categories = categoryMap({ maxDurationMinutes: 0 });
+    const result = evaluateConflicts({
+      proposed: base, events: [], rules: [rule], categories,
+      now: day(10, 0),
+    });
+    expect(result.violations).toEqual([]);
+  });
+
+  it('flags max-advance when event is farther out than allowed', () => {
+    // Event is April 10; allowed 3 days; now is April 1 ⇒ 9 days out.
+    const categories = categoryMap({ maxAdvanceDays: 3 });
+    const result = evaluateConflicts({
+      proposed: base, events: [], rules: [rule], categories,
+      now: day(1, 0),
+    });
+    expect(result.violations).toHaveLength(1);
+    expect(result.violations[0].details).toMatchObject({
+      type: 'policy-violation',
+      check: 'max-advance',
+      maxDays: 3,
+    });
+  });
+
+  it('passes max-advance when within the window', () => {
+    const categories = categoryMap({ maxAdvanceDays: 30 });
+    const result = evaluateConflicts({
+      proposed: base, events: [], rules: [rule], categories,
+      now: day(1, 0),
+    });
+    expect(result.violations).toEqual([]);
+  });
+
+  it('flags blackout-dates when the event start falls on a blackout', () => {
+    const categories = categoryMap({ blackoutDates: ['2026-04-10'] });
+    const result = evaluateConflicts({
+      proposed: base, events: [], rules: [rule], categories,
+      now: day(9, 0),
+    });
+    expect(result.violations).toHaveLength(1);
+    expect(result.violations[0].details).toMatchObject({
+      type: 'policy-violation',
+      check: 'blackout-dates',
+      blackoutDate: '2026-04-10',
+    });
+  });
+
+  it('ignores blackout-dates that don\'t match the event day', () => {
+    const categories = categoryMap({ blackoutDates: ['2026-04-11', '2026-12-25'] });
+    const result = evaluateConflicts({
+      proposed: base, events: [], rules: [rule], categories,
+      now: day(9, 0),
+    });
+    expect(result.violations).toEqual([]);
+  });
+
+  it('uses the resource timezone when deriving the blackout key', () => {
+    // 2026-04-10 23:30 UTC is 2026-04-11 in Tokyo — only the Tokyo-side
+    // blackout should fire.
+    const resources = new Map<string, EngineResource>([[
+      'N100',
+      { id: 'N100', name: 'Tokyo', timezone: 'Asia/Tokyo' } as EngineResource,
+    ]]);
+    const categories = categoryMap({ blackoutDates: ['2026-04-11'] });
+    const proposed: ConflictEvent = {
+      ...base,
+      start: new Date(Date.UTC(2026, 3, 10, 23, 30)),
+      end:   new Date(Date.UTC(2026, 3, 10, 23, 45)),
+    };
+    const result = evaluateConflicts({
+      proposed, events: [], rules: [rule], categories, resources,
+      now: new Date(Date.UTC(2026, 3, 10, 0, 0)),
+    });
+    expect(result.violations).toHaveLength(1);
+    expect(result.violations[0].details).toMatchObject({ blackoutDate: '2026-04-11' });
+  });
+
+  it('aggregates multiple sub-check violations into separate entries', () => {
+    const categories = categoryMap({
+      minLeadTimeMinutes: 120,
+      maxDurationMinutes: 30,
+    });
+    const result = evaluateConflicts({
+      proposed: base, events: [], rules: [rule], categories,
+      now: day(10, 8, 30),
+    });
+    expect(result.violations).toHaveLength(2);
+    const checks = result.violations.map(v =>
+      (v.details as { check: string } | undefined)?.check,
+    ).sort();
+    expect(checks).toEqual(['max-duration', 'min-lead-time']);
+  });
+
+  it('honors the `checks` allowlist — only runs listed sub-checks', () => {
+    const ruleLeadOnly: ConflictRule = {
+      id: 'pol-lead', type: 'policy-violation', checks: ['min-lead-time'],
+    };
+    const categories = categoryMap({
+      minLeadTimeMinutes: 120,
+      maxDurationMinutes: 30,
+    });
+    const result = evaluateConflicts({
+      proposed: base, events: [], rules: [ruleLeadOnly], categories,
+      now: day(10, 8, 30),
+    });
+    expect(result.violations).toHaveLength(1);
+    expect((result.violations[0].details as { check: string }).check).toBe('min-lead-time');
+  });
+
+  it('respects severity override to "soft"', () => {
+    const softRule: ConflictRule = {
+      id: 'pol-soft', type: 'policy-violation', severity: 'soft',
+    };
+    const categories = categoryMap({ blackoutDates: ['2026-04-10'] });
+    const result = evaluateConflicts({
+      proposed: base, events: [], rules: [softRule], categories,
+      now: day(9, 0),
+    });
+    expect(result.severity).toBe('soft');
+    expect(result.allowed).toBe(true);
   });
 });

--- a/src/core/__tests__/conflictEngine.test.ts
+++ b/src/core/__tests__/conflictEngine.test.ts
@@ -14,6 +14,8 @@ import {
   type ConflictEvent,
   type ConflictRule,
 } from '../conflictEngine';
+import type { EngineResource } from '../engine/schema/resourceSchema';
+import { makeAssignment, type Assignment } from '../engine/schema/assignmentSchema';
 
 const day = (d: number, h = 9, m = 0) => new Date(2026, 3, d, h, m);
 
@@ -299,5 +301,196 @@ describe('conflictEngine — aggregation', () => {
     const result = evaluateConflicts({ proposed: base, events: [other], rules });
     expect(result.severity).toBe('soft');
     expect(result.allowed).toBe(true);
+  });
+});
+
+// ─── Capacity overflow — issue #210 ──────────────────────────────────────────
+
+describe('conflictEngine — capacity-overflow rule', () => {
+  const rule: ConflictRule = { id: 'cap', type: 'capacity-overflow' };
+  const room: EngineResource = {
+    id: 'N100',
+    name: 'Conf Room A',
+    capacity: 2,
+  };
+  const resources = new Map<string, EngineResource>([[room.id, room]]);
+
+  it('flags overflow when three full-unit events overlap a capacity-2 resource', () => {
+    const a: ConflictEvent = { id: 'a', start: day(10, 10), end: day(10, 12), resource: 'N100' };
+    const b: ConflictEvent = { id: 'b', start: day(10, 9),  end: day(10, 11), resource: 'N100' };
+    const result = evaluateConflicts({
+      proposed: base,     // 9-11 on N100
+      events:   [a, b],
+      rules:    [rule],
+      resources,
+    });
+    expect(result.allowed).toBe(false);
+    expect(result.severity).toBe('hard');
+    expect(result.violations[0]).toMatchObject({
+      rule: 'cap',
+      details: { type: 'capacity-overflow' },
+    });
+  });
+
+  it('does NOT flag when fewer events overlap than capacity allows', () => {
+    const a: ConflictEvent = { id: 'a', start: day(10, 10), end: day(10, 12), resource: 'N100' };
+    const result = evaluateConflicts({
+      proposed: base,
+      events:   [a],
+      rules:    [rule],
+      resources,
+    });
+    expect(result.allowed).toBe(true);
+  });
+
+  it('respects partial assignment units (half-allocation)', () => {
+    // Three half-unit assignments = 150 units total, capacity 200 → allowed.
+    const a: ConflictEvent = { id: 'a', start: day(10, 10), end: day(10, 12), resource: 'N100' };
+    const b: ConflictEvent = { id: 'b', start: day(10, 9),  end: day(10, 11), resource: 'N100' };
+    const assignments = new Map<string, Assignment>([
+      ['asn-base', makeAssignment('asn-base', { eventId: base.id, resourceId: 'N100', units: 50 })],
+      ['asn-a',    makeAssignment('asn-a',    { eventId: 'a',     resourceId: 'N100', units: 50 })],
+      ['asn-b',    makeAssignment('asn-b',    { eventId: 'b',     resourceId: 'N100', units: 50 })],
+    ]);
+    const result = evaluateConflicts({
+      proposed: base,
+      events:   [a, b],
+      rules:    [rule],
+      resources,
+      assignments,
+    });
+    expect(result.allowed).toBe(true);
+  });
+
+  it('skips when capacity is null (unlimited)', () => {
+    const unlimited = new Map<string, EngineResource>([
+      ['N100', { id: 'N100', name: 'Open', capacity: null }],
+    ]);
+    const a: ConflictEvent = { id: 'a', start: day(10, 10), end: day(10, 12), resource: 'N100' };
+    const b: ConflictEvent = { id: 'b', start: day(10, 9),  end: day(10, 11), resource: 'N100' };
+    const result = evaluateConflicts({
+      proposed: base,
+      events:   [a, b],
+      rules:    [rule],
+      resources: unlimited,
+    });
+    expect(result.allowed).toBe(true);
+  });
+
+  it('skips when `resources` map is not provided (cannot evaluate)', () => {
+    const result = evaluateConflicts({
+      proposed: base,
+      events:   [],
+      rules:    [rule],
+    });
+    expect(result.allowed).toBe(true);
+    expect(result.violations).toEqual([]);
+  });
+
+  it('respects ignoreCategories', () => {
+    const skipRule: ConflictRule = {
+      id: 'cap', type: 'capacity-overflow', ignoreCategories: ['flight'],
+    };
+    const a: ConflictEvent = { id: 'a', start: day(10, 10), end: day(10, 12), resource: 'N100' };
+    const b: ConflictEvent = { id: 'b', start: day(10, 9),  end: day(10, 11), resource: 'N100' };
+    const result = evaluateConflicts({
+      proposed: base, events: [a, b], rules: [skipRule], resources,
+    });
+    expect(result.allowed).toBe(true);
+  });
+
+  it('only counts events overlapping the proposed window', () => {
+    // `a` and `b` are outside the 9-11 proposed window
+    const a: ConflictEvent = { id: 'a', start: day(10, 13), end: day(10, 15), resource: 'N100' };
+    const b: ConflictEvent = { id: 'b', start: day(10, 15), end: day(10, 17), resource: 'N100' };
+    const result = evaluateConflicts({
+      proposed: base, events: [a, b], rules: [rule], resources,
+    });
+    expect(result.allowed).toBe(true);
+  });
+});
+
+// ─── Outside business hours — issue #210 ─────────────────────────────────────
+
+describe('conflictEngine — outside-business-hours rule', () => {
+  const rule: ConflictRule = { id: 'bh', type: 'outside-business-hours' };
+  const withHours = (bh: EngineResource['businessHours']): Map<string, EngineResource> =>
+    new Map([[ 'N100', {
+      id: 'N100', name: 'Conf Room A', businessHours: bh, timezone: 'UTC',
+    }]]);
+
+  it('flags an event on a non-working day (Sunday, when M–F only)', () => {
+    // 2026-04-12 is a Sunday.
+    const sunday = new Date(Date.UTC(2026, 3, 12, 10, 0));
+    const sundayEnd = new Date(Date.UTC(2026, 3, 12, 11, 0));
+    const proposed: ConflictEvent = { ...base, start: sunday, end: sundayEnd };
+    const resources = withHours({ days: [1, 2, 3, 4, 5], start: '09:00', end: '17:00' });
+    const result = evaluateConflicts({ proposed, events: [], rules: [rule], resources });
+    expect(result.allowed).toBe(true); // soft by default
+    expect(result.severity).toBe('soft');
+    expect(result.violations[0].details).toMatchObject({ reason: 'closed-day' });
+  });
+
+  it('flags an event starting before business-hours open', () => {
+    const earlyStart = new Date(Date.UTC(2026, 3, 13, 7, 0));  // Mon 07:00 UTC
+    const earlyEnd   = new Date(Date.UTC(2026, 3, 13, 8, 0));
+    const proposed: ConflictEvent = { ...base, start: earlyStart, end: earlyEnd };
+    const resources = withHours({ days: [1, 2, 3, 4, 5], start: '09:00', end: '17:00' });
+    const result = evaluateConflicts({ proposed, events: [], rules: [rule], resources });
+    expect(result.violations[0].details).toMatchObject({ reason: 'outside-hours' });
+  });
+
+  it('flags an event ending after business-hours close', () => {
+    const lateStart = new Date(Date.UTC(2026, 3, 13, 16, 30)); // Mon 16:30
+    const lateEnd   = new Date(Date.UTC(2026, 3, 13, 18, 0));  // past 17:00
+    const proposed: ConflictEvent = { ...base, start: lateStart, end: lateEnd };
+    const resources = withHours({ days: [1, 2, 3, 4, 5], start: '09:00', end: '17:00' });
+    const result = evaluateConflicts({ proposed, events: [], rules: [rule], resources });
+    expect(result.violations).toHaveLength(1);
+  });
+
+  it('allows an event fully inside business hours on a working day', () => {
+    const okStart = new Date(Date.UTC(2026, 3, 13, 10, 0));    // Mon 10:00
+    const okEnd   = new Date(Date.UTC(2026, 3, 13, 11, 0));
+    const proposed: ConflictEvent = { ...base, start: okStart, end: okEnd };
+    const resources = withHours({ days: [1, 2, 3, 4, 5], start: '09:00', end: '17:00' });
+    const result = evaluateConflicts({ proposed, events: [], rules: [rule], resources });
+    expect(result.violations).toEqual([]);
+  });
+
+  it('respects resource timezone (event at midnight UTC = 19:00 America/New_York → inside)', () => {
+    // 2026-04-14 00:00 UTC = 2026-04-13 20:00 EDT (NY is UTC-4 in April).
+    const proposed: ConflictEvent = {
+      ...base,
+      start: new Date(Date.UTC(2026, 3, 14, 0, 0)),
+      end:   new Date(Date.UTC(2026, 3, 14, 1, 0)),
+    };
+    const nyResources = new Map<string, EngineResource>([[
+      'N100',
+      {
+        id: 'N100', name: 'NY Room',
+        businessHours: { days: [1, 2, 3, 4, 5], start: '09:00', end: '21:00' },
+        timezone: 'America/New_York',
+      },
+    ]]);
+    const result = evaluateConflicts({ proposed, events: [], rules: [rule], resources: nyResources });
+    expect(result.violations).toEqual([]); // 20:00 NYC is inside 09:00-21:00
+  });
+
+  it('skips when the resource has no businessHours', () => {
+    const resources = new Map<string, EngineResource>([[ 'N100', { id: 'N100', name: 'No hours' } ]]);
+    const result = evaluateConflicts({ proposed: base, events: [], rules: [rule], resources });
+    expect(result.violations).toEqual([]);
+  });
+
+  it('skips multi-day events', () => {
+    const proposed: ConflictEvent = {
+      ...base,
+      start: new Date(Date.UTC(2026, 3, 13, 0, 0)),
+      end:   new Date(Date.UTC(2026, 3, 15, 0, 0)),
+    };
+    const resources = withHours({ days: [1, 2, 3, 4, 5], start: '09:00', end: '17:00' });
+    const result = evaluateConflicts({ proposed, events: [], rules: [rule], resources });
+    expect(result.violations).toEqual([]);
   });
 });

--- a/src/core/approvals/__tests__/transitions.test.ts
+++ b/src/core/approvals/__tests__/transitions.test.ts
@@ -1,0 +1,207 @@
+/**
+ * transitions — unit specs (issue #209).
+ *
+ * Pins the legal-transition matrix for the 5-state approval workflow and the
+ * reducer's purity / history-append contract. The Workflow DSL interpreter
+ * (#219) depends on this being deterministic + side-effect-free.
+ */
+import { describe, it, expect } from 'vitest'
+import type { ApprovalStage } from '../../../types/assets'
+import {
+  LEGAL_TRANSITIONS,
+  legalActionsFrom,
+  transitionApproval,
+} from '../transitions'
+
+const AT = '2026-04-20T09:00:00.000Z'
+
+function stage(
+  s: ApprovalStage['stage'],
+  counts?: ApprovalStage['counts'],
+): ApprovalStage {
+  return {
+    stage: s,
+    updatedAt: AT,
+    history: [],
+    ...(counts ? { counts } : {}),
+  }
+}
+
+describe('transitionApproval — legal paths', () => {
+  it.each(LEGAL_TRANSITIONS.filter(t => t.from !== null))(
+    'allows %s --%s--> %s',
+    (t) => {
+      const current = stage(t.from as ApprovalStage['stage'])
+      const result = transitionApproval(current, {
+        action: t.action,
+        at: AT,
+        ...(t.action === 'deny' ? { reason: 'test' } : {}),
+      })
+      expect(result.ok).toBe(true)
+      if (result.ok) expect(result.stage.stage).toBe(t.to)
+    },
+  )
+
+  it('allows submit from null/undefined into `requested`', () => {
+    const fromNull = transitionApproval(null, { action: 'submit', at: AT })
+    const fromUndef = transitionApproval(undefined, { action: 'submit', at: AT })
+    expect(fromNull.ok && fromNull.stage.stage).toBe('requested')
+    expect(fromUndef.ok && fromUndef.stage.stage).toBe('requested')
+  })
+})
+
+describe('transitionApproval — illegal paths', () => {
+  it('rejects finalized → requested (only `revoke` can reopen)', () => {
+    const result = transitionApproval(stage('finalized'), { action: 'approve', at: AT })
+    expect(result).toMatchObject({ ok: false, error: { code: 'ILLEGAL_TRANSITION' } })
+  })
+
+  it('rejects denied → approved', () => {
+    const result = transitionApproval(stage('denied'), { action: 'approve', at: AT })
+    expect(result.ok).toBe(false)
+  })
+
+  it('rejects double-submit (requested → requested)', () => {
+    const result = transitionApproval(stage('requested'), { action: 'submit', at: AT })
+    expect(result.ok).toBe(false)
+  })
+
+  it('rejects finalize from requested (must pass through approved first)', () => {
+    const result = transitionApproval(stage('requested'), { action: 'finalize', at: AT })
+    expect(result.ok).toBe(false)
+  })
+
+  it('rejects revoke on non-terminal stages', () => {
+    for (const s of ['requested', 'approved', 'pending_higher'] as const) {
+      const result = transitionApproval(stage(s), { action: 'revoke', at: AT })
+      expect(result.ok).toBe(false)
+    }
+  })
+
+  it('rejects unknown stages with INVALID_STAGE', () => {
+    const bogus = { stage: 'bogus', updatedAt: AT, history: [] } as unknown as ApprovalStage
+    const result = transitionApproval(bogus, { action: 'approve', at: AT })
+    expect(result).toMatchObject({ ok: false, error: { code: 'INVALID_STAGE' } })
+  })
+})
+
+describe('transitionApproval — deny guard', () => {
+  it('requires a non-empty reason on deny', () => {
+    const result = transitionApproval(stage('requested'), { action: 'deny', at: AT })
+    expect(result).toMatchObject({ ok: false, error: { code: 'DENY_REQUIRES_REASON' } })
+  })
+
+  it('accepts deny when a reason is provided', () => {
+    const result = transitionApproval(
+      stage('requested'),
+      { action: 'deny', reason: 'duplicate booking', at: AT },
+    )
+    expect(result.ok).toBe(true)
+    if (result.ok) expect(result.stage.stage).toBe('denied')
+  })
+
+  it('rejects deny with whitespace-only reason', () => {
+    const result = transitionApproval(
+      stage('requested'),
+      { action: 'deny', reason: '   ', at: AT },
+    )
+    expect(result.ok).toBe(false)
+  })
+})
+
+describe('transitionApproval — history + purity', () => {
+  it('appends a history entry with actor, tier, and reason', () => {
+    const result = transitionApproval(stage('requested'), {
+      action: 'approve',
+      actor: 'alice',
+      tier: 1,
+      at: AT,
+    })
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+    expect(result.stage.history).toHaveLength(1)
+    expect(result.stage.history[0]).toMatchObject({
+      action: 'approve',
+      actor: 'alice',
+      tier: 1,
+      at: AT,
+    })
+  })
+
+  it('does not mutate the input stage', () => {
+    const current = stage('requested')
+    const snapshot = JSON.stringify(current)
+    transitionApproval(current, { action: 'approve', at: AT })
+    expect(JSON.stringify(current)).toBe(snapshot)
+  })
+
+  it('preserves prior history in order', () => {
+    const prior: ApprovalStage = {
+      stage: 'requested',
+      updatedAt: AT,
+      history: [{ action: 'submit', at: '2026-04-19T08:00:00.000Z', actor: 'bob' }],
+    }
+    const result = transitionApproval(prior, { action: 'approve', actor: 'alice', at: AT })
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+    expect(result.stage.history.map(h => h.action)).toEqual(['submit', 'approve'])
+  })
+
+  it('derives updatedAt from input.at', () => {
+    const result = transitionApproval(stage('requested'), { action: 'approve', at: AT })
+    expect(result.ok && result.stage.updatedAt).toBe(AT)
+  })
+})
+
+describe('transitionApproval — counts + single-tier shortcut', () => {
+  it('increments approvals on approve and denials on deny', () => {
+    const counts = { approvals: 0, denials: 0, requiredApprovals: 2 }
+    const afterApprove = transitionApproval(stage('requested', counts), { action: 'approve', at: AT })
+    expect(afterApprove.ok && afterApprove.stage.counts?.approvals).toBe(1)
+  })
+
+  it('single-tier (requiredApprovals=1) finalizes directly from requested on approve', () => {
+    const counts = { approvals: 0, denials: 0, requiredApprovals: 1 }
+    const result = transitionApproval(stage('requested', counts), { action: 'approve', at: AT })
+    expect(result.ok).toBe(true)
+    if (result.ok) expect(result.stage.stage).toBe('finalized')
+  })
+
+  it('multi-tier (requiredApprovals=2) still lands on `approved` first', () => {
+    const counts = { approvals: 0, denials: 0, requiredApprovals: 2 }
+    const result = transitionApproval(stage('requested', counts), { action: 'approve', at: AT })
+    expect(result.ok).toBe(true)
+    if (result.ok) expect(result.stage.stage).toBe('approved')
+  })
+
+  it('revoke resets approvals + denials to 0 while reopening to requested', () => {
+    const counts = { approvals: 1, denials: 0, requiredApprovals: 2 }
+    const result = transitionApproval(
+      stage('finalized', counts),
+      { action: 'revoke', at: AT },
+    )
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+    expect(result.stage.stage).toBe('requested')
+    expect(result.stage.counts).toEqual({ approvals: 0, denials: 0, requiredApprovals: 2 })
+  })
+})
+
+describe('legalActionsFrom', () => {
+  it('returns the entry action for null (submit only)', () => {
+    expect(legalActionsFrom(null)).toEqual(['submit'])
+  })
+
+  it('returns all configured actions for requested', () => {
+    const actions = legalActionsFrom('requested')
+    expect(actions).toContain('approve')
+    expect(actions).toContain('deny')
+    expect(actions).toContain('downgrade')
+    expect(actions).not.toContain('revoke')
+  })
+
+  it('returns only revoke for terminal stages', () => {
+    expect(legalActionsFrom('finalized')).toEqual(['revoke'])
+    expect(legalActionsFrom('denied')).toEqual(['revoke'])
+  })
+})

--- a/src/core/approvals/__tests__/transitions.test.ts
+++ b/src/core/approvals/__tests__/transitions.test.ts
@@ -71,11 +71,17 @@ describe('transitionApproval — illegal paths', () => {
     expect(result.ok).toBe(false)
   })
 
-  it('rejects revoke on non-terminal stages', () => {
-    for (const s of ['requested', 'approved', 'pending_higher'] as const) {
+  it('rejects revoke on pre-approval stages', () => {
+    for (const s of ['requested', 'pending_higher'] as const) {
       const result = transitionApproval(stage(s), { action: 'revoke', at: AT })
       expect(result.ok).toBe(false)
     }
+  })
+
+  it('allows revoke from `approved` (matches default config allow: [finalize, revoke])', () => {
+    const result = transitionApproval(stage('approved'), { action: 'revoke', at: AT })
+    expect(result.ok).toBe(true)
+    if (result.ok) expect(result.stage.stage).toBe('requested')
   })
 
   it('rejects unknown stages with INVALID_STAGE', () => {

--- a/src/core/approvals/transitions.ts
+++ b/src/core/approvals/transitions.ts
@@ -12,6 +12,7 @@
  */
 import type {
   ApprovalActionId,
+  ApprovalHistoryActionId,
   ApprovalStage,
   ApprovalStageId,
   ApprovalHistoryEntry,
@@ -28,7 +29,7 @@ export interface TransitionError {
   readonly code: TransitionErrorCode
   readonly message: string
   readonly from?: ApprovalStageId | null
-  readonly action?: ApprovalActionId
+  readonly action?: ApprovalHistoryActionId
 }
 
 // ─── Result type (Result<T, E>) ───────────────────────────────────────────
@@ -71,7 +72,10 @@ export const LEGAL_TRANSITIONS: readonly TransitionSpec[] = [
   { from: 'pending_higher', action: 'finalize',  to: 'finalized' },
   { from: 'pending_higher', action: 'deny',      to: 'denied' },
 
-  // Terminal stages reopen via `revoke`.
+  // Mid-flow + terminal stages reopen via `revoke`. `approved` is explicitly
+  // revocable to match the shipped default action config in
+  // `src/core/configSchema.ts` (approved.allow: ['finalize', 'revoke']).
+  { from: 'approved',       action: 'revoke',    to: 'requested' },
   { from: 'finalized',      action: 'revoke',    to: 'requested' },
   { from: 'denied',         action: 'revoke',    to: 'requested' },
 ]
@@ -141,7 +145,7 @@ export function transitionApproval(
         code: 'INVALID_STAGE',
         message: `Unknown stage "${current.stage}".`,
         from: current.stage,
-        action: input.action as ApprovalActionId,
+        action: input.action,
       },
     }
   }
@@ -166,14 +170,14 @@ export function transitionApproval(
         code: 'ILLEGAL_TRANSITION',
         message: `Cannot ${input.action} from stage "${from ?? 'null'}".`,
         from,
-        action: input.action as ApprovalActionId,
+        action: input.action,
       },
     }
   }
 
   const at = input.at ?? new Date().toISOString()
   const entry: ApprovalHistoryEntry = {
-    action: input.action as ApprovalActionId,
+    action: input.action,
     at,
     ...(input.actor !== undefined ? { actor: input.actor } : {}),
     ...(input.tier !== undefined ? { tier: input.tier } : {}),

--- a/src/core/approvals/transitions.ts
+++ b/src/core/approvals/transitions.ts
@@ -1,0 +1,225 @@
+/**
+ * Approval transition reducer — issue #209.
+ *
+ * Pure, side-effect-free state machine for `ApprovalStage`. Guards the 5-state
+ * workflow (`requested → approved → finalized | pending_higher | denied`) so
+ * host code cannot, e.g., jump from `finalized` straight back to `requested`
+ * without going through `revoke`.
+ *
+ * The reducer is the core primitive the Workflow DSL (#219) interpreter will
+ * drive — keeping it pure + serializable means the interpreter can be tested
+ * without any React or engine state.
+ */
+import type {
+  ApprovalActionId,
+  ApprovalStage,
+  ApprovalStageId,
+  ApprovalHistoryEntry,
+} from '../../types/assets'
+
+// ─── Errors ───────────────────────────────────────────────────────────────
+
+export type TransitionErrorCode =
+  | 'ILLEGAL_TRANSITION'
+  | 'DENY_REQUIRES_REASON'
+  | 'INVALID_STAGE'
+
+export interface TransitionError {
+  readonly code: TransitionErrorCode
+  readonly message: string
+  readonly from?: ApprovalStageId | null
+  readonly action?: ApprovalActionId
+}
+
+// ─── Result type (Result<T, E>) ───────────────────────────────────────────
+
+export type TransitionResult =
+  | { readonly ok: true; readonly stage: ApprovalStage }
+  | { readonly ok: false; readonly error: TransitionError }
+
+// ─── Legal transition table ───────────────────────────────────────────────
+//
+// Exported so the Workflow DSL builder UI can render the edges, and so
+// test fixtures stay honest.
+
+/** A null `from` means "no prior stage" (first `submit` action). */
+export type TransitionSource = ApprovalStageId | null
+
+export interface TransitionSpec {
+  readonly from: TransitionSource
+  readonly action: ApprovalActionId | 'revoke'
+  readonly to: ApprovalStageId
+}
+
+export const LEGAL_TRANSITIONS: readonly TransitionSpec[] = [
+  // Entry: a brand-new request.
+  { from: null,             action: 'submit',    to: 'requested' },
+
+  // requested → ...
+  { from: 'requested',      action: 'approve',   to: 'approved' },
+  { from: 'requested',      action: 'deny',      to: 'denied' },
+  { from: 'requested',      action: 'downgrade', to: 'pending_higher' },
+
+  // approved → ...
+  { from: 'approved',       action: 'approve',   to: 'finalized' },
+  { from: 'approved',       action: 'finalize',  to: 'finalized' },
+  { from: 'approved',       action: 'deny',      to: 'denied' },
+  { from: 'approved',       action: 'downgrade', to: 'pending_higher' },
+
+  // pending_higher → ...
+  { from: 'pending_higher', action: 'approve',   to: 'finalized' },
+  { from: 'pending_higher', action: 'finalize',  to: 'finalized' },
+  { from: 'pending_higher', action: 'deny',      to: 'denied' },
+
+  // Terminal stages reopen via `revoke`.
+  { from: 'finalized',      action: 'revoke',    to: 'requested' },
+  { from: 'denied',         action: 'revoke',    to: 'requested' },
+]
+
+const VALID_STAGES: ReadonlySet<ApprovalStageId> = new Set<ApprovalStageId>([
+  'requested', 'approved', 'finalized', 'pending_higher', 'denied',
+])
+
+function findTransition(
+  from: TransitionSource,
+  action: ApprovalActionId | 'revoke',
+): TransitionSpec | undefined {
+  for (const t of LEGAL_TRANSITIONS) {
+    if (t.from === from && t.action === action) return t
+  }
+  return undefined
+}
+
+// ─── Finalization helper ──────────────────────────────────────────────────
+
+/**
+ * Single-tier flows finalize on the first approval. When `counts.requiredApprovals
+ * === 1`, an `approve` from `requested` goes straight to `finalized` instead of
+ * `approved`. Without `counts`, the caller's requested flow is honored.
+ */
+function resolveApproveTarget(
+  from: ApprovalStageId,
+  currentCounts: ApprovalStage['counts'] | undefined,
+  projectedApprovals: number,
+): ApprovalStageId | null {
+  if (from !== 'requested') return null
+  const required = currentCounts?.requiredApprovals
+  if (typeof required === 'number' && projectedApprovals >= required) {
+    return 'finalized'
+  }
+  return null
+}
+
+// ─── Public API ───────────────────────────────────────────────────────────
+
+export interface TransitionInput {
+  readonly action: ApprovalActionId | 'revoke'
+  readonly actor?: string
+  readonly tier?: number
+  readonly reason?: string
+  /** ISO timestamp for determinism in tests; defaults to `new Date().toISOString()`. */
+  readonly at?: string
+}
+
+/**
+ * Advance an approval stage. Returns a new stage + appended history entry,
+ * or a `TransitionError` for illegal moves.
+ *
+ * Pure: no Date.now() reads when `input.at` is supplied, no mutation of
+ * the `current` argument.
+ */
+export function transitionApproval(
+  current: ApprovalStage | null | undefined,
+  input: TransitionInput,
+): TransitionResult {
+  const from: TransitionSource = current?.stage ?? null
+
+  if (current && !VALID_STAGES.has(current.stage)) {
+    return {
+      ok: false,
+      error: {
+        code: 'INVALID_STAGE',
+        message: `Unknown stage "${current.stage}".`,
+        from: current.stage,
+        action: input.action as ApprovalActionId,
+      },
+    }
+  }
+
+  if (input.action === 'deny' && !input.reason?.trim()) {
+    return {
+      ok: false,
+      error: {
+        code: 'DENY_REQUIRES_REASON',
+        message: 'A reason is required when denying a request.',
+        from,
+        action: 'deny',
+      },
+    }
+  }
+
+  const transition = findTransition(from, input.action)
+  if (!transition) {
+    return {
+      ok: false,
+      error: {
+        code: 'ILLEGAL_TRANSITION',
+        message: `Cannot ${input.action} from stage "${from ?? 'null'}".`,
+        from,
+        action: input.action as ApprovalActionId,
+      },
+    }
+  }
+
+  const at = input.at ?? new Date().toISOString()
+  const entry: ApprovalHistoryEntry = {
+    action: input.action as ApprovalActionId,
+    at,
+    ...(input.actor !== undefined ? { actor: input.actor } : {}),
+    ...(input.tier !== undefined ? { tier: input.tier } : {}),
+    ...(input.reason !== undefined ? { reason: input.reason } : {}),
+  }
+
+  const prevCounts = current?.counts
+  const nextApprovals = (prevCounts?.approvals ?? 0) + (input.action === 'approve' ? 1 : 0)
+  const nextDenials   = (prevCounts?.denials   ?? 0) + (input.action === 'deny'    ? 1 : 0)
+
+  // Single-tier shortcut: approve from `requested` lands on `finalized` when
+  // requiredApprovals === 1. Multi-tier flows still hit `approved` first.
+  const autoFinalized = input.action === 'approve'
+    ? resolveApproveTarget(from as ApprovalStageId, prevCounts, nextApprovals)
+    : null
+  const nextStage: ApprovalStageId = autoFinalized ?? transition.to
+
+  // `revoke` resets the counts — the new request starts fresh.
+  const resetCounts = input.action === 'revoke'
+  const counts = prevCounts
+    ? resetCounts
+      ? { ...prevCounts, approvals: 0, denials: 0 }
+      : { ...prevCounts, approvals: nextApprovals, denials: nextDenials }
+    : undefined
+
+  const nextStageObj: ApprovalStage = {
+    stage: nextStage,
+    updatedAt: at,
+    history: [...(current?.history ?? []), entry],
+    ...(counts ? { counts } : {}),
+  }
+
+  return { ok: true, stage: nextStageObj }
+}
+
+/**
+ * Convenience: returns the set of legal actions from a given stage, for
+ * UI rendering. Does not read owner config — the `ConfigPanel.approvals`
+ * block still filters which of these actions are surfaced to the user.
+ */
+export function legalActionsFrom(
+  from: TransitionSource,
+): readonly (ApprovalActionId | 'revoke')[] {
+  const out = new Set<ApprovalActionId | 'revoke'>()
+  for (const t of LEGAL_TRANSITIONS) {
+    if (t.from === from) out.add(t.action)
+  }
+  return Array.from(out)
+}

--- a/src/core/conflictEngine.ts
+++ b/src/core/conflictEngine.ts
@@ -17,6 +17,7 @@
 import type { Violation } from './engine/validation/validationTypes'
 import type { EngineResource } from './engine/schema/resourceSchema'
 import type { Assignment } from './engine/schema/assignmentSchema'
+import type { CategoryDef } from '../types/assets'
 import { parseHoursString } from './engine/time/dateMath'
 import { partsInTimezone } from './engine/time/timezone'
 
@@ -39,6 +40,7 @@ export type ConflictRule =
   | MinRestRule
   | CapacityOverflowRule
   | OutsideBusinessHoursRule
+  | PolicyViolationRule
 
 export interface ResourceOverlapRule {
   readonly id: string
@@ -82,6 +84,22 @@ export interface OutsideBusinessHoursRule {
   readonly ignoreCategories?: readonly string[]
 }
 
+export interface PolicyViolationRule {
+  readonly id: string
+  readonly type: 'policy-violation'
+  /**
+   * Defaults to 'hard' — policies are owner-set constraints on bookings.
+   * Owners can relax to 'soft' to surface a warning only.
+   */
+  readonly severity?: 'soft' | 'hard'
+  /**
+   * Which policy sub-checks to run. Defaults to all four when omitted.
+   * Allows owners to tune a single rule per sub-check if they want
+   * independent severities (e.g., blackouts=hard, lead-time=soft).
+   */
+  readonly checks?: readonly ('min-lead-time' | 'max-duration' | 'max-advance' | 'blackout-dates')[]
+}
+
 export interface ConflictEvaluationResult {
   readonly violations: readonly Violation[]
   readonly severity: 'none' | 'soft' | 'hard'
@@ -112,6 +130,19 @@ export interface EvaluateConflictsInput {
    * 100 units (one full slot).
    */
   readonly assignments?: ReadonlyMap<string, Assignment>
+  /**
+   * Category definitions keyed by category id. Required for the
+   * `policy-violation` rule (#213); ignored by every other rule. When
+   * the proposed event's category is not in the map or has no `policy`
+   * block, the rule skips silently.
+   */
+  readonly categories?: ReadonlyMap<string, CategoryDef>
+  /**
+   * "Now" reference for time-based policy checks (min-lead-time,
+   * max-advance). Defaults to `Date.now()`. Overridable for
+   * deterministic tests.
+   */
+  readonly now?: Date | string | number
 }
 
 const VALID: ConflictEvaluationResult = {
@@ -314,6 +345,131 @@ function evalOutsideBusinessHours(
   return null
 }
 
+/** Format a Date as `YYYY-MM-DD` in the given IANA zone (UTC when unset). */
+function dateKey(d: Date, tz: string | undefined): string {
+  if (!tz || tz === 'UTC') {
+    const y = d.getUTCFullYear()
+    const m = String(d.getUTCMonth() + 1).padStart(2, '0')
+    const day = String(d.getUTCDate()).padStart(2, '0')
+    return `${y}-${m}-${day}`
+  }
+  const parts = partsInTimezone(d, tz)
+  const m = String(parts.month).padStart(2, '0')
+  const day = String(parts.day).padStart(2, '0')
+  return `${parts.year}-${m}-${day}`
+}
+
+function evalPolicyViolation(
+  rule: PolicyViolationRule,
+  proposed: ConflictEvent,
+  categories: ReadonlyMap<string, CategoryDef> | undefined,
+  resources: ReadonlyMap<string, EngineResource> | undefined,
+  nowMs: number,
+): Violation[] {
+  if (!categories) return []
+  const categoryId = proposed.category ?? ''
+  if (!categoryId) return []
+  const category = categories.get(categoryId)
+  const policy = category?.policy
+  if (!policy) return []
+
+  const active = new Set(rule.checks ?? ['min-lead-time', 'max-duration', 'max-advance', 'blackout-dates'])
+  const severity = rule.severity ?? 'hard'
+  const ps = toDate(proposed.start)
+  const pe = toDate(proposed.end)
+  const out: Violation[] = []
+
+  if (active.has('min-lead-time') && typeof policy.minLeadTimeMinutes === 'number' && policy.minLeadTimeMinutes > 0) {
+    const leadMs = ps.getTime() - nowMs
+    const requiredMs = policy.minLeadTimeMinutes * 60_000
+    if (leadMs < requiredMs) {
+      out.push({
+        rule: rule.id,
+        severity,
+        message: `Category "${category?.label ?? categoryId}" requires ≥${policy.minLeadTimeMinutes} min lead time.`,
+        details: {
+          type: 'policy-violation',
+          check: 'min-lead-time',
+          leadMinutes: Math.max(0, leadMs / 60_000),
+          requiredMinutes: policy.minLeadTimeMinutes,
+        },
+      })
+    }
+  }
+
+  if (active.has('max-duration') && typeof policy.maxDurationMinutes === 'number' && policy.maxDurationMinutes > 0) {
+    const durMinutes = (pe.getTime() - ps.getTime()) / 60_000
+    if (durMinutes > policy.maxDurationMinutes) {
+      out.push({
+        rule: rule.id,
+        severity,
+        message: `Category "${category?.label ?? categoryId}" caps duration at ${policy.maxDurationMinutes} min.`,
+        details: {
+          type: 'policy-violation',
+          check: 'max-duration',
+          durationMinutes: durMinutes,
+          maxMinutes: policy.maxDurationMinutes,
+        },
+      })
+    }
+  }
+
+  if (active.has('max-advance') && typeof policy.maxAdvanceDays === 'number' && policy.maxAdvanceDays >= 0) {
+    const advanceMs = ps.getTime() - nowMs
+    const maxMs = policy.maxAdvanceDays * DAY_MS
+    if (advanceMs > maxMs) {
+      out.push({
+        rule: rule.id,
+        severity,
+        message: `Category "${category?.label ?? categoryId}" cannot be booked more than ${policy.maxAdvanceDays} day(s) in advance.`,
+        details: {
+          type: 'policy-violation',
+          check: 'max-advance',
+          advanceDays: advanceMs / DAY_MS,
+          maxDays: policy.maxAdvanceDays,
+        },
+      })
+    }
+  }
+
+  if (active.has('blackout-dates') && policy.blackoutDates && policy.blackoutDates.length > 0) {
+    const tz = proposed.resource
+      ? resources?.get(proposed.resource)?.timezone
+      : undefined
+    const blackoutSet = new Set(policy.blackoutDates)
+    // Check every calendar date the event touches (in the resource's zone).
+    const endInclusive = new Date(pe.getTime() - 1)
+    const startKey = dateKey(ps, tz)
+    const endKey = dateKey(endInclusive, tz)
+    let hit: string | null = null
+    if (blackoutSet.has(startKey)) hit = startKey
+    else if (startKey !== endKey && blackoutSet.has(endKey)) hit = endKey
+    else if (startKey !== endKey) {
+      // Multi-day: walk each calendar day between start + end, inclusive.
+      const cursor = new Date(ps.getTime())
+      while (cursor <= endInclusive) {
+        const k = dateKey(cursor, tz)
+        if (blackoutSet.has(k)) { hit = k; break }
+        cursor.setUTCDate(cursor.getUTCDate() + 1)
+      }
+    }
+    if (hit) {
+      out.push({
+        rule: rule.id,
+        severity,
+        message: `Category "${category?.label ?? categoryId}" is blacked out on ${hit}.`,
+        details: {
+          type: 'policy-violation',
+          check: 'blackout-dates',
+          blackoutDate: hit,
+        },
+      })
+    }
+  }
+
+  return out
+}
+
 function evalMinRest(
   rule: MinRestRule,
   proposed: ConflictEvent,
@@ -353,9 +509,10 @@ function evalMinRest(
  * pure and side-effect-free so the result is fully memoisable by caller.
  */
 export function evaluateConflicts(input: EvaluateConflictsInput): ConflictEvaluationResult {
-  const { proposed, events, rules, enabled = true, resources, assignments } = input
+  const { proposed, events, rules, enabled = true, resources, assignments, categories, now } = input
   if (!enabled || rules.length === 0) return VALID
 
+  const nowMs = now !== undefined ? toDate(now).getTime() : Date.now()
   const violations: Violation[] = []
 
   // Single-pass (non-pairwise) rules — evaluated once per rule.
@@ -367,6 +524,9 @@ export function evaluateConflicts(input: EvaluateConflictsInput): ConflictEvalua
         break
       case 'outside-business-hours':
         v = evalOutsideBusinessHours(rule, proposed, resources)
+        break
+      case 'policy-violation':
+        violations.push(...evalPolicyViolation(rule, proposed, categories, resources, nowMs))
         break
       default:
         break
@@ -404,4 +564,5 @@ export const CONFLICT_RULE_TYPES: readonly ConflictRule['type'][] = [
   'min-rest',
   'capacity-overflow',
   'outside-business-hours',
+  'policy-violation',
 ] as const

--- a/src/core/conflictEngine.ts
+++ b/src/core/conflictEngine.ts
@@ -15,6 +15,10 @@
  * overall severity.
  */
 import type { Violation } from './engine/validation/validationTypes'
+import type { EngineResource } from './engine/schema/resourceSchema'
+import type { Assignment } from './engine/schema/assignmentSchema'
+import { parseHoursString } from './engine/time/dateMath'
+import { partsInTimezone } from './engine/time/timezone'
 
 // ─── Types ──────────────────────────────────────────────────────────────────
 
@@ -33,6 +37,8 @@ export type ConflictRule =
   | ResourceOverlapRule
   | CategoryMutexRule
   | MinRestRule
+  | CapacityOverflowRule
+  | OutsideBusinessHoursRule
 
 export interface ResourceOverlapRule {
   readonly id: string
@@ -58,6 +64,24 @@ export interface MinRestRule {
   readonly minutes: number
 }
 
+export interface CapacityOverflowRule {
+  readonly id: string
+  readonly type: 'capacity-overflow'
+  /** Defaults to 'hard' — capacity is a physical constraint, not a hint. */
+  readonly severity?: 'soft' | 'hard'
+  /** Skip when the proposed event's category matches any of these. */
+  readonly ignoreCategories?: readonly string[]
+}
+
+export interface OutsideBusinessHoursRule {
+  readonly id: string
+  readonly type: 'outside-business-hours'
+  /** Defaults to 'soft' — users often book outside hours intentionally. */
+  readonly severity?: 'soft' | 'hard'
+  /** Skip when the proposed event's category matches any of these. */
+  readonly ignoreCategories?: readonly string[]
+}
+
 export interface ConflictEvaluationResult {
   readonly violations: readonly Violation[]
   readonly severity: 'none' | 'soft' | 'hard'
@@ -74,6 +98,20 @@ export interface EvaluateConflictsInput {
   readonly rules: readonly ConflictRule[]
   /** Master switch — when false, returns `VALID` without running any rule. */
   readonly enabled?: boolean
+  /**
+   * Resource records keyed by id. Required for `capacity-overflow` and
+   * `outside-business-hours` rules; other rules ignore this map. When the
+   * proposed event's resource is not in the map, capacity/hours rules skip
+   * silently (unknown capacity / hours ⇒ cannot evaluate ⇒ no violation).
+   */
+  readonly resources?: ReadonlyMap<string, EngineResource>
+  /**
+   * Assignment records keyed by assignment id. When provided, the
+   * capacity-overflow rule sums `units` per overlapping same-resource
+   * assignment; when absent, each overlapping event is assumed to occupy
+   * 100 units (one full slot).
+   */
+  readonly assignments?: ReadonlyMap<string, Assignment>
 }
 
 const VALID: ConflictEvaluationResult = {
@@ -152,6 +190,130 @@ function evalCategoryMutex(
   }
 }
 
+const DAY_MS = 24 * 60 * 60 * 1000
+
+/** Units a single event contributes to the resource's workload for capacity checks. */
+function unitsFor(
+  event: ConflictEvent,
+  resourceId: string,
+  assignments: ReadonlyMap<string, Assignment> | undefined,
+): number {
+  if (!assignments) return 100
+  let total = 0
+  let matched = false
+  for (const a of assignments.values()) {
+    if (a.eventId === event.id && a.resourceId === resourceId) {
+      total += a.units
+      matched = true
+    }
+  }
+  return matched ? total : 100
+}
+
+function evalCapacityOverflow(
+  rule: CapacityOverflowRule,
+  proposed: ConflictEvent,
+  events: readonly ConflictEvent[],
+  resources: ReadonlyMap<string, EngineResource> | undefined,
+  assignments: ReadonlyMap<string, Assignment> | undefined,
+): Violation | null {
+  if (!resources) return null
+  const ignore = new Set(rule.ignoreCategories ?? [])
+  if (proposed.category && ignore.has(proposed.category)) return null
+
+  const resourceId = proposed.resource ?? ''
+  if (!resourceId) return null
+  const resource = resources.get(resourceId)
+  // Unknown capacity (missing resource or null capacity) ⇒ unlimited ⇒ skip.
+  if (!resource || resource.capacity == null) return null
+  const capacityUnits = resource.capacity * 100
+
+  const ps = toDate(proposed.start)
+  const pe = toDate(proposed.end)
+
+  const proposedUnits = unitsFor(proposed, resourceId, assignments)
+  let totalUnits = proposedUnits
+  for (const other of events) {
+    if (other.id && proposed.id && other.id === proposed.id) continue
+    if (!sameResource(proposed, other)) continue
+    const os = toDate(other.start)
+    const oe = toDate(other.end)
+    if (!overlaps(ps, pe, os, oe)) continue
+    totalUnits += unitsFor(other, resourceId, assignments)
+  }
+
+  if (totalUnits <= capacityUnits) return null
+  return {
+    rule: rule.id,
+    severity: rule.severity ?? 'hard',
+    message: `Resource "${resource.name}" over capacity (${totalUnits / 100} of ${resource.capacity}).`,
+    details: { type: 'capacity-overflow', totalUnits, capacityUnits },
+  }
+}
+
+function evalOutsideBusinessHours(
+  rule: OutsideBusinessHoursRule,
+  proposed: ConflictEvent,
+  resources: ReadonlyMap<string, EngineResource> | undefined,
+): Violation | null {
+  if (!resources) return null
+  const ignore = new Set(rule.ignoreCategories ?? [])
+  if (proposed.category && ignore.has(proposed.category)) return null
+
+  const resourceId = proposed.resource ?? ''
+  if (!resourceId) return null
+  const resource = resources.get(resourceId)
+  if (!resource?.businessHours) return null
+
+  const ps = toDate(proposed.start)
+  const pe = toDate(proposed.end)
+
+  // Skip multi-day spans — "outside hours" isn't meaningful for them.
+  if (pe.getTime() - ps.getTime() >= DAY_MS) return null
+
+  const tz = resource.timezone ?? 'UTC'
+  const startParts = partsInTimezone(ps, tz)
+  // Day-of-week is computed by treating the wall-clock date as UTC and
+  // reading getUTCDay() — avoids double timezone shift from local Date.
+  const startDow = new Date(Date.UTC(
+    startParts.year, startParts.month - 1, startParts.day,
+  )).getUTCDay()
+
+  const bizDays = resource.businessHours.days
+  if (!bizDays.includes(startDow)) {
+    return {
+      rule: rule.id,
+      severity: rule.severity ?? 'soft',
+      message: `"${resource.name}" is closed on this day.`,
+      details: { type: 'outside-business-hours', reason: 'closed-day', dayOfWeek: startDow },
+    }
+  }
+
+  const endParts = partsInTimezone(pe, tz)
+  const bizStart = parseHoursString(resource.businessHours.start)
+  const bizEnd   = parseHoursString(resource.businessHours.end)
+  const evStartH = startParts.hour + startParts.minute / 60
+  const evEndHRaw = endParts.hour + endParts.minute / 60
+  // Midnight end (00:00) means "runs to end of day" — treat as 24.
+  const evEndH = evEndHRaw === 0 ? 24 : evEndHRaw
+
+  if (evStartH < bizStart || evEndH > bizEnd) {
+    return {
+      rule: rule.id,
+      severity: rule.severity ?? 'soft',
+      message: `"${resource.name}" is only open ${resource.businessHours.start}–${resource.businessHours.end}.`,
+      details: {
+        type: 'outside-business-hours',
+        reason: 'outside-hours',
+        proposedStartHour: evStartH,
+        proposedEndHour: evEndH,
+      },
+    }
+  }
+
+  return null
+}
+
 function evalMinRest(
   rule: MinRestRule,
   proposed: ConflictEvent,
@@ -191,10 +353,28 @@ function evalMinRest(
  * pure and side-effect-free so the result is fully memoisable by caller.
  */
 export function evaluateConflicts(input: EvaluateConflictsInput): ConflictEvaluationResult {
-  const { proposed, events, rules, enabled = true } = input
+  const { proposed, events, rules, enabled = true, resources, assignments } = input
   if (!enabled || rules.length === 0) return VALID
 
   const violations: Violation[] = []
+
+  // Single-pass (non-pairwise) rules — evaluated once per rule.
+  for (const rule of rules) {
+    let v: Violation | null = null
+    switch (rule.type) {
+      case 'capacity-overflow':
+        v = evalCapacityOverflow(rule, proposed, events, resources, assignments)
+        break
+      case 'outside-business-hours':
+        v = evalOutsideBusinessHours(rule, proposed, resources)
+        break
+      default:
+        break
+    }
+    if (v) violations.push(v)
+  }
+
+  // Pairwise rules — evaluated for every (other, rule) combination.
   for (const other of events) {
     if (other.id && proposed.id && other.id === proposed.id) continue
     for (const rule of rules) {
@@ -222,4 +402,6 @@ export const CONFLICT_RULE_TYPES: readonly ConflictRule['type'][] = [
   'resource-overlap',
   'category-mutex',
   'min-rest',
+  'capacity-overflow',
+  'outside-business-hours',
 ] as const

--- a/src/core/events/__tests__/eventBus.test.ts
+++ b/src/core/events/__tests__/eventBus.test.ts
@@ -1,0 +1,179 @@
+/**
+ * eventBus — unit specs (issue #216).
+ *
+ * Pins the pub/sub contract the Workflow DSL interpreter (#219) and adapter
+ * integrations depend on: type-filtered delivery, error isolation, snapshot
+ * semantics on publish, and stable unsubscribe handles.
+ */
+import { afterEach, describe, it, expect, vi } from 'vitest'
+import {
+  createEventBus,
+  LIFECYCLE_EVENT_TYPES,
+  type LifecycleEvent,
+} from '../eventBus'
+import type { EngineEvent } from '../../engine/schema/eventSchema'
+
+const stubEvent = { id: 'e1' } as unknown as EngineEvent
+
+function ev(
+  type: LifecycleEvent['type'],
+  overrides: Partial<Record<string, unknown>> = {},
+): LifecycleEvent {
+  return {
+    id: `emit-${Math.random().toString(36).slice(2, 8)}`,
+    at: '2026-04-20T09:00:00.000Z',
+    event: stubEvent,
+    type,
+    ...(type === 'booking.denied' ? { reason: 'test' } : {}),
+    ...overrides,
+  } as LifecycleEvent
+}
+
+describe('eventBus — LIFECYCLE_EVENT_TYPES registry', () => {
+  it('enumerates all 7 canonical lifecycle types', () => {
+    expect(LIFECYCLE_EVENT_TYPES).toEqual([
+      'booking.requested',
+      'booking.approved',
+      'booking.denied',
+      'booking.finalized',
+      'booking.cancelled',
+      'booking.completed',
+      'booking.revoked',
+    ])
+  })
+})
+
+describe('eventBus — subscribe + publish', () => {
+  const errorSink = vi.fn()
+
+  afterEach(() => { errorSink.mockClear() })
+
+  it('delivers a single-type subscription only for that type', () => {
+    const bus = createEventBus({ onError: errorSink })
+    const listener = vi.fn()
+    bus.subscribe('booking.approved', listener)
+    bus.publish(ev('booking.approved'))
+    bus.publish(ev('booking.denied'))
+    expect(listener).toHaveBeenCalledTimes(1)
+    expect(listener.mock.calls[0][0].type).toBe('booking.approved')
+  })
+
+  it('delivers an array-of-types subscription for each matching type', () => {
+    const bus = createEventBus({ onError: errorSink })
+    const listener = vi.fn()
+    bus.subscribe(['booking.requested', 'booking.finalized'], listener)
+    bus.publish(ev('booking.requested'))
+    bus.publish(ev('booking.approved'))
+    bus.publish(ev('booking.finalized'))
+    expect(listener).toHaveBeenCalledTimes(2)
+    const types = listener.mock.calls.map(c => (c[0] as LifecycleEvent).type)
+    expect(types).toEqual(['booking.requested', 'booking.finalized'])
+  })
+
+  it('wildcard subscription ("*") receives every event', () => {
+    const bus = createEventBus({ onError: errorSink })
+    const listener = vi.fn()
+    bus.subscribe('*', listener)
+    for (const t of LIFECYCLE_EVENT_TYPES) bus.publish(ev(t))
+    expect(listener).toHaveBeenCalledTimes(LIFECYCLE_EVENT_TYPES.length)
+  })
+
+  it('multiple subscribers all receive the event in registration order', () => {
+    const bus = createEventBus({ onError: errorSink })
+    const order: string[] = []
+    bus.subscribe('booking.requested', () => order.push('a'))
+    bus.subscribe('booking.requested', () => order.push('b'))
+    bus.subscribe('booking.requested', () => order.push('c'))
+    bus.publish(ev('booking.requested'))
+    expect(order).toEqual(['a', 'b', 'c'])
+  })
+})
+
+describe('eventBus — unsubscribe', () => {
+  it('removes the listener from future emissions', () => {
+    const bus = createEventBus({ onError: () => {} })
+    const listener = vi.fn()
+    const off = bus.subscribe('booking.approved', listener)
+    bus.publish(ev('booking.approved'))
+    off()
+    bus.publish(ev('booking.approved'))
+    expect(listener).toHaveBeenCalledTimes(1)
+  })
+
+  it('is idempotent — calling twice does not throw', () => {
+    const bus = createEventBus({ onError: () => {} })
+    const off = bus.subscribe('booking.approved', () => {})
+    off()
+    expect(() => off()).not.toThrow()
+    expect(bus.size).toBe(0)
+  })
+
+  it('clear() drops every subscription', () => {
+    const bus = createEventBus({ onError: () => {} })
+    bus.subscribe('*', () => {})
+    bus.subscribe('booking.denied', () => {})
+    expect(bus.size).toBe(2)
+    bus.clear()
+    expect(bus.size).toBe(0)
+  })
+})
+
+describe('eventBus — error isolation', () => {
+  it('routes a throwing listener to onError and still invokes siblings', () => {
+    const onError = vi.fn()
+    const bus = createEventBus({ onError })
+    const a = vi.fn(() => { throw new Error('boom') })
+    const b = vi.fn()
+    bus.subscribe('booking.approved', a)
+    bus.subscribe('booking.approved', b)
+    const event = ev('booking.approved')
+    bus.publish(event)
+    expect(a).toHaveBeenCalledTimes(1)
+    expect(b).toHaveBeenCalledTimes(1)
+    expect(onError).toHaveBeenCalledTimes(1)
+    expect(onError.mock.calls[0][0]).toBeInstanceOf(Error)
+    expect((onError.mock.calls[0][0] as Error).message).toBe('boom')
+    expect(onError.mock.calls[0][1]).toBe(event)
+  })
+
+  it('does not propagate a listener throw back to the publisher', () => {
+    const bus = createEventBus({ onError: () => {} })
+    bus.subscribe('booking.finalized', () => { throw new Error('still boom') })
+    expect(() => bus.publish(ev('booking.finalized'))).not.toThrow()
+  })
+})
+
+describe('eventBus — snapshot semantics during publish', () => {
+  it('subscribes added during dispatch are NOT invoked for the current event', () => {
+    const bus = createEventBus({ onError: () => {} })
+    const late = vi.fn()
+    bus.subscribe('booking.requested', () => {
+      bus.subscribe('booking.requested', late)
+    })
+    bus.publish(ev('booking.requested'))
+    expect(late).not.toHaveBeenCalled()
+  })
+
+  it('a subscriber that unsubscribes a sibling still lets the sibling receive the current event', () => {
+    const bus = createEventBus({ onError: () => {} })
+    const b = vi.fn()
+    const offB = bus.subscribe('booking.approved', b)
+    bus.subscribe('booking.approved', () => { offB() })
+    bus.publish(ev('booking.approved'))
+    // snapshot semantics — `b` still fires this round; next round it won't.
+    expect(b).toHaveBeenCalledTimes(1)
+    bus.publish(ev('booking.approved'))
+    expect(b).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('eventBus — default onError', () => {
+  it('falls back to console.error when no onError is provided', () => {
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const bus = createEventBus()
+    bus.subscribe('booking.approved', () => { throw new Error('x') })
+    bus.publish(ev('booking.approved'))
+    expect(spy).toHaveBeenCalledTimes(1)
+    spy.mockRestore()
+  })
+})

--- a/src/core/events/eventBus.ts
+++ b/src/core/events/eventBus.ts
@@ -1,0 +1,161 @@
+/**
+ * Lifecycle event bus — issue #216.
+ *
+ * A tiny typed pub/sub the engine and approval reducer emit on. Host-side
+ * adapters (Slack, webhook, billing) subscribe to the specific events they
+ * care about instead of patching `onApprovalAction` + `onEventCreate` +
+ * `onEventUpdate` individually.
+ *
+ * Why a dedicated module:
+ *   - Keeps publishers (approval reducer, operation pipeline, workflow
+ *     interpreter) decoupled from subscribers (notifications, webhooks).
+ *   - Pre-requisite for the Workflow DSL (#219): workflow `notify` nodes
+ *     publish through this bus instead of owning their own I/O.
+ *   - Error-isolated: one throwing subscriber cannot break sibling
+ *     subscribers or the publisher.
+ */
+import type { EngineEvent } from '../engine/schema/eventSchema'
+
+// ─── Lifecycle event types ────────────────────────────────────────────────
+
+/** Common envelope fields shared by every lifecycle event. */
+interface BaseLifecycleEvent {
+  /** Stable id per emission — useful for dedup in at-least-once delivery. */
+  readonly id: string
+  /** ISO timestamp at which the event was published. */
+  readonly at: string
+  /** Optional human/system actor that caused the emission. */
+  readonly actor?: string
+}
+
+export type LifecycleEvent =
+  | (BaseLifecycleEvent & { readonly type: 'booking.requested';  readonly event: EngineEvent })
+  | (BaseLifecycleEvent & { readonly type: 'booking.approved';   readonly event: EngineEvent; readonly tier?: number })
+  | (BaseLifecycleEvent & { readonly type: 'booking.denied';     readonly event: EngineEvent; readonly reason: string })
+  | (BaseLifecycleEvent & { readonly type: 'booking.finalized';  readonly event: EngineEvent })
+  | (BaseLifecycleEvent & { readonly type: 'booking.cancelled';  readonly event: EngineEvent })
+  | (BaseLifecycleEvent & { readonly type: 'booking.completed';  readonly event: EngineEvent })
+  | (BaseLifecycleEvent & { readonly type: 'booking.revoked';    readonly event: EngineEvent })
+
+export type LifecycleEventType = LifecycleEvent['type']
+
+export const LIFECYCLE_EVENT_TYPES: readonly LifecycleEventType[] = [
+  'booking.requested',
+  'booking.approved',
+  'booking.denied',
+  'booking.finalized',
+  'booking.cancelled',
+  'booking.completed',
+  'booking.revoked',
+] as const
+
+/**
+ * Narrows `LifecycleEvent` to a single variant based on the subscription
+ * filter. `'*'` matches every variant.
+ */
+export type LifecycleEventOf<T extends LifecycleEventType | '*'> =
+  T extends '*' ? LifecycleEvent : Extract<LifecycleEvent, { type: T }>
+
+export type LifecycleListener<T extends LifecycleEventType | '*' = '*'> =
+  (event: LifecycleEventOf<T>) => void
+
+export type SubscriptionFilter = '*' | LifecycleEventType | readonly LifecycleEventType[]
+
+/** Returned by `subscribe()` — call to remove the listener. */
+export type Unsubscribe = () => void
+
+// ─── Bus contract ─────────────────────────────────────────────────────────
+
+export interface EventBus {
+  /**
+   * Register a listener for one or more event types. `'*'` matches every
+   * lifecycle event. The returned function removes the subscription.
+   */
+  subscribe<T extends LifecycleEventType>(
+    types: T | readonly T[],
+    listener: LifecycleListener<T>,
+  ): Unsubscribe
+  subscribe(
+    types: '*',
+    listener: LifecycleListener<'*'>,
+  ): Unsubscribe
+
+  /**
+   * Publish a lifecycle event to every matching subscriber. Subscribers
+   * are invoked synchronously in registration order; a throwing
+   * subscriber is reported via `onError` (or logged) and does NOT abort
+   * the remaining subscribers or the caller.
+   */
+  publish(event: LifecycleEvent): void
+
+  /** Remove every subscription. Primarily for test teardown. */
+  clear(): void
+
+  /** Current total subscriber count — test helper. */
+  readonly size: number
+}
+
+export interface EventBusOptions {
+  /**
+   * Invoked when a subscriber throws. Receives the thrown value, the
+   * offending event, and the listener index. Defaults to
+   * `console.error`. Pass `() => {}` to silence.
+   */
+  readonly onError?: (err: unknown, event: LifecycleEvent) => void
+}
+
+// ─── Implementation ───────────────────────────────────────────────────────
+
+interface Subscription {
+  readonly id: number
+  readonly filter: ReadonlySet<LifecycleEventType> | '*'
+  readonly listener: LifecycleListener<LifecycleEventType | '*'>
+}
+
+export function createEventBus(options: EventBusOptions = {}): EventBus {
+  const subs = new Map<number, Subscription>()
+  let nextId = 1
+
+  const onError = options.onError ?? ((err, event) => {
+    // eslint-disable-next-line no-console
+    console.error(`[EventBus] subscriber threw for ${event.type}:`, err)
+  })
+
+  function subscribe(
+    types: SubscriptionFilter,
+    listener: LifecycleListener<LifecycleEventType | '*'>,
+  ): Unsubscribe {
+    const id = nextId++
+    const filter: ReadonlySet<LifecycleEventType> | '*' =
+      types === '*'
+        ? '*'
+        : new Set<LifecycleEventType>(Array.isArray(types) ? types : [types as LifecycleEventType])
+    subs.set(id, { id, filter, listener })
+    return () => { subs.delete(id) }
+  }
+
+  function publish(event: LifecycleEvent): void {
+    // Snapshot so a listener that unsubscribes (or adds a new sub) during
+    // dispatch doesn't mutate the iterator mid-flight.
+    const snapshot = Array.from(subs.values())
+    for (const sub of snapshot) {
+      if (sub.filter !== '*' && !sub.filter.has(event.type)) continue
+      try {
+        sub.listener(event)
+      } catch (err) {
+        onError(err, event)
+      }
+    }
+  }
+
+  function clear(): void {
+    subs.clear()
+  }
+
+  return {
+    subscribe: subscribe as EventBus['subscribe'],
+    publish,
+    clear,
+    get size() { return subs.size },
+  }
+}

--- a/src/types/assets.ts
+++ b/src/types/assets.ts
@@ -224,6 +224,42 @@ export interface CategoryDef {
   approvalTier?: 1 | 2;
   /** Disabled categories stay in historical data but can't be selected new. */
   disabled?: boolean;
+  /**
+   * Booking policy — enforced by the `policy-violation` conflict rule
+   * (issue #213). Host surfaces violations in the conflict drawer just
+   * like overlap/capacity rules; keeps lead-time / duration / blackouts
+   * as *data* so owners tune them from ConfigPanel without host JS.
+   */
+  policy?: BookingPolicy;
+}
+
+/**
+ * Per-category booking constraints. Every field is optional; a category
+ * with no policy is unconstrained. Checked by the `policy-violation`
+ * conflict rule (see `src/core/conflictEngine.ts`).
+ */
+export interface BookingPolicy {
+  /**
+   * Minimum time between "now" and the event start, in minutes. Blocks
+   * last-minute bookings. `0` or unset disables the check.
+   */
+  minLeadTimeMinutes?: number;
+  /**
+   * Maximum event duration in minutes. Blocks over-long holds. Unset
+   * disables the check; `0` is treated as unset (any duration allowed).
+   */
+  maxDurationMinutes?: number;
+  /**
+   * Maximum days in advance the event can be booked — i.e., the event
+   * start must be ≤ now + `maxAdvanceDays`. Unset disables the check.
+   */
+  maxAdvanceDays?: number;
+  /**
+   * Calendar dates on which this category may not be booked. Strings in
+   * `YYYY-MM-DD` form, interpreted in the *resource's* timezone when one
+   * is available, else UTC. Intended for holidays + corporate blackouts.
+   */
+  blackoutDates?: readonly string[];
 }
 
 export interface CategoriesConfig {

--- a/src/types/assets.ts
+++ b/src/types/assets.ts
@@ -31,8 +31,16 @@ export type ApprovalStageId =
 export type ApprovalActionId =
   | 'submit' | 'approve' | 'deny' | 'downgrade' | 'finalize';
 
+/**
+ * Superset of `ApprovalActionId` that the history log records. `revoke`
+ * is a reducer-level action (reopen a terminal stage) that does not
+ * appear in the owner-configurable action menu but IS persisted in the
+ * audit trail when the reducer is invoked.
+ */
+export type ApprovalHistoryActionId = ApprovalActionId | 'revoke';
+
 export interface ApprovalHistoryEntry {
-  action: ApprovalActionId;
+  action: ApprovalHistoryActionId;
   /** ISO timestamp. */
   at: string;
   /** Actor display name or id. Optional — host may redact. */


### PR DESCRIPTION
## Summary

Opening this as the Sprint 1 hardening stack so CI can run at each step. Closes #209 on merge; more Sprint 1 tickets (#210 capacity/business-hours, #213 policy rules, #216 lifecycle bus) will be stacked as additional commits on this branch.

## What's in this PR so far

**#209 — Approval transition reducer** (`src/core/approvals/transitions.ts`)
- Pure, side-effect-free reducer for the 5-state workflow (`requested → approved → finalized | pending_higher | denied`)
- Legal-transition matrix exported as `LEGAL_TRANSITIONS` so the Workflow DSL builder UI and tests share one source of truth
- `legalActionsFrom(stage)` helper for action menus
- `Result<stage, TransitionError>` return type with three error codes: `ILLEGAL_TRANSITION`, `DENY_REQUIRES_REASON`, `INVALID_STAGE`
- Single-tier shortcut: when `counts.requiredApprovals === 1`, an `approve` from `requested` lands on `finalized` directly
- `revoke` from terminal stages reopens to `requested` and resets approval counts
- 33 table-driven unit tests covering legal paths, illegal paths, deny-reason guard, counts, revoke reset, purity, and history order

Why this first: the reducer is the load-bearing primitive the Workflow DSL epic (#219) will drive. Shipping it independently de-risks the moonshot and unblocks #210 through #218.

## Test plan

- [x] `npm test` — 1284/1284 pass (33 new, 0 regressions)
- [x] `npm run type-check` — clean
- [x] CI checks on this PR
- [x] E2E suite (`npm run test:browser`) — no UI changes in this commit, smoke-check only

## Deliberately deferred

- **Validator-pipeline plug-in** for approval transitions. The reducer is the primary deliverable; wiring a `GroupChangeRule` that rejects illegal `meta.approvalStage` patches is a short follow-up commit best done once a host flow actually mutates through the pipeline.

## Out of scope (future Sprint 1 commits on this branch)

- #210 — Capacity + business-hours conflict rules
- #213 — Per-category booking policy rules
- #216 — Lifecycle event bus

https://claude.ai/code/session_01DH75m5LQKHtgGFcCPiCw8K