### PR TITLE
feat(workflow): useSavedWorkflows hook for per-calendar persistence

### DIFF
--- a/src/hooks/__tests__/useSavedWorkflows.test.ts
+++ b/src/hooks/__tests__/useSavedWorkflows.test.ts
@@ -1,0 +1,177 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import { useSavedWorkflows } from '../useSavedWorkflows'
+import { singleApproverWorkflow } from '../../core/workflow/templates'
+import type { Workflow, WorkflowLayout } from '../../core/workflow/workflowSchema'
+
+const CAL_ID = 'test-cal'
+const KEY = `wc-saved-workflows-${CAL_ID}`
+
+const layout: WorkflowLayout = {
+  workflowId: singleApproverWorkflow.id,
+  workflowVersion: singleApproverWorkflow.version,
+  positions: { approve: { x: 40, y: 40 } },
+}
+
+beforeEach(() => {
+  localStorage.clear()
+})
+
+describe('useSavedWorkflows — save / update / delete', () => {
+  it('starts empty for a fresh calendar id', () => {
+    const { result } = renderHook(() => useSavedWorkflows(CAL_ID))
+    expect(result.current.workflows).toEqual([])
+  })
+
+  it('saveWorkflow appends, assigns an id, and persists to localStorage', () => {
+    const { result } = renderHook(() => useSavedWorkflows(CAL_ID))
+    let returned: ReturnType<typeof result.current.saveWorkflow> | undefined
+    act(() => {
+      returned = result.current.saveWorkflow('My flow', singleApproverWorkflow, layout)
+    })
+    expect(result.current.workflows.length).toBe(1)
+    expect(returned!.id).toMatch(/^wf-/)
+    expect(returned!.name).toBe('My flow')
+    expect(returned!.workflow.id).toBe(singleApproverWorkflow.id)
+    // layout coords survive
+    expect(returned!.layout.positions.approve).toEqual({ x: 40, y: 40 })
+
+    const raw = localStorage.getItem(KEY)!
+    expect(raw).toBeTruthy()
+    const parsed = JSON.parse(raw)
+    expect(parsed.version).toBe(1)
+    expect(parsed.workflows).toHaveLength(1)
+  })
+
+  it('reloads persisted workflows when remounted with the same calendar id', () => {
+    const { result, unmount } = renderHook(() => useSavedWorkflows(CAL_ID))
+    act(() => {
+      result.current.saveWorkflow('My flow', singleApproverWorkflow, layout)
+    })
+    unmount()
+
+    const { result: r2 } = renderHook(() => useSavedWorkflows(CAL_ID))
+    expect(r2.current.workflows).toHaveLength(1)
+    expect(r2.current.workflows[0].name).toBe('My flow')
+  })
+
+  it('isolates storage per calendar id', () => {
+    const { result: a } = renderHook(() => useSavedWorkflows('cal-a'))
+    act(() => {
+      a.current.saveWorkflow('for A', singleApproverWorkflow, layout)
+    })
+    const { result: b } = renderHook(() => useSavedWorkflows('cal-b'))
+    expect(b.current.workflows).toEqual([])
+  })
+
+  it('updateWorkflow bumps workflow.version and keeps layout.workflowVersion aligned', () => {
+    const { result } = renderHook(() => useSavedWorkflows(CAL_ID))
+    let saved: ReturnType<typeof result.current.saveWorkflow> | undefined
+    act(() => {
+      saved = result.current.saveWorkflow('v1', singleApproverWorkflow, layout)
+    })
+    const originalVersion = saved!.workflow.version
+
+    const mutated: Workflow = {
+      ...saved!.workflow,
+      nodes: [
+        ...saved!.workflow.nodes,
+        { id: 'extra', type: 'terminal', outcome: 'cancelled' },
+      ],
+    }
+    act(() => {
+      result.current.updateWorkflow(saved!.id, { workflow: mutated })
+    })
+
+    const updated = result.current.workflows[0]
+    expect(updated.workflow.version).toBe(originalVersion + 1)
+    expect(updated.layout.workflowVersion).toBe(originalVersion + 1)
+    expect(updated.workflow.nodes.some(n => n.id === 'extra')).toBe(true)
+  })
+
+  it('updateWorkflow with only a layout patch does NOT bump version', () => {
+    const { result } = renderHook(() => useSavedWorkflows(CAL_ID))
+    let saved: ReturnType<typeof result.current.saveWorkflow> | undefined
+    act(() => {
+      saved = result.current.saveWorkflow('v1', singleApproverWorkflow, layout)
+    })
+    const originalVersion = saved!.workflow.version
+
+    const nextLayout: WorkflowLayout = {
+      workflowId: saved!.workflow.id,
+      workflowVersion: saved!.workflow.version,
+      positions: { approve: { x: 200, y: 200 } },
+    }
+    act(() => {
+      result.current.updateWorkflow(saved!.id, { layout: nextLayout })
+    })
+
+    const updated = result.current.workflows[0]
+    expect(updated.workflow.version).toBe(originalVersion)
+    expect(updated.layout.positions.approve).toEqual({ x: 200, y: 200 })
+  })
+
+  it('updateWorkflow can rename without touching version', () => {
+    const { result } = renderHook(() => useSavedWorkflows(CAL_ID))
+    let saved: ReturnType<typeof result.current.saveWorkflow> | undefined
+    act(() => {
+      saved = result.current.saveWorkflow('old', singleApproverWorkflow, layout)
+    })
+    const originalVersion = saved!.workflow.version
+
+    act(() => {
+      result.current.updateWorkflow(saved!.id, { name: 'renamed' })
+    })
+
+    expect(result.current.workflows[0].name).toBe('renamed')
+    expect(result.current.workflows[0].workflow.version).toBe(originalVersion)
+  })
+
+  it('deleteWorkflow removes the matching entry', () => {
+    const { result } = renderHook(() => useSavedWorkflows(CAL_ID))
+    let saved: ReturnType<typeof result.current.saveWorkflow> | undefined
+    act(() => {
+      result.current.saveWorkflow('keep', singleApproverWorkflow, layout)
+      saved = result.current.saveWorkflow('drop', singleApproverWorkflow, layout)
+    })
+    expect(result.current.workflows).toHaveLength(2)
+    act(() => {
+      result.current.deleteWorkflow(saved!.id)
+    })
+    expect(result.current.workflows).toHaveLength(1)
+    expect(result.current.workflows[0].name).toBe('keep')
+  })
+})
+
+describe('useSavedWorkflows — storage hygiene', () => {
+  it('ignores payloads with an unknown version', () => {
+    localStorage.setItem(
+      KEY,
+      JSON.stringify({ version: 99, workflows: [{ id: 'x' }] }),
+    )
+    const { result } = renderHook(() => useSavedWorkflows(CAL_ID))
+    expect(result.current.workflows).toEqual([])
+  })
+
+  it('ignores malformed JSON', () => {
+    localStorage.setItem(KEY, 'not-json')
+    const { result } = renderHook(() => useSavedWorkflows(CAL_ID))
+    expect(result.current.workflows).toEqual([])
+  })
+
+  it('filters out entries missing required fields', () => {
+    localStorage.setItem(
+      KEY,
+      JSON.stringify({
+        version: 1,
+        workflows: [
+          { id: 'ok', name: 'good', createdAt: '2026-04-20', workflow: singleApproverWorkflow, layout },
+          { id: 'bad' /* missing name, workflow, layout */ },
+        ],
+      }),
+    )
+    const { result } = renderHook(() => useSavedWorkflows(CAL_ID))
+    expect(result.current.workflows).toHaveLength(1)
+    expect(result.current.workflows[0].id).toBe('ok')
+  })
+})

