### PR TITLE
plan(workflow): Phase 2 visual builder — plan + validator/layout foundations

### DIFF
--- a/docs/phase-2-visual-builder-plan.md
+++ b/docs/phase-2-visual-builder-plan.md
@@ -1,0 +1,177 @@
+# Phase 2 — Workflow Visual Builder
+
+## Context
+
+Phase 1 (PR #219, commit `da05b47`) shipped a JSON-only workflow DSL under `src/core/workflow/`: a typed schema (`workflowSchema.ts`), a safe Pratt-parser expression evaluator (`expression.ts`), a pure interpreter (`advance.ts`), and three starter workflows (`templates.ts`). Today there is **no UI** for owners to view, edit, or author these workflows — they must hand-write JSON. The commit message for Phase 1 explicitly defers "the visual builder, SLA timers, and parallel branches" to later phases.
+
+Phase 2 delivers that visual builder so owners can fork a starter template, wire nodes/edges on a canvas, test it against sample variables, and save it — without writing JSON.
+
+### User-confirmed scope
+
+- Editor paradigm: **node-and-edge graph canvas** (hand-rolled SVG, no new deps).
+- **Include simulator** that steps `advance()` against user-supplied variables.
+- Host surface: **standalone modal** launched from a new Workflows tab in `ConfigPanel` (templates list + per-template Edit button + "Create blank" button).
+
+### Hard constraints
+
+- Shipped npm library — **no new dependencies** (stay with `date-fns` + `lucide-react`).
+- Bundle impact must stay small (lazy-load the modal).
+- Do not break Phase 1 tests — `Workflow` / `WorkflowNode` types stay as-is; layout coordinates live in a side-car `WorkflowLayout`, not on the nodes.
+- TypeScript strict mode.
+
+## Approach
+
+Hand-rolled SVG canvas with BFS auto-layout as the default, per-node drag overrides stored in a separate `WorkflowLayout`. "Fork on edit" semantics — editing a starter template creates a new `SavedWorkflow` rather than mutating `WORKFLOW_TEMPLATES`. All validation reuses Phase 1 types and helpers (`findNode`, `resolveNextEdge`, `evaluate` for expression syntax checking). Modal is lazy-loaded from ConfigPanel via `React.lazy`.
+
+## Files
+
+### New core (pure — test-first)
+
+- `src/core/workflow/validate.ts` — `validateWorkflow(wf): readonly ValidationIssue[]`. Save gate + inline builder badges. Each rule has an explicit severity:
+
+  | Rule (code) | Severity |
+  |---|---|
+  | `duplicate-node-id` | error |
+  | `start-node-missing` | error |
+  | `edge-endpoint-missing` | error |
+  | `no-terminal-node` | error |
+  | `unreachable-node` | warning |
+  | `dead-end-node` (non-terminal with no outgoing edge) | error |
+  | `multiple-default-edges` (>1 default edge from same source) | error |
+  | `approval-missing-signal-coverage` | error |
+  | `condition-missing-signal-coverage` | error |
+  | `illegal-guard-for-source` (e.g. `approved` out of a condition) | error |
+  | `expression-syntax` | error |
+  | `terminal-has-outgoing` | warning |
+
+  **Signal coverage (amended from review #3)**: for each required signal a node emits (`approved`/`denied` on approvals, `true`/`false` on conditions), there must be *either* an exact-`when` edge *or* a default edge. The validator calls `resolveNextEdge(wf, nodeId, signal)` for each required signal so the check matches runtime semantics exactly. This permits e.g. `approved` + `default` edge pairs, which the earlier "both exact guards required" phrasing over-constrained.
+
+  **Expression syntax (amended from review #2)**: small additive extension to `src/core/workflow/expression.ts` — `ExpressionError` now carries `readonly kind: 'syntax' | 'undefined-variable' | 'non-object' | 'type' | 'unknown-operator' | 'unsupported-value'`. `validateExpressionSyntax` matches on `err.kind` (ignoring the three variable-bound kinds that are expected at edit time) instead of sniffing message prefixes. Back-compat: constructor accepts the old `(message, position?: number)` signature, so the Phase 1 evaluator tests stay green.
+
+- `src/core/workflow/layout.ts` — `layoutWorkflow(wf, overrides?): { positions, size, edgePaths }`. BFS-leveled layout (rank = depth from `startNodeId`, x = indexInRank × `COLUMN_STEP`, y = rank × `ROW_STEP`); overrides from `WorkflowLayout.positions` win per-node.
+
+  **Corner cases (amended from review #5)**:
+  - Unreachable nodes are piled into a trailing orphan lane (each on its own y below `max(reachableRank)+1`), so they always render somewhere.
+  - Back-edges (target rank ≤ source rank) route through a lateral channel to the left of the graph (`M src.left → channelX → target.left`) so they're visibly distinct from forward edges.
+  - Self-loops render as an SVG cubic-Bezier semicircle bulging out the right side of the node.
+- `src/core/workflow/__tests__/validate.test.ts` — one `it` per rule (positive + negative). Shipped templates must validate clean.
+- `src/core/workflow/__tests__/layout.test.ts` — rank assertions + override-wins.
+
+### Schema extension (additive only)
+
+- `src/core/workflow/workflowSchema.ts` — add and export:
+  ```ts
+  interface WorkflowLayout {
+    readonly workflowId: string
+    readonly workflowVersion: number
+    readonly positions: Readonly<Record<string, { x: number; y: number }>>
+  }
+  ```
+  `Workflow` / `WorkflowNode` unchanged. `advance()`, `findNode`, `resolveNextEdge`, `templates.ts`, and Phase 1 tests stay green.
+
+### New UI
+
+- `src/ui/WorkflowBuilderModal.tsx` — modal shell (focus-trap matching `ConfigPanel.focusTrap.test.tsx` pattern), owns draft `{workflow, layout}`, single-level undo (stack ≤10, cleared on close), hosts the three panes, Save disabled while any `severity:'error'` issue exists.
+- `src/ui/WorkflowBuilderModal.module.css`.
+- `src/ui/WorkflowCanvas.tsx` — SVG canvas: renders nodes + edges via `layoutWorkflow`, click-source-handle → click-target to connect, drag to reposition (snap 20px grid), selection state, active-node pulse when simulator hands back `currentNodeId`.
+- `src/ui/WorkflowNodeInspector.tsx` — per-type forms:
+  - common: read-only `id`, editable `label`
+  - condition: `expr` textarea with debounced syntax check
+  - approval: `assignTo`, `slaMinutes`, `onTimeout` (`escalate|auto-approve|auto-deny`)
+  - notify: `channel`, `template`
+  - terminal: `outcome` (`finalized|denied|cancelled`)
+- `src/ui/WorkflowEdgeGuardPicker.tsx` — popover after edge creation; options filtered by source type (condition→`true`/`false`, approval→`approved`/`denied`, notify/terminal→`default`).
+- `src/ui/WorkflowSimulator.tsx` — variables JSON textarea (pre-seeded `{"event":{"cost":1000},"actor":{"role":"director"}}`), Start/Approve/Deny(+reason)/Cancel/Reset buttons wired to `advance()`, current node badge, colored emit log, history table from `instance.history`. Emits `onActiveNodeChange` so canvas can highlight. **Step cap (amended from review #8)**: internal counter enforces ≤100 actions per simulator session; on reaching the cap, action buttons are disabled with a visible "step limit reached — reset to continue" banner. (Note: `advance()` is already cycle-guarded within a single call, but a user can still keep pressing Approve on a pathological graph — the UI cap covers that.)
+- Component tests: `WorkflowBuilderModal.test.tsx`, `WorkflowCanvas.test.tsx`, `WorkflowSimulator.test.tsx` under `src/ui/__tests__/`.
+
+### Persistence hook (mirrors `useSavedViews`)
+
+- `src/hooks/useSavedWorkflows.ts` — localStorage-backed. Key `wc-saved-workflows-${calendarId}`, wrapper `{ version: 1, workflows: SavedWorkflow[] }`:
+  ```ts
+  interface SavedWorkflow {
+    readonly id: string
+    readonly name: string
+    readonly createdAt: string
+    readonly workflow: Workflow
+    readonly layout: WorkflowLayout
+  }
+  ```
+  Returns `{ workflows, saveWorkflow, updateWorkflow, deleteWorkflow }`. `updateWorkflow` bumps `workflow.version`.
+- `src/hooks/__tests__/useSavedWorkflows.test.ts`.
+
+**Persistence destination (amended from review #4)**:
+- Owner: `useSavedWorkflows(calendarId)` is the single source of truth for saved workflows. No `ownerConfig` / ConfigPanel-side plumbing in Phase 2 — hosts who want server-side persistence subscribe to the hook's return and sync themselves.
+- Layout coupling: `WorkflowLayout.positions` lives in the same `SavedWorkflow` record, keyed by `workflow.id`. On fork-from-template, the new `SavedWorkflow` gets a deep-cloned layout so the forked graph opens laid out identically to its parent; thereafter they evolve independently.
+- Runtime consumption (dispatching `advance()` against saved workflows at event time) is **out of scope for Phase 2** — the builder ships as an authoring tool only. Phase 3 can wire saved workflows into the host's event lifecycle.
+
+### ConfigPanel integration
+
+- `src/ui/ConfigPanel.tsx` — add a **new tab id** to avoid collision with the existing `workflows` *section* id (the section already contains `templates`/`smartViews`/`approvals`/`conflicts`/`requestForm`). Use `approvalFlows`:
+  1. Append `{ id: 'approvalFlows', label: 'Approval Flows' }` to the `TABS` array (`ConfigPanel.tsx:39-50`).
+  2. Add `'approvalFlows'` to the `tabs` list of the `workflows` entry in `SECTIONS` (`ConfigPanel.tsx:58`) — position it right after `'approvals'` so the Approvals tab and Approval Flows builder sit side-by-side.
+  3. Add a render branch `{tab === 'approvalFlows' && <ApprovalFlowsTab ... />}` next to the existing `tab === 'approvals'` branch (~`ConfigPanel.tsx:227`).
+- New local `ApprovalFlowsTab` component (in `ConfigPanel.tsx` alongside `TemplatesTab`/`SmartViewsTab`):
+  - reads `WORKFLOW_TEMPLATES` + `useSavedWorkflows(calendarId)`
+  - renders "Starter templates" (Edit opens modal in **fork** mode — deep-clone template with fresh `createId('wf')`) and "My workflows" (Edit + Delete)
+  - "Create blank workflow" button — seeds the minimal validator-clean shape: one `approval` + two `terminal` (finalized/denied) + the two guarded edges
+  - owns `editing` state; when set, mounts the lazy-loaded `WorkflowBuilderModal`
+- Existing tests that look up tabs by id (`ConfigPanel.approvalsTab.test.tsx`, `ConfigPanel.focusTrap.test.tsx`) continue to pass because no existing ids are renamed.
+
+### E2E
+
+- `tests-e2e/workflow-builder.spec.ts` — open ConfigPanel → Workflows, Edit `conditional-by-cost`, drag `notify-ops`, change `director.assignTo`, simulate with cost=1000 (Start → Approve → complete with emitted notify), Save, verify new entry under "My workflows" + localStorage contents.
+- **Keyboard-only pass (amended from review #7)**: a second e2e scenario drives the same flow without using the mouse — Tab iterates nodes in BFS order, Arrow keys nudge a selected node by one `GRID_SNAP`, `Ctrl+E` enters edge-draw mode then Tab+Enter commits, Delete removes, Enter opens the inspector. Asserts focus-ring visibility and live-region announcements for node/edge changes.
+
+## Existing helpers to reuse (do not re-implement)
+
+- `findNode`, `resolveNextEdge` — `src/core/workflow/workflowSchema.ts`
+- `advance`, `WorkflowAction`, `WorkflowEmitEvent` — `src/core/workflow/advance.ts`
+- `evaluate`, `ExpressionError` — `src/core/workflow/expression.ts` (for syntax check only)
+- `WORKFLOW_TEMPLATES` — `src/core/workflow/templates.ts`
+- `createId` — `src/core/createId`
+- Storage-versioned localStorage pattern — mirror `src/hooks/useSavedViews.ts`
+- Modal/focus-trap + tab pattern — `src/ui/ConfigPanel.tsx` + `ConfigPanel.module.css`
+- Condition-row form pattern + styling — `src/ui/AdvancedFilterBuilder.tsx` + `AdvancedFilterBuilder.module.css`
+
+## Review amendments (applied 2026-04-20)
+
+1. Truncation — full schema extension + later sections are in place above.
+2. `ExpressionError.kind` field added (additive, back-compat); validator switched off prefix-sniffing. See "Expression syntax (amended from review #2)".
+3. Approval/condition fan-out replaced with `resolveNextEdge`-based signal coverage. See "Signal coverage (amended from review #3)".
+4. `SavedWorkflow` / `WorkflowLayout` persistence destination pinned — single localStorage hook; no ownerConfig plumbing; runtime wiring deferred. See "Persistence destination (amended from review #4)".
+5. Layout spec'd for unreachable nodes (trailing lane), back-edges (lateral channel), self-loops (cubic Bezier). See "Corner cases (amended from review #5)".
+6. Rule-by-rule severity table added to validator section above.
+7. Keyboard-only e2e pass added to the E2E section; component tests gate Tab/Arrow/Ctrl+E/Enter/Delete on `WorkflowCanvas`.
+8. Simulator UI step cap (100 actions/session) added to complement `advance()`'s existing cycle guard.
+
+## Out of scope (deferred)
+
+- SLA timers / `onTimeout` enforcement (Phase 3 per Phase 1 comment).
+- `parallel` node type (Phase 4).
+- In-flight `WorkflowInstance` migration when a saved workflow is edited — Phase 2 surfaces a post-save toast only ("Running instances continue on v{old}; new triggers use v{new}").
+- Full multi-step undo (only single-level delete undo ships).
+- Narrative screen-reader description of the graph (per-node labels + live-region announcements ship; full description is backlog).
+- Hoisting `parse()` out of `expression.ts` — Phase 2 uses `evaluate(expr,{})` + filtered catch.
+
+## Verification
+
+1. **Unit** — `npm run test` must pass; new suites cover every validator rule, layout overrides, and `useSavedWorkflows` round-trip. All three shipped templates validate clean.
+2. **Component** — simulator stepping through `singleApproverWorkflow`, `twoTierApproverWorkflow`, `conditionalByCostWorkflow` reaches `status: 'completed'` with expected emit events and outcomes.
+3. **E2E** — `npm run test:browser` runs `workflow-builder.spec.ts`; assertions on SVG node count, drag-applied position, simulator outcomes, and localStorage persistence.
+4. **Bundle** — re-run the audit in `docs/bundle-size-audit.md`; main chunk delta ≤2 KB gzipped (the builder loads lazily). Record new baseline.
+5. **Type check** — `npm run type-check` clean under strict.
+6. **Manual demo** — `npm run dev`, open ConfigPanel → Workflows, fork `conditional-by-cost`, edit `director.assignTo`, drag a node, simulate cost=1000 and cost=100, save, reload demo, confirm the saved workflow persists.
+
+## Critical files
+
+- `src/core/workflow/validate.ts` (new)
+- `src/core/workflow/layout.ts` (new)
+- `src/core/workflow/workflowSchema.ts` (additive: `WorkflowLayout` export)
+- `src/ui/WorkflowBuilderModal.tsx` (new)
+- `src/ui/WorkflowCanvas.tsx` (new)
+- `src/ui/WorkflowNodeInspector.tsx` (new)
+- `src/ui/WorkflowSimulator.tsx` (new)
+- `src/ui/WorkflowEdgeGuardPicker.tsx` (new)
+- `src/hooks/useSavedWorkflows.ts` (new)
+- `src/ui/ConfigPanel.tsx` (add `approvalFlows` tab to TABS + `workflows` SECTION, render `ApprovalFlowsTab`, lazy-mount modal)
+- `tests-e2e/workflow-builder.spec.ts` (new)

--- a/src/core/workflow/__tests__/layout.test.ts
+++ b/src/core/workflow/__tests__/layout.test.ts
@@ -1,0 +1,131 @@
+import { describe, it, expect } from 'vitest'
+import { layoutWorkflow, snapToGrid, NODE_WIDTH, NODE_HEIGHT } from '../layout'
+import {
+  singleApproverWorkflow,
+  twoTierApproverWorkflow,
+  conditionalByCostWorkflow,
+} from '../templates'
+import type { Workflow, WorkflowLayout } from '../workflowSchema'
+
+describe('layoutWorkflow — BFS-leveled', () => {
+  it('places startNodeId at the top row', () => {
+    const r = layoutWorkflow(singleApproverWorkflow)
+    const start = r.positions[singleApproverWorkflow.startNodeId]
+    for (const [id, p] of Object.entries(r.positions)) {
+      if (id === singleApproverWorkflow.startNodeId) continue
+      expect(p.y).toBeGreaterThanOrEqual(start.y)
+    }
+  })
+
+  it('assigns every node a position', () => {
+    const r = layoutWorkflow(twoTierApproverWorkflow)
+    for (const n of twoTierApproverWorkflow.nodes) {
+      expect(r.positions[n.id]).toBeDefined()
+    }
+  })
+
+  it('produces non-empty edge paths for every edge', () => {
+    const r = layoutWorkflow(conditionalByCostWorkflow)
+    expect(r.edgePaths.length).toBe(conditionalByCostWorkflow.edges.length)
+    for (const e of r.edgePaths) {
+      expect(e.d.length).toBeGreaterThan(0)
+    }
+  })
+
+  it('size covers all nodes + margin', () => {
+    const r = layoutWorkflow(twoTierApproverWorkflow)
+    for (const p of Object.values(r.positions)) {
+      expect(r.size.w).toBeGreaterThanOrEqual(p.x + NODE_WIDTH)
+      expect(r.size.h).toBeGreaterThanOrEqual(p.y + NODE_HEIGHT)
+    }
+  })
+})
+
+describe('layoutWorkflow — overrides', () => {
+  it('override positions win over BFS defaults', () => {
+    const overrides: WorkflowLayout = {
+      workflowId: singleApproverWorkflow.id,
+      workflowVersion: singleApproverWorkflow.version,
+      positions: { approve: { x: 1000, y: 2000 } },
+    }
+    const r = layoutWorkflow(singleApproverWorkflow, overrides)
+    expect(r.positions.approve).toEqual({ x: 1000, y: 2000 })
+    // Other nodes fall back to BFS positions.
+    expect(r.positions.done).toBeDefined()
+    expect(r.positions.done.y).not.toBe(2000)
+  })
+})
+
+describe('layoutWorkflow — corner cases', () => {
+  it('places unreachable nodes below the main graph', () => {
+    const wf: Workflow = {
+      ...singleApproverWorkflow,
+      nodes: [
+        ...singleApproverWorkflow.nodes,
+        { id: 'orphan', type: 'terminal', outcome: 'cancelled' },
+      ],
+    }
+    const r = layoutWorkflow(wf)
+    const maxReachableY = Math.max(
+      r.positions.approve.y,
+      r.positions.done.y,
+      r.positions.denied.y,
+    )
+    expect(r.positions.orphan.y).toBeGreaterThan(maxReachableY)
+  })
+
+  it('back-edges get a detour path (different from forward L-shape)', () => {
+    // Build a trivial cycle: a → b → a
+    const wf: Workflow = {
+      id: 'cycle', version: 1, trigger: 'on_submit', startNodeId: 'a',
+      nodes: [
+        { id: 'a', type: 'approval', assignTo: 'role:x' },
+        { id: 'b', type: 'approval', assignTo: 'role:y' },
+        { id: 'done', type: 'terminal', outcome: 'finalized' },
+        { id: 'denied', type: 'terminal', outcome: 'denied' },
+      ],
+      edges: [
+        { from: 'a', to: 'b', when: 'approved' },
+        { from: 'a', to: 'denied', when: 'denied' },
+        { from: 'b', to: 'a', when: 'denied' },
+        { from: 'b', to: 'done', when: 'approved' },
+      ],
+    }
+    const r = layoutWorkflow(wf)
+    const backEdge = r.edgePaths.find(e => e.from === 'b' && e.to === 'a')
+    expect(backEdge).toBeDefined()
+    // Back-edge d-string includes a negative-X detour channel
+    // (channelX = min(ax, bx) - 40) so it exits left of the graph.
+    expect(backEdge!.d).toContain('L ')
+    expect(backEdge!.d.split('L').length).toBeGreaterThanOrEqual(3)
+  })
+
+  it('self-loops render as a curve', () => {
+    const wf: Workflow = {
+      id: 'self', version: 1, trigger: 'on_submit', startNodeId: 'a',
+      nodes: [
+        { id: 'a', type: 'approval', assignTo: 'role:x' },
+        { id: 'done', type: 'terminal', outcome: 'finalized' },
+      ],
+      edges: [
+        { from: 'a', to: 'a', when: 'denied' },
+        { from: 'a', to: 'done', when: 'approved' },
+      ],
+    }
+    const r = layoutWorkflow(wf)
+    const loop = r.edgePaths.find(e => e.from === 'a' && e.to === 'a')
+    expect(loop?.d.startsWith('M ')).toBe(true)
+    expect(loop?.d).toContain('C ')
+  })
+})
+
+describe('snapToGrid', () => {
+  it('rounds to the nearest 20px', () => {
+    expect(snapToGrid(0)).toBe(0)
+    expect(snapToGrid(9)).toBe(0)
+    expect(snapToGrid(11)).toBe(20)
+    expect(snapToGrid(100)).toBe(100)
+    expect(snapToGrid(109)).toBe(100)
+    expect(snapToGrid(-11)).toBe(-20)
+  })
+})

--- a/src/core/workflow/__tests__/layout.test.ts
+++ b/src/core/workflow/__tests__/layout.test.ts
@@ -32,11 +32,13 @@ describe('layoutWorkflow — BFS-leveled', () => {
     }
   })
 
-  it('size covers all nodes + margin', () => {
+  it('size + origin cover all nodes (forms a valid SVG viewBox)', () => {
     const r = layoutWorkflow(twoTierApproverWorkflow)
     for (const p of Object.values(r.positions)) {
-      expect(r.size.w).toBeGreaterThanOrEqual(p.x + NODE_WIDTH)
-      expect(r.size.h).toBeGreaterThanOrEqual(p.y + NODE_HEIGHT)
+      expect(p.x).toBeGreaterThanOrEqual(r.origin.x)
+      expect(p.y).toBeGreaterThanOrEqual(r.origin.y)
+      expect(p.x + NODE_WIDTH).toBeLessThanOrEqual(r.origin.x + r.size.w)
+      expect(p.y + NODE_HEIGHT).toBeLessThanOrEqual(r.origin.y + r.size.h)
     }
   })
 })
@@ -53,6 +55,55 @@ describe('layoutWorkflow — overrides', () => {
     // Other nodes fall back to BFS positions.
     expect(r.positions.done).toBeDefined()
     expect(r.positions.done.y).not.toBe(2000)
+  })
+})
+
+describe('layoutWorkflow — bounding box', () => {
+  it('origin + size cover negative-coordinate overrides', () => {
+    const overrides: WorkflowLayout = {
+      workflowId: singleApproverWorkflow.id,
+      workflowVersion: singleApproverWorkflow.version,
+      positions: { approve: { x: -200, y: -120 } },
+    }
+    const r = layoutWorkflow(singleApproverWorkflow, overrides)
+    // origin must be at least as far left/up as the dragged node.
+    expect(r.origin.x).toBeLessThanOrEqual(-200)
+    expect(r.origin.y).toBeLessThanOrEqual(-120)
+    // and the box must reach the dragged node's far edges.
+    expect(r.origin.x + r.size.w).toBeGreaterThanOrEqual(-200 + NODE_WIDTH)
+    expect(r.origin.y + r.size.h).toBeGreaterThanOrEqual(-120 + NODE_HEIGHT)
+    // every node (override or BFS-default) fits inside the box.
+    for (const p of Object.values(r.positions)) {
+      expect(p.x).toBeGreaterThanOrEqual(r.origin.x)
+      expect(p.y).toBeGreaterThanOrEqual(r.origin.y)
+      expect(p.x + NODE_WIDTH).toBeLessThanOrEqual(r.origin.x + r.size.w)
+      expect(p.y + NODE_HEIGHT).toBeLessThanOrEqual(r.origin.y + r.size.h)
+    }
+  })
+
+  it('bounding box includes back-edge detour channel', () => {
+    const wf: Workflow = {
+      id: 'cycle', version: 1, trigger: 'on_submit', startNodeId: 'a',
+      nodes: [
+        { id: 'a', type: 'approval', assignTo: 'role:x' },
+        { id: 'b', type: 'approval', assignTo: 'role:y' },
+        { id: 'done', type: 'terminal', outcome: 'finalized' },
+        { id: 'denied', type: 'terminal', outcome: 'denied' },
+      ],
+      edges: [
+        { from: 'a', to: 'b', when: 'approved' },
+        { from: 'a', to: 'denied', when: 'denied' },
+        { from: 'b', to: 'a', when: 'denied' },
+        { from: 'b', to: 'done', when: 'approved' },
+      ],
+    }
+    const r = layoutWorkflow(wf)
+    const backEdge = r.edgePaths.find(e => e.from === 'b' && e.to === 'a')
+    expect(backEdge).toBeDefined()
+    // Back-edge channel sits left of every node; origin.x must be at
+    // least that far left so the detour isn't clipped.
+    const minNodeX = Math.min(...Object.values(r.positions).map(p => p.x))
+    expect(r.origin.x).toBeLessThan(minNodeX)
   })
 })
 

--- a/src/core/workflow/__tests__/layout.test.ts
+++ b/src/core/workflow/__tests__/layout.test.ts
@@ -56,6 +56,62 @@ describe('layoutWorkflow — overrides', () => {
     expect(r.positions.done).toBeDefined()
     expect(r.positions.done.y).not.toBe(2000)
   })
+
+  it('ignores overrides whose workflowId does not match', () => {
+    const overrides: WorkflowLayout = {
+      workflowId: 'some-other-workflow',
+      workflowVersion: singleApproverWorkflow.version,
+      positions: { approve: { x: 1000, y: 2000 } },
+    }
+    const r = layoutWorkflow(singleApproverWorkflow, overrides)
+    expect(r.positions.approve).not.toEqual({ x: 1000, y: 2000 })
+  })
+
+  it('ignores overrides whose workflowVersion does not match', () => {
+    const overrides: WorkflowLayout = {
+      workflowId: singleApproverWorkflow.id,
+      workflowVersion: singleApproverWorkflow.version + 1,
+      positions: { approve: { x: 1000, y: 2000 } },
+    }
+    const r = layoutWorkflow(singleApproverWorkflow, overrides)
+    expect(r.positions.approve).not.toEqual({ x: 1000, y: 2000 })
+  })
+})
+
+describe('layoutWorkflow — BFS visitation-order columns', () => {
+  it('columns follow BFS order, not workflow.nodes declaration order', () => {
+    // Declare start LAST in `nodes`. If we used declaration order,
+    // `start` would land in column 2 at rank 0 — but there is no
+    // sibling at rank 0, so col must be 0.
+    const wf: Workflow = {
+      id: 'w', version: 1, trigger: 'on_submit', startNodeId: 'start',
+      nodes: [
+        { id: 'childA', type: 'approval', assignTo: 'role:x' },
+        { id: 'childB', type: 'approval', assignTo: 'role:y' },
+        { id: 'done',   type: 'terminal', outcome: 'finalized' },
+        { id: 'denied', type: 'terminal', outcome: 'denied' },
+        { id: 'start',  type: 'condition', expr: 'event.cost > 0' },
+      ],
+      edges: [
+        { from: 'start',  to: 'childA', when: 'true' },
+        { from: 'start',  to: 'childB', when: 'false' },
+        { from: 'childA', to: 'done',   when: 'approved' },
+        { from: 'childA', to: 'denied', when: 'denied'   },
+        { from: 'childB', to: 'done',   when: 'approved' },
+        { from: 'childB', to: 'denied', when: 'denied'   },
+      ],
+    }
+    const r = layoutWorkflow(wf)
+    // rank → y (start is above its children)
+    expect(r.positions.start.y).toBeLessThan(r.positions.childA.y)
+    expect(r.positions.start.y).toBeLessThan(r.positions.childB.y)
+    // start is alone at rank 0 → col 0 (same x as the first child).
+    expect(r.positions.start.x).toBe(r.positions.childA.x)
+    // childA visited before childB (edge declaration order) → A < B on x.
+    expect(r.positions.childA.x).toBeLessThan(r.positions.childB.x)
+    // Same rank → same y.
+    expect(r.positions.childA.y).toBe(r.positions.childB.y)
+  })
 })
 
 describe('layoutWorkflow — bounding box', () => {

--- a/src/core/workflow/__tests__/validate.test.ts
+++ b/src/core/workflow/__tests__/validate.test.ts
@@ -1,0 +1,244 @@
+import { describe, it, expect } from 'vitest'
+import {
+  validateWorkflow,
+  hasBlockingErrors,
+  validateExpressionSyntax,
+} from '../validate'
+import {
+  WORKFLOW_TEMPLATES,
+  singleApproverWorkflow,
+  conditionalByCostWorkflow,
+} from '../templates'
+import type { Workflow } from '../workflowSchema'
+
+describe('validateWorkflow — shipped templates', () => {
+  it('every shipped template validates clean (no errors)', () => {
+    for (const wf of WORKFLOW_TEMPLATES) {
+      const issues = validateWorkflow(wf)
+      const errors = issues.filter(i => i.severity === 'error')
+      expect(errors).toEqual([])
+    }
+  })
+})
+
+describe('validateWorkflow — rules', () => {
+  it('flags duplicate node ids', () => {
+    const wf: Workflow = {
+      ...singleApproverWorkflow,
+      nodes: [
+        ...singleApproverWorkflow.nodes,
+        { id: 'approve', type: 'terminal', outcome: 'finalized' },
+      ],
+    }
+    const issues = validateWorkflow(wf)
+    expect(issues.some(i => i.code === 'duplicate-node-id')).toBe(true)
+  })
+
+  it('flags missing startNodeId', () => {
+    const wf: Workflow = { ...singleApproverWorkflow, startNodeId: 'ghost' }
+    const issues = validateWorkflow(wf)
+    expect(issues.some(i => i.code === 'start-node-missing')).toBe(true)
+  })
+
+  it('flags edges pointing at non-existent nodes', () => {
+    const wf: Workflow = {
+      ...singleApproverWorkflow,
+      edges: [
+        ...singleApproverWorkflow.edges,
+        { from: 'approve', to: 'ghost', when: 'approved' },
+      ],
+    }
+    const issues = validateWorkflow(wf)
+    expect(issues.some(i => i.code === 'edge-endpoint-missing')).toBe(true)
+  })
+
+  it('flags workflows with no terminal nodes', () => {
+    const wf: Workflow = {
+      id: 'w', version: 1, trigger: 'on_submit', startNodeId: 'a',
+      nodes: [
+        { id: 'a', type: 'approval', assignTo: 'role:x' },
+      ],
+      edges: [
+        { from: 'a', to: 'a', when: 'approved' },
+        { from: 'a', to: 'a', when: 'denied' },
+      ],
+    }
+    const issues = validateWorkflow(wf)
+    expect(issues.some(i => i.code === 'no-terminal-node')).toBe(true)
+  })
+
+  it('flags unreachable nodes as warnings', () => {
+    const wf: Workflow = {
+      ...singleApproverWorkflow,
+      nodes: [
+        ...singleApproverWorkflow.nodes,
+        { id: 'orphan', type: 'terminal', outcome: 'cancelled' },
+      ],
+    }
+    const issues = validateWorkflow(wf)
+    const orphan = issues.find(i => i.code === 'unreachable-node' && i.nodeId === 'orphan')
+    expect(orphan?.severity).toBe('warning')
+  })
+
+  it('flags non-terminal nodes with no outgoing edges', () => {
+    const wf: Workflow = {
+      id: 'w', version: 1, trigger: 'on_submit', startNodeId: 'a',
+      nodes: [
+        { id: 'a', type: 'approval', assignTo: 'role:x' },
+        { id: 'done', type: 'terminal', outcome: 'finalized' },
+      ],
+      edges: [{ from: 'a', to: 'done', when: 'approved' }],
+    }
+    // Approval 'a' is missing its denied edge — but crucially it still
+    // has an outgoing edge. Add a node 'b' with no outgoing at all:
+    const wf2: Workflow = {
+      ...wf,
+      nodes: [
+        ...wf.nodes,
+        { id: 'b', type: 'notify', channel: 'slack' },
+      ],
+      edges: [
+        ...wf.edges,
+        { from: 'a', to: 'b', when: 'denied' },
+      ],
+    }
+    const issues = validateWorkflow(wf2)
+    expect(issues.some(i => i.code === 'dead-end-node' && i.nodeId === 'b')).toBe(true)
+  })
+
+  it('flags multiple default edges from the same source', () => {
+    const wf: Workflow = {
+      ...conditionalByCostWorkflow,
+      edges: [
+        ...conditionalByCostWorkflow.edges,
+        { from: 'notify-ops', to: 'done' },
+      ],
+    }
+    const issues = validateWorkflow(wf)
+    expect(issues.some(i => i.code === 'multiple-default-edges')).toBe(true)
+  })
+
+  it('flags approvals missing approved or denied outgoing edges', () => {
+    const wf: Workflow = {
+      ...singleApproverWorkflow,
+      edges: singleApproverWorkflow.edges.filter(e => e.when !== 'denied'),
+    }
+    const issues = validateWorkflow(wf)
+    expect(
+      issues.some(i => i.code === 'approval-missing-signal-coverage' && i.message.includes('denied')),
+    ).toBe(true)
+  })
+
+  it('accepts approval with approved+default edges (signal coverage via default)', () => {
+    const wf: Workflow = {
+      id: 'w', version: 1, trigger: 'on_submit', startNodeId: 'a',
+      nodes: [
+        { id: 'a', type: 'approval', assignTo: 'role:x' },
+        { id: 'done', type: 'terminal', outcome: 'finalized' },
+        { id: 'denied', type: 'terminal', outcome: 'denied' },
+      ],
+      // No explicit 'denied' edge — default covers it.
+      edges: [
+        { from: 'a', to: 'done',   when: 'approved' },
+        { from: 'a', to: 'denied', when: 'default'  },
+      ],
+    }
+    const issues = validateWorkflow(wf).filter(i => i.severity === 'error')
+    expect(issues).toEqual([])
+  })
+
+  it('accepts condition with true+default edges (signal coverage via default)', () => {
+    const wf: Workflow = {
+      id: 'w', version: 1, trigger: 'on_submit', startNodeId: 'c',
+      nodes: [
+        { id: 'c', type: 'condition', expr: 'event.cost > 500' },
+        { id: 'hi', type: 'terminal', outcome: 'finalized' },
+        { id: 'lo', type: 'terminal', outcome: 'finalized' },
+      ],
+      edges: [
+        { from: 'c', to: 'hi', when: 'true' },
+        { from: 'c', to: 'lo' /* default */ },
+      ],
+    }
+    const issues = validateWorkflow(wf).filter(i => i.severity === 'error')
+    expect(issues).toEqual([])
+  })
+
+  it('flags conditions missing true or false outgoing edges', () => {
+    const wf: Workflow = {
+      ...conditionalByCostWorkflow,
+      edges: conditionalByCostWorkflow.edges.filter(e => e.when !== 'true'),
+    }
+    const issues = validateWorkflow(wf)
+    expect(issues.some(i => i.code === 'condition-missing-signal-coverage')).toBe(true)
+  })
+
+  it('flags guards that are illegal for their source node type', () => {
+    const wf: Workflow = {
+      ...singleApproverWorkflow,
+      edges: [
+        ...singleApproverWorkflow.edges,
+        { from: 'approve', to: 'done', when: 'true' },
+      ],
+    }
+    const issues = validateWorkflow(wf)
+    expect(issues.some(i => i.code === 'illegal-guard-for-source')).toBe(true)
+  })
+
+  it('flags condition nodes with bad expression syntax', () => {
+    const wf: Workflow = {
+      ...conditionalByCostWorkflow,
+      nodes: conditionalByCostWorkflow.nodes.map(n =>
+        n.id === 'check-cost'
+          ? { ...n, expr: 'event.cost >' }
+          : n,
+      ),
+    }
+    const issues = validateWorkflow(wf)
+    expect(issues.some(i => i.code === 'expression-syntax')).toBe(true)
+  })
+
+  it('flags terminals that carry outgoing edges (warning)', () => {
+    const wf: Workflow = {
+      ...singleApproverWorkflow,
+      edges: [
+        ...singleApproverWorkflow.edges,
+        { from: 'done', to: 'denied' },
+      ],
+    }
+    const issues = validateWorkflow(wf)
+    const warn = issues.find(i => i.code === 'terminal-has-outgoing')
+    expect(warn?.severity).toBe('warning')
+  })
+})
+
+describe('hasBlockingErrors', () => {
+  it('is false when only warnings exist', () => {
+    const issues = [
+      { code: 'unreachable-node' as const, severity: 'warning' as const, message: 'x' },
+    ]
+    expect(hasBlockingErrors(issues)).toBe(false)
+  })
+  it('is true when any error exists', () => {
+    const issues = [
+      { code: 'unreachable-node' as const, severity: 'warning' as const, message: 'x' },
+      { code: 'no-terminal-node' as const, severity: 'error' as const, message: 'y' },
+    ]
+    expect(hasBlockingErrors(issues)).toBe(true)
+  })
+})
+
+describe('validateExpressionSyntax', () => {
+  it('returns null for clean expressions (even with unbound vars)', () => {
+    expect(validateExpressionSyntax('event.cost > 500')).toBeNull()
+    expect(validateExpressionSyntax('1 + 2 == 3')).toBeNull()
+  })
+  it('reports empty expressions', () => {
+    expect(validateExpressionSyntax('')).toMatch(/empty/i)
+    expect(validateExpressionSyntax('   ')).toMatch(/empty/i)
+  })
+  it('reports syntax errors', () => {
+    expect(validateExpressionSyntax('event.cost >')).not.toBeNull()
+    expect(validateExpressionSyntax('(1 + 2')).not.toBeNull()
+  })
+})

--- a/src/core/workflow/expression.ts
+++ b/src/core/workflow/expression.ts
@@ -24,10 +24,40 @@
 
 export type ExpressionValue = number | string | boolean | null
 
+/**
+ * Classification of `ExpressionError` causes. Callers match on `kind`
+ * instead of string-sniffing `message` so validator / UI code stays
+ * decoupled from error wording.
+ */
+export type ExpressionErrorKind =
+  | 'syntax'
+  | 'undefined-variable'
+  | 'non-object'
+  | 'type'
+  | 'unknown-operator'
+  | 'unsupported-value'
+
 export class ExpressionError extends Error {
-  constructor(message: string, readonly position?: number) {
-    super(position !== undefined ? `${message} (at ${position})` : message)
+  readonly kind: ExpressionErrorKind
+  readonly position?: number
+  constructor(
+    message: string,
+    kindOrPosition?: ExpressionErrorKind | number,
+    position?: number,
+  ) {
+    // Back-compat: old signature (message, position?: number) still works.
+    let kind: ExpressionErrorKind = 'syntax'
+    let pos: number | undefined
+    if (typeof kindOrPosition === 'number') {
+      pos = kindOrPosition
+    } else if (typeof kindOrPosition === 'string') {
+      kind = kindOrPosition
+      pos = position
+    }
+    super(pos !== undefined ? `${message} (at ${pos})` : message)
     this.name = 'ExpressionError'
+    this.kind = kind
+    this.position = pos
   }
 }
 
@@ -237,22 +267,22 @@ function resolvePath(
   let cur: unknown = vars
   for (const part of path) {
     if (cur === null || typeof cur !== 'object') {
-      throw new ExpressionError(`Cannot resolve "${path.join('.')}" — non-object at "${part}"`)
+      throw new ExpressionError(`Cannot resolve "${path.join('.')}" — non-object at "${part}"`, 'non-object')
     }
     cur = (cur as Record<string, unknown>)[part]
     if (cur === undefined) {
-      throw new ExpressionError(`Undefined variable "${path.join('.')}"`)
+      throw new ExpressionError(`Undefined variable "${path.join('.')}"`, 'undefined-variable')
     }
   }
   if (cur === null) return null
   const t = typeof cur
   if (t === 'string' || t === 'number' || t === 'boolean') return cur as ExpressionValue
-  throw new ExpressionError(`Unsupported value type for "${path.join('.')}": ${t}`)
+  throw new ExpressionError(`Unsupported value type for "${path.join('.')}": ${t}`, 'unsupported-value')
 }
 
 function toNumber(v: ExpressionValue, op: string): number {
   if (typeof v === 'number') return v
-  throw new ExpressionError(`Operator "${op}" requires a number, got ${typeof v}`)
+  throw new ExpressionError(`Operator "${op}" requires a number, got ${typeof v}`, 'type')
 }
 
 function evalAst(
@@ -289,7 +319,7 @@ function evalAst(
         case '*':  return toNumber(l, '*') * toNumber(r, '*')
         case '/':  return toNumber(l, '/') / toNumber(r, '/')
       }
-      throw new ExpressionError(`Unknown operator "${node.op}"`)
+      throw new ExpressionError(`Unknown operator "${node.op}"`, 'unknown-operator')
     }
   }
 }

--- a/src/core/workflow/layout.ts
+++ b/src/core/workflow/layout.ts
@@ -42,23 +42,27 @@ export function layoutWorkflow(
   workflow: Workflow,
   overrides?: WorkflowLayout | null,
 ): LayoutResult {
-  const ranks = bfsRanks(workflow)
-  const columnsInRank = new Map<number, number>()
+  const placement = bfsPlacement(workflow)
   const auto: Record<string, NodePosition> = {}
-
   for (const node of workflow.nodes) {
-    const rank = ranks.get(node.id) ?? 0
-    const col = columnsInRank.get(rank) ?? 0
-    columnsInRank.set(rank, col + 1)
+    const p = placement.get(node.id) ?? { rank: 0, col: 0 }
     auto[node.id] = {
-      x: MARGIN + col * COLUMN_STEP,
-      y: MARGIN + rank * ROW_STEP,
+      x: MARGIN + p.col * COLUMN_STEP,
+      y: MARGIN + p.rank * ROW_STEP,
     }
   }
 
+  // Overrides are scoped: silently ignore a stale `WorkflowLayout` that
+  // was saved against a different workflow id or version. This keeps
+  // accidentally-mismatched coordinates from being rendered against
+  // the wrong graph.
+  const overridesMatch =
+    overrides != null &&
+    overrides.workflowId === workflow.id &&
+    overrides.workflowVersion === workflow.version
   const positions: Record<string, NodePosition> = {}
   for (const node of workflow.nodes) {
-    const override = overrides?.positions?.[node.id]
+    const override = overridesMatch ? overrides!.positions[node.id] : undefined
     positions[node.id] = override ?? auto[node.id]
   }
 
@@ -190,35 +194,68 @@ function selfLoopPath(
   }
 }
 
-function bfsRanks(workflow: Workflow): Map<string, number> {
-  const ranks = new Map<string, number>()
+/**
+ * BFS from `startNodeId` that assigns each node a `{rank, col}`:
+ *  - rank = depth from start (row),
+ *  - col  = zero-based index in that rank's *visitation order* (not the
+ *    `workflow.nodes` declaration order — visitation order keeps
+ *    children of the same parent horizontally adjacent).
+ *
+ * Uses an index-based queue (O(1) dequeue) and a prebuilt adjacency
+ * map so the traversal is O(V + E) — safe to call on every edit.
+ * Nodes unreachable from `startNodeId` are piled into trailing ranks
+ * (one per row) below the main graph.
+ */
+function bfsPlacement(
+  workflow: Workflow,
+): Map<string, { rank: number; col: number }> {
+  const placement = new Map<string, { rank: number; col: number }>()
   const present = new Set(workflow.nodes.map(n => n.id))
-  if (!present.has(workflow.startNodeId)) {
-    // Fall back to row 0 for all nodes so the layout is still defined.
-    workflow.nodes.forEach(n => ranks.set(n.id, 0))
-    return ranks
+
+  // Adjacency: map<from, to[]> preserving edge-declaration order.
+  const adj = new Map<string, string[]>()
+  for (const edge of workflow.edges) {
+    if (!present.has(edge.from) || !present.has(edge.to)) continue
+    let list = adj.get(edge.from)
+    if (!list) { list = []; adj.set(edge.from, list) }
+    list.push(edge.to)
   }
-  ranks.set(workflow.startNodeId, 0)
-  const queue: string[] = [workflow.startNodeId]
-  while (queue.length > 0) {
-    const id = queue.shift() as string
-    const rank = ranks.get(id) ?? 0
-    for (const edge of workflow.edges) {
-      if (edge.from !== id) continue
-      if (!present.has(edge.to)) continue
-      if (!ranks.has(edge.to)) {
-        ranks.set(edge.to, rank + 1)
-        queue.push(edge.to)
+
+  const colsInRank = new Map<number, number>()
+  let maxReachableRank = 0
+
+  if (present.has(workflow.startNodeId)) {
+    const queue: Array<{ id: string; rank: number }> = [
+      { id: workflow.startNodeId, rank: 0 },
+    ]
+    placement.set(workflow.startNodeId, { rank: 0, col: 0 })
+    colsInRank.set(0, 1)
+    for (let head = 0; head < queue.length; head++) {
+      const { id, rank } = queue[head]
+      if (rank > maxReachableRank) maxReachableRank = rank
+      const neighbors = adj.get(id)
+      if (!neighbors) continue
+      for (const to of neighbors) {
+        if (placement.has(to)) continue
+        const nextRank = rank + 1
+        const col = colsInRank.get(nextRank) ?? 0
+        colsInRank.set(nextRank, col + 1)
+        placement.set(to, { rank: nextRank, col })
+        queue.push({ id: to, rank: nextRank })
       }
     }
   }
-  // Nodes unreachable from start still need a row — pile them below.
-  let orphanRank = (Math.max(0, ...Array.from(ranks.values())) ?? 0) + 1
+
+  // Orphans: one per trailing rank, column 0. Deterministic ordering
+  // comes from workflow.nodes declaration order.
+  let orphanRank = maxReachableRank + 1
   for (const node of workflow.nodes) {
-    if (!ranks.has(node.id)) {
-      ranks.set(node.id, orphanRank)
-      orphanRank++
-    }
+    if (placement.has(node.id)) continue
+    placement.set(node.id, { rank: orphanRank, col: 0 })
+    orphanRank++
   }
-  return ranks
+  // Edge case: startNodeId wasn't in the graph at all — every node is
+  // now an orphan at its own row, which matches the previous fallback
+  // behavior of "layout is still defined".
+  return placement
 }

--- a/src/core/workflow/layout.ts
+++ b/src/core/workflow/layout.ts
@@ -31,6 +31,9 @@ export interface EdgePath {
 
 export interface LayoutResult {
   readonly positions: Readonly<Record<string, NodePosition>>
+  /** Top-left corner of the bounding box covering all nodes + edges. */
+  readonly origin: NodePosition
+  /** Width and height from `origin`. Consumers wire both into an SVG viewBox. */
   readonly size: { readonly w: number; readonly h: number }
   readonly edgePaths: readonly EdgePath[]
 }
@@ -59,13 +62,6 @@ export function layoutWorkflow(
     positions[node.id] = override ?? auto[node.id]
   }
 
-  let maxX = 0
-  let maxY = 0
-  for (const pos of Object.values(positions)) {
-    if (pos.x + NODE_WIDTH > maxX) maxX = pos.x + NODE_WIDTH
-    if (pos.y + NODE_HEIGHT > maxY) maxY = pos.y + NODE_HEIGHT
-  }
-
   const edgePaths: EdgePath[] = workflow.edges.map(edge => {
     const a = positions[edge.from]
     const b = positions[edge.to]
@@ -79,11 +75,56 @@ export function layoutWorkflow(
         : forwardEdgePath(edge, a, b)
   })
 
+  // Bounding box covers node rectangles AND edge-path extremes
+  // (back-edge detour channels + self-loop bulges can exit the node
+  // grid). Track both min and max so negative coordinates from
+  // user-dragged overrides aren't clipped by consumers sizing the SVG.
+  let minX = Infinity
+  let minY = Infinity
+  let maxX = -Infinity
+  let maxY = -Infinity
+
+  for (const pos of Object.values(positions)) {
+    if (pos.x < minX) minX = pos.x
+    if (pos.y < minY) minY = pos.y
+    if (pos.x + NODE_WIDTH > maxX) maxX = pos.x + NODE_WIDTH
+    if (pos.y + NODE_HEIGHT > maxY) maxY = pos.y + NODE_HEIGHT
+  }
+  for (const path of edgePaths) {
+    for (const pt of extremesOfPath(path.d)) {
+      if (pt.x < minX) minX = pt.x
+      if (pt.y < minY) minY = pt.y
+      if (pt.x > maxX) maxX = pt.x
+      if (pt.y > maxY) maxY = pt.y
+    }
+  }
+  if (!Number.isFinite(minX)) { minX = 0; minY = 0; maxX = 0; maxY = 0 }
+
   return {
     positions,
-    size: { w: maxX + MARGIN, h: maxY + MARGIN },
+    origin: { x: minX - MARGIN, y: minY - MARGIN },
+    size: { w: (maxX - minX) + 2 * MARGIN, h: (maxY - minY) + 2 * MARGIN },
     edgePaths,
   }
+}
+
+/**
+ * Extract the absolute `(x, y)` pairs from an SVG path `d` string so
+ * we can expand the bounding box to cover edge-only geometry (back-edge
+ * channels, self-loop arcs). Handles the command set we emit: `M L C`.
+ */
+function extremesOfPath(d: string): readonly NodePosition[] {
+  if (!d) return []
+  const pts: NodePosition[] = []
+  // Split on M/L/C commands and parse number pairs.
+  const tokens = d.trim().split(/[MLC]/i).filter(t => t.trim().length > 0)
+  for (const t of tokens) {
+    const nums = t.trim().split(/[\s,]+/).map(Number).filter(n => !Number.isNaN(n))
+    for (let i = 0; i + 1 < nums.length; i += 2) {
+      pts.push({ x: nums[i], y: nums[i + 1] })
+    }
+  }
+  return pts
 }
 
 export function snapToGrid(value: number): number {

--- a/src/core/workflow/layout.ts
+++ b/src/core/workflow/layout.ts
@@ -1,0 +1,183 @@
+/**
+ * Workflow layout — Phase 2 visual builder.
+ *
+ * Pure function that computes SVG positions for each node and an
+ * orthogonal path per edge. BFS from `startNodeId` determines the row
+ * (rank); order-of-first-visit within a rank determines the column.
+ * User-provided `WorkflowLayout.positions` always wins over the
+ * auto-computed values.
+ */
+import { type Workflow, type WorkflowLayout } from './workflowSchema'
+
+export const NODE_WIDTH = 140
+export const NODE_HEIGHT = 56
+export const COLUMN_STEP = 180
+export const ROW_STEP = 120
+export const GRID_SNAP = 20
+const MARGIN = 40
+
+export interface NodePosition {
+  readonly x: number
+  readonly y: number
+}
+
+export interface EdgePath {
+  readonly from: string
+  readonly to: string
+  readonly d: string
+  readonly midpoint: NodePosition
+  readonly guard?: string
+}
+
+export interface LayoutResult {
+  readonly positions: Readonly<Record<string, NodePosition>>
+  readonly size: { readonly w: number; readonly h: number }
+  readonly edgePaths: readonly EdgePath[]
+}
+
+export function layoutWorkflow(
+  workflow: Workflow,
+  overrides?: WorkflowLayout | null,
+): LayoutResult {
+  const ranks = bfsRanks(workflow)
+  const columnsInRank = new Map<number, number>()
+  const auto: Record<string, NodePosition> = {}
+
+  for (const node of workflow.nodes) {
+    const rank = ranks.get(node.id) ?? 0
+    const col = columnsInRank.get(rank) ?? 0
+    columnsInRank.set(rank, col + 1)
+    auto[node.id] = {
+      x: MARGIN + col * COLUMN_STEP,
+      y: MARGIN + rank * ROW_STEP,
+    }
+  }
+
+  const positions: Record<string, NodePosition> = {}
+  for (const node of workflow.nodes) {
+    const override = overrides?.positions?.[node.id]
+    positions[node.id] = override ?? auto[node.id]
+  }
+
+  let maxX = 0
+  let maxY = 0
+  for (const pos of Object.values(positions)) {
+    if (pos.x + NODE_WIDTH > maxX) maxX = pos.x + NODE_WIDTH
+    if (pos.y + NODE_HEIGHT > maxY) maxY = pos.y + NODE_HEIGHT
+  }
+
+  const edgePaths: EdgePath[] = workflow.edges.map(edge => {
+    const a = positions[edge.from]
+    const b = positions[edge.to]
+    if (!a || !b) {
+      return { from: edge.from, to: edge.to, d: '', midpoint: { x: 0, y: 0 }, guard: edge.when }
+    }
+    return edge.from === edge.to
+      ? selfLoopPath(edge, a)
+      : a.y >= b.y
+        ? backEdgePath(edge, a, b)
+        : forwardEdgePath(edge, a, b)
+  })
+
+  return {
+    positions,
+    size: { w: maxX + MARGIN, h: maxY + MARGIN },
+    edgePaths,
+  }
+}
+
+export function snapToGrid(value: number): number {
+  return Math.round(value / GRID_SNAP) * GRID_SNAP
+}
+
+function forwardEdgePath(
+  edge: { from: string; to: string; when?: string },
+  a: NodePosition,
+  b: NodePosition,
+): EdgePath {
+  const ax = a.x + NODE_WIDTH / 2
+  const ay = a.y + NODE_HEIGHT
+  const bx = b.x + NODE_WIDTH / 2
+  const by = b.y
+  const midY = (ay + by) / 2
+  return {
+    from: edge.from,
+    to: edge.to,
+    d: `M ${ax} ${ay} L ${ax} ${midY} L ${bx} ${midY} L ${bx} ${by}`,
+    midpoint: { x: (ax + bx) / 2, y: midY },
+    guard: edge.when,
+  }
+}
+
+/**
+ * Back-edge (target rank ≤ source rank) — detours through a channel to
+ * the left of the graph so the line is visible and can't be confused
+ * with forward edges.
+ */
+function backEdgePath(
+  edge: { from: string; to: string; when?: string },
+  a: NodePosition,
+  b: NodePosition,
+): EdgePath {
+  const ax = a.x
+  const ay = a.y + NODE_HEIGHT / 2
+  const bx = b.x
+  const by = b.y + NODE_HEIGHT / 2
+  const channelX = Math.min(ax, bx) - 40
+  return {
+    from: edge.from,
+    to: edge.to,
+    d: `M ${ax} ${ay} L ${channelX} ${ay} L ${channelX} ${by} L ${bx} ${by}`,
+    midpoint: { x: channelX, y: (ay + by) / 2 },
+    guard: edge.when,
+  }
+}
+
+function selfLoopPath(
+  edge: { from: string; to: string; when?: string },
+  a: NodePosition,
+): EdgePath {
+  const rx = a.x + NODE_WIDTH
+  const ry = a.y + NODE_HEIGHT / 2
+  const loopX = rx + 32
+  return {
+    from: edge.from,
+    to: edge.to,
+    d: `M ${rx} ${ry} C ${loopX} ${ry - 32}, ${loopX} ${ry + 32}, ${rx} ${ry}`,
+    midpoint: { x: loopX, y: ry },
+    guard: edge.when,
+  }
+}
+
+function bfsRanks(workflow: Workflow): Map<string, number> {
+  const ranks = new Map<string, number>()
+  const present = new Set(workflow.nodes.map(n => n.id))
+  if (!present.has(workflow.startNodeId)) {
+    // Fall back to row 0 for all nodes so the layout is still defined.
+    workflow.nodes.forEach(n => ranks.set(n.id, 0))
+    return ranks
+  }
+  ranks.set(workflow.startNodeId, 0)
+  const queue: string[] = [workflow.startNodeId]
+  while (queue.length > 0) {
+    const id = queue.shift() as string
+    const rank = ranks.get(id) ?? 0
+    for (const edge of workflow.edges) {
+      if (edge.from !== id) continue
+      if (!present.has(edge.to)) continue
+      if (!ranks.has(edge.to)) {
+        ranks.set(edge.to, rank + 1)
+        queue.push(edge.to)
+      }
+    }
+  }
+  // Nodes unreachable from start still need a row — pile them below.
+  let orphanRank = (Math.max(0, ...Array.from(ranks.values())) ?? 0) + 1
+  for (const node of workflow.nodes) {
+    if (!ranks.has(node.id)) {
+      ranks.set(node.id, orphanRank)
+      orphanRank++
+    }
+  }
+  return ranks
+}

--- a/src/core/workflow/validate.ts
+++ b/src/core/workflow/validate.ts
@@ -1,0 +1,286 @@
+/**
+ * Workflow validator — Phase 2 visual builder.
+ *
+ * Pure, synchronous check that gates Save in the builder UI and surfaces
+ * inline badges per node / edge. Runs against the draft `Workflow` before
+ * the user is allowed to persist.
+ *
+ * Split into `error` (blocks save) and `warning` (surfaced but not
+ * blocking). All rules refer exclusively to Phase 1 helpers so the
+ * semantic contract cannot drift.
+ */
+import { evaluate, ExpressionError } from './expression'
+import {
+  findNode,
+  resolveNextEdge,
+  type EdgeGuard,
+  type Workflow,
+  type WorkflowNode,
+} from './workflowSchema'
+
+export type ValidationSeverity = 'error' | 'warning'
+
+export type ValidationCode =
+  | 'duplicate-node-id'
+  | 'start-node-missing'
+  | 'edge-endpoint-missing'
+  | 'no-terminal-node'
+  | 'unreachable-node'
+  | 'dead-end-node'
+  | 'multiple-default-edges'
+  | 'approval-missing-signal-coverage'
+  | 'condition-missing-signal-coverage'
+  | 'illegal-guard-for-source'
+  | 'expression-syntax'
+  | 'terminal-has-outgoing'
+
+export interface ValidationIssue {
+  readonly code: ValidationCode
+  readonly severity: ValidationSeverity
+  readonly message: string
+  readonly nodeId?: string
+  readonly edgeIndex?: number
+}
+
+export function validateWorkflow(
+  workflow: Workflow,
+): readonly ValidationIssue[] {
+  const issues: ValidationIssue[] = []
+
+  // 1. unique node ids
+  const seen = new Set<string>()
+  for (const node of workflow.nodes) {
+    if (seen.has(node.id)) {
+      issues.push({
+        code: 'duplicate-node-id',
+        severity: 'error',
+        message: `Duplicate node id "${node.id}"`,
+        nodeId: node.id,
+      })
+    }
+    seen.add(node.id)
+  }
+
+  // 2. startNodeId exists
+  if (!findNode(workflow, workflow.startNodeId)) {
+    issues.push({
+      code: 'start-node-missing',
+      severity: 'error',
+      message: `Start node "${workflow.startNodeId}" is not in nodes`,
+    })
+  }
+
+  // 3. edge endpoints resolve
+  workflow.edges.forEach((edge, idx) => {
+    if (!findNode(workflow, edge.from)) {
+      issues.push({
+        code: 'edge-endpoint-missing',
+        severity: 'error',
+        message: `Edge #${idx} source "${edge.from}" is not a node`,
+        edgeIndex: idx,
+      })
+    }
+    if (!findNode(workflow, edge.to)) {
+      issues.push({
+        code: 'edge-endpoint-missing',
+        severity: 'error',
+        message: `Edge #${idx} target "${edge.to}" is not a node`,
+        edgeIndex: idx,
+      })
+    }
+  })
+
+  // 4. at least one terminal
+  if (!workflow.nodes.some(n => n.type === 'terminal')) {
+    issues.push({
+      code: 'no-terminal-node',
+      severity: 'error',
+      message: 'Workflow needs at least one terminal node',
+    })
+  }
+
+  // 5. reachability from startNodeId
+  const reachable = reachableNodeIds(workflow)
+  for (const node of workflow.nodes) {
+    if (!reachable.has(node.id) && node.id !== workflow.startNodeId) {
+      issues.push({
+        code: 'unreachable-node',
+        severity: 'warning',
+        message: `Node "${node.id}" is not reachable from the start`,
+        nodeId: node.id,
+      })
+    }
+  }
+
+  // 6. sink safety — non-terminal node with no outgoing edges
+  for (const node of workflow.nodes) {
+    if (node.type === 'terminal') continue
+    const hasOut = workflow.edges.some(e => e.from === node.id)
+    if (!hasOut) {
+      issues.push({
+        code: 'dead-end-node',
+        severity: 'error',
+        message: `Node "${node.id}" has no outgoing edges`,
+        nodeId: node.id,
+      })
+    }
+  }
+
+  // 7. at most one default edge per source
+  const defaultsPerSource = new Map<string, number>()
+  for (const edge of workflow.edges) {
+    if (edge.when === undefined || edge.when === 'default') {
+      defaultsPerSource.set(edge.from, (defaultsPerSource.get(edge.from) ?? 0) + 1)
+    }
+  }
+  for (const [from, count] of defaultsPerSource) {
+    if (count > 1) {
+      issues.push({
+        code: 'multiple-default-edges',
+        severity: 'error',
+        message: `Node "${from}" has ${count} default edges (max 1)`,
+        nodeId: from,
+      })
+    }
+  }
+
+  // 8 & 9. Signal coverage — every signal a node can emit must resolve
+  // via `resolveNextEdge` (exact-match OR default edge). Reusing the
+  // interpreter's resolver keeps the validator perfectly aligned with
+  // runtime semantics.
+  for (const node of workflow.nodes) {
+    const required = requiredSignalsFor(node)
+    for (const signal of required) {
+      if (!resolveNextEdge(workflow, node.id, signal)) {
+        const code: ValidationCode =
+          node.type === 'approval'
+            ? 'approval-missing-signal-coverage'
+            : 'condition-missing-signal-coverage'
+        issues.push({
+          code,
+          severity: 'error',
+          message: `${capitalize(node.type)} "${node.id}" cannot resolve "${signal}" (add an exact or default edge)`,
+          nodeId: node.id,
+        })
+      }
+    }
+  }
+
+  // 10. guard legality vs. source type
+  workflow.edges.forEach((edge, idx) => {
+    const src = findNode(workflow, edge.from)
+    if (!src) return
+    const guard = edge.when
+    if (guard === undefined || guard === 'default') return
+    if (!isGuardLegal(src, guard)) {
+      issues.push({
+        code: 'illegal-guard-for-source',
+        severity: 'error',
+        message: `Edge #${idx} from ${src.type} "${src.id}" uses illegal guard "${guard}"`,
+        edgeIndex: idx,
+        nodeId: src.id,
+      })
+    }
+  })
+
+  // 11. expression syntax on condition nodes (uses err.kind, not string prefix)
+  for (const node of workflow.nodes) {
+    if (node.type !== 'condition') continue
+    const syntaxError = validateExpressionSyntax(node.expr)
+    if (syntaxError) {
+      issues.push({
+        code: 'expression-syntax',
+        severity: 'error',
+        message: `Condition "${node.id}": ${syntaxError}`,
+        nodeId: node.id,
+      })
+    }
+  }
+
+  // 12. terminal has no outgoing edges (warning)
+  for (const node of workflow.nodes) {
+    if (node.type !== 'terminal') continue
+    const hasOut = workflow.edges.some(e => e.from === node.id)
+    if (hasOut) {
+      issues.push({
+        code: 'terminal-has-outgoing',
+        severity: 'warning',
+        message: `Terminal "${node.id}" has outgoing edges that will never fire`,
+        nodeId: node.id,
+      })
+    }
+  }
+
+  return issues
+}
+
+export function hasBlockingErrors(
+  issues: readonly ValidationIssue[],
+): boolean {
+  return issues.some(i => i.severity === 'error')
+}
+
+// ─── Internal helpers ─────────────────────────────────────────────────────
+
+function reachableNodeIds(workflow: Workflow): Set<string> {
+  const reachable = new Set<string>()
+  if (!findNode(workflow, workflow.startNodeId)) return reachable
+  const queue: string[] = [workflow.startNodeId]
+  reachable.add(workflow.startNodeId)
+  while (queue.length > 0) {
+    const id = queue.shift() as string
+    for (const edge of workflow.edges) {
+      if (edge.from !== id) continue
+      if (!reachable.has(edge.to) && findNode(workflow, edge.to)) {
+        reachable.add(edge.to)
+        queue.push(edge.to)
+      }
+    }
+  }
+  return reachable
+}
+
+function isGuardLegal(node: WorkflowNode, guard: EdgeGuard): boolean {
+  switch (node.type) {
+    case 'condition': return guard === 'true' || guard === 'false'
+    case 'approval':  return guard === 'approved' || guard === 'denied'
+    case 'notify':    return guard === 'default'
+    case 'terminal':  return false
+  }
+}
+
+function requiredSignalsFor(node: WorkflowNode): readonly EdgeGuard[] {
+  switch (node.type) {
+    case 'condition': return ['true', 'false']
+    case 'approval':  return ['approved', 'denied']
+    default:          return []
+  }
+}
+
+function capitalize(s: string): string {
+  return s.length === 0 ? s : s[0].toUpperCase() + s.slice(1)
+}
+
+/**
+ * Parse-only syntax check for condition expressions. Calls `evaluate`
+ * with an empty variable bag and surfaces only `ExpressionError` whose
+ * `kind` is a genuine shape problem — variable-binding errors expected
+ * at edit time (no variables yet) are suppressed by matching on
+ * `err.kind`, not on message prefixes.
+ */
+export function validateExpressionSyntax(expr: string): string | null {
+  if (!expr.trim()) return 'Expression is empty'
+  try {
+    evaluate(expr, {})
+    return null
+  } catch (err) {
+    if (err instanceof ExpressionError) {
+      // These kinds are purely runtime/variable-bound; ignore at edit time.
+      if (err.kind === 'undefined-variable') return null
+      if (err.kind === 'non-object') return null
+      if (err.kind === 'unsupported-value') return null
+      return err.message
+    }
+    return String(err)
+  }
+}

--- a/src/core/workflow/validate.ts
+++ b/src/core/workflow/validate.ts
@@ -222,19 +222,34 @@ export function hasBlockingErrors(
 
 // ─── Internal helpers ─────────────────────────────────────────────────────
 
+/**
+ * BFS reachability from `startNodeId`. Uses an index-based queue (O(1)
+ * dequeue) and a pre-built `nodeIds` Set + adjacency map so the
+ * traversal is O(V + E) — the validator runs on every keystroke, so
+ * accidental O(V*E) behavior from `queue.shift()` and in-loop
+ * `findNode` scans would bite on larger graphs.
+ */
 function reachableNodeIds(workflow: Workflow): Set<string> {
   const reachable = new Set<string>()
-  if (!findNode(workflow, workflow.startNodeId)) return reachable
+  const nodeIds = new Set(workflow.nodes.map(n => n.id))
+  if (!nodeIds.has(workflow.startNodeId)) return reachable
+  const adj = new Map<string, string[]>()
+  for (const edge of workflow.edges) {
+    if (!nodeIds.has(edge.from) || !nodeIds.has(edge.to)) continue
+    let list = adj.get(edge.from)
+    if (!list) { list = []; adj.set(edge.from, list) }
+    list.push(edge.to)
+  }
   const queue: string[] = [workflow.startNodeId]
   reachable.add(workflow.startNodeId)
-  while (queue.length > 0) {
-    const id = queue.shift() as string
-    for (const edge of workflow.edges) {
-      if (edge.from !== id) continue
-      if (!reachable.has(edge.to) && findNode(workflow, edge.to)) {
-        reachable.add(edge.to)
-        queue.push(edge.to)
-      }
+  for (let head = 0; head < queue.length; head++) {
+    const id = queue[head]
+    const neighbors = adj.get(id)
+    if (!neighbors) continue
+    for (const to of neighbors) {
+      if (reachable.has(to)) continue
+      reachable.add(to)
+      queue.push(to)
     }
   }
   return reachable
@@ -262,11 +277,19 @@ function capitalize(s: string): string {
 }
 
 /**
- * Parse-only syntax check for condition expressions. Calls `evaluate`
- * with an empty variable bag and surfaces only `ExpressionError` whose
- * `kind` is a genuine shape problem — variable-binding errors expected
- * at edit time (no variables yet) are suppressed by matching on
- * `err.kind`, not on message prefixes.
+ * Best-effort syntax / shape check for condition expressions.
+ *
+ * This calls `evaluate(expr, {})`, which runs the full parse + eval
+ * pipeline — it is NOT a pure parse-only check. Variable-binding
+ * errors (`undefined-variable`, `non-object`, `unsupported-value`)
+ * are expected at edit time when the user hasn't supplied vars yet,
+ * so we suppress them by matching on `ExpressionError.kind`.
+ *
+ * Everything else surfaces: literal syntax errors (`kind: 'syntax'`),
+ * type errors on constant sub-expressions (`1 + "a" * 2` → `'type'`),
+ * and unknown operators (`kind: 'unknown-operator'`). If Phase 3 adds
+ * a pure parse API we should switch to that here and reclassify this
+ * as a true syntax check.
  */
 export function validateExpressionSyntax(expr: string): string | null {
   if (!expr.trim()) return 'Expression is empty'
@@ -275,7 +298,7 @@ export function validateExpressionSyntax(expr: string): string | null {
     return null
   } catch (err) {
     if (err instanceof ExpressionError) {
-      // These kinds are purely runtime/variable-bound; ignore at edit time.
+      // Variable-bound kinds are runtime-only; ignore at edit time.
       if (err.kind === 'undefined-variable') return null
       if (err.kind === 'non-object') return null
       if (err.kind === 'unsupported-value') return null

--- a/src/core/workflow/workflowSchema.ts
+++ b/src/core/workflow/workflowSchema.ts
@@ -137,6 +137,20 @@ export interface WorkflowInstance {
   readonly outcome?: WorkflowOutcome
 }
 
+// ─── Layout (Phase 2 visual builder — side-car, NOT part of Workflow) ─────
+
+/**
+ * Cosmetic node coordinates for the visual builder. Stored alongside a
+ * `Workflow` rather than on its nodes so the runtime contract (schema +
+ * interpreter) stays free of UI-only data. The interpreter ignores this
+ * entirely; `advance()`, `findNode`, and `resolveNextEdge` never read it.
+ */
+export interface WorkflowLayout {
+  readonly workflowId: string
+  readonly workflowVersion: number
+  readonly positions: Readonly<Record<string, { readonly x: number; readonly y: number }>>
+}
+
 // ─── Helpers ──────────────────────────────────────────────────────────────
 
 /** Look up a node by id. Returns undefined when missing. */


### PR DESCRIPTION
Ship the Phase 2 plan doc and the pure-core scaffolding the UI will build
on, amended per review feedback before any React code lands.

Plan (docs/phase-2-visual-builder-plan.md) — node-and-edge SVG canvas,
simulator panel, ConfigPanel "Approval Flows" tab, lazy-loaded modal.
Six review amendments applied: ExpressionError kind field instead of
prefix sniffing; signal-coverage rule via resolveNextEdge (permits
exact-OR-default); explicit severity table; localStorage persistence
pinned; back-edge / orphan / self-loop layout spec; simulator step cap.

Schema (workflowSchema.ts) — additive WorkflowLayout side-car for
cosmetic node coordinates. Runtime contract (Workflow / advance /
findNode / resolveNextEdge) unchanged.

Expression evaluator (expression.ts) — ExpressionError gains a typed
`kind` field and back-compat (message, position) constructor. All
existing throw sites tagged (syntax / undefined-variable / non-object /
type / unknown-operator / unsupported-value). Phase 1 tests unaffected.

Validator (validate.ts + tests) — 12 rules, signal coverage via
resolveNextEdge, expression syntax via err.kind. All three shipped
templates validate clean.

Layout (layout.ts + tests) — BFS-leveled positioning with per-node
override support, back-edge detour channel, self-loop cubic Bezier,
trailing orphan lane for unreachable nodes, snapToGrid helper.

All 82 workflow tests pass; tsc --noEmit clean. Next commits add the
useSavedWorkflows hook and the UI layer.