### PR TITLE
test(#212): end-to-end pool booking resolves to a concrete member

### DIFF
--- a/src/WorksCalendar.tsx
+++ b/src/WorksCalendar.tsx
@@ -1464,8 +1464,14 @@ export const WorksCalendar = forwardRef<CalendarApi, WorksCalendarProps>(functio
         },
         source: 'form',
       };
-      applyEngineOp(op, () => {
-        const savedPayload = getSavedEventPayload(createdId, rawEv, { id: createdId });
+      applyEngineOp(op, (result) => {
+        // applyCreate generates its own engine id, so look the saved
+        // record up by the id the engine actually assigned — otherwise
+        // pool-resolved events fall through to the fallback payload,
+        // which still carries resource: null from the form (#212).
+        const createdChange = result?.changes?.find((c: any) => c.type === 'created');
+        const engineId = createdChange?.event?.id ?? createdId;
+        const savedPayload = getSavedEventPayload(engineId, rawEv, { id: engineId });
         if (savedPayload) onEventSave?.(savedPayload);
         setFormEvent(null);
       });

--- a/src/__tests__/WorksCalendar.poolBooking.integration.test.tsx
+++ b/src/__tests__/WorksCalendar.poolBooking.integration.test.tsx
@@ -1,0 +1,80 @@
+// @vitest-environment happy-dom
+/**
+ * WorksCalendar — pool booking end-to-end (issue #212).
+ *
+ * Acceptance criterion from the issue:
+ *   "UI test: booking against a pool in the Assets view resolves to a
+ *    concrete resource in the saved event."
+ *
+ * The test mounts the full WorksCalendar in Assets view, seeds a pool
+ * with two members, clicks an empty cell on the pool row to open the
+ * EventForm, submits with a title, and asserts the onEventSave payload:
+ *   - carries a concrete `resource` that is one of the pool members
+ *     (not the pool id, not null),
+ *   - preserves `meta.resolvedFromPoolId` for audit.
+ */
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import '@testing-library/jest-dom';
+import React from 'react';
+
+import { WorksCalendar } from '../WorksCalendar.tsx';
+
+describe('WorksCalendar — pool booking (end-to-end, #212)', () => {
+  const assets = [
+    { id: 'N121AB', label: 'N121AB', meta: {} },
+    { id: 'N505CD', label: 'N505CD', meta: {} },
+  ];
+
+  const pools = [
+    {
+      id:        'fleet-west',
+      name:      'West Fleet',
+      memberIds: ['N121AB', 'N505CD'],
+      strategy:  'first-available' as const,
+    },
+  ];
+
+  it('resolves the pool to a concrete member on save', async () => {
+    const onEventSave = vi.fn();
+
+    render(
+      <WorksCalendar
+        devMode
+        initialView="assets"
+        assets={assets}
+        pools={pools}
+        events={[]}
+        onEventSave={onEventSave}
+      />,
+    );
+
+    // Locate the pool row by its rowheader aria-label and click its first
+    // empty day cell. Day 0 is guaranteed unoccupied (events: []) so the
+    // click opens the EventForm seeded with the pool id.
+    const poolHeader = await screen.findByRole('rowheader', { name: 'Pool: West Fleet' });
+    const poolRow = poolHeader.closest('[role=row]') as HTMLElement;
+    const firstCell = poolRow.querySelector('[role=gridcell]') as HTMLElement;
+    expect(firstCell).toBeTruthy();
+    fireEvent.click(firstCell);
+
+    // Form should open with an "Add Event" title — empty draft apart from
+    // the seeded start/end/resourcePoolId.
+    const titleInput = await screen.findByLabelText(/^Title/);
+    fireEvent.change(titleInput, { target: { value: 'Charter run' } });
+
+    const saveBtn = screen.getByRole('button', { name: 'Add Event' });
+    fireEvent.click(saveBtn);
+
+    await waitFor(() => {
+      expect(onEventSave).toHaveBeenCalledTimes(1);
+    });
+
+    const saved = onEventSave.mock.calls[0][0];
+    expect(saved.title).toBe('Charter run');
+    // Concrete resource in the pool — not the pool id, not null.
+    expect(['N121AB', 'N505CD']).toContain(saved.resource);
+    // Audit trail preserves which pool the booking was drawn from.
+    expect(saved.meta?.resolvedFromPoolId).toBe('fleet-west');
+  }, 30000);
+});


### PR DESCRIPTION
Covers the issue's UI-test acceptance criterion: booking against a pool in the Assets view resolves to a concrete resource in the saved event. Mounts WorksCalendar in Assets view, clicks an empty pool-row cell, submits the EventForm, and asserts onEventSave fires with resource ∈ pool members and meta.resolvedFromPoolId preserved for audit.

Fixes a latent regression surfaced by the test: applyCreate generates its own engine id via nextEngineId(), so getSavedEventPayload lookup by the WorksCalendar-assigned id always missed and fell back to the pre-save form payload. For pools that meant onEventSave reported resource: null — the concrete member picked by the resolver was invisible to the host. The handler now takes the engine-assigned id from result.changes.

https://claude.ai/code/session_01CrtvpvDfVASzce1f2vNiZh