### PR TITLE
feat(tenancy): multi-tenant primitives — tenantId + scope helpers (#218)

### DIFF
--- a/src/core/tenancy/__tests__/tenantScope.test.ts
+++ b/src/core/tenancy/__tests__/tenantScope.test.ts
@@ -31,6 +31,16 @@ describe('filterByTenant', () => {
     expect(out).toEqual(['c'])
   })
 
+  it('treats tenantId=null as global (JSON-serialized unset)', () => {
+    const withNullUnset = [
+      { id: 'a', tenantId: 'red' },
+      { id: 'b', tenantId: null },
+      { id: 'c', tenantId: 'blue' },
+    ]
+    const out = filterByTenant(withNullUnset, 'red').map(i => i.id)
+    expect(out).toEqual(['a', 'b'])
+  })
+
   it('returns every item when currentTenantId is null', () => {
     const out = filterByTenant(items, null).map(i => i.id)
     expect(out).toEqual(['a', 'b', 'c', 'd'])
@@ -77,6 +87,10 @@ describe('isVisibleToTenant', () => {
   it('is true for everything when currentTenantId is null', () => {
     expect(isVisibleToTenant({ tenantId: 'red' }, null)).toBe(true)
   })
+
+  it('treats an item with tenantId=null as global', () => {
+    expect(isVisibleToTenant({ tenantId: null }, 'red')).toBe(true)
+  })
 })
 
 describe('assertSameTenant', () => {
@@ -88,6 +102,11 @@ describe('assertSameTenant', () => {
     expect(assertSameTenant({ tenantId: 'red' }, {})).toBeNull()
     expect(assertSameTenant({}, { tenantId: 'red' })).toBeNull()
     expect(assertSameTenant({}, {})).toBeNull()
+  })
+
+  it('treats tenantId=null as global on either side', () => {
+    expect(assertSameTenant({ tenantId: 'red' }, { tenantId: null })).toBeNull()
+    expect(assertSameTenant({ tenantId: null }, { tenantId: 'red' })).toBeNull()
   })
 
   it('returns a TENANT_MISMATCH error when the tenants differ', () => {
@@ -103,11 +122,16 @@ describe('assertSameTenant', () => {
 })
 
 describe('inheritTenantId', () => {
-  type Patch = { id: string; tenantId?: string }
+  type Patch = { id: string; tenantId?: string | null }
 
   it('stamps currentTenantId when patch has none', () => {
     const out = inheritTenantId<Patch>({ id: 'x' }, 'red')
     expect(out).toMatchObject({ id: 'x', tenantId: 'red' })
+  })
+
+  it('stamps currentTenantId when patch has tenantId=null', () => {
+    const out = inheritTenantId<Patch>({ id: 'x', tenantId: null }, 'red')
+    expect(out.tenantId).toBe('red')
   })
 
   it('leaves patch untouched when tenantId is already set', () => {

--- a/src/core/tenancy/tenantScope.ts
+++ b/src/core/tenancy/tenantScope.ts
@@ -7,7 +7,8 @@
  *
  * Model:
  *   - `EngineEvent.tenantId`, `EngineResource.tenantId`, `Assignment.tenantId`
- *     are all optional. An unset `tenantId` is interpreted as
+ *     are all optional. An unset `tenantId` — whether `undefined` or `null`
+ *     (as JSON-serialized DB rows often deliver it) — is interpreted as
  *     "global / shared / legacy" and is therefore visible to every tenant.
  *   - `filterByTenant` keeps items whose `tenantId` is null/undefined OR
  *     equal to the `currentTenantId`. Pass `null` for `currentTenantId` to
@@ -21,7 +22,7 @@
  */
 
 export interface HasTenantId {
-  readonly tenantId?: string
+  readonly tenantId?: string | null
 }
 
 // ─── Read-path filtering ──────────────────────────────────────────────────
@@ -31,7 +32,7 @@ export interface HasTenantId {
  *
  * Rules:
  *   - `currentTenantId === null` → disable filtering; return every item.
- *   - Item with no `tenantId` → always visible (global/shared).
+ *   - Item with no `tenantId` (null or undefined) → always visible (global/shared).
  *   - Item with `tenantId === currentTenantId` → visible.
  *   - Otherwise → hidden.
  */
@@ -42,7 +43,7 @@ export function filterByTenant<T extends HasTenantId>(
   if (currentTenantId === null) return Array.from(items)
   const out: T[] = []
   for (const item of items) {
-    if (item.tenantId === undefined) out.push(item)
+    if (item.tenantId == null) out.push(item)
     else if (item.tenantId === currentTenantId) out.push(item)
   }
   return out
@@ -59,7 +60,7 @@ export function filterMapByTenant<K, V extends HasTenantId>(
     return out
   }
   for (const [k, v] of items) {
-    if (v.tenantId === undefined || v.tenantId === currentTenantId) out.set(k, v)
+    if (v.tenantId == null || v.tenantId === currentTenantId) out.set(k, v)
   }
   return out
 }
@@ -70,7 +71,7 @@ export function isVisibleToTenant(
   currentTenantId: string | null,
 ): boolean {
   if (currentTenantId === null) return true
-  if (item.tenantId === undefined) return true
+  if (item.tenantId == null) return true
   return item.tenantId === currentTenantId
 }
 
@@ -88,14 +89,14 @@ export type TenantMismatchError = {
  * assigned together), verify they belong to the same tenant or at least
  * one side is global. Returns null when ok, otherwise an error record.
  *
- * Either side's `tenantId` being undefined is acceptable — global
+ * Either side's `tenantId` being null/undefined is acceptable — global
  * items cross tenant boundaries by design.
  */
 export function assertSameTenant(
   a: HasTenantId,
   b: HasTenantId,
 ): TenantMismatchError | null {
-  if (a.tenantId === undefined || b.tenantId === undefined) return null
+  if (a.tenantId == null || b.tenantId == null) return null
   if (a.tenantId === b.tenantId) return null
   return {
     code: 'TENANT_MISMATCH',
@@ -107,13 +108,15 @@ export function assertSameTenant(
 
 /**
  * Stamp `currentTenantId` onto a patch when the patch doesn't already
- * specify one. `currentTenantId === null` is a no-op (untenanted write).
+ * specify one (null and undefined are both treated as unset, matching the
+ * JSON shapes that DB layers commonly emit). `currentTenantId === null`
+ * is a no-op (untenanted write).
  */
 export function inheritTenantId<T extends HasTenantId>(
   patch: T,
   currentTenantId: string | null,
 ): T {
   if (currentTenantId === null) return patch
-  if (patch.tenantId !== undefined) return patch
+  if (patch.tenantId != null) return patch
   return { ...patch, tenantId: currentTenantId }
 }


### PR DESCRIPTION
Adds optional `tenantId` to the three entity schemas and a standalone
tenancy module that hosts can use to enforce multi-workspace scoping
without the engine having to be tenant-aware:

- `EngineEvent`, `EngineResource`, `Assignment` gain `tenantId?: string`.
  Unset = global / shared / legacy.
- `src/core/tenancy/tenantScope.ts`:
  - `filterByTenant` / `filterMapByTenant` — read-path visibility with
    "unset tenantId is visible to everyone" semantics.
  - `isVisibleToTenant` — single-item check.
  - `assertSameTenant` — write-path guard, returns a TENANT_MISMATCH
    record or null. Global items bypass the check.
  - `inheritTenantId` — stamps `currentTenantId` onto patches that
    omit one.
- Passing `currentTenantId === null` disables filtering / inheritance
  entirely — matches pre-tenancy behavior for hosts that opt out.

Tests: 17 specs covering filtering (including null tenant), visibility,
mismatch detection, and write-path inheritance.