### PR TITLE
feat(#212): disclose resolved pool member on event pill hover

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -14,6 +14,7 @@ This index is the canonical docs entrypoint for the package.
 - [Advanced filters](./AdvancedFilters.md)
 - [Setup wizard](./SetupWizard.md)
 - [Data adapter](./DataAdapter.md)
+- [Resource pools](./ResourcePools.md)
 
 ## Provider setup guides
 

--- a/docs/ResourcePools.md
+++ b/docs/ResourcePools.md
@@ -1,0 +1,157 @@
+# Resource pools
+
+A `ResourcePool` lets bookings target **"any available member"** instead
+of a specific asset or employee. When an event carries a
+`resourcePoolId`, the engine resolves it to a concrete `resource` at
+submit time using a configurable strategy.
+
+Use pools when the customer doesn't care who runs the job — just that
+it gets run:
+
+- "Any West-region aircraft" for charter dispatch
+- "Any available driver" for fleet routing
+- "Any hot-desk in the SF office" for coworking
+
+## Data shape
+
+```ts
+export interface ResourcePool {
+  id:         string;
+  name:       string;
+  memberIds:  string[];                 // ids from the asset/employee registry
+  strategy:   'first-available' | 'least-loaded' | 'round-robin';
+  rrCursor?:  number;                   // round-robin only; engine-owned
+  disabled?:  boolean;                  // history stays; new bookings rejected
+}
+```
+
+Members are referenced by registry id, not by label. Pools that list
+unknown ids still work — the resolver simply skips them.
+
+## Wiring
+
+Pass the pool list and an `onPoolsChange` callback to `WorksCalendar`.
+Persist the pools wherever you keep calendar config (`localStorage`, a
+JSON file in S3, a settings table). The round-robin cursor advances
+inside the engine and echoes back through `onPoolsChange` on every
+commit so the rotation survives a reload.
+
+```tsx
+import { WorksCalendar } from 'works-calendar';
+import { loadPools, savePools } from 'works-calendar';
+
+const CALENDAR_ID = 'fleet-ops';
+
+function FleetCalendar() {
+  const [pools, setPools] = useState(() => {
+    const persisted = loadPools(CALENDAR_ID);
+    return persisted.length > 0 ? persisted : DEFAULT_POOLS;
+  });
+
+  const handlePoolsChange = (next) => {
+    setPools(next);
+    savePools(CALENDAR_ID, next);
+  };
+
+  return (
+    <WorksCalendar
+      assets={assets}
+      pools={pools}
+      onPoolsChange={handlePoolsChange}
+      events={events}
+      onEventSave={onEventSave}
+    />
+  );
+}
+
+const DEFAULT_POOLS = [
+  {
+    id:        'fleet-west',
+    name:      'West Fleet',
+    memberIds: ['N121AB', 'N505CD'],
+    strategy:  'round-robin',
+  },
+  {
+    id:        'fleet-central',
+    name:      'Central Fleet',
+    memberIds: ['N88QR', 'N733XY'],
+    strategy:  'first-available',
+  },
+];
+```
+
+The demo app at `demo/App.tsx` wires the exact snippet above against
+`localStorage`; use it as a reference implementation.
+
+## Booking flow
+
+1. The Assets view renders each pool as a virtual row at the top, with
+   a `POOL` chip and a hover tooltip listing its members.
+2. Clicking an empty day cell on a pool row opens the EventForm with
+   `resourcePoolId` seeded; the form doesn't expose the field, so the
+   user fills in a title as usual and saves.
+3. On submit, the engine:
+   - picks a concrete member via the pool's strategy,
+   - runs the normal conflict/overlap validators against the resolved
+     member,
+   - commits the event with `resource = <member>` and
+     `meta.resolvedFromPoolId = <pool id>`.
+4. `onEventSave` fires with the resolved payload, so the host sees the
+   concrete member, not the pool id.
+
+The pool row aggregates member bookings — any event on any member
+appears on the pool row. Click a "busy" cell anyway; the resolver will
+still find a free member if one exists.
+
+## Strategies
+
+| Strategy          | Picks                                                    |
+|-------------------|----------------------------------------------------------|
+| `first-available` | First member, in declared order, with no hard conflict   |
+| `least-loaded`    | Member with the lowest `workloadForResource()` in window |
+| `round-robin`     | Next member after the stored cursor, skipping conflicts  |
+
+`round-robin` persists its cursor (`rrCursor`) on the pool itself. The
+engine advances the cursor atomically with the booking commit and
+includes the updated pool in the next `onPoolsChange`.
+
+If every member is in hard conflict, the submit is rejected with a
+`POOL_EXHAUSTED` violation — nothing is written and no member rotates.
+An unknown pool id rejects with `POOL_UNKNOWN`; a disabled pool rejects
+with `POOL_DISABLED`.
+
+## Disabled pools
+
+Flip `disabled: true` to retire a pool. History stays searchable but:
+
+- the Assets view stops rendering the pool row (no more drafts get
+  started against it),
+- API submits that still reference the pool id are rejected with
+  `POOL_DISABLED`.
+
+Re-enable by clearing the flag.
+
+## Audit trail
+
+Every pool-resolved event carries `meta.resolvedFromPoolId` so the
+audit lineage is never lost. The Assets view surfaces this on the
+event pill's hover tooltip, including the pool name when it can be
+looked up, so an operator scanning utilization can see at a glance
+which bookings originated from a pool.
+
+## Storage helper
+
+`works-calendar` ships a tiny `localStorage` adapter that
+round-trips the pool list. It's deliberately small — swap it out for
+your own adapter if you need server-backed persistence.
+
+```ts
+import { loadPools, savePools, clearPools } from 'works-calendar';
+
+savePools('calendar-1', pools);
+const restored = loadPools('calendar-1');
+clearPools('calendar-1');
+```
+
+Keys are namespaced by calendar id, so multiple calendars on the same
+origin don't collide.

--- a/examples/README.md
+++ b/examples/README.md
@@ -28,8 +28,15 @@ npm run examples
 - `external-form.jsx` — standalone `CalendarExternalForm`
 - `basic-usage.jsx` — compact docs/tutorial starter
 
+## Feature demos
+
+- `../demo/App.tsx` — unified calendar demo; wires resource pools with
+  `localStorage` persistence (see
+  [docs/ResourcePools.md](../docs/ResourcePools.md)).
+
 ## Related docs
 
 - [Workflow map](./WORKFLOWS.md)
 - [Documentation index](../docs/README.md)
+- [Resource pools](../docs/ResourcePools.md)
 - [Microsoft 365 adapter notes](./microsoft-365/README.md)

--- a/src/index.ts
+++ b/src/index.ts
@@ -71,6 +71,10 @@ export type {
 export { useBookingHold } from './hooks/useBookingHold';
 export type { UseBookingHoldOptions, UseBookingHoldState } from './hooks/useBookingHold';
 
+// ── Resource pools (#212) ───────────────────────────────────────────────────
+export { loadPools, savePools, clearPools, poolStorageKey } from './core/pools/poolStore';
+export type { ResourcePool } from './core/pools/resourcePoolSchema';
+
 // ── Lifecycle event bus (#216) ──────────────────────────────────────────────
 export { EventBus, channelForApprovalTransition } from './core/engine/eventBus';
 export type {

--- a/src/views/AssetsView.tsx
+++ b/src/views/AssetsView.tsx
@@ -1087,8 +1087,33 @@ export default function AssetsView({
                     const showCaret = approvalActions.length > 0
                       && typeof onApprovalAction === 'function';
 
+                    // Pool-resolved-member disclosure (#212). On pool rows
+                    // every pill is a member event, but the pill itself
+                    // renders on the aggregate row, so hover/aria has to
+                    // spell out which concrete member it's bound to.
+                    // For events originally resolved from a pool (anywhere
+                    // in the view), surface the pool lineage so the audit
+                    // trail stays visible at a glance.
+                    const memberLabel = isPool && ev.resource
+                      ? (assetById.get(ev.resource)?.label ?? ev.resource)
+                      : null;
+                    const resolvedFromPoolId =
+                      typeof ev.meta?.resolvedFromPoolId === 'string'
+                        ? ev.meta.resolvedFromPoolId
+                        : null;
+                    const poolName = resolvedFromPoolId
+                      ? (pools.find((p: any) => p?.id === resolvedFromPoolId)?.name ?? resolvedFromPoolId)
+                      : null;
+                    const hoverTitle = [
+                      ev.title,
+                      memberLabel && `Assigned to ${memberLabel}`,
+                      poolName && `Resolved from pool: ${poolName}`,
+                    ].filter(Boolean).join(' — ') || undefined;
+
                     const ariaLabel = [
                       ev.title,
+                      memberLabel && `assigned to ${memberLabel}`,
+                      poolName && `resolved from pool ${poolName}`,
                       ev.category && `category ${ev.category}`,
                       stage && `stage ${stage.replace('_', ' ')}`,
                       ev.status && ev.status !== 'confirmed' && ev.status,
@@ -1106,6 +1131,7 @@ export default function AssetsView({
                           style={{ left, top, width, height: LANE_H, '--ev-color': evColor }}
                           onClick={onClick}
                           aria-label={ariaLabel}
+                          title={hoverTitle}
                           data-stage={stage || undefined}
                         >
                           {prefix && (

--- a/src/views/__tests__/AssetsView.pools.test.tsx
+++ b/src/views/__tests__/AssetsView.pools.test.tsx
@@ -132,6 +132,51 @@ describe('AssetsView — resource pools (issue #212)', () => {
     expect(onEventClick).not.toHaveBeenCalled();
   });
 
+  it('shows the resolved member in the hover title on pool-row pills', () => {
+    // Pool-row pills aggregate member bookings, so a viewer can't tell by
+    // looking which concrete member is on the pill. The hover title must
+    // disclose the assigned member so operators can audit utilization at
+    // a glance (#212 acceptance: "show resolved member on hover").
+    renderView({
+      assets: basicAssets,
+      pools:  [{ id: 'fleet-west', name: 'West Fleet', memberIds: ['N121AB', 'N505CD'], strategy: 'round-robin' }],
+      events: [
+        { id: 'e1', title: 'Charter', start: evOn(3), end: evOn(4), resource: 'N121AB' },
+      ],
+    });
+    const poolRow = screen.getByRole('rowheader', { name: 'Pool: West Fleet' }).closest('[role=row]') as HTMLElement;
+    const pill = poolRow.querySelector('button[aria-label*="Charter"]') as HTMLElement;
+    expect(pill).toBeTruthy();
+    expect(pill.getAttribute('title')).toContain('Charter');
+    expect(pill.getAttribute('title')).toContain('N121AB');
+    expect(pill.getAttribute('aria-label')).toContain('assigned to N121AB');
+  });
+
+  it('surfaces pool lineage on pills for pool-resolved events', () => {
+    // Events whose meta.resolvedFromPoolId is set were drawn from a pool;
+    // the hover title should disclose which pool they came from so the
+    // audit trail is visible without opening the event.
+    renderView({
+      assets: basicAssets,
+      pools:  [{ id: 'fleet-west', name: 'West Fleet', memberIds: ['N121AB', 'N505CD'], strategy: 'round-robin' }],
+      events: [
+        {
+          id: 'e1',
+          title: 'Charter',
+          start: evOn(3),
+          end: evOn(4),
+          resource: 'N121AB',
+          meta: { resolvedFromPoolId: 'fleet-west' },
+        },
+      ],
+    });
+    // Asset-row pill for N121AB carries the pool lineage.
+    const assetRow = screen.getByRole('rowheader', { name: 'N121AB' }).closest('[role=row]') as HTMLElement;
+    const pill = assetRow.querySelector('button[aria-label*="Charter"]') as HTMLElement;
+    expect(pill.getAttribute('title')).toContain('West Fleet');
+    expect(pill.getAttribute('aria-label')).toContain('resolved from pool West Fleet');
+  });
+
   it('does not render disabled pools as rows', () => {
     // Disabled pools stay in history but can't accept new bookings — the
     // resolver rejects them as POOL_DISABLED — so they must not render as


### PR DESCRIPTION
Covers the issue's AssetsView acceptance bullet: "render pool row; show resolved member on hover". Pool-row pills represent individual member events but render on the aggregate row, so without a hover tooltip a viewer can't tell which member is actually booked. The pill now carries a title + aria-label segment for the assigned member.

Events whose meta.resolvedFromPoolId is set — i.e. bookings the engine drew from a pool — surface the pool name in the same tooltip wherever they render (pool row or asset row), so the audit lineage stays visible.

https://claude.ai/code/session_01CrtvpvDfVASzce1f2vNiZh