### PR TITLE
feat(#212): resolve resourcePoolId on submit

### DIFF
--- a/src/core/engine/CalendarEngine.ts
+++ b/src/core/engine/CalendarEngine.ts
@@ -48,6 +48,7 @@ import type { OperationResult, EventChange } from './operations/operationResult'
 import type { EngineOperation } from './schema/operationSchema';
 import type { EngineOccurrence } from './schema/occurrenceSchema';
 import type { OperationContext } from './validation/validationTypes';
+import { resolvePoolForOp } from './resolvePoolOnSubmit';
 import type {
   CalendarState,
   CalendarEngineInit,
@@ -180,6 +181,19 @@ export class CalendarEngine {
     ctx: OperationContext = {},
     opts: ApplyOptions = {},
   ): OperationResult {
+    // Pool resolve (#212): a create op with resourcePoolId is rewritten to
+    // target a concrete member before validation. Unresolvable pools surface
+    // as hard violations; the round-robin cursor advance comes back as a
+    // pool-update that we persist atomically with the booking commit.
+    const resolved = resolvePoolForOp(op, {
+      events:      this._state.events,
+      pools:       this._state.pools,
+      assignments: ctx.assignments ?? this._state.assignments,
+    });
+    if (resolved.kind === 'rejected') return resolved.result;
+    const effectiveOp = resolved.kind === 'rewritten' ? resolved.op : op;
+    const poolUpdate  = resolved.kind === 'rewritten' ? resolved.poolUpdate : undefined;
+
     // Merge engine-owned structural state into the validation context so rules
     // like dependency and overlap checking see the full picture.
     const enrichedCtx: OperationContext = {
@@ -188,15 +202,22 @@ export class CalendarEngine {
       resourceCalendars: ctx.resourceCalendars ?? this._state.resourceCalendars,
       ...ctx,
     };
-    const result = applyMutationOp(op, this._state.events, enrichedCtx, opts);
+    const result = applyMutationOp(effectiveOp, this._state.events, enrichedCtx, opts);
 
     if (result.status === 'accepted' || result.status === 'accepted-with-warnings') {
-      // Commit changes to state
+      // Commit event changes and (if a pool was resolved with cursor advance)
+      // the pool update in a single state swap — one _notify per mutation.
       const tx = beginTransaction(this._state.events);
       const commit = commitTransaction(tx, this._state.events, result.changes);
-      this._state = { ...this._state, events: commit.events };
+      let pools = this._state.pools;
+      if (poolUpdate) {
+        const map = new Map(pools);
+        map.set(poolUpdate.id, poolUpdate);
+        pools = map;
+      }
+      this._state = { ...this._state, events: commit.events, pools };
       this._notify();
-      this._emitBookingLifecycle(result.changes, op, ctx);
+      this._emitBookingLifecycle(result.changes, effectiveOp, ctx);
     }
 
     return result;

--- a/src/core/engine/CalendarEngine.ts
+++ b/src/core/engine/CalendarEngine.ts
@@ -486,13 +486,17 @@ export class CalendarEngine {
    * Use rollbackTo(handle) to restore this snapshot.
    */
   snapshot(label?: string): TransactionHandle {
-    return beginTransaction(this._state.events, label);
+    return beginTransaction(this._state.events, { pools: this._state.pools, label });
   }
 
   /** Restore state to a previous snapshot. Notifies subscribers. */
   rollbackTo(handle: TransactionHandle): void {
     const restored = rollbackTransaction(handle);
-    this._state = { ...this._state, events: restored };
+    this._state = {
+      ...this._state,
+      events: restored.events,
+      ...(restored.pools ? { pools: restored.pools } : {}),
+    };
     this._notify();
   }
 

--- a/src/core/engine/UndoRedoManager.ts
+++ b/src/core/engine/UndoRedoManager.ts
@@ -23,6 +23,7 @@ import type { EngineEvent }    from './schema/eventSchema';
 import type { Assignment }     from './schema/assignmentSchema';
 import type { Dependency }     from './schema/dependencySchema';
 import type { ResourceCalendar } from './schema/resourceCalendarSchema';
+import type { ResourcePool }   from '../pools/resourcePoolSchema';
 
 // ─── Snapshot type ────────────────────────────────────────────────────────────
 
@@ -32,6 +33,13 @@ export interface EngineSnapshot {
   readonly assignments:       ReadonlyMap<string, Assignment>;
   readonly dependencies:      ReadonlyMap<string, Dependency>;
   readonly resourceCalendars: ReadonlyMap<string, ResourceCalendar>;
+  /**
+   * Resource pools (#212). Included so undo of a pool-resolved booking
+   * also reverts any round-robin cursor advance — otherwise the pool
+   * drifts and the next booking skips the member the undone booking
+   * was assigned to.
+   */
+  readonly pools:             ReadonlyMap<string, ResourcePool>;
 }
 
 export interface HistoryEntry {
@@ -153,6 +161,7 @@ export class UndoRedoManager {
       assignments:       new Map(s.assignments),
       dependencies:      new Map(s.dependencies),
       resourceCalendars: new Map(s.resourceCalendars),
+      pools:             new Map(s.pools),
     };
   }
 

--- a/src/core/engine/__tests__/resolvePoolOnSubmit.test.ts
+++ b/src/core/engine/__tests__/resolvePoolOnSubmit.test.ts
@@ -1,0 +1,159 @@
+/**
+ * Pool resolve on submit (issue #212) — end-to-end through
+ * CalendarEngine.applyMutation.
+ *
+ * Pins the behavior stated in the issue:
+ *   - Event with resourcePoolId resolves to a concrete resourceId on
+ *     the saved event.
+ *   - meta.resolvedFromPoolId retained for audit.
+ *   - Round-robin cursor advances and is visible on engine.getPool()
+ *     in the same mutation (one _notify, atomic with the commit).
+ *   - Exhausted / unknown pools surface a hard violation and do not
+ *     mutate state.
+ */
+import { describe, it, expect } from 'vitest';
+import { CalendarEngine } from '../CalendarEngine';
+import type { ResourcePool } from '../../pools/resourcePoolSchema';
+import type { EngineOperation } from '../schema/operationSchema';
+import { makeEvent } from '../schema/eventSchema';
+
+const START = new Date('2026-04-20T09:00:00Z');
+const END   = new Date('2026-04-20T10:00:00Z');
+
+function createOp(patch: Partial<Parameters<typeof makeEvent>[1]> = {}): EngineOperation {
+  return {
+    type:   'create',
+    event: {
+      title: 'booking',
+      start: START,
+      end:   END,
+      ...patch,
+    },
+    source: 'api',
+  };
+}
+
+function pool(patch: Partial<ResourcePool> & Pick<ResourcePool, 'id' | 'memberIds'>): ResourcePool {
+  return {
+    name:     patch.id.toUpperCase(),
+    strategy: 'first-available',
+    ...patch,
+  };
+}
+
+describe('applyMutation — pool resolve on submit', () => {
+  it('rewrites a create op to a concrete member and stashes the pool id', () => {
+    const engine = new CalendarEngine({
+      pools: [pool({ id: 'drivers', memberIds: ['d1', 'd2'] })],
+    });
+
+    const result = engine.applyMutation(createOp({ resourcePoolId: 'drivers' }));
+    expect(result.status).toBe('accepted');
+
+    const saved = Array.from(engine.state.events.values())[0];
+    expect(saved.resourceId).toBe('d1');
+    expect(saved.resourcePoolId).toBeNull();
+    expect(saved.meta.resolvedFromPoolId).toBe('drivers');
+    expect(saved.meta.poolEvaluated).toEqual(['d1']);
+  });
+
+  it('skips members in hard conflict and picks the next available', () => {
+    const engine = new CalendarEngine({
+      events: [makeEvent('blocker', {
+        title: 'blocker', start: START, end: END, resourceId: 'd1',
+      })],
+      pools:  [pool({ id: 'drivers', memberIds: ['d1', 'd2'] })],
+    });
+
+    const result = engine.applyMutation(createOp({ resourcePoolId: 'drivers' }));
+    expect(result.status).toBe('accepted');
+
+    const saved = Array.from(engine.state.events.values()).find(e => e.id !== 'blocker')!;
+    expect(saved.resourceId).toBe('d2');
+    expect(saved.meta.poolEvaluated).toEqual(['d1', 'd2']);
+  });
+
+  it('advances the round-robin cursor and persists it in state', () => {
+    const engine = new CalendarEngine({
+      pools: [pool({ id: 'agents', memberIds: ['a', 'b', 'c'], strategy: 'round-robin' })],
+    });
+
+    const r1 = engine.applyMutation(createOp({ resourcePoolId: 'agents' }));
+    expect(r1.status).toBe('accepted');
+    expect(engine.getPool('agents')?.rrCursor).toBe(0);
+
+    const r2 = engine.applyMutation(createOp({
+      resourcePoolId: 'agents',
+      start: new Date('2026-04-21T09:00:00Z'),
+      end:   new Date('2026-04-21T10:00:00Z'),
+    }));
+    expect(r2.status).toBe('accepted');
+    expect(engine.getPool('agents')?.rrCursor).toBe(1);
+
+    const picked = Array.from(engine.state.events.values()).map(e => e.resourceId);
+    expect(picked.sort()).toEqual(['a', 'b']);
+  });
+
+  it('rejects with a hard violation when every member is in conflict', () => {
+    const engine = new CalendarEngine({
+      events: [
+        makeEvent('b1', { title: 'x', start: START, end: END, resourceId: 'd1' }),
+        makeEvent('b2', { title: 'y', start: START, end: END, resourceId: 'd2' }),
+      ],
+      pools:  [pool({ id: 'drivers', memberIds: ['d1', 'd2'] })],
+    });
+
+    const before = engine.state.events;
+    const result = engine.applyMutation(createOp({ resourcePoolId: 'drivers' }));
+
+    expect(result.status).toBe('rejected');
+    expect(result.validation.severity).toBe('hard');
+    expect(result.validation.violations[0]?.rule).toBe('pool-unresolvable');
+    expect(result.validation.violations[0]?.details?.code).toBe('NO_AVAILABLE_MEMBER');
+    expect(engine.state.events).toBe(before); // state unchanged
+  });
+
+  it('rejects when the pool id is unknown', () => {
+    const engine = new CalendarEngine();
+    const result = engine.applyMutation(createOp({ resourcePoolId: 'ghost' }));
+    expect(result.status).toBe('rejected');
+    expect(result.validation.violations[0]?.rule).toBe('pool-unresolvable');
+    expect(result.validation.violations[0]?.details?.code).toBe('POOL_UNKNOWN');
+  });
+
+  it('leaves a concrete resourceId alone when both resourceId and resourcePoolId are set', () => {
+    // Defensive: concrete wins. Pool is ignored and state does not advance.
+    const engine = new CalendarEngine({
+      pools: [pool({ id: 'agents', memberIds: ['a', 'b'], strategy: 'round-robin' })],
+    });
+
+    const result = engine.applyMutation(createOp({
+      resourceId:     'preset',
+      resourcePoolId: 'agents',
+    }));
+    expect(result.status).toBe('accepted');
+    const saved = Array.from(engine.state.events.values())[0];
+    expect(saved.resourceId).toBe('preset');
+    expect(engine.getPool('agents')?.rrCursor).toBeUndefined();
+  });
+
+  it('passes through non-pool create ops unchanged', () => {
+    const engine = new CalendarEngine();
+    const result = engine.applyMutation(createOp({ resourceId: 'r1' }));
+    expect(result.status).toBe('accepted');
+    const saved = Array.from(engine.state.events.values())[0];
+    expect(saved.resourceId).toBe('r1');
+    expect(saved.meta.resolvedFromPoolId).toBeUndefined();
+  });
+
+  it('fires a single notify per mutation (event + pool commit are atomic)', () => {
+    const engine = new CalendarEngine({
+      pools: [pool({ id: 'agents', memberIds: ['a', 'b'], strategy: 'round-robin' })],
+    });
+    let notifications = 0;
+    engine.subscribe(() => { notifications++; });
+
+    engine.applyMutation(createOp({ resourcePoolId: 'agents' }));
+    expect(notifications).toBe(1);
+  });
+});

--- a/src/core/engine/__tests__/resolvePoolOnSubmit.test.ts
+++ b/src/core/engine/__tests__/resolvePoolOnSubmit.test.ts
@@ -13,9 +13,11 @@
  */
 import { describe, it, expect } from 'vitest';
 import { CalendarEngine } from '../CalendarEngine';
+import { UndoRedoManager } from '../UndoRedoManager';
 import type { ResourcePool } from '../../pools/resourcePoolSchema';
 import type { EngineOperation } from '../schema/operationSchema';
 import { makeEvent } from '../schema/eventSchema';
+import { makeAssignment } from '../schema/assignmentSchema';
 
 const START = new Date('2026-04-20T09:00:00Z');
 const END   = new Date('2026-04-20T10:00:00Z');
@@ -155,5 +157,61 @@ describe('applyMutation — pool resolve on submit', () => {
 
     engine.applyMutation(createOp({ resourcePoolId: 'agents' }));
     expect(notifications).toBe(1);
+  });
+
+  it('treats assignment-backed occupancy as a pool-member conflict', () => {
+    // d1 is not on the raw event (resourceId=null) but is assigned via an
+    // Assignment record — the resolver must still skip it.
+    const engine = new CalendarEngine({
+      events: [makeEvent('blocker', {
+        title: 'blocker', start: START, end: END, resourceId: null,
+      })],
+      assignments: [makeAssignment('a1', { eventId: 'blocker', resourceId: 'd1' })],
+      pools:       [pool({ id: 'drivers', memberIds: ['d1', 'd2'] })],
+    });
+
+    const result = engine.applyMutation(createOp({ resourcePoolId: 'drivers' }));
+    expect(result.status).toBe('accepted');
+
+    const saved = Array.from(engine.state.events.values()).find(e => e.id !== 'blocker')!;
+    expect(saved.resourceId).toBe('d2');
+    expect(saved.meta.poolEvaluated).toEqual(['d1', 'd2']);
+  });
+
+  it('undo reverts the round-robin cursor alongside the event', () => {
+    const engine  = new CalendarEngine({
+      pools: [pool({ id: 'agents', memberIds: ['a', 'b', 'c'], strategy: 'round-robin' })],
+    });
+    const manager = new UndoRedoManager(engine);
+
+    manager.push('book-1');
+    engine.applyMutation(createOp({ resourcePoolId: 'agents' }));
+    expect(engine.getPool('agents')?.rrCursor).toBe(0);
+
+    manager.undo();
+    expect(engine.state.events.size).toBe(0);
+    // Without pool-snapshot plumbing the cursor would stay at 0 and the
+    // next booking would skip 'a' — pin that it truly rewinds.
+    expect(engine.getPool('agents')?.rrCursor).toBeUndefined();
+
+    const retry = engine.applyMutation(createOp({ resourcePoolId: 'agents' }));
+    expect(retry.status).toBe('accepted');
+    const savedAfter = Array.from(engine.state.events.values())[0];
+    expect(savedAfter.resourceId).toBe('a');
+    expect(engine.getPool('agents')?.rrCursor).toBe(0);
+  });
+
+  it('rollbackTo(snapshot) restores pool cursor state', () => {
+    const engine = new CalendarEngine({
+      pools: [pool({ id: 'agents', memberIds: ['a', 'b'], strategy: 'round-robin' })],
+    });
+
+    const handle = engine.snapshot('pre-book');
+    engine.applyMutation(createOp({ resourcePoolId: 'agents' }));
+    expect(engine.getPool('agents')?.rrCursor).toBe(0);
+
+    engine.rollbackTo(handle);
+    expect(engine.state.events.size).toBe(0);
+    expect(engine.getPool('agents')?.rrCursor).toBeUndefined();
   });
 });

--- a/src/core/engine/resolvePoolOnSubmit.ts
+++ b/src/core/engine/resolvePoolOnSubmit.ts
@@ -1,0 +1,161 @@
+/**
+ * Resolve-on-submit for resource pools (issue #212).
+ *
+ * When an engine operation references a `ResourcePool` via
+ * `event.resourcePoolId`, the concrete resource is picked here — before
+ * validation — so the rest of the pipeline (overlap, dependencies,
+ * lifecycle emit) sees a plain single-resource booking.
+ *
+ * Scope in this revision: `create` ops only. `update` / `group-change`
+ * can set `resourcePoolId` too, but those paths are deferred until the
+ * primary booking flow lands — matching the issue's "booking against a
+ * pool in the Assets view resolves to a concrete resource in the saved
+ * event" acceptance criterion.
+ *
+ * This module stays pure: no state mutation. The caller (engine) is
+ * responsible for persisting any returned pool-cursor advance.
+ */
+import type { EngineOperation } from './schema/operationSchema';
+import type { EngineResource } from './schema/resourceSchema';
+import type { Assignment } from './schema/assignmentSchema';
+import type { ResourcePool } from '../pools/resourcePoolSchema';
+import type { ConflictEvent, ConflictRule } from '../conflictEngine';
+import type { Violation } from './validation/validationTypes';
+import type { OperationResult } from './operations/operationResult';
+import { resolvePool } from '../pools/resolvePool';
+
+// ─── Default rule set ────────────────────────────────────────────────────────
+
+/**
+ * The resolver disqualifies a pool member when it would collide on a
+ * hard rule. We always include resource-overlap as hard — a pool should
+ * never hand out a member that would reject the booking anyway.
+ */
+const DEFAULT_HARD_OVERLAP: ConflictRule = {
+  id: '__pool-overlap',
+  type: 'resource-overlap',
+  severity: 'hard',
+};
+
+// ─── Types ───────────────────────────────────────────────────────────────────
+
+export interface PoolResolveContext {
+  readonly events: ReadonlyMap<string, import('./schema/eventSchema').EngineEvent>;
+  readonly pools: ReadonlyMap<string, ResourcePool>;
+  readonly assignments?: ReadonlyMap<string, Assignment>;
+  readonly resources?: ReadonlyMap<string, EngineResource>;
+  /**
+   * Extra rules the resolver must satisfy. Host wiring can add
+   * min-rest, category-mutex, etc. Resource-overlap is always included
+   * as a hard rule so the resolver never returns a member the main
+   * validator would reject.
+   */
+  readonly rules?: readonly ConflictRule[];
+}
+
+export type PoolResolveOutcome =
+  | { readonly kind: 'passthrough' }                           // no pool on op
+  | { readonly kind: 'rewritten'; readonly op: EngineOperation; readonly poolUpdate?: ResourcePool }
+  | { readonly kind: 'rejected';  readonly result: OperationResult };
+
+// ─── Public API ──────────────────────────────────────────────────────────────
+
+export function resolvePoolForOp(
+  op: EngineOperation,
+  ctx: PoolResolveContext,
+): PoolResolveOutcome {
+  if (op.type !== 'create') return { kind: 'passthrough' };
+
+  const raw = op.event;
+  const poolId = raw.resourcePoolId ?? null;
+  if (!poolId)           return { kind: 'passthrough' };
+  if (raw.resourceId)    return { kind: 'passthrough' };   // concrete wins
+
+  const pool = ctx.pools.get(poolId);
+  if (!pool) {
+    return { kind: 'rejected', result: rejectedFor(op, {
+      rule:    'pool-unresolvable',
+      severity:'hard',
+      message: `Pool "${poolId}" is not registered.`,
+      details: { poolId, code: 'POOL_UNKNOWN' },
+    }) };
+  }
+
+  const proposed: Omit<ConflictEvent, 'resource'> = {
+    id:       '__proposed__',
+    start:    raw.start,
+    end:      raw.end,
+    category: raw.category ?? null,
+  };
+
+  const events: ConflictEvent[] = [];
+  for (const ev of ctx.events.values()) {
+    events.push({
+      id:       ev.id,
+      start:    ev.start,
+      end:      ev.end,
+      resource: ev.resourceId,
+      category: ev.category,
+    });
+  }
+
+  const rules = [DEFAULT_HARD_OVERLAP, ...(ctx.rules ?? [])];
+  const result = resolvePool({
+    pool, proposed, events, rules,
+    ...(ctx.assignments && { assignments: ctx.assignments }),
+    ...(ctx.resources   && { resources:   ctx.resources }),
+  });
+
+  if (result.ok === false) {
+    const err = result.error;
+    return { kind: 'rejected', result: rejectedFor(op, {
+      rule:    'pool-unresolvable',
+      severity:'hard',
+      message: err.message,
+      details: {
+        poolId:    err.poolId,
+        code:      err.code,
+        evaluated: pool.memberIds,
+      },
+    }) };
+  }
+
+  const prevMeta = (raw.meta ?? {}) as Record<string, unknown>;
+  const rewrittenEvent: typeof raw = {
+    ...raw,
+    resourceId:     result.resourceId,
+    resourcePoolId: null,
+    meta: {
+      ...prevMeta,
+      resolvedFromPoolId: poolId,
+      poolEvaluated:      result.evaluated,
+    },
+  };
+
+  const rewrittenOp: EngineOperation = { ...op, event: rewrittenEvent };
+
+  const outcome: PoolResolveOutcome = {
+    kind: 'rewritten',
+    op:   rewrittenOp,
+    ...(result.rrCursor !== undefined
+      ? { poolUpdate: { ...pool, rrCursor: result.rrCursor } }
+      : {}),
+  };
+  return outcome;
+}
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function rejectedFor(op: EngineOperation, violation: Violation): OperationResult {
+  return {
+    status:    'rejected',
+    operation: op,
+    validation: {
+      allowed:    false,
+      severity:   'hard',
+      violations: [violation],
+      suggestedPatch: null,
+    },
+    changes: [],
+  };
+}

--- a/src/core/engine/resolvePoolOnSubmit.ts
+++ b/src/core/engine/resolvePoolOnSubmit.ts
@@ -18,6 +18,7 @@
 import type { EngineOperation } from './schema/operationSchema';
 import type { EngineResource } from './schema/resourceSchema';
 import type { Assignment } from './schema/assignmentSchema';
+import { assignmentsForEvent } from './schema/assignmentSchema';
 import type { ResourcePool } from '../pools/resourcePoolSchema';
 import type { ConflictEvent, ConflictRule } from '../conflictEngine';
 import type { Violation } from './validation/validationTypes';
@@ -90,13 +91,26 @@ export function resolvePoolForOp(
 
   const events: ConflictEvent[] = [];
   for (const ev of ctx.events.values()) {
-    events.push({
-      id:       ev.id,
-      start:    ev.start,
-      end:      ev.end,
-      resource: ev.resourceId,
-      category: ev.category,
-    });
+    // Assignment-backed occupancy: an event may have resourceId=null but
+    // hold one or more resources via Assignment records. Emit one
+    // ConflictEvent per effective resource so the resolver's conflict
+    // check matches what the assignment-aware overlap validator will do
+    // downstream.
+    const assigned = ctx.assignments
+      ? assignmentsForEvent(ctx.assignments, ev.id).map(a => a.resourceId)
+      : [];
+    const resources = assigned.length > 0
+      ? assigned
+      : [ev.resourceId];
+    for (const resource of resources) {
+      events.push({
+        id:       ev.id,
+        start:    ev.start,
+        end:      ev.end,
+        resource,
+        category: ev.category,
+      });
+    }
   }
 
   const rules = [DEFAULT_HARD_OVERLAP, ...(ctx.rules ?? [])];

--- a/src/core/engine/transactions/beginTransaction.ts
+++ b/src/core/engine/transactions/beginTransaction.ts
@@ -12,12 +12,20 @@
  */
 
 import type { EngineEvent } from '../schema/eventSchema';
+import type { ResourcePool } from '../../pools/resourcePoolSchema';
 
 // ─── Transaction handle ───────────────────────────────────────────────────────
 
 export interface TransactionHandle {
   /** Snapshot of the events map at the time the transaction began. */
   readonly snapshot: ReadonlyMap<string, EngineEvent>;
+  /**
+   * Snapshot of the pools map (#212). Included so rollback reverts any
+   * round-robin cursor advance produced by a mutation — without this,
+   * a rolled-back booking would still leave the pool skipped forward.
+   * Absent on handles built by callers that predate pool support.
+   */
+  readonly poolsSnapshot?: ReadonlyMap<string, ResourcePool>;
   /** ISO timestamp when the transaction was opened. */
   readonly openedAt: string;
   /** Optional label for debugging. */
@@ -27,18 +35,24 @@ export interface TransactionHandle {
 // ─── Public API ───────────────────────────────────────────────────────────────
 
 /**
- * Create a transaction handle from the current events map.
+ * Create a transaction handle from the current events map (and pools).
  *
  * @param events  The current events map to snapshot
- * @param label   Optional human-readable label for debugging
+ * @param labelOrPools  Either the legacy label (string) or an options object
+ *                      with pools + label. Overloaded to keep the 2-arg
+ *                      callsites compiling without a sweep.
  */
 export function beginTransaction(
   events: ReadonlyMap<string, EngineEvent>,
-  label?: string,
+  labelOrPools?: string | { pools?: ReadonlyMap<string, ResourcePool>; label?: string },
 ): TransactionHandle {
+  const opts = typeof labelOrPools === 'string'
+    ? { label: labelOrPools }
+    : labelOrPools ?? {};
   return {
     snapshot:  new Map(events),
+    ...(opts.pools ? { poolsSnapshot: new Map(opts.pools) } : {}),
     openedAt:  new Date().toISOString(),
-    label,
+    ...(opts.label !== undefined ? { label: opts.label } : {}),
   };
 }

--- a/src/core/engine/transactions/rollbackTransaction.ts
+++ b/src/core/engine/transactions/rollbackTransaction.ts
@@ -1,23 +1,35 @@
 /**
  * CalendarEngine — rollback a transaction.
  *
- * Restores the events map to the snapshot captured by beginTransaction.
- * Pure function — returns the snapshot map directly.
+ * Restores the events map (and, when the handle carries one, the pools
+ * map) to the snapshot captured by beginTransaction.
+ * Pure function — returns fresh copies of the snapshotted maps.
  */
 
 import type { EngineEvent } from '../schema/eventSchema';
+import type { ResourcePool } from '../../pools/resourcePoolSchema';
 import type { TransactionHandle } from './beginTransaction';
+
+export interface RollbackResult {
+  readonly events: ReadonlyMap<string, EngineEvent>;
+  /**
+   * Only present when the handle was opened with a pools snapshot
+   * (#212). Callers that predate pool support will receive undefined
+   * here and should leave their pools map untouched.
+   */
+  readonly pools?: ReadonlyMap<string, ResourcePool>;
+}
 
 /**
  * Discard any changes made since the transaction was opened and return
- * the snapshotted events map.
+ * the snapshotted maps.
  *
  * @param tx  The transaction handle returned by beginTransaction
- * @returns   The original events map (a copy of the snapshot)
+ * @returns   The original maps (fresh copies)
  */
-export function rollbackTransaction(
-  tx: TransactionHandle,
-): ReadonlyMap<string, EngineEvent> {
-  // Return a fresh copy so the caller gets an immutable view
-  return new Map(tx.snapshot);
+export function rollbackTransaction(tx: TransactionHandle): RollbackResult {
+  return {
+    events: new Map(tx.snapshot),
+    ...(tx.poolsSnapshot ? { pools: new Map(tx.poolsSnapshot) } : {}),
+  };
 }


### PR DESCRIPTION
When a create op references a ResourcePool via event.resourcePoolId, CalendarEngine.applyMutation now resolves it to a concrete member before validation, rewriting the op with the winning resourceId and stashing the pool id on meta.resolvedFromPoolId for audit. Overlap / dependency / lifecycle rules downstream see a plain single-resource booking.

Exhausted or unknown pools surface as rejected OperationResults with a hard 'pool-unresolvable' violation and leave state untouched. For round-robin pools, the advanced cursor is committed to state.pools in the same state swap as the event commit — one _notify, atomic.

Scope: create ops only. update / group-change with resourcePoolId are deferred until the primary booking flow lands, matching the issue's acceptance criterion ("booking against a pool resolves to a concrete resource in the saved event").

Adds resolvePoolOnSubmit.test.ts with 8 cases covering the resolve, conflict-skip, rr-persistence, exhausted/unknown rejection, passthrough, concrete-wins, and single-notify invariants.