### PR TITLE
feat(#212): pool rows in AssetsView with member tooltip and booking

### DIFF
--- a/src/WorksCalendar.tsx
+++ b/src/WorksCalendar.tsx
@@ -1446,18 +1446,21 @@ export const WorksCalendar = forwardRef<CalendarApi, WorksCalendarProps>(functio
       const op = {
         type:  'create',
         event: {
-          id:         createdId,
-          title:      rawEv.title      ?? '(untitled)',
-          start:      newStart,
-          end:        newEnd,
-          allDay:     rawEv.allDay     ?? false,
-          resourceId: rawEv.resource   ?? null,
-          category:   rawEv.category   ?? null,
-          color:      rawEv.color      ?? null,
-          status:     rawEv.status     ?? 'confirmed',
-          rrule:      resolvedRrule,
-          exdates:    rawEv.exdates    ?? [],
-          meta:       rawEv.meta       ?? {},
+          id:             createdId,
+          title:          rawEv.title      ?? '(untitled)',
+          start:          newStart,
+          end:            newEnd,
+          allDay:         rawEv.allDay     ?? false,
+          resourceId:     rawEv.resource   ?? null,
+          // Pool-seeded drafts carry resourcePoolId through; the engine
+          // resolves it to a concrete resourceId at submit (#212).
+          resourcePoolId: rawEv.resourcePoolId ?? null,
+          category:       rawEv.category   ?? null,
+          color:          rawEv.color      ?? null,
+          status:         rawEv.status     ?? 'confirmed',
+          rrule:          resolvedRrule,
+          exdates:        rawEv.exdates    ?? [],
+          meta:           rawEv.meta       ?? {},
         },
         source: 'form',
       };
@@ -1873,6 +1876,17 @@ export const WorksCalendar = forwardRef<CalendarApi, WorksCalendarProps>(functio
     setScheduleEditorState({ emp, start: startDate, end: endDate });
   }, [configuredEmployees, hasAddButton, onDateSelect]);
 
+  // Pool cell select (AssetsView pool row, #212). The EventForm spreads
+  // the initial formEvent into its submit payload, so seeding
+  // resourcePoolId here is enough to get the engine to resolve it on
+  // save — the generic form doesn't need a pool-picker field.
+  const handlePoolDateSelect = useCallback((start, end, poolId) => {
+    if (!hasAddButton) return;
+    const startDate = start instanceof Date ? start : new Date(start);
+    const endDate   = end   instanceof Date ? end   : new Date(end);
+    setFormEvent({ start: startDate, end: endDate, resourcePoolId: poolId });
+  }, [hasAddButton]);
+
   const sharedViewProps = {
     currentDate:   cal.currentDate,
     events:        visibleEvents,
@@ -2174,10 +2188,12 @@ export const WorksCalendar = forwardRef<CalendarApi, WorksCalendarProps>(functio
                   events={visibleEvents}
                   onEventClick={handleEventClick}
                   onDateSelect={handleScheduleDateSelect}
+                  onPoolDateSelect={handlePoolDateSelect}
                   groupBy={activeGroupBy}
                   onGroupByChange={setActiveGroupBy}
                   categoriesConfig={categoriesConfig ?? ownerCfg.config?.categoriesConfig}
                   assets={effectiveAssets}
+                  pools={rawPools ?? []}
                   strictAssetFiltering={strictAssetFiltering}
                   resolveResourceLabel={resolveResourceLabel}
                   zoomLevel={activeAssetsZoom}
@@ -2218,7 +2234,11 @@ export const WorksCalendar = forwardRef<CalendarApi, WorksCalendarProps>(functio
         {/* ── Event form ── */}
         {formEvent !== null && perms.canAddEvent && (
           <EventForm
-            event={formEvent.id ? formEvent : null}
+            // Pass formEvent through (not null) for pool-seeded drafts so
+            // resourcePoolId survives the form round-trip and the engine
+            // resolves it at submit. New drafts without pool context keep
+            // the legacy behavior: start from a blank form.
+            event={formEvent.id || formEvent.resourcePoolId ? formEvent : null}
             config={ownerCfg.config}
             categories={[...eventFormCats, ...eventOptions.categories]}
             onSave={handleEventSave}

--- a/src/views/AssetsView.module.css
+++ b/src/views/AssetsView.module.css
@@ -268,6 +268,32 @@
   background: color-mix(in srgb, var(--wc-text) 1.5%, transparent);
 }
 
+/* Pool rows (#212): synthetic "any member" rows at the top of the view.
+   Distinguish from asset rows with a subtle left accent + surface tint
+   so owners can tell at a glance which rows are virtual. */
+.poolRow {
+  background: color-mix(in srgb, var(--wc-accent, #6366f1) 4%, transparent);
+  border-left: 3px solid var(--wc-accent, #6366f1);
+}
+
+.poolRow:hover {
+  background: color-mix(in srgb, var(--wc-accent, #6366f1) 8%, transparent);
+}
+
+.poolChip {
+  display: inline-block;
+  margin-right: 6px;
+  padding: 0 6px;
+  font-size: 9px;
+  font-weight: 700;
+  line-height: 14px;
+  letter-spacing: 0.06em;
+  color: var(--wc-bg);
+  background: var(--wc-accent, #6366f1);
+  border-radius: 3px;
+  vertical-align: middle;
+}
+
 /* ── Sticky asset cell ──────────────────────────────────────────── */
 .nameCell {
   position: sticky;

--- a/src/views/AssetsView.tsx
+++ b/src/views/AssetsView.tsx
@@ -522,7 +522,11 @@ export default function AssetsView({
   const poolRows = useMemo(() => {
     if (!Array.isArray(pools) || pools.length === 0) return [];
     return pools
-      .filter(p => p && typeof p.id === 'string' && Array.isArray(p.memberIds))
+      // Disabled pools are documented as "stay in history but can't be
+      // selected for new bookings" — keep them out of the row list
+      // entirely so users don't start drafts the resolver would reject
+      // as POOL_DISABLED.
+      .filter(p => p && typeof p.id === 'string' && Array.isArray(p.memberIds) && !p.disabled)
       .map(p => {
         const memberSet = new Set(p.memberIds);
         // Scope to member-held events; use the raw events list (not the
@@ -689,7 +693,11 @@ export default function AssetsView({
       case ' ': {
         e.preventDefault();
         const hit = cellRowEvents.find(ev => ev._dayStart <= di && ev._dayEnd >= di);
-        if (hit) {
+        // On pool rows, rowEvents is the aggregate of member bookings — an
+        // occupied cell just means *some* member is busy, not that the pool
+        // itself is taken. Always route pool cells to onPoolDateSelect so
+        // the resolver can pick a free member at submit time.
+        if (hit && !isPoolRow) {
           const hitStage = getApprovalStage(hit);
           if (AUDIT_STAGES.has(hitStage)) openAudit(hit, e.currentTarget);
           else onEventClick?.(hit);
@@ -1024,7 +1032,17 @@ export default function AssetsView({
                         role="gridcell"
                         tabIndex={isFocused ? 0 : -1}
                         data-cell={`${rowIdx}-${di}`}
-                        aria-label={`${resource}, ${format(day, 'MMMM d')}${isToday(day) ? ', today' : ''}${cellHasEvent ? '' : ', empty — click to create'}`}
+                        aria-label={(() => {
+                          const datePart = `${format(day, 'MMMM d')}${isToday(day) ? ', today' : ''}`;
+                          if (isPool) {
+                            // Pool cells are always bookable — the resolver
+                            // picks a free member at submit time — so skip
+                            // the "empty" qualifier that would lie when the
+                            // aggregate row shows a member event.
+                            return `${displayLabel}, ${datePart}, click to book any available member`;
+                          }
+                          return `${resource}, ${datePart}${cellHasEvent ? '' : ', empty — click to create'}`;
+                        })()}
                         aria-rowindex={rowIdx + 2}
                         aria-colindex={di + 2}
                         className={styles.kbCell}
@@ -1032,7 +1050,10 @@ export default function AssetsView({
                         onKeyDown={e => handleCellKeyDown(e, rowIdx, di, rowEvents, resourceId, isPool)}
                         onClick={() => {
                           setFocusedCell({ rowIdx, dayIdx: di });
-                          if (cellHasEvent) return;
+                          // Pool rows aggregate member bookings, so a "busy"
+                          // cell still has free members the resolver can
+                          // assign. Only the asset-row path short-circuits.
+                          if (cellHasEvent && !isPool) return;
                           const from = startOfDay(day);
                           const to   = addDays(startOfDay(day), 1);
                           if (isPool) {

--- a/src/views/AssetsView.tsx
+++ b/src/views/AssetsView.tsx
@@ -183,6 +183,11 @@ export default function AssetsView({
   onApprovalAction,
   resolveResourceLabel,
   strictAssetFiltering = false,
+  // Resource pools (#212). Rendered as rows at the top of the view so
+  // bookings can target "any member" instead of a specific asset. The
+  // engine resolves the pool to a concrete resourceId at submit time.
+  pools = [],
+  onPoolDateSelect,
 }: any) {
   const ctx = useCalendarContext();
 
@@ -509,13 +514,50 @@ export default function AssetsView({
     return node.children.reduce((sum, c) => sum + countEvents(c), 0);
   }, []);
 
+  // Pool rows (#212): each pool renders as a synthetic row at the top of
+  // the body so owners can book against "any member". Events shown on a
+  // pool row are the union of bookings on its members — i.e. the row
+  // reflects aggregate availability so a busy cell is obvious before
+  // the user drops a new booking on it.
+  const poolRows = useMemo(() => {
+    if (!Array.isArray(pools) || pools.length === 0) return [];
+    return pools
+      .filter(p => p && typeof p.id === 'string' && Array.isArray(p.memberIds))
+      .map(p => {
+        const memberSet = new Set(p.memberIds);
+        // Scope to member-held events; use the raw events list (not the
+        // strictly-filtered one) so a pool row stays populated even when
+        // strictAssetFiltering hides some members.
+        const scoped = eventsProp.filter(e => e.resource != null && memberSet.has(e.resource));
+        const { events: laned, laneCount } = assignLanes(scoped, monthStart, monthEnd);
+        const rowH = Math.max(
+          laneCount * (LANE_H + LANE_GAP) + ROW_PAD * 2,
+          ROW_PAD * 2 + LANE_H + 16,
+        );
+        const memberLabels = p.memberIds.map(id => assetById.get(id)?.label ?? id);
+        return {
+          _type:       'poolRow',
+          key:         `__pool__${p.id}`,
+          poolId:      p.id,
+          label:       p.name || p.id,
+          sublabel:    p.strategy ? `Pool · ${p.strategy}` : 'Pool',
+          memberIds:   p.memberIds,
+          memberLabels,
+          events:      laned,
+          laneCount,
+          rowH,
+        };
+      });
+  }, [pools, eventsProp, assetById, monthStart.toISOString(), monthEnd.toISOString()]);
+
   // Flat list of rows for virtualization: interleaves groupHeader pseudo-rows
   // with asset rows scoped to the leaf group's events.
   const flatRows = useMemo(() => {
+    const prefix = poolRows;
     if (!groupTree) {
-      return resourceList.map(r => buildAssetRow(r, events));
+      return [...prefix, ...resourceList.map(r => buildAssetRow(r, events))];
     }
-    const out = [];
+    const out: any[] = [...prefix];
     const walk = (nodes, parentPath) => {
       nodes.forEach((node, i) => {
         const path = parentPath ? `${parentPath}/${node.key}` : node.key;
@@ -551,7 +593,7 @@ export default function AssetsView({
     };
     walk(groupTree, '');
     return out;
-  }, [groupTree, collapsedGroups, events, resourceList, buildAssetRow, countEvents, sortResourceKeys]);
+  }, [groupTree, collapsedGroups, events, resourceList, buildAssetRow, countEvents, sortResourceKeys, poolRows]);
 
   // ── Cumulative row offsets ─────────────────────────────────────────────────
   const rowOffsets = useMemo(() => {
@@ -631,7 +673,7 @@ export default function AssetsView({
     }
   }, [focusedCell, rowOffsets, flatRows]);
 
-  const handleCellKeyDown = useCallback((e, ri, di, cellRowEvents, resourceId) => {
+  const handleCellKeyDown = useCallback((e, ri, di, cellRowEvents, resourceId, isPoolRow) => {
     const maxRi = flatRows.length - 1;
     const maxDi = totalDays - 1;
     let nextRi = ri, nextDi = di;
@@ -653,7 +695,10 @@ export default function AssetsView({
           else onEventClick?.(hit);
         } else {
           const dayDate = days[di];
-          onDateSelect?.(startOfDay(dayDate), addDays(startOfDay(dayDate), 1), resourceId);
+          const from = startOfDay(dayDate);
+          const to   = addDays(startOfDay(dayDate), 1);
+          if (isPoolRow) onPoolDateSelect?.(from, to, resourceId);
+          else           onDateSelect?.(from, to, resourceId);
         }
         return;
       }
@@ -664,7 +709,7 @@ export default function AssetsView({
       lastKeyNavCell.current = true;
       setFocusedCell({ rowIdx: nextRi, dayIdx: nextDi });
     }
-  }, [flatRows.length, totalDays, onEventClick, onDateSelect, days, openAudit]);
+  }, [flatRows.length, totalDays, onEventClick, onDateSelect, onPoolDateSelect, days, openAudit]);
 
   /**
    * Header-row keyboard handling:
@@ -881,15 +926,24 @@ export default function AssetsView({
               );
             }
 
-            const { key, resource, label, sublabel, events: rowEvents, rowH } = rowData;
+            const isPool  = rowData._type === 'poolRow';
+            const { key, label, sublabel, events: rowEvents, rowH } = rowData;
+            const resource = isPool ? rowData.poolId : rowData.resource;
             const displayLabel = label ?? resource;
             const topOffset = rowOffsets[rowIdx];
-            const locationData = locations.get(resource) ?? null;
+            const locationData = isPool ? null : locations.get(resource) ?? null;
+            // Pool rows use the same sticky/event layout as asset rows but
+            // skip the location banner and carry a title-attr tooltip
+            // listing member labels so owners can verify the pool's makeup
+            // without leaving the view.
+            const memberTooltip = isPool
+              ? `Pool members:\n${(rowData.memberLabels ?? []).join('\n')}`
+              : undefined;
 
             return (
               <div
                 key={key}
-                className={styles.row}
+                className={[styles.row, isPool && styles.poolRow].filter(Boolean).join(' ')}
                 style={{
                   position: 'absolute',
                   top:      topOffset,
@@ -900,35 +954,42 @@ export default function AssetsView({
                 }}
                 role="row"
                 aria-rowindex={rowIdx + 2}
+                data-pool-id={isPool ? rowData.poolId : undefined}
               >
                 {/* Sticky asset cell — row header */}
                 <div
                   className={styles.nameCell}
                   style={{ width: NAME_W, minWidth: NAME_W, height: rowH }}
                   role="rowheader"
-                  aria-label={displayLabel}
+                  aria-label={isPool ? `Pool: ${displayLabel}` : displayLabel}
                   data-resource={resource}
+                  title={memberTooltip}
                 >
                   <div className={styles.assetMeta}>
-                    <span className={styles.assetRegistration}>{displayLabel}</span>
+                    <span className={styles.assetRegistration}>
+                      {isPool && <span className={styles.poolChip} aria-hidden="true">POOL</span>}
+                      {displayLabel}
+                    </span>
                     {sublabel && (
                       <span className={styles.assetSublabel}>{sublabel}</span>
                     )}
                   </div>
-                  <div
-                    className={styles.locationBanner}
-                    aria-label={locationData
-                      ? `Asset location: ${locationData.text} (${locationData.status})`
-                      : 'Asset location'}
-                    data-status={locationData?.status ?? 'placeholder'}
-                  >
-                    {renderAssetLocation
-                      ? renderAssetLocation(locationData, { id: resource })
-                      : locationData
-                        ? <span className={styles.locationText}>{locationData.text}</span>
-                        : <span className={styles.locationPlaceholder}>Location —</span>
-                    }
-                  </div>
+                  {!isPool && (
+                    <div
+                      className={styles.locationBanner}
+                      aria-label={locationData
+                        ? `Asset location: ${locationData.text} (${locationData.status})`
+                        : 'Asset location'}
+                      data-status={locationData?.status ?? 'placeholder'}
+                    >
+                      {renderAssetLocation
+                        ? renderAssetLocation(locationData, { id: resource })
+                        : locationData
+                          ? <span className={styles.locationText}>{locationData.text}</span>
+                          : <span className={styles.locationPlaceholder}>Location —</span>
+                      }
+                    </div>
+                  )}
                 </div>
 
                 {/* Event zone */}
@@ -968,11 +1029,16 @@ export default function AssetsView({
                         aria-colindex={di + 2}
                         className={styles.kbCell}
                         style={{ left: di * dayColW, width: dayColW, top: 0, height: rowH }}
-                        onKeyDown={e => handleCellKeyDown(e, rowIdx, di, rowEvents, resourceId)}
+                        onKeyDown={e => handleCellKeyDown(e, rowIdx, di, rowEvents, resourceId, isPool)}
                         onClick={() => {
                           setFocusedCell({ rowIdx, dayIdx: di });
-                          if (!cellHasEvent) {
-                            onDateSelect?.(startOfDay(day), addDays(startOfDay(day), 1), resourceId);
+                          if (cellHasEvent) return;
+                          const from = startOfDay(day);
+                          const to   = addDays(startOfDay(day), 1);
+                          if (isPool) {
+                            onPoolDateSelect?.(from, to, rowData.poolId);
+                          } else {
+                            onDateSelect?.(from, to, resourceId);
                           }
                         }}
                       />

--- a/src/views/__tests__/AssetsView.pools.test.tsx
+++ b/src/views/__tests__/AssetsView.pools.test.tsx
@@ -1,0 +1,108 @@
+// @vitest-environment happy-dom
+/**
+ * AssetsView — resource pool rows (#212).
+ *
+ * Pins the surface described in the issue: pools render as virtual
+ * rows at the top of the Assets view, the row label shows a POOL
+ * chip and hover-tooltips the member list, and a click on an empty
+ * pool cell fires `onPoolDateSelect` with the pool id (not
+ * `onDateSelect`, since the pool resolves to a concrete member
+ * downstream via the engine).
+ */
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import '@testing-library/jest-dom';
+import React from 'react';
+
+import AssetsView from '../AssetsView';
+import { CalendarContext } from '../../core/CalendarContext';
+
+const currentDate = new Date(2026, 3, 1); // April 2026
+const evOn = (day) => new Date(2026, 3, day);
+
+function renderView(props = {}) {
+  return render(
+    <CalendarContext.Provider value={null}>
+      <AssetsView
+        currentDate={currentDate}
+        events={[]}
+        onEventClick={vi.fn()}
+        {...props}
+      />
+    </CalendarContext.Provider>,
+  );
+}
+
+const basicAssets = [
+  { id: 'N121AB', label: 'N121AB', meta: {} },
+  { id: 'N505CD', label: 'N505CD', meta: {} },
+  { id: 'N88QR',  label: 'N88QR',  meta: {} },
+];
+
+describe('AssetsView — resource pools (issue #212)', () => {
+  it('renders a POOL row at the top for each pool', () => {
+    renderView({
+      assets: basicAssets,
+      pools:  [
+        { id: 'fleet-west',    name: 'West Fleet',    memberIds: ['N121AB', 'N505CD'], strategy: 'round-robin' },
+        { id: 'fleet-central', name: 'Central Fleet', memberIds: ['N88QR'],            strategy: 'first-available' },
+      ],
+    });
+    const labels = screen.getAllByRole('rowheader').map(el => el.getAttribute('aria-label'));
+    // Pool rows come first, then asset rows in declared order.
+    expect(labels.slice(0, 2)).toEqual(['Pool: West Fleet', 'Pool: Central Fleet']);
+    expect(labels.slice(2)).toEqual(['N121AB', 'N505CD', 'N88QR']);
+  });
+
+  it('tooltips member labels on the pool row label', () => {
+    renderView({
+      assets: basicAssets,
+      pools:  [{ id: 'fleet-west', name: 'West Fleet', memberIds: ['N121AB', 'N505CD'], strategy: 'round-robin' }],
+    });
+    const header = screen.getByRole('rowheader', { name: 'Pool: West Fleet' });
+    expect(header.getAttribute('title')).toContain('N121AB');
+    expect(header.getAttribute('title')).toContain('N505CD');
+  });
+
+  it('clicking an empty pool cell fires onPoolDateSelect with the pool id', () => {
+    const onPoolDateSelect = vi.fn();
+    const onDateSelect     = vi.fn();
+    renderView({
+      assets: basicAssets,
+      pools:  [{ id: 'fleet-west', name: 'West Fleet', memberIds: ['N121AB', 'N505CD'], strategy: 'round-robin' }],
+      onPoolDateSelect,
+      onDateSelect,
+    });
+
+    const poolRow = screen.getByRole('rowheader', { name: 'Pool: West Fleet' }).closest('[role=row]') as HTMLElement;
+    const firstCell = poolRow.querySelector('[role=gridcell]') as HTMLElement;
+    fireEvent.click(firstCell);
+
+    expect(onPoolDateSelect).toHaveBeenCalledTimes(1);
+    expect(onPoolDateSelect.mock.calls[0][2]).toBe('fleet-west');
+    expect(onDateSelect).not.toHaveBeenCalled();
+  });
+
+  it('shows member-held events on the pool row (aggregate utilization view)', () => {
+    renderView({
+      assets: basicAssets,
+      pools:  [{ id: 'fleet-west', name: 'West Fleet', memberIds: ['N121AB', 'N505CD'], strategy: 'round-robin' }],
+      events: [
+        { id: 'e1', title: 'Charter',  start: evOn(3),  end: evOn(4),  resource: 'N121AB' },
+        { id: 'e2', title: 'A-check',  start: evOn(10), end: evOn(12), resource: 'N505CD' },
+        { id: 'e3', title: 'Unrelated', start: evOn(3), end: evOn(4),  resource: 'N88QR'  },
+      ],
+    });
+    const poolRow = screen.getByRole('rowheader', { name: 'Pool: West Fleet' }).closest('[role=row]') as HTMLElement;
+    // Member events appear on the pool row; non-member events don't.
+    expect(poolRow.textContent).toContain('Charter');
+    expect(poolRow.textContent).toContain('A-check');
+    expect(poolRow.textContent).not.toContain('Unrelated');
+  });
+
+  it('renders no pool rows when pools is empty or absent', () => {
+    renderView({ assets: basicAssets });
+    const labels = screen.getAllByRole('rowheader').map(el => el.getAttribute('aria-label'));
+    expect(labels.some(l => l?.startsWith('Pool:'))).toBe(false);
+  });
+});

--- a/src/views/__tests__/AssetsView.pools.test.tsx
+++ b/src/views/__tests__/AssetsView.pools.test.tsx
@@ -105,4 +105,46 @@ describe('AssetsView — resource pools (issue #212)', () => {
     const labels = screen.getAllByRole('rowheader').map(el => el.getAttribute('aria-label'));
     expect(labels.some(l => l?.startsWith('Pool:'))).toBe(false);
   });
+
+  it('still books via onPoolDateSelect when a member event occupies the cell', () => {
+    // Regression for the P1 review: the pool row aggregates member events,
+    // so clicking a "busy" cell must still create a pool booking — the
+    // resolver picks whichever member is actually free at submit time.
+    const onPoolDateSelect = vi.fn();
+    const onEventClick     = vi.fn();
+    renderView({
+      assets: basicAssets,
+      pools:  [{ id: 'fleet-west', name: 'West Fleet', memberIds: ['N121AB', 'N505CD'], strategy: 'round-robin' }],
+      events: [
+        // Member N121AB is busy on the 3rd; N505CD is still free.
+        { id: 'e1', title: 'Charter', start: evOn(3), end: evOn(4), resource: 'N121AB' },
+      ],
+      onPoolDateSelect,
+      onEventClick,
+    });
+    const poolRow = screen.getByRole('rowheader', { name: 'Pool: West Fleet' }).closest('[role=row]') as HTMLElement;
+    const cells = poolRow.querySelectorAll('[role=gridcell]');
+    // Day index 2 → April 3rd (month starts on the 1st).
+    fireEvent.click(cells[2] as HTMLElement);
+
+    expect(onPoolDateSelect).toHaveBeenCalledTimes(1);
+    expect(onPoolDateSelect.mock.calls[0][2]).toBe('fleet-west');
+    expect(onEventClick).not.toHaveBeenCalled();
+  });
+
+  it('does not render disabled pools as rows', () => {
+    // Disabled pools stay in history but can't accept new bookings — the
+    // resolver rejects them as POOL_DISABLED — so they must not render as
+    // interactive rows either.
+    renderView({
+      assets: basicAssets,
+      pools: [
+        { id: 'fleet-west', name: 'West Fleet', memberIds: ['N121AB'], strategy: 'round-robin' },
+        { id: 'fleet-old',  name: 'Retired Fleet', memberIds: ['N505CD'], strategy: 'round-robin', disabled: true },
+      ],
+    });
+    const labels = screen.getAllByRole('rowheader').map(el => el.getAttribute('aria-label'));
+    expect(labels).toContain('Pool: West Fleet');
+    expect(labels).not.toContain('Pool: Retired Fleet');
+  });
 });


### PR DESCRIPTION
Adds the Assets-view surface the issue calls for:

AssetsView
- New `pools` prop + `onPoolDateSelect` callback. Pools render as synthetic rows at the top of the view with a POOL chip, pool name, and strategy subtitle.
- Row label carries a native title tooltip listing member labels so owners can verify pool membership at a hover without opening a panel.
- Pool rows reuse the existing lane/event-pill pipeline so a booking on any member shows up on the pool row — aggregate occupancy is obvious before you drop a new booking on it.
- Empty-cell click or Enter/Space on a pool row routes through `onPoolDateSelect(start, end, poolId)` rather than the concrete- resource `onDateSelect` path, so the host doesn't have to guess whether a resourceId is a pool id.

WorksCalendar
- Wires the new callback into `handlePoolDateSelect` which seeds `formEvent` with `resourcePoolId`. The generic EventForm spreads the initial formEvent into its submit payload, so no form changes were needed for the pool field to survive.
- Event form is now passed the initial formEvent (instead of null) whenever the draft carries a resourcePoolId, so the pool id actually round-trips through EventForm.handleSubmit.
- `handleEventSave` threads `resourcePoolId` onto the create op so the engine's resolve-on-submit (landed earlier in this branch) picks a concrete member.

Tests: 5 specs covering pool row rendering order, tooltip content, pool-cell click routing to onPoolDateSelect (not onDateSelect), aggregate member-event display, and absent-pools fallback.