### PR TITLE
feat(#212): persist resource pools across page reloads

### DIFF
--- a/demo/App.tsx
+++ b/demo/App.tsx
@@ -10,6 +10,7 @@ import {
 import { THEMES } from '../src/styles/themes';
 import { saveProfiles } from '../src/core/profileStore';
 import { loadConfig, saveConfig, DEFAULT_CONFIG } from '../src/core/configSchema';
+import { loadPools, savePools } from '../src/core/pools/poolStore';
 
 /* ─── Demo profiles ─────────────────────────────────────────────── */
 const DEMO_CALENDAR_ID = 'ihc-oncall-demo';
@@ -222,6 +223,21 @@ const FLEET_EVENTS = [
   { id: 'f12', title: 'SIM session',          start: d(11, 9),  end: dEnd(11, 9, 4), category: 'training',    resource: 'N505CD', meta: { sublabel: 'Phenom 300',    region: 'West' } },
 ];
 
+/* ─── Resource pools (#212) ─────────────────────────────────────── */
+// Demo pools group aircraft by region. Bookings that target a pool id
+// (via event.resourcePoolId) resolve to a concrete tail number at
+// submit time; the round-robin cursor persists in localStorage so a
+// refresh doesn't reset the rotation.
+const DEMO_POOLS_DEFAULT = [
+  { id: 'fleet-west',    name: 'West Fleet',    memberIds: ['N121AB', 'N505CD'],          strategy: 'round-robin'    },
+  { id: 'fleet-central', name: 'Central Fleet', memberIds: ['N88QR',  'N733XY'],          strategy: 'round-robin'    },
+  { id: 'fleet-east',    name: 'East Fleet',    memberIds: ['N901JT', 'N245LM'],          strategy: 'first-available' },
+];
+// Seed once — on subsequent loads we read the persisted pools so a
+// cursor advance from the previous session survives the reload.
+const _storedPools = loadPools(DEMO_CALENDAR_ID);
+if (_storedPools.length === 0) savePools(DEMO_CALENDAR_ID, DEMO_POOLS_DEFAULT);
+
 // Unified category palette — engineering ops + fleet ops. The calendar
 // uses a single category set across views; each event references whichever
 // category suits it (on-call / Incident / Deploy for people, training /
@@ -418,6 +434,18 @@ function App() {
   const [employees,    setEmployees]    = useState(INITIAL_EMPLOYEES);
   const [eventLog,     setEventLog]     = useState([]);
   const [needsRefresh, setNeedsRefresh] = useState(false);
+  // Resource pools (#212). Hydrated from localStorage so the round-robin
+  // cursor persists across reloads. WorksCalendar calls onPoolsChange
+  // after each cursor advance; we push that back to storage and state so
+  // the next mutation (or reload) sees the updated cursor.
+  const [pools, setPools] = useState(() => {
+    const persisted = loadPools(DEMO_CALENDAR_ID);
+    return persisted.length > 0 ? persisted : DEMO_POOLS_DEFAULT;
+  });
+  const handlePoolsChange = useCallback((next) => {
+    setPools(next);
+    savePools(DEMO_CALENDAR_ID, next);
+  }, []);
 
   const assetLocationProvider = useMemo(
     () => createManualLocationProvider({ resources: AIRCRAFT_RESOURCES }),
@@ -528,6 +556,8 @@ function App() {
             events={events}
             employees={employees}
             assets={AIRCRAFT_RESOURCES}
+            pools={pools}
+            onPoolsChange={handlePoolsChange}
             strictAssetFiltering={true}
             assetRequestCategories={['maintenance', 'pr', 'training', 'aircraft-movement']}
             onEmployeeAdd={handleEmployeeAdd}

--- a/src/WorksCalendar.tsx
+++ b/src/WorksCalendar.tsx
@@ -29,6 +29,7 @@ import { CalendarContext }    from './core/CalendarContext';
 import { normalizeEvents }    from './core/eventModel';
 import { CalendarEngine }     from './core/engine/CalendarEngine.ts';
 import { UndoRedoManager }   from './core/engine/UndoRedoManager.ts';
+import type { ResourcePool } from './core/pools/resourcePoolSchema.ts';
 import { fromLegacyEvents }   from './core/engine/adapters/fromLegacyEvents.ts';
 import { occurrenceToLegacy, toLegacyEvent } from './core/engine/adapters/toLegacyEvents.ts';
 import { validateOperation } from './core/engine/validation/validateOperation.ts';
@@ -188,6 +189,21 @@ export type WorksCalendarProps = {
   onApprovalAction?: (...args: unknown[]) => void | Promise<void>;
   renderAssetLocation?: (...args: unknown[]) => ReactNode;
   renderConflictBody?: (...args: unknown[]) => ReactNode;
+
+  /**
+   * Resource pools (#212). Bookings can target a pool id via
+   * `event.resourcePoolId`; the engine resolves a concrete member at
+   * submit time and advances the round-robin cursor. Hosts that care
+   * about cross-reload persistence should read the initial array from
+   * their own store and keep it in sync via `onPoolsChange`.
+   */
+  pools?: ResourcePool[];
+  /**
+   * Fires whenever the engine commits a pool state change (e.g. a
+   * round-robin cursor advance). Hosts should persist the array so the
+   * cursor survives page reloads. Omit to skip persistence entirely.
+   */
+  onPoolsChange?: (pools: ResourcePool[]) => void;
 };
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
@@ -409,6 +425,10 @@ export const WorksCalendar = forwardRef<CalendarApi, WorksCalendarProps>(functio
     onApprovalAction,
     renderAssetLocation,
     renderConflictBody,
+
+    // ── Resource pools (#212) ──
+    pools: rawPools,
+    onPoolsChange,
   }: WorksCalendarProps,
   ref: ForwardedRef<CalendarApi>,
 ) {
@@ -734,9 +754,16 @@ export const WorksCalendar = forwardRef<CalendarApi, WorksCalendarProps>(functio
   const engineRef      = useRef(null);
   const undoManagerRef = useRef(null);
   const announcerRef   = useRef(null);
+  // Tracks the pools map we last emitted so subsequent engine _notify calls
+  // only fire onPoolsChange on real pool mutations (e.g. round-robin cursor
+  // advance), not on every state tick.
+  const lastPoolsRef = useRef<ReadonlyMap<string, ResourcePool> | null>(null);
   if (engineRef.current === null) {
-    engineRef.current = new CalendarEngine();
+    engineRef.current = new CalendarEngine(
+      rawPools && rawPools.length > 0 ? { pools: rawPools } : undefined,
+    );
     undoManagerRef.current = new UndoRedoManager(engineRef.current, { maxSize: 50 });
+    lastPoolsRef.current = engineRef.current.state.pools;
   }
 
   // Counts how many onEventSave-triggered prop updates to suppress clear() for.
@@ -747,6 +774,28 @@ export const WorksCalendar = forwardRef<CalendarApi, WorksCalendarProps>(functio
   // Version counter: increments whenever the engine emits a state change.
   const [engineVer, tickEngine] = useReducer(n => n + 1, 0);
   useEffect(() => engineRef.current.subscribe(() => tickEngine()), []);
+
+  // Keep engine pools in sync when the host rewrites the prop (controlled
+  // pattern: demo persists to localStorage in onPoolsChange, then re-renders
+  // with the new array). Only the engine advances rrCursor, so replacing
+  // via setPools after a mutation is safe as long as the host echoed the
+  // latest onPoolsChange payload back in.
+  useEffect(() => {
+    if (!rawPools) return;
+    engineRef.current.setPools(rawPools);
+    lastPoolsRef.current = engineRef.current.state.pools;
+  }, [rawPools]);
+
+  // Emit onPoolsChange whenever the engine commits a new pools map (typically
+  // a round-robin cursor advance during applyMutation). Suppress emissions
+  // driven by the host's own setPools round-trip above.
+  useEffect(() => {
+    if (!onPoolsChange) return;
+    const current = engineRef.current.state.pools;
+    if (current === lastPoolsRef.current) return;
+    lastPoolsRef.current = current;
+    onPoolsChange(Array.from(current.values()));
+  }, [engineVer, onPoolsChange]);
 
   // Keep engine in sync with the merged+normalized event list from all sources.
   // Skip clear() when the change was triggered by our own onEventSave so the

--- a/src/core/pools/__tests__/poolStore.test.ts
+++ b/src/core/pools/__tests__/poolStore.test.ts
@@ -1,0 +1,88 @@
+/**
+ * poolStore — localStorage persistence specs (issue #212).
+ *
+ * Pins the acceptance criterion "round-robin cursor persists across
+ * page reloads" at the storage-helper level: once a pool (including
+ * its rrCursor) is saved, a fresh load returns the same state that
+ * the engine can be rehydrated with.
+ */
+import { describe, it, expect, beforeEach } from 'vitest';
+import { savePools, loadPools, clearPools, poolStorageKey } from '../poolStore';
+import type { ResourcePool } from '../resourcePoolSchema';
+
+const CAL = 'test-cal';
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+const pool = (patch: Partial<ResourcePool> & Pick<ResourcePool, 'id' | 'memberIds'>): ResourcePool => ({
+  name:     patch.id.toUpperCase(),
+  strategy: 'round-robin',
+  ...patch,
+});
+
+describe('poolStore', () => {
+  it('returns [] when no entry is stored', () => {
+    expect(loadPools(CAL)).toEqual([]);
+  });
+
+  it('round-trips a pools array, preserving rrCursor', () => {
+    const pools: ResourcePool[] = [
+      pool({ id: 'agents', memberIds: ['a', 'b', 'c'], rrCursor: 2 }),
+      pool({ id: 'rooms',  memberIds: ['r1', 'r2'],   strategy: 'first-available' }),
+    ];
+    savePools(CAL, pools);
+
+    const loaded = loadPools(CAL);
+    expect(loaded).toHaveLength(2);
+    expect(loaded[0].id).toBe('agents');
+    expect(loaded[0].rrCursor).toBe(2);
+    expect(loaded[1].strategy).toBe('first-available');
+  });
+
+  it('accepts a Map and serializes only the values', () => {
+    const map = new Map<string, ResourcePool>([
+      ['agents', pool({ id: 'agents', memberIds: ['a'], rrCursor: 0 })],
+    ]);
+    savePools(CAL, map);
+
+    const loaded = loadPools(CAL);
+    expect(loaded).toEqual([
+      { id: 'agents', name: 'AGENTS', strategy: 'round-robin', memberIds: ['a'], rrCursor: 0 },
+    ]);
+  });
+
+  it('omits rrCursor / disabled when absent', () => {
+    savePools(CAL, [pool({ id: 'p', memberIds: ['m'] })]);
+    const loaded = loadPools(CAL);
+    expect(loaded[0]).not.toHaveProperty('rrCursor');
+    expect(loaded[0]).not.toHaveProperty('disabled');
+  });
+
+  it('drops entries with an unknown strategy instead of corrupting the load', () => {
+    localStorage.setItem(poolStorageKey(CAL), JSON.stringify([
+      { id: 'bad',  name: 'BAD',  memberIds: ['x'], strategy: 'random' },
+      { id: 'good', name: 'GOOD', memberIds: ['x'], strategy: 'round-robin' },
+    ]));
+    expect(loadPools(CAL).map(p => p.id)).toEqual(['good']);
+  });
+
+  it('returns [] on malformed JSON', () => {
+    localStorage.setItem(poolStorageKey(CAL), '{not-json');
+    expect(loadPools(CAL)).toEqual([]);
+  });
+
+  it('clearPools removes the entry', () => {
+    savePools(CAL, [pool({ id: 'x', memberIds: ['m'] })]);
+    clearPools(CAL);
+    expect(loadPools(CAL)).toEqual([]);
+  });
+
+  it('keys are scoped per calendarId', () => {
+    savePools('cal-a', [pool({ id: 'pa', memberIds: ['a'] })]);
+    savePools('cal-b', [pool({ id: 'pb', memberIds: ['b'] })]);
+    expect(loadPools('cal-a').map(p => p.id)).toEqual(['pa']);
+    expect(loadPools('cal-b').map(p => p.id)).toEqual(['pb']);
+  });
+});

--- a/src/core/pools/poolStore.ts
+++ b/src/core/pools/poolStore.ts
@@ -1,0 +1,86 @@
+/**
+ * CalendarEngine — poolStore (#212).
+ *
+ * Small localStorage adapter for `ResourcePool` maps. Lives alongside
+ * the schema so any host (demo, examples, custom integrations) can
+ * persist round-robin cursor advances across page reloads without
+ * having to handle the Map<->JSON round-trip itself.
+ *
+ * Keyed by calendarId so multi-calendar demos don't collide.
+ *
+ * The store is defensive: any storage or parse failure yields an
+ * empty map rather than throwing. That matches `profileStore.ts`
+ * and keeps the demo booting even when localStorage is disabled
+ * (private-mode Safari, etc.).
+ */
+
+import type { ResourcePool, PoolStrategy } from './resourcePoolSchema';
+
+// ─── Storage key ─────────────────────────────────────────────────────────────
+
+export function poolStorageKey(calendarId: string): string {
+  return `wc-pools-${calendarId}`;
+}
+
+// ─── Public API ──────────────────────────────────────────────────────────────
+
+/**
+ * Persist the given pools map. Call after each engine state change
+ * where the pools differ from what was last saved.
+ */
+export function savePools(
+  calendarId: string,
+  pools: ReadonlyMap<string, ResourcePool> | readonly ResourcePool[],
+): void {
+  try {
+    const arr = Array.isArray(pools) ? pools : Array.from((pools as ReadonlyMap<string, ResourcePool>).values());
+    localStorage.setItem(poolStorageKey(calendarId), JSON.stringify(arr));
+  } catch { /* non-fatal: private mode, quota, serialization */ }
+}
+
+/**
+ * Read pools previously saved for `calendarId`. Returns an empty
+ * array when storage is empty, disabled, or corrupt.
+ */
+export function loadPools(calendarId: string): ResourcePool[] {
+  try {
+    const raw = localStorage.getItem(poolStorageKey(calendarId));
+    if (!raw) return [];
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+    const out: ResourcePool[] = [];
+    for (const item of parsed) {
+      const pool = coerce(item);
+      if (pool) out.push(pool);
+    }
+    return out;
+  } catch {
+    return [];
+  }
+}
+
+/** Remove the stored pools entry (e.g. on "reset demo" actions). */
+export function clearPools(calendarId: string): void {
+  try { localStorage.removeItem(poolStorageKey(calendarId)); } catch { /* ignore */ }
+}
+
+// ─── Internals ───────────────────────────────────────────────────────────────
+
+const STRATEGIES: readonly PoolStrategy[] = ['first-available', 'least-loaded', 'round-robin'];
+
+function coerce(item: unknown): ResourcePool | null {
+  if (!item || typeof item !== 'object') return null;
+  const r = item as Record<string, unknown>;
+  if (typeof r.id !== 'string' || typeof r.name !== 'string') return null;
+  if (!Array.isArray(r.memberIds) || !r.memberIds.every(m => typeof m === 'string')) return null;
+  if (typeof r.strategy !== 'string' || !STRATEGIES.includes(r.strategy as PoolStrategy)) return null;
+  const out: ResourcePool = {
+    id:        r.id,
+    name:      r.name,
+    memberIds: r.memberIds as string[],
+    strategy:  r.strategy as PoolStrategy,
+    ...(typeof r.rrCursor === 'number'  ? { rrCursor: r.rrCursor } : {}),
+    ...(typeof r.disabled === 'boolean' ? { disabled: r.disabled } : {}),
+  };
+  return out;
+}


### PR DESCRIPTION
Round-robin cursor must survive reloads per the issue's acceptance criterion. This wires the full path:

1. core/pools/poolStore — small localStorage helper. Save/load pools arrays keyed by calendarId, defensive against private-mode storage and malformed entries (unknown strategies drop on load).
2. WorksCalendar — new pools prop + onPoolsChange callback. The engine seeds from pools at construction and re-seeds when the host rewrites the prop. onPoolsChange fires only when the engine's pools map diverges from what the host last sent (not on plain state ticks), so a round-robin cursor advance round-trips cleanly without feedback loops.
3. demo/App.tsx — three fleet pools (west/central/east) seeded once, hydrated from localStorage on subsequent loads. onPoolsChange writes both React state and storage so re-renders keep the engine in sync with the persisted cursor.

Tests: 8 specs on the poolStore cover round-trip, map<->array coercion, corruption handling, and per-calendar key scoping.