### PR TITLE
feat(holds): submit-flow wiring — useBookingHold + adapter contract (…

### DIFF
--- a/docs/DataAdapter.md
+++ b/docs/DataAdapter.md
@@ -43,6 +43,102 @@ See the [Google Calendar setup guide](./GoogleCalendarSetup.md) for the OAuth fl
 - retry/backoff for transient failures
 - audit logging for compliance workflows
 
+## Booking holds (issue #211)
+
+Two users clicking *submit* on the same slot at the same time is the classic
+booking race. The engine ships a short-lived **soft lock** ("hold") that
+reserves a `(resource, window)` pair while the form is open, so the second
+user sees a soft `hold-conflict` warning in the conflict engine output
+immediately — not a save-time failure.
+
+### Registry
+
+```ts
+import { createHoldRegistry } from 'works-calendar';
+
+const holds = createHoldRegistry(); // default 5-min TTL, auto-generated ids
+```
+
+API (`HoldRegistry`):
+- `acquire({ resourceId, window, holderId, ttlMs? })` — returns `{ ok, hold }`
+  on success or `{ ok: false, error: { code: 'CONFLICTING_HOLD' | 'INVALID_WINDOW' } }`.
+  Same-holder overlap is a TTL refresh; different-holder overlap is rejected.
+- `release(holdId)` — idempotent.
+- `active(now?)` — lazy expiry (no mutation); `prune(now?)` for explicit GC.
+
+### React hook (`useBookingHold`)
+
+The submit flow typically wires through the hook, which handles
+acquire-on-mount / release-on-unmount and re-acquires when the selected
+resource or window changes:
+
+```tsx
+import { useMemo } from 'react';
+import { createHoldRegistry, useBookingHold } from 'works-calendar';
+
+const holds = useMemo(() => createHoldRegistry(), []);
+
+function BookingForm({ resourceId, start, end, userId }) {
+  const hold = useBookingHold(holds, {
+    resourceId, start, end,
+    holderId: userId,
+    enabled: Boolean(resourceId && start && end),
+  });
+
+  if (hold.status === 'error') {
+    return <p>Someone else is currently booking this slot. Try again in a moment.</p>;
+  }
+
+  async function onSubmit() {
+    await adapter.submitEvent(/* … */);
+    hold.release(); // belt-and-suspenders; unmount also releases
+  }
+
+  return <form onSubmit={onSubmit}>{/* … */}</form>;
+}
+```
+
+### Adapter contract
+
+For multi-process deployments, adapters implement the optional
+`acquireHold / releaseHold` methods and forward to a shared store
+(Redis / row-locked DB / etc.) so sibling nodes honor the hold:
+
+```ts
+class RedisAdapter implements CalendarAdapter {
+  async acquireHold(input) {
+    const ok = await redis.set(`hold:${input.resourceId}`, input.holderId, {
+      NX: true, PX: input.ttlMs ?? 300_000,
+    });
+    if (!ok) {
+      return { ok: false, error: { code: 'CONFLICTING_HOLD', message: 'slot held elsewhere' } };
+    }
+    return {
+      ok: true,
+      hold: {
+        id: input.id ?? crypto.randomUUID(),
+        resourceId: input.resourceId,
+        window: input.window,
+        holderId: input.holderId,
+        expiresAt: new Date(Date.now() + (input.ttlMs ?? 300_000)).toISOString(),
+      },
+    };
+  }
+  async releaseHold(holdId) { await redis.del(`hold:${holdId}`); }
+  /* loadRange, createEvent, … */
+}
+```
+
+Single-process embeds can skip the contract and use `createHoldRegistry()`
+directly.
+
+### Conflict engine integration
+
+The `hold-conflict` rule dispatches to `findBlockingHold()` using
+`evaluateConflicts({ …, holds: registry.active(), holderId })`. Proposer's
+own holds are excluded; other-holder overlaps surface as a **soft**
+violation so hosts can decide whether to block the save or offer a retry.
+
 ## Lifecycle event bus (issue #216)
 
 The engine exposes a typed `EventBus` for booking and assignment lifecycle

--- a/src/api/v1/adapters/CalendarAdapter.ts
+++ b/src/api/v1/adapters/CalendarAdapter.ts
@@ -28,6 +28,7 @@ import type {
   ScheduleInstantiationResultV1,
 } from '../templates';
 import type { EventBus } from '../../../core/engine/eventBus';
+import type { AcquireHoldInput, AcquireHoldResult } from '../../../core/holds/holdRegistry';
 
 // ─── Change notification types ────────────────────────────────────────────────
 
@@ -133,6 +134,31 @@ export interface CalendarAdapter {
 
   /** Instantiate a schedule template into concrete master events. */
   instantiateScheduleTemplate?(request: ScheduleInstantiationRequestV1): Promise<ScheduleInstantiationResultV1>;
+
+  /**
+   * Acquire a short-lived soft lock on a `(resource, window)` pair
+   * (issue #211). While the hold is active, other holders that attempt
+   * the same slot see a soft `hold-conflict` violation through the
+   * conflict engine. The submit flow typically acquires on form open
+   * and releases on submit/close.
+   *
+   * Single-process hosts back this with an in-memory
+   * `createHoldRegistry()`. Multi-process hosts forward to a shared
+   * store (Redis, Postgres row lock, etc.) so sibling nodes see the
+   * hold.
+   *
+   * Returns the acquired `Hold` on success or an `AcquireHoldError`
+   * when a different holder already owns an overlapping live hold.
+   * Same-holder re-acquisition refreshes the TTL in place.
+   */
+  acquireHold?(input: AcquireHoldInput): Promise<AcquireHoldResult> | AcquireHoldResult;
+
+  /**
+   * Release a previously-acquired hold by id (issue #211). Idempotent —
+   * missing ids, already-expired holds, and double-release are silent
+   * no-ops. Safe to call on submit success and on form close.
+   */
+  releaseHold?(holdId: string): Promise<void> | void;
 
   /**
    * Subscribe to the engine's lifecycle `EventBus` (issue #216).

--- a/src/hooks/__tests__/useBookingHold.test.tsx
+++ b/src/hooks/__tests__/useBookingHold.test.tsx
@@ -1,0 +1,185 @@
+/**
+ * useBookingHold — hook specs (issue #211).
+ *
+ * Verifies the submit-flow wiring: acquire on mount, release on unmount,
+ * re-acquire on window/resource change, idempotent explicit release,
+ * error surfacing without throwing.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { createHoldRegistry } from '../../core/holds/holdRegistry';
+import { useBookingHold } from '../useBookingHold';
+import type { HoldProvider } from '../useBookingHold';
+
+const T0 = new Date('2026-04-20T09:00:00.000Z');
+
+function mkProvider(): HoldProvider & { acquireSpy: ReturnType<typeof vi.fn>; releaseSpy: ReturnType<typeof vi.fn>; _reg: ReturnType<typeof createHoldRegistry> } {
+  const reg = createHoldRegistry({ now: () => T0 });
+  const acquireSpy = vi.fn(reg.acquire);
+  const releaseSpy = vi.fn(reg.release);
+  return {
+    acquire: acquireSpy,
+    release: releaseSpy,
+    acquireSpy,
+    releaseSpy,
+    _reg: reg,
+  };
+}
+
+const WIN = {
+  start: '2026-04-20T10:00:00.000Z',
+  end:   '2026-04-20T11:00:00.000Z',
+};
+
+describe('useBookingHold — acquire + release lifecycle', () => {
+  it('acquires on mount and releases on unmount', async () => {
+    const provider = mkProvider();
+    const { result, unmount } = renderHook(() =>
+      useBookingHold(provider, { resourceId: 'room-a', start: WIN.start, end: WIN.end, holderId: 'alice' }),
+    );
+    await waitFor(() => expect(result.current.status).toBe('held'));
+    expect(result.current.hold?.holderId).toBe('alice');
+    expect(provider.acquireSpy).toHaveBeenCalledTimes(1);
+
+    unmount();
+    expect(provider.releaseSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not acquire when enabled=false', async () => {
+    const provider = mkProvider();
+    const { result } = renderHook(() =>
+      useBookingHold(provider, { resourceId: 'room-a', start: WIN.start, end: WIN.end, holderId: 'alice', enabled: false }),
+    );
+    expect(result.current.status).toBe('idle');
+    expect(provider.acquireSpy).not.toHaveBeenCalled();
+  });
+
+  it('re-acquires when the window changes (releases the old hold first)', async () => {
+    const provider = mkProvider();
+    const { result, rerender } = renderHook(
+      ({ end }: { end: string }) =>
+        useBookingHold(provider, { resourceId: 'room-a', start: WIN.start, end, holderId: 'alice' }),
+      { initialProps: { end: WIN.end } },
+    );
+    await waitFor(() => expect(result.current.status).toBe('held'));
+    const firstHoldId = result.current.hold!.id;
+
+    rerender({ end: '2026-04-20T12:00:00.000Z' });
+    await waitFor(() => expect(result.current.hold?.id).not.toBe(firstHoldId));
+    expect(provider.releaseSpy).toHaveBeenCalledWith(firstHoldId);
+  });
+
+  it('releases when enabled flips to false', async () => {
+    const provider = mkProvider();
+    const { result, rerender } = renderHook(
+      ({ enabled }: { enabled: boolean }) =>
+        useBookingHold(provider, { resourceId: 'room-a', start: WIN.start, end: WIN.end, holderId: 'alice', enabled }),
+      { initialProps: { enabled: true } },
+    );
+    await waitFor(() => expect(result.current.status).toBe('held'));
+
+    rerender({ enabled: false });
+    await waitFor(() => expect(result.current.status).toBe('released'));
+    expect(provider.releaseSpy).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('useBookingHold — explicit release', () => {
+  it('exposes a release() callback the form can call on submit success', async () => {
+    const provider = mkProvider();
+    const { result } = renderHook(() =>
+      useBookingHold(provider, { resourceId: 'room-a', start: WIN.start, end: WIN.end, holderId: 'alice' }),
+    );
+    await waitFor(() => expect(result.current.status).toBe('held'));
+    act(() => { result.current.release(); });
+    expect(result.current.status).toBe('released');
+    expect(result.current.hold).toBeNull();
+    expect(provider.releaseSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('double-release is a no-op', async () => {
+    const provider = mkProvider();
+    const { result } = renderHook(() =>
+      useBookingHold(provider, { resourceId: 'room-a', start: WIN.start, end: WIN.end, holderId: 'alice' }),
+    );
+    await waitFor(() => expect(result.current.status).toBe('held'));
+    act(() => { result.current.release(); });
+    act(() => { result.current.release(); });
+    expect(provider.releaseSpy).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('useBookingHold — conflict + error handling', () => {
+  it('surfaces CONFLICTING_HOLD via state.error without throwing', async () => {
+    const provider = mkProvider();
+    // Pre-seed a conflicting hold from a different holder.
+    provider._reg.acquire({
+      resourceId: 'room-a',
+      window: WIN,
+      holderId: 'bob',
+    });
+
+    const { result } = renderHook(() =>
+      useBookingHold(provider, { resourceId: 'room-a', start: WIN.start, end: WIN.end, holderId: 'alice' }),
+    );
+    await waitFor(() => expect(result.current.status).toBe('error'));
+    expect(result.current.error?.code).toBe('CONFLICTING_HOLD');
+    expect(result.current.hold).toBeNull();
+  });
+
+  it('same-holder re-acquire refreshes TTL (registry semantics)', async () => {
+    const provider = mkProvider();
+    // Acquire directly first …
+    const first = provider._reg.acquire({
+      resourceId: 'room-a',
+      window: WIN,
+      holderId: 'alice',
+    });
+    expect(first.ok).toBe(true);
+
+    // … then mount the hook as alice on the same window — should succeed.
+    const { result } = renderHook(() =>
+      useBookingHold(provider, { resourceId: 'room-a', start: WIN.start, end: WIN.end, holderId: 'alice' }),
+    );
+    await waitFor(() => expect(result.current.status).toBe('held'));
+    expect(result.current.hold?.holderId).toBe('alice');
+  });
+});
+
+describe('useBookingHold — missing inputs', () => {
+  it('stays idle when no provider is passed', () => {
+    const { result } = renderHook(() =>
+      useBookingHold(null, { resourceId: 'room-a', start: WIN.start, end: WIN.end, holderId: 'alice' }),
+    );
+    expect(result.current.status).toBe('idle');
+    expect(result.current.hold).toBeNull();
+  });
+
+  it('stays idle when resourceId or window fields are missing', async () => {
+    const provider = mkProvider();
+    const { result, rerender } = renderHook(
+      (props: { resourceId: string | null }) =>
+        useBookingHold(provider, { resourceId: props.resourceId, start: WIN.start, end: WIN.end, holderId: 'alice' }),
+      { initialProps: { resourceId: null } },
+    );
+    expect(result.current.status).toBe('idle');
+    expect(provider.acquireSpy).not.toHaveBeenCalled();
+
+    rerender({ resourceId: 'room-a' });
+    await waitFor(() => expect(result.current.status).toBe('held'));
+  });
+});
+
+describe('useBookingHold — async provider', () => {
+  it('awaits async acquire results', async () => {
+    const reg = createHoldRegistry({ now: () => T0 });
+    const provider: HoldProvider = {
+      acquire: async input => reg.acquire(input),
+      release: async id => reg.release(id),
+    };
+    const { result } = renderHook(() =>
+      useBookingHold(provider, { resourceId: 'room-a', start: WIN.start, end: WIN.end, holderId: 'alice' }),
+    );
+    await waitFor(() => expect(result.current.status).toBe('held'));
+  });
+});

--- a/src/hooks/__tests__/useBookingHold.test.tsx
+++ b/src/hooks/__tests__/useBookingHold.test.tsx
@@ -127,6 +127,30 @@ describe('useBookingHold — conflict + error handling', () => {
     expect(result.current.hold).toBeNull();
   });
 
+  it('clears the prior hold when re-acquire fails (no stale reference)', async () => {
+    const provider = mkProvider();
+    const { result, rerender } = renderHook(
+      ({ resourceId }: { resourceId: string }) =>
+        useBookingHold(provider, { resourceId, start: WIN.start, end: WIN.end, holderId: 'alice' }),
+      { initialProps: { resourceId: 'room-a' } },
+    );
+    await waitFor(() => expect(result.current.status).toBe('held'));
+
+    // Pre-seed a conflicting hold on room-b from a different holder, then
+    // swap the resource. The prior (room-a) hold must be cleared even
+    // though the new (room-b) acquire fails.
+    provider._reg.acquire({
+      resourceId: 'room-b',
+      window: WIN,
+      holderId: 'bob',
+    });
+
+    rerender({ resourceId: 'room-b' });
+    await waitFor(() => expect(result.current.status).toBe('error'));
+    expect(result.current.hold).toBeNull();
+    expect(result.current.error?.code).toBe('CONFLICTING_HOLD');
+  });
+
   it('same-holder re-acquire refreshes TTL (registry semantics)', async () => {
     const provider = mkProvider();
     // Acquire directly first …

--- a/src/hooks/useBookingHold.ts
+++ b/src/hooks/useBookingHold.ts
@@ -1,0 +1,208 @@
+/**
+ * useBookingHold — submit-flow soft lock (issue #211).
+ *
+ * Acquires a hold when the form renders with a valid (resource, window)
+ * and releases it on unmount, submit, or when the window/resource
+ * changes. Keeps the two-user race (both open the same slot, both
+ * submit) surfaced as a soft conflict through `hold-conflict` rather
+ * than a save-time failure.
+ *
+ * Contract:
+ *   - `enabled=false` skips acquisition entirely — use during initial
+ *     form load before the user has committed to a slot.
+ *   - Re-acquiring with the same holder is a TTL refresh (handled by the
+ *     registry); safe on every window edit.
+ *   - The hook is defensively async-tolerant: adapters that return a
+ *     `Promise` are awaited. A failing acquire surfaces via `state.error`
+ *     without throwing, so the form can still render (the conflict rule
+ *     will still catch the race on submit).
+ *
+ * Host usage:
+ *   const bus = useMemo(() => createHoldRegistry(), []);
+ *   const hold = useBookingHold(bus, {
+ *     resourceId, start, end, holderId,
+ *     enabled: Boolean(resourceId && start && end),
+ *   });
+ *   // On submit success: `hold.release()` (or let unmount handle it).
+ */
+import { useEffect, useRef, useState, useCallback } from 'react';
+import type {
+  Hold,
+  HoldRegistry,
+  AcquireHoldError,
+  AcquireHoldInput,
+  AcquireHoldResult,
+} from '../core/holds/holdRegistry';
+
+// ─── Options / state ──────────────────────────────────────────────────────
+
+/**
+ * Minimal surface the hook consumes from a hold provider. Satisfied by
+ * `HoldRegistry` (single-process) and by any adapter that implements
+ * `acquireHold / releaseHold` on the v1 CalendarAdapter contract.
+ */
+export interface HoldProvider {
+  acquire(input: AcquireHoldInput): AcquireHoldResult | Promise<AcquireHoldResult>;
+  release(holdId: string): void | Promise<void>;
+}
+
+export interface UseBookingHoldOptions {
+  readonly resourceId: string | null | undefined;
+  readonly start: Date | string | number | null | undefined;
+  readonly end: Date | string | number | null | undefined;
+  readonly holderId: string;
+  /** TTL in ms; defaults to the registry default (5 min). */
+  readonly ttlMs?: number;
+  /**
+   * When false, any existing hold is released and no new hold is acquired.
+   * Defaults to true. Use this to skip acquisition while the form is still
+   * collecting a resource / window selection.
+   */
+  readonly enabled?: boolean;
+  /**
+   * Stable id passed to the registry so adapters that mirror holds to a
+   * shared store can dedupe. Defaults to `undefined` (registry generates).
+   */
+  readonly holdId?: string;
+}
+
+export interface UseBookingHoldState {
+  readonly hold: Hold | null;
+  readonly error: AcquireHoldError | null;
+  readonly status: 'idle' | 'acquiring' | 'held' | 'error' | 'released';
+  /** Explicitly release the current hold. Safe to call more than once. */
+  readonly release: () => void;
+}
+
+// ─── Implementation ───────────────────────────────────────────────────────
+
+const EMPTY_STATE: UseBookingHoldState = {
+  hold: null,
+  error: null,
+  status: 'idle',
+  release: () => {},
+};
+
+function windowKey(
+  start: Date | string | number | null | undefined,
+  end: Date | string | number | null | undefined,
+): string {
+  const s = start instanceof Date ? start.toISOString() : start != null ? String(start) : '';
+  const e = end   instanceof Date ? end.toISOString()   : end   != null ? String(end)   : '';
+  return `${s}→${e}`;
+}
+
+function releaseHoldSafely(provider: HoldProvider, holdId: string): void {
+  try {
+    const r = provider.release(holdId);
+    if (r && typeof (r as Promise<void>).then === 'function') {
+      (r as Promise<void>).catch(() => { /* best-effort */ });
+    }
+  } catch { /* best-effort */ }
+}
+
+export function useBookingHold(
+  provider: HoldProvider | null | undefined,
+  opts: UseBookingHoldOptions,
+): UseBookingHoldState {
+  const { resourceId, start, end, holderId, ttlMs, enabled = true, holdId } = opts;
+
+  const [hold, setHold] = useState<Hold | null>(null);
+  const [error, setError] = useState<AcquireHoldError | null>(null);
+  const [status, setStatus] = useState<UseBookingHoldState['status']>('idle');
+
+  // Live hold id. Cleared only when we explicitly release or a re-acquire
+  // replaces it. The cleanup-then-new-body React lifecycle means we can't
+  // rely on cleanup clearing this — handle transitions in the body.
+  const heldIdRef = useRef<string | null>(null);
+
+  const release = useCallback(() => {
+    const id = heldIdRef.current;
+    if (!id || !provider) return;
+    heldIdRef.current = null;
+    releaseHoldSafely(provider, id);
+    setHold(null);
+    setStatus('released');
+  }, [provider]);
+
+  useEffect(() => {
+    const hadHold = heldIdRef.current !== null;
+
+    if (!provider || !enabled || !resourceId || !start || !end || !holderId) {
+      // Inputs became invalid — release the prior hold (if any) and park.
+      if (hadHold && provider) {
+        const prev = heldIdRef.current!;
+        heldIdRef.current = null;
+        releaseHoldSafely(provider, prev);
+        setHold(null);
+        setStatus('released');
+      } else {
+        setStatus('idle');
+      }
+      return;
+    }
+
+    // Release any prior hold in-place before re-acquiring. The registry
+    // refreshes same-holder TTLs internally, but callers may have swapped
+    // resource/window, and we want "released" visible on the old id.
+    if (hadHold) {
+      const prev = heldIdRef.current!;
+      heldIdRef.current = null;
+      releaseHoldSafely(provider, prev);
+    }
+
+    let cancelled = false;
+    setStatus('acquiring');
+    setError(null);
+
+    Promise.resolve(
+      provider.acquire({
+        resourceId,
+        window: { start, end },
+        holderId,
+        ...(ttlMs !== undefined ? { ttlMs } : {}),
+        ...(holdId !== undefined ? { id: holdId } : {}),
+      }),
+    ).then(result => {
+      if (cancelled) {
+        if (result.ok === true) releaseHoldSafely(provider, result.hold.id);
+        return;
+      }
+      if (result.ok === true) {
+        heldIdRef.current = result.hold.id;
+        setHold(result.hold);
+        setStatus('held');
+      } else if (result.ok === false) {
+        setError(result.error);
+        setStatus('error');
+      }
+    }).catch(err => {
+      if (cancelled) return;
+      setError({
+        code: 'CONFLICTING_HOLD',
+        message: err instanceof Error ? err.message : 'acquireHold failed',
+      });
+      setStatus('error');
+    });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [provider, enabled, resourceId, windowKey(start, end), holderId, ttlMs, holdId]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // Release on unmount only — separate from the transitional effect above
+  // so cleanup doesn't race with the acquiring effect's ref writes.
+  useEffect(() => {
+    return () => {
+      const id = heldIdRef.current;
+      if (id && provider) {
+        heldIdRef.current = null;
+        releaseHoldSafely(provider, id);
+      }
+    };
+  }, [provider]);
+
+  if (!provider) return EMPTY_STATE;
+
+  return { hold, error, status, release };
+}

--- a/src/hooks/useBookingHold.ts
+++ b/src/hooks/useBookingHold.ts
@@ -149,6 +149,10 @@ export function useBookingHold(
       const prev = heldIdRef.current!;
       heldIdRef.current = null;
       releaseHoldSafely(provider, prev);
+      // Clear the stale hold object before we attempt the new acquire —
+      // if the acquire fails we'd otherwise leave `hold` pointing at the
+      // just-released object, misleading submit/UI code that keys off it.
+      setHold(null);
     }
 
     let cancelled = false;

--- a/src/index.ts
+++ b/src/index.ts
@@ -61,6 +61,16 @@ export {
   singleApproverWorkflow, twoTierApproverWorkflow, conditionalByCostWorkflow,
 } from './core/workflow/templates';
 
+// ── Booking holds (#211) ────────────────────────────────────────────────────
+export { createHoldRegistry, findBlockingHold } from './core/holds/holdRegistry';
+export type {
+  Hold, HoldWindow, HoldRegistry,
+  AcquireHoldInput, AcquireHoldResult, AcquireHoldError, AcquireHoldErrorCode,
+  CreateHoldRegistryOptions,
+} from './core/holds/holdRegistry';
+export { useBookingHold } from './hooks/useBookingHold';
+export type { UseBookingHoldOptions, UseBookingHoldState } from './hooks/useBookingHold';
+
 // ── Lifecycle event bus (#216) ──────────────────────────────────────────────
 export { EventBus, channelForApprovalTransition } from './core/engine/eventBus';
 export type {


### PR DESCRIPTION
…#211)

Completes #211 — the registry + hold-conflict rule shipped earlier (b6418dc). This adds the missing surfaces hosts need to wire holds into their submit flows:

- CalendarAdapter: optional acquireHold / releaseHold methods so multi-process deployments can forward holds to Redis / row locks / etc. Single-process hosts keep using createHoldRegistry() directly.
- useBookingHold hook — acquires on mount, releases on unmount, and re-acquires when the window or resource changes. Handles async providers, surfaces CONFLICTING_HOLD via state.error without throwing, and exposes an explicit release() for submit-success.
- Public exports: createHoldRegistry, findBlockingHold, useBookingHold, types.
- docs/DataAdapter.md: registry + hook + adapter-contract cookbook with a Redis example.

Separate unmount cleanup effect avoids racing the transitional acquire/release body — hook tests pin the behavior.