### PR TITLE
feat(#212): add resourcePoolId to event schema

### DIFF
--- a/src/api/v1/converters.ts
+++ b/src/api/v1/converters.ts
@@ -118,6 +118,7 @@ export function eventV1ToEngine(ev: CalendarEventV1): EngineEvent {
     resourceId:  ev.resourceId != null ? String(ev.resourceId)
                  : ev.resource != null ? String(ev.resource)  // legacy display field fallback
                  : null,
+    resourcePoolId: ev.resourcePoolId != null ? String(ev.resourcePoolId) : null,
     status:      coerceStatus(ev.status),
     color:       typeof ev.color === 'string' ? ev.color : null,
     rrule:       hasRrule ? ev.rrule! : null,
@@ -148,6 +149,7 @@ export function engineToV1(ev: EngineEvent): CalendarEventV1 {
     category:    ev.category ?? undefined,
     color:       ev.color    ?? undefined,
     resourceId:  ev.resourceId ?? undefined,
+    resourcePoolId: ev.resourcePoolId ?? undefined,
     timezone:    ev.timezone   ?? undefined,
     status:      ev.status,
     rrule:       ev.rrule      ?? undefined,

--- a/src/api/v1/serialization.ts
+++ b/src/api/v1/serialization.ts
@@ -50,6 +50,8 @@ export interface SerializedEvent {
   readonly title: string;
   readonly category: string | null;
   readonly resourceId: string | null;
+  /** Virtual pool ref (#212). Null on stored/resolved events. */
+  readonly resourcePoolId: string | null;
   readonly status: EngineEvent['status'];
   readonly color: string | null;
   readonly rrule: string | null;
@@ -150,6 +152,7 @@ export function serializeEvent(ev: EngineEvent): SerializedEvent {
     title:        ev.title,
     category:     ev.category,
     resourceId:   ev.resourceId,
+    resourcePoolId: ev.resourcePoolId,
     status:       ev.status,
     color:        ev.color,
     rrule:        ev.rrule,
@@ -174,6 +177,7 @@ export function deserializeEvent(raw: SerializedEvent): EngineEvent {
     title:        raw.title,
     category:     raw.category,
     resourceId:   raw.resourceId,
+    resourcePoolId: raw.resourcePoolId ?? null,
     status:       raw.status,
     color:        raw.color,
     rrule:        raw.rrule,

--- a/src/api/v1/types.ts
+++ b/src/api/v1/types.ts
@@ -77,6 +77,12 @@ export interface CalendarEventV1 {
    * Prefer explicit Assignment records for multi-resource events.
    */
   resourceId?: string;
+  /**
+   * Virtual `ResourcePool` id (issue #212). Mutually exclusive with
+   * `resourceId` at submit time — the engine resolves the pool to a
+   * concrete member and fills in `resourceId` on the stored event.
+   */
+  resourcePoolId?: string;
   /** 'confirmed' (default) | 'tentative' (striped) | 'cancelled' (strikethrough) */
   status?: EventStatus;
   /** iCal RRULE string, e.g. "FREQ=MONTHLY;INTERVAL=3;COUNT=8" */
@@ -152,6 +158,10 @@ export type {
   EngineResource,
   ResourceBusinessHours,
 } from '../../core/engine/schema/resourceSchema';
+
+// ── Resource pool (issue #212) ───────────────────────────────────────────────
+
+export type { PoolStrategy, ResourcePool } from '../../core/pools/resourcePoolSchema';
 
 // ── Assignment ───────────────────────────────────────────────────────────────
 

--- a/src/core/engine/CalendarEngine.ts
+++ b/src/core/engine/CalendarEngine.ts
@@ -29,6 +29,7 @@ import {
 import type { Assignment }       from './schema/assignmentSchema';
 import type { Dependency }       from './schema/dependencySchema';
 import type { ResourceCalendar } from './schema/resourceCalendarSchema';
+import type { ResourcePool }     from '../pools/resourcePoolSchema';
 import {
   getOccurrencesInRange,
   type GetOccurrencesOptions,
@@ -79,6 +80,9 @@ export function createInitialState(init: CalendarEngineInit = {}): CalendarState
   const calMap = new Map<string, ResourceCalendar>();
   for (const c of init.resourceCalendars ?? []) calMap.set(c.id, c);
 
+  const poolMap = new Map<string, ResourcePool>();
+  for (const p of init.pools ?? []) poolMap.set(p.id, p);
+
   const defaultFilter: FilterState = {
     search: '',
     categories: new Set(),
@@ -98,6 +102,7 @@ export function createInitialState(init: CalendarEngineInit = {}): CalendarState
     assignments:       assignMap,
     dependencies:      depMap,
     resourceCalendars: calMap,
+    pools:             poolMap,
     view:     init.view   ?? 'month',
     cursor:   init.cursor ?? new Date(),
     filter,
@@ -422,6 +427,37 @@ export class CalendarEngine {
     return null;
   }
 
+  // ── Resource pool CRUD (issue #212) ──────────────────────────────────────────
+
+  /** Replace all pools atomically. Notifies subscribers once. */
+  setPools(pools: ReadonlyArray<ResourcePool>): void {
+    const map = new Map<string, ResourcePool>(pools.map(p => [p.id, p]));
+    this._state = { ...this._state, pools: map };
+    this._notify();
+  }
+
+  /** Add or replace a single pool. */
+  upsertPool(pool: ResourcePool): void {
+    const map = new Map(this._state.pools);
+    map.set(pool.id, pool);
+    this._state = { ...this._state, pools: map };
+    this._notify();
+  }
+
+  /** Remove a pool by id. No-op when not found. */
+  removePool(id: string): void {
+    if (!this._state.pools.has(id)) return;
+    const map = new Map(this._state.pools);
+    map.delete(id);
+    this._state = { ...this._state, pools: map };
+    this._notify();
+  }
+
+  /** Return the pool for the given id, or null if not registered. */
+  getPool(id: string): ResourcePool | null {
+    return this._state.pools.get(id) ?? null;
+  }
+
   // ── Transaction helpers ───────────────────────────────────────────────────────
 
   /**
@@ -454,6 +490,7 @@ export class CalendarEngine {
     readonly assignments?:       ReadonlyMap<string, Assignment>;
     readonly dependencies?:      ReadonlyMap<string, Dependency>;
     readonly resourceCalendars?: ReadonlyMap<string, ResourceCalendar>;
+    readonly pools?:             ReadonlyMap<string, ResourcePool>;
   }): void {
     this._state = {
       ...this._state,
@@ -461,6 +498,7 @@ export class CalendarEngine {
       ...(snapshot.assignments       != null && { assignments:       snapshot.assignments }),
       ...(snapshot.dependencies      != null && { dependencies:      snapshot.dependencies }),
       ...(snapshot.resourceCalendars != null && { resourceCalendars: snapshot.resourceCalendars }),
+      ...(snapshot.pools             != null && { pools:             snapshot.pools }),
     };
     if (snapshot.assignments != null) this._rebuildAssignmentIndex();
     this._notify();

--- a/src/core/engine/__tests__/poolsCrud.test.ts
+++ b/src/core/engine/__tests__/poolsCrud.test.ts
@@ -1,0 +1,81 @@
+/**
+ * CalendarEngine — resource pool CRUD (issue #212).
+ *
+ * Pools live in CalendarState alongside assignments/dependencies.
+ * This file pins the surface so the submit-flow resolver and UI can
+ * rely on stable lookup + mutation semantics.
+ */
+import { describe, it, expect } from 'vitest';
+import { CalendarEngine } from '../CalendarEngine';
+import type { ResourcePool } from '../../pools/resourcePoolSchema';
+
+function pool(id: string, patch: Partial<ResourcePool> = {}): ResourcePool {
+  return {
+    id,
+    name: id.toUpperCase(),
+    memberIds: ['m1', 'm2'],
+    strategy: 'first-available',
+    ...patch,
+  };
+}
+
+describe('CalendarEngine — pool CRUD', () => {
+  it('hydrates pools from init', () => {
+    const engine = new CalendarEngine({ pools: [pool('drivers')] });
+    expect(engine.state.pools.size).toBe(1);
+    expect(engine.getPool('drivers')?.name).toBe('DRIVERS');
+  });
+
+  it('setPools replaces the map atomically and notifies once', () => {
+    const engine = new CalendarEngine({ pools: [pool('a')] });
+    let notifications = 0;
+    engine.subscribe(() => { notifications++; });
+    engine.setPools([pool('b'), pool('c')]);
+    expect(notifications).toBe(1);
+    expect(engine.state.pools.size).toBe(2);
+    expect(engine.getPool('a')).toBeNull();
+    expect(engine.getPool('b')?.id).toBe('b');
+  });
+
+  it('upsertPool inserts and updates by id', () => {
+    const engine = new CalendarEngine();
+    engine.upsertPool(pool('rooms', { strategy: 'round-robin' }));
+    expect(engine.getPool('rooms')?.strategy).toBe('round-robin');
+
+    engine.upsertPool(pool('rooms', { strategy: 'least-loaded', rrCursor: 2 }));
+    expect(engine.getPool('rooms')?.strategy).toBe('least-loaded');
+    expect(engine.getPool('rooms')?.rrCursor).toBe(2);
+    expect(engine.state.pools.size).toBe(1);
+  });
+
+  it('removePool deletes an existing pool and is a no-op when missing', () => {
+    const engine = new CalendarEngine({ pools: [pool('a'), pool('b')] });
+    let notifications = 0;
+    engine.subscribe(() => { notifications++; });
+
+    engine.removePool('missing');
+    expect(notifications).toBe(0);
+    expect(engine.state.pools.size).toBe(2);
+
+    engine.removePool('a');
+    expect(notifications).toBe(1);
+    expect(engine.getPool('a')).toBeNull();
+    expect(engine.state.pools.size).toBe(1);
+  });
+
+  it('restoreState accepts a pools snapshot', () => {
+    const engine = new CalendarEngine({ pools: [pool('a')] });
+    const snapshotPools = new Map([['b', pool('b')]]);
+    engine.restoreState({ pools: snapshotPools });
+    expect(engine.state.pools).toBe(snapshotPools);
+    expect(engine.getPool('a')).toBeNull();
+    expect(engine.getPool('b')?.id).toBe('b');
+  });
+
+  it('state.pools is a fresh reference after every mutation (identity check)', () => {
+    const engine = new CalendarEngine({ pools: [pool('a')] });
+    const before = engine.state.pools;
+    engine.upsertPool(pool('b'));
+    expect(engine.state.pools).not.toBe(before);
+  });
+});

--- a/src/core/engine/__tests__/resourcePoolIdPassthrough.test.ts
+++ b/src/core/engine/__tests__/resourcePoolIdPassthrough.test.ts
@@ -1,0 +1,99 @@
+/**
+ * Pool-id passthrough (issue #212) — regression pins for the ingestion
+ * and recurrence paths flagged in code review. Any new call site that
+ * builds an EngineEvent from another event must forward resourcePoolId
+ * or a pool-backed booking silently loses its pool reference.
+ */
+import { describe, it, expect } from 'vitest';
+import { fromLegacyEvent } from '../adapters/fromLegacyEvents';
+import { normalizeInputEvent } from '../adapters/normalizeInputEvent';
+import { detachOccurrence } from '../recurrence/detachOccurrence';
+import { resolveRecurringEdit } from '../recurrence/resolveRecurringEdit';
+import { makeEvent } from '../schema/eventSchema';
+
+function makeMaster(pool: string | null): ReturnType<typeof makeEvent> {
+  return makeEvent('master', {
+    title: 'weekly standup',
+    start: new Date('2026-04-20T09:00:00Z'),
+    end:   new Date('2026-04-20T09:30:00Z'),
+    rrule: 'FREQ=WEEKLY',
+    seriesId: 'master',
+    resourcePoolId: pool,
+  });
+}
+
+describe('resourcePoolId passthrough — ingestion', () => {
+  it('fromLegacyEvent preserves resourcePoolId when present on the payload', () => {
+    const ev = fromLegacyEvent({
+      id: '1',
+      title: 't',
+      start: '2026-04-20T09:00:00Z',
+      end:   '2026-04-20T10:00:00Z',
+      resourcePoolId: 'drivers',
+    });
+    expect(ev.resourcePoolId).toBe('drivers');
+  });
+
+  it('fromLegacyEvent defaults resourcePoolId to null when absent', () => {
+    const ev = fromLegacyEvent({
+      id: '1',
+      title: 't',
+      start: '2026-04-20T09:00:00Z',
+      end:   '2026-04-20T10:00:00Z',
+    });
+    expect(ev.resourcePoolId).toBeNull();
+  });
+
+  it('normalizeInputEvent preserves resourcePoolId when present on the payload', () => {
+    const ev = normalizeInputEvent({
+      id: '1',
+      title: 't',
+      start: '2026-04-20T09:00:00Z',
+      end:   '2026-04-20T10:00:00Z',
+      resourcePoolId: 'rooms',
+    });
+    expect(ev.resourcePoolId).toBe('rooms');
+  });
+});
+
+describe('resourcePoolId passthrough — recurrence builders', () => {
+  const occurrenceStart = new Date('2026-04-27T09:00:00Z');
+
+  it('detachOccurrence inherits the master’s resourcePoolId', () => {
+    const master = makeMaster('drivers');
+    const { detached } = detachOccurrence(master, occurrenceStart);
+    expect(detached.resourcePoolId).toBe('drivers');
+  });
+
+  it('detachOccurrence allows patch override of resourcePoolId', () => {
+    const master = makeMaster('drivers');
+    const { detached } = detachOccurrence(master, occurrenceStart, { resourcePoolId: 'vip-drivers' });
+    expect(detached.resourcePoolId).toBe('vip-drivers');
+  });
+
+  it('resolveRecurringEdit (single) carries resourcePoolId onto the detached record', () => {
+    const master = makeMaster('drivers');
+    const changes = resolveRecurringEdit(master, occurrenceStart, {}, 'single');
+    const created = changes.find(c => c.type === 'created');
+    if (created?.type !== 'created') throw new Error('expected created change');
+    expect(created.event.resourcePoolId).toBe('drivers');
+  });
+
+  it('resolveRecurringEdit (following) carries resourcePoolId onto the new series', () => {
+    const master = makeMaster('drivers');
+    const changes = resolveRecurringEdit(master, occurrenceStart, {}, 'following');
+    const created = changes.find(c => c.type === 'created');
+    if (created?.type !== 'created') throw new Error('expected created change');
+    expect(created.event.resourcePoolId).toBe('drivers');
+  });
+
+  it('resolveRecurringEdit (series) accepts resourcePoolId in the patch', () => {
+    const master = makeMaster('drivers');
+    const changes = resolveRecurringEdit(
+      master, occurrenceStart, { resourcePoolId: 'premium-drivers' }, 'series',
+    );
+    const updated = changes.find(c => c.type === 'updated');
+    if (updated?.type !== 'updated') throw new Error('expected updated change');
+    expect(updated.after.resourcePoolId).toBe('premium-drivers');
+  });
+});

--- a/src/core/engine/adapters/fromLegacyEvents.ts
+++ b/src/core/engine/adapters/fromLegacyEvents.ts
@@ -23,6 +23,8 @@ export interface LegacyEvent {
   color?: string | null;
   /** Old resource field — becomes resourceId in EngineEvent. */
   resource?: string | null;
+  /** Virtual pool ref (#212). Passthrough when present on migrated payloads. */
+  resourcePoolId?: string | null;
   status?: string;
   rrule?: string | null;
   exdates?: Array<Date | string>;
@@ -89,7 +91,7 @@ export function fromLegacyEvent(raw: LegacyEvent): EngineEvent {
     title:         raw.title ?? '(untitled)',
     category:      raw.category ?? null,
     resourceId:    raw.resource ?? null,
-    resourcePoolId: null,
+    resourcePoolId: raw.resourcePoolId ?? null,
     status:        STATUS_MAP[raw.status ?? ''] ?? 'confirmed',
     color:         raw.color ?? null,
     rrule:         hasRrule ? raw.rrule! : null,

--- a/src/core/engine/adapters/fromLegacyEvents.ts
+++ b/src/core/engine/adapters/fromLegacyEvents.ts
@@ -89,6 +89,7 @@ export function fromLegacyEvent(raw: LegacyEvent): EngineEvent {
     title:         raw.title ?? '(untitled)',
     category:      raw.category ?? null,
     resourceId:    raw.resource ?? null,
+    resourcePoolId: null,
     status:        STATUS_MAP[raw.status ?? ''] ?? 'confirmed',
     color:         raw.color ?? null,
     rrule:         hasRrule ? raw.rrule! : null,

--- a/src/core/engine/adapters/normalizeInputEvent.ts
+++ b/src/core/engine/adapters/normalizeInputEvent.ts
@@ -117,6 +117,7 @@ export function normalizeInputEvent(raw: RawInputEvent): EngineEvent {
     resourceId:    raw.resourceId != null ? String(raw.resourceId)
                    : raw.resource != null ? String(raw.resource)   // legacy field
                    : null,
+    resourcePoolId: raw.resourcePoolId != null ? String(raw.resourcePoolId) : null,
     status:        toStatus(raw.status),
     color:         typeof raw.color === 'string' ? raw.color : null,
     rrule:         hasRrule ? String(raw.rrule) : null,

--- a/src/core/engine/operations/applyOperation.ts
+++ b/src/core/engine/operations/applyOperation.ts
@@ -116,6 +116,7 @@ function applyCreate(
     allDay:       raw.allDay       ?? false,
     category:     raw.category     ?? null,
     resourceId:   raw.resourceId   ?? null,
+    resourcePoolId: raw.resourcePoolId ?? null,
     status:       raw.status       ?? 'confirmed',
     color:        raw.color        ?? null,
     rrule:        raw.rrule        ?? null,

--- a/src/core/engine/recurrence/detachOccurrence.ts
+++ b/src/core/engine/recurrence/detachOccurrence.ts
@@ -56,6 +56,7 @@ export function detachOccurrence(
     allDay:     master.allDay,
     category:   master.category,
     resourceId: master.resourceId,
+    resourcePoolId: master.resourcePoolId,
     status:     master.status,
     color:      master.color,
     meta:       master.meta,

--- a/src/core/engine/recurrence/resolveRecurringEdit.ts
+++ b/src/core/engine/recurrence/resolveRecurringEdit.ts
@@ -24,6 +24,7 @@ export interface RecurringEditPatch {
   readonly title?: string;
   readonly category?: string | null;
   readonly resourceId?: string | null;
+  readonly resourcePoolId?: string | null;
   readonly color?: string | null;
   readonly status?: EngineEvent['status'];
   [key: string]: unknown;
@@ -84,6 +85,7 @@ function resolveSingleEdit(
     allDay:       master.allDay,
     category:     patch.category    ?? master.category,
     resourceId:   patch.resourceId  ?? master.resourceId,
+    resourcePoolId: patch.resourcePoolId ?? master.resourcePoolId,
     status:       patch.status      ?? master.status,
     color:        patch.color       ?? master.color,
     rrule:        null,
@@ -131,6 +133,7 @@ function resolveFollowingEdit(
     allDay:     master.allDay,
     category:   patch.category   ?? master.category,
     resourceId: patch.resourceId ?? master.resourceId,
+    resourcePoolId: patch.resourcePoolId ?? master.resourcePoolId,
     status:     patch.status     ?? master.status,
     color:      patch.color      ?? master.color,
     rrule:      master.rrule,   // same rule, new start anchor
@@ -209,8 +212,9 @@ function resolveSeriesEdit(
     ...master,
     ...(patch.title      !== undefined && { title:      patch.title }),
     ...(patch.category   !== undefined && { category:   patch.category }),
-    ...(patch.resourceId !== undefined && { resourceId: patch.resourceId }),
-    ...(patch.color      !== undefined && { color:      patch.color }),
+    ...(patch.resourceId     !== undefined && { resourceId:     patch.resourceId }),
+    ...(patch.resourcePoolId !== undefined && { resourcePoolId: patch.resourcePoolId }),
+    ...(patch.color          !== undefined && { color:          patch.color }),
     ...(patch.status     !== undefined && { status:     patch.status }),
     // For series edits, time changes adjust the master start/end
     // (keeping duration) which shifts all unexpanded occurrences.

--- a/src/core/engine/schema/eventSchema.ts
+++ b/src/core/engine/schema/eventSchema.ts
@@ -61,6 +61,13 @@ export interface EngineEvent {
   readonly title: string;
   readonly category: string | null;
   readonly resourceId: string | null;
+  /**
+   * Virtual-pool reference (issue #212). When set and `resourceId` is null,
+   * the engine resolves a concrete member at submit time and rewrites
+   * `resourceId` on the stored record. Retained on `meta.resolvedFromPoolId`
+   * for audit once resolved.
+   */
+  readonly resourcePoolId: string | null;
   readonly status: EventStatus;
   readonly color: string | null;
 
@@ -126,6 +133,7 @@ export function makeEvent(
     allDay:      false,
     category:    null,
     resourceId:  null,
+    resourcePoolId: null,
     status:      'confirmed',
     color:       null,
     rrule:       null,

--- a/src/core/engine/schema/resourcePoolSchema.ts
+++ b/src/core/engine/schema/resourcePoolSchema.ts
@@ -1,0 +1,11 @@
+/**
+ * Resource pool schema — re-export shim (issue #212).
+ *
+ * The canonical implementation lives at `src/core/pools/resourcePoolSchema.ts`
+ * alongside the resolver (which depends on `conflictEngine`). This file
+ * exists so the issue's documented import path
+ * (`src/core/engine/schema/resourcePoolSchema.ts`) resolves without moving
+ * the resolver into the schema tree.
+ */
+
+export type { PoolStrategy, ResourcePool } from '../../pools/resourcePoolSchema';

--- a/src/core/engine/types.ts
+++ b/src/core/engine/types.ts
@@ -57,6 +57,8 @@ export interface CalendarState {
   readonly dependencies:     ReadonlyMap<string, import('./schema/dependencySchema.js').Dependency>;
   /** Per-resource working-time exception calendars. */
   readonly resourceCalendars: ReadonlyMap<string, import('./schema/resourceCalendarSchema.js').ResourceCalendar>;
+  /** Virtual resource pools (#212). Resolved to concrete members at submit time. */
+  readonly pools: ReadonlyMap<string, import('../pools/resourcePoolSchema.js').ResourcePool>;
   readonly view:    CalendarView;
   /** The "anchor" date — used to compute the visible range for the current view. */
   readonly cursor:  Date;
@@ -128,6 +130,7 @@ export interface CalendarEngineInit {
   readonly assignments?:       ReadonlyArray<import('./schema/assignmentSchema.js').Assignment>;
   readonly dependencies?:      ReadonlyArray<import('./schema/dependencySchema.js').Dependency>;
   readonly resourceCalendars?: ReadonlyArray<import('./schema/resourceCalendarSchema.js').ResourceCalendar>;
+  readonly pools?:             ReadonlyArray<import('../pools/resourcePoolSchema.js').ResourcePool>;
   readonly view?:   CalendarView;
   /** Defaults to today. */
   readonly cursor?: Date;


### PR DESCRIPTION
Thread the new optional `resourcePoolId` field through EngineEvent, the v1 public API (CalendarEventV1, SerializedEvent, converters), and every normalize/legacy adapter so pool-referencing events round-trip cleanly. Add a re-export shim at the schema path the issue specifies (src/core/engine/schema/resourcePoolSchema.ts) pointing to the canonical file under src/core/pools/.

No resolver wiring yet — step 1 of the pools plan.