--- a/src/hooks/useSavedWorkflows.ts
+++ b/src/hooks/useSavedWorkflows.ts
@@ -1,0 +1,173 @@
+/**
+ * useSavedWorkflows — per-calendar persistence for visual-builder workflows.
+ *
+ * Storage key: `wc-saved-workflows-${calendarId}`
+ * Payload:     `{ version: 1, workflows: SavedWorkflow[] }`
+ *
+ * Each `SavedWorkflow` bundles the runtime `Workflow` with its side-car
+ * `WorkflowLayout` so on reopen the builder renders at the exact
+ * positions the user last saved. `updateWorkflow` bumps
+ * `workflow.version` (and the paired `layout.workflowVersion`) on every
+ * structural change so stale layouts can't be rendered against a graph
+ * whose topology has moved on — matching the guard in `layoutWorkflow`.
+ */
+import { useCallback, useEffect, useState } from 'react'
+import { createId } from '../core/createId'
+import type { Workflow, WorkflowLayout } from '../core/workflow/workflowSchema'
+
+const STORAGE_VERSION = 1
+
+export interface SavedWorkflow {
+  readonly id: string
+  readonly name: string
+  readonly createdAt: string
+  readonly workflow: Workflow
+  readonly layout: WorkflowLayout
+}
+
+export interface UseSavedWorkflowsResult {
+  readonly workflows: readonly SavedWorkflow[]
+  readonly saveWorkflow: (
+    name: string,
+    workflow: Workflow,
+    layout: WorkflowLayout,
+  ) => SavedWorkflow
+  readonly updateWorkflow: (
+    id: string,
+    patch: { name?: string; workflow?: Workflow; layout?: WorkflowLayout },
+  ) => void
+  readonly deleteWorkflow: (id: string) => void
+}
+
+function storageKey(calendarId: string): string {
+  return `wc-saved-workflows-${calendarId}`
+}
+
+function isSavedWorkflow(value: unknown): value is SavedWorkflow {
+  if (!value || typeof value !== 'object') return false
+  const v = value as Partial<SavedWorkflow>
+  return (
+    typeof v.id === 'string' &&
+    typeof v.name === 'string' &&
+    typeof v.createdAt === 'string' &&
+    !!v.workflow &&
+    typeof v.workflow === 'object' &&
+    !!v.layout &&
+    typeof v.layout === 'object'
+  )
+}
+
+function loadWorkflows(calendarId: string): SavedWorkflow[] {
+  try {
+    const raw = localStorage.getItem(storageKey(calendarId))
+    if (!raw) return []
+    const parsed = JSON.parse(raw)
+    if (
+      !parsed ||
+      typeof parsed !== 'object' ||
+      parsed.version !== STORAGE_VERSION ||
+      !Array.isArray(parsed.workflows)
+    ) {
+      return []
+    }
+    return parsed.workflows.filter(isSavedWorkflow)
+  } catch {
+    return []
+  }
+}
+
+function persistWorkflows(
+  calendarId: string,
+  workflows: readonly SavedWorkflow[],
+): void {
+  try {
+    localStorage.setItem(
+      storageKey(calendarId),
+      JSON.stringify({ version: STORAGE_VERSION, workflows }),
+    )
+  } catch {
+    // Quota / disabled storage — silently drop, matching useSavedViews.
+  }
+}
+
+export function useSavedWorkflows(calendarId: string): UseSavedWorkflowsResult {
+  const [workflows, setWorkflows] = useState<SavedWorkflow[]>(() =>
+    loadWorkflows(calendarId),
+  )
+
+  useEffect(() => {
+    setWorkflows(loadWorkflows(calendarId))
+  }, [calendarId])
+
+  useEffect(() => {
+    persistWorkflows(calendarId, workflows)
+  }, [calendarId, workflows])
+
+  const saveWorkflow = useCallback(
+    (name: string, workflow: Workflow, layout: WorkflowLayout): SavedWorkflow => {
+      const saved: SavedWorkflow = {
+        id: createId('wf'),
+        name,
+        createdAt: new Date().toISOString(),
+        workflow,
+        layout: {
+          ...layout,
+          workflowId: workflow.id,
+          workflowVersion: workflow.version,
+        },
+      }
+      setWorkflows(prev => [...prev, saved])
+      return saved
+    },
+    [],
+  )
+
+  const updateWorkflow = useCallback(
+    (
+      id: string,
+      patch: { name?: string; workflow?: Workflow; layout?: WorkflowLayout },
+    ) => {
+      setWorkflows(prev =>
+        prev.map(saved => {
+          if (saved.id !== id) return saved
+          if (patch.workflow === undefined) {
+            // Layout-only / rename: keep the existing version number.
+            return {
+              ...saved,
+              ...(patch.name !== undefined ? { name: patch.name } : {}),
+              ...(patch.layout !== undefined
+                ? {
+                    layout: {
+                      ...patch.layout,
+                      workflowId: saved.workflow.id,
+                      workflowVersion: saved.workflow.version,
+                    },
+                  }
+                : {}),
+            }
+          }
+          const nextVersion = saved.workflow.version + 1
+          const nextWorkflow: Workflow = { ...patch.workflow, version: nextVersion }
+          const sourceLayout = patch.layout ?? saved.layout
+          return {
+            ...saved,
+            ...(patch.name !== undefined ? { name: patch.name } : {}),
+            workflow: nextWorkflow,
+            layout: {
+              ...sourceLayout,
+              workflowId: nextWorkflow.id,
+              workflowVersion: nextVersion,
+            },
+          }
+        }),
+      )
+    },
+    [],
+  )
+
+  const deleteWorkflow = useCallback((id: string) => {
+    setWorkflows(prev => prev.filter(saved => saved.id !== id))
+  }, [])
+
+  return { workflows, saveWorkflow, updateWorkflow, deleteWorkflow }
+}


### PR DESCRIPTION
Bundles each Workflow with its side-car WorkflowLayout in localStorage under wc-saved-workflows-${calendarId} (wrapper { version: 1, workflows[] }). updateWorkflow bumps workflow.version on any structural change and keeps layout.workflowVersion aligned so the layoutWorkflow stale-override guard stays meaningful. Layout-only patches and renames leave the version alone.

Unknown-version payloads, malformed JSON, and entries missing required fields are dropped on load — mirrors the defensive read path in useSavedViews.

https://claude.ai/code/session_014vuvkCTA8VA3RpPwenpmZS