### PR TITLE
fix(useSavedWorkflows): couple calendarId + workflows in one state atom

### DIFF
--- a/src/hooks/__tests__/useSavedWorkflows.test.ts
+++ b/src/hooks/__tests__/useSavedWorkflows.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach } from 'vitest'
+import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { renderHook, act } from '@testing-library/react'
 import { useSavedWorkflows } from '../useSavedWorkflows'
 import { singleApproverWorkflow } from '../../core/workflow/templates'
@@ -62,6 +62,60 @@ describe('useSavedWorkflows — save / update / delete', () => {
     })
     const { result: b } = renderHook(() => useSavedWorkflows('cal-b'))
     expect(b.current.workflows).toEqual([])
+  })
+
+  it('switching calendarId never writes the old calendar\'s workflows under the new key', () => {
+    // Regression: with the reload + persist effects both keyed on
+    // calendarId, the persist effect would fire once with the NEW id
+    // but the STALE workflows state — briefly writing calendar A's
+    // workflows under calendar B's storage key before the reload
+    // effect's setState settled. A follow-up write corrects it, but
+    // if the component unmounts (or the follow-up write fails) the
+    // corruption sticks. Spy has to be installed before renderHook so
+    // we can retrospectively inspect every write during the swap.
+    const setSpy = vi.spyOn(localStorage, 'setItem')
+    const { result, rerender } = renderHook(
+      ({ id }: { id: string }) => useSavedWorkflows(id),
+      { initialProps: { id: 'cal-a' } },
+    )
+    act(() => {
+      result.current.saveWorkflow('for A', singleApproverWorkflow, layout)
+    })
+    setSpy.mockClear()
+    rerender({ id: 'cal-b' })
+
+    // Every setItem call targeting cal-b must NOT carry A's workflows
+    // (i.e. must not contain the name "for A") — asserting no
+    // cross-contamination even in the intermediate render pass.
+    const bWrites = setSpy.mock.calls.filter(
+      ([key]) => key === 'wc-saved-workflows-cal-b',
+    )
+    for (const [, value] of bWrites) {
+      expect(value as string).not.toContain('for A')
+    }
+    setSpy.mockRestore()
+
+    // End state: hook reports empty for B, A is untouched.
+    expect(result.current.workflows).toEqual([])
+    expect(JSON.parse(localStorage.getItem('wc-saved-workflows-cal-a')!).workflows).toHaveLength(1)
+  })
+
+  it('saves made after a calendarId switch persist under the new calendar\'s key', () => {
+    const { result, rerender } = renderHook(
+      ({ id }: { id: string }) => useSavedWorkflows(id),
+      { initialProps: { id: 'cal-a' } },
+    )
+    act(() => {
+      result.current.saveWorkflow('for A', singleApproverWorkflow, layout)
+    })
+    rerender({ id: 'cal-b' })
+    act(() => {
+      result.current.saveWorkflow('for B', singleApproverWorkflow, layout)
+    })
+    const aWorkflows = JSON.parse(localStorage.getItem('wc-saved-workflows-cal-a')!).workflows
+    const bWorkflows = JSON.parse(localStorage.getItem('wc-saved-workflows-cal-b')!).workflows
+    expect(aWorkflows.map((w: { name: string }) => w.name)).toEqual(['for A'])
+    expect(bWorkflows.map((w: { name: string }) => w.name)).toEqual(['for B'])
   })
 
   it('updateWorkflow bumps workflow.version and keeps layout.workflowVersion aligned', () => {

--- a/src/hooks/useSavedWorkflows.ts
+++ b/src/hooks/useSavedWorkflows.ts
@@ -10,6 +10,13 @@
  * `workflow.version` (and the paired `layout.workflowVersion`) on every
  * structural change so stale layouts can't be rendered against a graph
  * whose topology has moved on — matching the guard in `layoutWorkflow`.
+ *
+ * State + the id it was loaded for live in a single atom so a
+ * calendarId switch can't trigger a persist against the new key with
+ * the previous calendar's workflows (the reload and the persist
+ * effects both depend on calendarId; without this coupling the persist
+ * effect would fire once before `setWorkflows` settles and corrupt
+ * storage for the new calendar).
  */
 import { useCallback, useEffect, useState } from 'react'
 import { createId } from '../core/createId'
@@ -37,6 +44,11 @@ export interface UseSavedWorkflowsResult {
     patch: { name?: string; workflow?: Workflow; layout?: WorkflowLayout },
   ) => void
   readonly deleteWorkflow: (id: string) => void
+}
+
+interface HookState {
+  readonly calendarId: string
+  readonly workflows: readonly SavedWorkflow[]
 }
 
 function storageKey(calendarId: string): string {
@@ -91,17 +103,28 @@ function persistWorkflows(
 }
 
 export function useSavedWorkflows(calendarId: string): UseSavedWorkflowsResult {
-  const [workflows, setWorkflows] = useState<SavedWorkflow[]>(() =>
-    loadWorkflows(calendarId),
-  )
+  const [state, setState] = useState<HookState>(() => ({
+    calendarId,
+    workflows: loadWorkflows(calendarId),
+  }))
 
+  // Reload when the prop flips. Couples the swap in a single setState
+  // so `state.calendarId` and `state.workflows` are never out of sync.
   useEffect(() => {
-    setWorkflows(loadWorkflows(calendarId))
+    setState(prev =>
+      prev.calendarId === calendarId
+        ? prev
+        : { calendarId, workflows: loadWorkflows(calendarId) },
+    )
   }, [calendarId])
 
+  // Persist only when state matches the rendered prop. On a prop flip
+  // this render carries the stale state; we skip the write until the
+  // reload-effect's setState commits with the new id's workflows.
   useEffect(() => {
-    persistWorkflows(calendarId, workflows)
-  }, [calendarId, workflows])
+    if (state.calendarId !== calendarId) return
+    persistWorkflows(state.calendarId, state.workflows)
+  }, [state, calendarId])
 
   const saveWorkflow = useCallback(
     (name: string, workflow: Workflow, layout: WorkflowLayout): SavedWorkflow => {
@@ -116,7 +139,7 @@ export function useSavedWorkflows(calendarId: string): UseSavedWorkflowsResult {
           workflowVersion: workflow.version,
         },
       }
-      setWorkflows(prev => [...prev, saved])
+      setState(prev => ({ ...prev, workflows: [...prev.workflows, saved] }))
       return saved
     },
     [],
@@ -127,11 +150,11 @@ export function useSavedWorkflows(calendarId: string): UseSavedWorkflowsResult {
       id: string,
       patch: { name?: string; workflow?: Workflow; layout?: WorkflowLayout },
     ) => {
-      setWorkflows(prev =>
-        prev.map(saved => {
+      setState(prev => ({
+        ...prev,
+        workflows: prev.workflows.map(saved => {
           if (saved.id !== id) return saved
           if (patch.workflow === undefined) {
-            // Layout-only / rename: keep the existing version number.
             return {
               ...saved,
               ...(patch.name !== undefined ? { name: patch.name } : {}),
@@ -160,14 +183,17 @@ export function useSavedWorkflows(calendarId: string): UseSavedWorkflowsResult {
             },
           }
         }),
-      )
+      }))
     },
     [],
   )
 
   const deleteWorkflow = useCallback((id: string) => {
-    setWorkflows(prev => prev.filter(saved => saved.id !== id))
+    setState(prev => ({
+      ...prev,
+      workflows: prev.workflows.filter(saved => saved.id !== id),
+    }))
   }, [])
 
-  return { workflows, saveWorkflow, updateWorkflow, deleteWorkflow }
+  return { workflows: state.workflows, saveWorkflow, updateWorkflow, deleteWorkflow }
 }

--- a/src/ui/WorkflowCanvas.module.css
+++ b/src/ui/WorkflowCanvas.module.css
@@ -1,0 +1,123 @@
+.wrap {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  background: var(--wc-bg-muted, #f9fafb);
+  border: 1px solid var(--wc-border, #d1d5db);
+  border-radius: 6px;
+  overflow: hidden;
+}
+
+.canvas {
+  display: block;
+  width: 100%;
+  height: 100%;
+  touch-action: none;
+}
+
+.node {
+  cursor: grab;
+}
+
+.node.dragging {
+  cursor: grabbing;
+}
+
+.nodeRect {
+  fill: var(--wc-bg, #ffffff);
+  stroke: var(--wc-border, #d1d5db);
+  stroke-width: 1.5;
+  rx: 6;
+  ry: 6;
+}
+
+.node:focus-visible {
+  outline: none;
+}
+
+.node:focus-visible .nodeRect,
+.nodeSelected .nodeRect {
+  stroke: var(--wc-accent, #2563eb);
+  stroke-width: 2;
+}
+
+.nodeActive .nodeRect {
+  stroke: var(--wc-success, #16a34a);
+  stroke-width: 3;
+  animation: wc-node-pulse 1.2s ease-in-out infinite;
+}
+
+@keyframes wc-node-pulse {
+  0%, 100% { filter: drop-shadow(0 0 0 rgba(22, 163, 74, 0.5)); }
+  50%      { filter: drop-shadow(0 0 6px rgba(22, 163, 74, 0.6)); }
+}
+
+.nodeKindApproval .nodeRect { fill: #eff6ff; }
+.nodeKindCondition .nodeRect { fill: #fefce8; }
+.nodeKindNotify .nodeRect { fill: #f3e8ff; }
+.nodeKindTerminal .nodeRect { fill: #f3f4f6; }
+
+.nodeKind {
+  font: 10px var(--wc-font, system-ui, sans-serif);
+  fill: var(--wc-muted, #6b7280);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  pointer-events: none;
+  user-select: none;
+}
+
+.nodeLabel {
+  font: 12px var(--wc-font, system-ui, sans-serif);
+  fill: var(--wc-text, #111827);
+  pointer-events: none;
+  user-select: none;
+}
+
+.handle {
+  fill: var(--wc-accent, #2563eb);
+  stroke: var(--wc-bg, #fff);
+  stroke-width: 1.5;
+  cursor: crosshair;
+  opacity: 0;
+  transition: opacity 120ms ease-in-out;
+}
+
+.node:hover .handle,
+.node:focus-within .handle,
+.nodeSelected .handle,
+.edgeDrawSource .handle {
+  opacity: 1;
+}
+
+.edgeDrawSource .nodeRect {
+  stroke: var(--wc-accent, #2563eb);
+  stroke-width: 2;
+  stroke-dasharray: 4 3;
+}
+
+.edge {
+  fill: none;
+  stroke: var(--wc-muted, #6b7280);
+  stroke-width: 1.5;
+}
+
+.edgeGuard {
+  font: 10px var(--wc-font, system-ui, sans-serif);
+  fill: var(--wc-text, #111827);
+  pointer-events: none;
+  user-select: none;
+}
+
+.edgeGuardBg {
+  fill: var(--wc-bg, #fff);
+  stroke: var(--wc-border, #d1d5db);
+}
+
+.liveRegion {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  white-space: nowrap;
+}

--- a/src/ui/WorkflowCanvas.tsx
+++ b/src/ui/WorkflowCanvas.tsx
@@ -1,0 +1,460 @@
+/**
+ * WorkflowCanvas — hand-rolled SVG graph editor.
+ *
+ * Renders nodes + edges from `layoutWorkflow(workflow, layout)` and
+ * surfaces pointer and keyboard interactions back up via props — the
+ * parent owns `workflow`, `layout`, and selection state so Save / undo
+ * in the modal can reason about them.
+ *
+ * Keyboard contract (see Phase 2 plan → a11y section):
+ *   - Tab        : native DOM order; nodes render in BFS order so the
+ *                  natural tab sequence is also graph order.
+ *   - Arrow keys : nudge the selected node by `GRID_SNAP` px.
+ *   - Enter      : open the inspector for the selected node, OR commit
+ *                  an edge when in edge-draw mode with a different
+ *                  node focused.
+ *   - Delete     : remove the selected node.
+ *   - Ctrl/⌘ + E : enter edge-draw mode; source = selected node.
+ *   - Escape     : cancel edge-draw mode / clear selection.
+ *
+ * Drag: pointer events on each node group; the viewBox → client scale
+ * is captured on pointerdown so concurrent CSS resizes don't poison
+ * the delta. Position is committed (and snapped to the grid) on
+ * pointerup, so intermediate moves don't spam the parent.
+ */
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type KeyboardEvent,
+  type PointerEvent as ReactPointerEvent,
+} from 'react'
+import {
+  GRID_SNAP,
+  NODE_HEIGHT,
+  NODE_WIDTH,
+  layoutWorkflow,
+  snapToGrid,
+} from '../core/workflow/layout'
+import type {
+  Workflow,
+  WorkflowLayout,
+  WorkflowNode,
+} from '../core/workflow/workflowSchema'
+import styles from './WorkflowCanvas.module.css'
+
+export interface WorkflowCanvasProps {
+  readonly workflow: Workflow
+  readonly layout: WorkflowLayout
+  readonly selectedNodeId: string | null
+  /** If set, the matching node pulses — driven by the simulator. */
+  readonly activeNodeId?: string | null
+  readonly onSelectNode: (id: string | null) => void
+  readonly onMoveNode: (id: string, pos: { x: number; y: number }) => void
+  readonly onOpenInspector: (id: string) => void
+  readonly onDeleteNode: (id: string) => void
+  readonly onCreateEdge: (from: string, to: string) => void
+}
+
+interface DragState {
+  readonly nodeId: string
+  readonly pointerId: number
+  readonly scaleX: number
+  readonly scaleY: number
+  readonly startClientX: number
+  readonly startClientY: number
+  readonly origin: { x: number; y: number }
+  currentPos: { x: number; y: number }
+}
+
+function displayLabel(node: WorkflowNode): string {
+  if (node.label) return node.label
+  switch (node.type) {
+    case 'approval':  return node.assignTo
+    case 'condition': return node.expr
+    case 'notify':    return node.channel
+    case 'terminal':  return node.outcome
+  }
+}
+
+/**
+ * Sort nodes by (y, x). Layout assigns rank → y and col → x by BFS
+ * visitation order, so this yields the same sequence as the BFS walk
+ * — which is what Tab should traverse.
+ */
+function bfsOrderedNodes(
+  nodes: readonly WorkflowNode[],
+  positions: Record<string, { x: number; y: number }>,
+): readonly WorkflowNode[] {
+  return [...nodes].sort((a, b) => {
+    const pa = positions[a.id]
+    const pb = positions[b.id]
+    if (!pa || !pb) return 0
+    if (pa.y !== pb.y) return pa.y - pb.y
+    return pa.x - pb.x
+  })
+}
+
+export function WorkflowCanvas(props: WorkflowCanvasProps): JSX.Element {
+  const {
+    workflow,
+    layout,
+    selectedNodeId,
+    activeNodeId,
+    onSelectNode,
+    onMoveNode,
+    onOpenInspector,
+    onDeleteNode,
+    onCreateEdge,
+  } = props
+
+  const svgRef = useRef<SVGSVGElement | null>(null)
+  const [pendingEdgeFrom, setPendingEdgeFrom] = useState<string | null>(null)
+  const [focusedNodeId, setFocusedNodeId] = useState<string | null>(null)
+  const [liveMessage, setLiveMessage] = useState<string>('')
+  const [drag, setDrag] = useState<DragState | null>(null)
+
+  // Recompute layout + paths on every workflow/layout change.
+  const rendered = useMemo(
+    () => layoutWorkflow(workflow, layout),
+    [workflow, layout],
+  )
+  const orderedNodes = useMemo(
+    () => bfsOrderedNodes(workflow.nodes, rendered.positions),
+    [workflow.nodes, rendered.positions],
+  )
+
+  // Cancel any pending edge-draw when the workflow mutates under us
+  // (nodes deleted, etc.) so we don't dangle a pointer at a gone node.
+  useEffect(() => {
+    if (pendingEdgeFrom && !workflow.nodes.some(n => n.id === pendingEdgeFrom)) {
+      setPendingEdgeFrom(null)
+    }
+  }, [workflow, pendingEdgeFrom])
+
+  const announce = useCallback((msg: string) => setLiveMessage(msg), [])
+
+  const commitEdgeDrawTo = useCallback(
+    (targetId: string) => {
+      if (!pendingEdgeFrom) return
+      if (pendingEdgeFrom === targetId) {
+        announce('Cannot draw an edge to the same node')
+        return
+      }
+      onCreateEdge(pendingEdgeFrom, targetId)
+      announce(`Edge created from ${pendingEdgeFrom} to ${targetId}`)
+      setPendingEdgeFrom(null)
+    },
+    [pendingEdgeFrom, onCreateEdge, announce],
+  )
+
+  // ─── Node pointer handlers ──────────────────────────────────────────────
+
+  const handleNodePointerDown = useCallback(
+    (e: ReactPointerEvent<SVGGElement>, node: WorkflowNode) => {
+      if (pendingEdgeFrom && pendingEdgeFrom !== node.id) {
+        e.preventDefault()
+        commitEdgeDrawTo(node.id)
+        return
+      }
+      onSelectNode(node.id)
+      const svg = svgRef.current
+      if (!svg) return
+      const rect = svg.getBoundingClientRect()
+      if (rect.width === 0 || rect.height === 0) return
+      const scaleX = rendered.size.w / rect.width
+      const scaleY = rendered.size.h / rect.height
+      const origin = rendered.positions[node.id]
+      if (!origin) return
+      const g = e.currentTarget
+      try { g.setPointerCapture(e.pointerId) } catch { /* happy-dom no-op */ }
+      setDrag({
+        nodeId: node.id,
+        pointerId: e.pointerId,
+        scaleX,
+        scaleY,
+        startClientX: e.clientX,
+        startClientY: e.clientY,
+        origin,
+        currentPos: origin,
+      })
+    },
+    [pendingEdgeFrom, commitEdgeDrawTo, onSelectNode, rendered.positions, rendered.size],
+  )
+
+  const handleNodePointerMove = useCallback(
+    (e: ReactPointerEvent<SVGGElement>) => {
+      if (!drag || e.pointerId !== drag.pointerId) return
+      const dx = (e.clientX - drag.startClientX) * drag.scaleX
+      const dy = (e.clientY - drag.startClientY) * drag.scaleY
+      const next = { x: drag.origin.x + dx, y: drag.origin.y + dy }
+      setDrag({ ...drag, currentPos: next })
+    },
+    [drag],
+  )
+
+  const handleNodePointerUp = useCallback(
+    (e: ReactPointerEvent<SVGGElement>) => {
+      if (!drag || e.pointerId !== drag.pointerId) return
+      const g = e.currentTarget
+      try { g.releasePointerCapture(e.pointerId) } catch { /* happy-dom no-op */ }
+      const snapped = {
+        x: snapToGrid(drag.currentPos.x),
+        y: snapToGrid(drag.currentPos.y),
+      }
+      if (snapped.x !== drag.origin.x || snapped.y !== drag.origin.y) {
+        onMoveNode(drag.nodeId, snapped)
+      }
+      setDrag(null)
+    },
+    [drag, onMoveNode],
+  )
+
+  // ─── Source-handle click → start edge-draw ──────────────────────────────
+
+  const handleSourceHandleClick = useCallback(
+    (e: ReactPointerEvent<SVGElement>, nodeId: string) => {
+      e.stopPropagation()
+      setPendingEdgeFrom(nodeId)
+      onSelectNode(nodeId)
+      announce(`Drawing edge from ${nodeId} — select a target node`)
+    },
+    [announce, onSelectNode],
+  )
+
+  // ─── Keyboard ───────────────────────────────────────────────────────────
+
+  const handleKeyDown = useCallback(
+    (e: KeyboardEvent<SVGSVGElement>) => {
+      if (e.key === 'Escape') {
+        if (pendingEdgeFrom) {
+          setPendingEdgeFrom(null)
+          announce('Edge-draw cancelled')
+          e.preventDefault()
+          return
+        }
+        if (selectedNodeId) {
+          onSelectNode(null)
+          e.preventDefault()
+        }
+        return
+      }
+
+      if (e.key === 'Enter') {
+        if (pendingEdgeFrom && focusedNodeId && focusedNodeId !== pendingEdgeFrom) {
+          commitEdgeDrawTo(focusedNodeId)
+          e.preventDefault()
+          return
+        }
+        const target = focusedNodeId ?? selectedNodeId
+        if (target) {
+          onOpenInspector(target)
+          e.preventDefault()
+        }
+        return
+      }
+
+      if ((e.key === 'Delete' || e.key === 'Backspace') && selectedNodeId) {
+        onDeleteNode(selectedNodeId)
+        announce(`Node ${selectedNodeId} deleted`)
+        e.preventDefault()
+        return
+      }
+
+      if ((e.ctrlKey || e.metaKey) && e.key.toLowerCase() === 'e' && selectedNodeId) {
+        setPendingEdgeFrom(selectedNodeId)
+        announce(
+          `Drawing edge from ${selectedNodeId} — Tab to a target node, then Enter`,
+        )
+        e.preventDefault()
+        return
+      }
+
+      if (selectedNodeId && e.key.startsWith('Arrow')) {
+        const pos = rendered.positions[selectedNodeId]
+        if (!pos) return
+        let dx = 0, dy = 0
+        if (e.key === 'ArrowLeft')  dx = -GRID_SNAP
+        if (e.key === 'ArrowRight') dx = +GRID_SNAP
+        if (e.key === 'ArrowUp')    dy = -GRID_SNAP
+        if (e.key === 'ArrowDown')  dy = +GRID_SNAP
+        onMoveNode(selectedNodeId, {
+          x: snapToGrid(pos.x + dx),
+          y: snapToGrid(pos.y + dy),
+        })
+        e.preventDefault()
+      }
+    },
+    [
+      pendingEdgeFrom,
+      focusedNodeId,
+      selectedNodeId,
+      commitEdgeDrawTo,
+      onOpenInspector,
+      onDeleteNode,
+      onMoveNode,
+      rendered.positions,
+      announce,
+      onSelectNode,
+    ],
+  )
+
+  // Clicking empty space deselects / cancels edge-draw.
+  const handleBackgroundPointerDown = useCallback(
+    (e: ReactPointerEvent<SVGSVGElement>) => {
+      if (e.target !== e.currentTarget) return
+      if (pendingEdgeFrom) {
+        setPendingEdgeFrom(null)
+        announce('Edge-draw cancelled')
+      }
+      onSelectNode(null)
+    },
+    [onSelectNode, pendingEdgeFrom, announce],
+  )
+
+  // ─── Render ─────────────────────────────────────────────────────────────
+
+  const viewBox = `${rendered.origin.x} ${rendered.origin.y} ${rendered.size.w} ${rendered.size.h}`
+
+  return (
+    <div className={styles.wrap}>
+      <svg
+        ref={svgRef}
+        className={styles.canvas}
+        viewBox={viewBox}
+        role="application"
+        aria-label="Workflow graph editor"
+        tabIndex={0}
+        onKeyDown={handleKeyDown}
+        onPointerDown={handleBackgroundPointerDown}
+        data-testid="workflow-canvas"
+      >
+        <defs>
+          <marker
+            id="wc-edge-arrow"
+            viewBox="0 0 10 10"
+            refX="8"
+            refY="5"
+            markerWidth="6"
+            markerHeight="6"
+            orient="auto-start-reverse"
+          >
+            <path d="M 0 0 L 10 5 L 0 10 z" fill="currentColor" />
+          </marker>
+        </defs>
+
+        {rendered.edgePaths.map((edge, idx) => (
+          <g key={`e-${idx}`} className={styles.edge} data-edge-index={idx}>
+            <path
+              d={edge.d}
+              className={styles.edge}
+              markerEnd="url(#wc-edge-arrow)"
+              data-edge-from={edge.from}
+              data-edge-to={edge.to}
+            />
+            {edge.guard && edge.guard !== 'default' ? (
+              <>
+                <rect
+                  className={styles.edgeGuardBg}
+                  x={edge.midpoint.x - 26}
+                  y={edge.midpoint.y - 8}
+                  width={52}
+                  height={16}
+                  rx={3}
+                  ry={3}
+                />
+                <text
+                  className={styles.edgeGuard}
+                  x={edge.midpoint.x}
+                  y={edge.midpoint.y + 4}
+                  textAnchor="middle"
+                >
+                  {edge.guard}
+                </text>
+              </>
+            ) : null}
+          </g>
+        ))}
+
+        {orderedNodes.map(node => {
+          const pos = rendered.positions[node.id]
+          if (!pos) return null
+          const live = drag && drag.nodeId === node.id ? drag.currentPos : pos
+          const kindClass =
+            node.type === 'approval'  ? styles.nodeKindApproval  :
+            node.type === 'condition' ? styles.nodeKindCondition :
+            node.type === 'notify'    ? styles.nodeKindNotify    :
+                                        styles.nodeKindTerminal
+          const classes = [
+            styles.node,
+            kindClass,
+            selectedNodeId === node.id ? styles.nodeSelected : '',
+            activeNodeId === node.id ? styles.nodeActive : '',
+            pendingEdgeFrom === node.id ? styles.edgeDrawSource : '',
+            drag?.nodeId === node.id ? styles.dragging : '',
+          ].filter(Boolean).join(' ')
+
+          return (
+            <g
+              key={node.id}
+              className={classes}
+              transform={`translate(${live.x} ${live.y})`}
+              tabIndex={0}
+              role="button"
+              aria-label={`${node.type} node ${displayLabel(node)}`}
+              aria-pressed={selectedNodeId === node.id}
+              data-node-id={node.id}
+              onFocus={() => setFocusedNodeId(node.id)}
+              onBlur={() => setFocusedNodeId(prev => (prev === node.id ? null : prev))}
+              onPointerDown={e => handleNodePointerDown(e, node)}
+              onPointerMove={handleNodePointerMove}
+              onPointerUp={handleNodePointerUp}
+              onPointerCancel={handleNodePointerUp}
+              onDoubleClick={() => onOpenInspector(node.id)}
+            >
+              <rect
+                className={styles.nodeRect}
+                x={0}
+                y={0}
+                width={NODE_WIDTH}
+                height={NODE_HEIGHT}
+                rx={6}
+                ry={6}
+              />
+              <text x={10} y={18} className={styles.nodeKind}>{node.type}</text>
+              <text x={10} y={38} className={styles.nodeLabel}>
+                {displayLabel(node).length > 22
+                  ? displayLabel(node).slice(0, 21) + '…'
+                  : displayLabel(node)}
+              </text>
+              {node.type !== 'terminal' ? (
+                <circle
+                  className={styles.handle}
+                  cx={NODE_WIDTH / 2}
+                  cy={NODE_HEIGHT}
+                  r={5}
+                  role="button"
+                  aria-label={`Start an edge from ${node.id}`}
+                  data-handle-for={node.id}
+                  onPointerDown={e => handleSourceHandleClick(e, node.id)}
+                />
+              ) : null}
+            </g>
+          )
+        })}
+      </svg>
+      <div
+        className={styles.liveRegion}
+        role="status"
+        aria-live="polite"
+        data-testid="workflow-canvas-live"
+      >
+        {liveMessage}
+      </div>
+    </div>
+  )
+}
+
+export default WorkflowCanvas

--- a/src/ui/__tests__/WorkflowCanvas.test.tsx
+++ b/src/ui/__tests__/WorkflowCanvas.test.tsx
@@ -1,0 +1,210 @@
+// @vitest-environment happy-dom
+import { render, screen, fireEvent } from '@testing-library/react'
+import { describe, it, expect, vi } from 'vitest'
+import '@testing-library/jest-dom'
+
+import { WorkflowCanvas } from '../WorkflowCanvas'
+import { GRID_SNAP } from '../../core/workflow/layout'
+import {
+  singleApproverWorkflow,
+  conditionalByCostWorkflow,
+} from '../../core/workflow/templates'
+import type { Workflow, WorkflowLayout } from '../../core/workflow/workflowSchema'
+
+const emptyLayout = (wf: Workflow): WorkflowLayout => ({
+  workflowId: wf.id,
+  workflowVersion: wf.version,
+  positions: {},
+})
+
+function renderCanvas(
+  wf: Workflow,
+  overrides: Partial<React.ComponentProps<typeof WorkflowCanvas>> = {},
+) {
+  const handlers = {
+    onSelectNode: vi.fn(),
+    onMoveNode: vi.fn(),
+    onOpenInspector: vi.fn(),
+    onDeleteNode: vi.fn(),
+    onCreateEdge: vi.fn(),
+  }
+  const utils = render(
+    <WorkflowCanvas
+      workflow={wf}
+      layout={emptyLayout(wf)}
+      selectedNodeId={null}
+      {...handlers}
+      {...overrides}
+    />,
+  )
+  return { ...utils, ...handlers }
+}
+
+describe('WorkflowCanvas — rendering', () => {
+  it('renders one <g> per node with a data-node-id', () => {
+    renderCanvas(singleApproverWorkflow)
+    for (const n of singleApproverWorkflow.nodes) {
+      expect(document.querySelector(`[data-node-id="${n.id}"]`)).toBeInTheDocument()
+    }
+  })
+
+  it('renders one edge path per edge with correct from/to attrs', () => {
+    renderCanvas(conditionalByCostWorkflow)
+    const paths = document.querySelectorAll('[data-edge-from]')
+    expect(paths.length).toBe(conditionalByCostWorkflow.edges.length)
+    expect(document.querySelector('[data-edge-from="check-cost"][data-edge-to="director"]'))
+      .toBeInTheDocument()
+  })
+
+  it('marks the selected node with aria-pressed=true', () => {
+    renderCanvas(singleApproverWorkflow, { selectedNodeId: 'approve' })
+    const node = document.querySelector('[data-node-id="approve"]')
+    expect(node?.getAttribute('aria-pressed')).toBe('true')
+  })
+
+  it('adds the active-node class when activeNodeId matches', () => {
+    renderCanvas(singleApproverWorkflow, { activeNodeId: 'approve' })
+    const node = document.querySelector('[data-node-id="approve"]')
+    expect(node?.className).toMatch(/nodeActive/)
+  })
+})
+
+describe('WorkflowCanvas — pointer interactions', () => {
+  it('clicking a node calls onSelectNode with its id', () => {
+    const { onSelectNode } = renderCanvas(singleApproverWorkflow)
+    const node = document.querySelector('[data-node-id="approve"]')!
+    fireEvent.pointerDown(node, { pointerId: 1, clientX: 0, clientY: 0 })
+    expect(onSelectNode).toHaveBeenCalledWith('approve')
+  })
+
+  it('double-clicking a node calls onOpenInspector', () => {
+    const { onOpenInspector } = renderCanvas(singleApproverWorkflow)
+    const node = document.querySelector('[data-node-id="approve"]')!
+    fireEvent.doubleClick(node)
+    expect(onOpenInspector).toHaveBeenCalledWith('approve')
+  })
+
+  it('clicking the source handle starts edge-draw mode', () => {
+    renderCanvas(singleApproverWorkflow)
+    const handle = document.querySelector('[data-handle-for="approve"]')!
+    fireEvent.pointerDown(handle, { pointerId: 1 })
+    const live = screen.getByTestId('workflow-canvas-live')
+    expect(live.textContent).toMatch(/drawing edge from approve/i)
+  })
+
+  it('clicking a target node while in edge-draw mode commits the edge', () => {
+    const { onCreateEdge } = renderCanvas(singleApproverWorkflow)
+    fireEvent.pointerDown(
+      document.querySelector('[data-handle-for="approve"]')!,
+      { pointerId: 1 },
+    )
+    fireEvent.pointerDown(
+      document.querySelector('[data-node-id="done"]')!,
+      { pointerId: 2, clientX: 0, clientY: 0 },
+    )
+    expect(onCreateEdge).toHaveBeenCalledWith('approve', 'done')
+  })
+
+  it('terminal nodes do NOT render a source handle', () => {
+    renderCanvas(singleApproverWorkflow)
+    expect(document.querySelector('[data-handle-for="done"]')).toBeNull()
+    expect(document.querySelector('[data-handle-for="denied"]')).toBeNull()
+  })
+})
+
+describe('WorkflowCanvas — keyboard', () => {
+  it('Arrow keys nudge the selected node by GRID_SNAP', () => {
+    const { onMoveNode } = renderCanvas(singleApproverWorkflow, {
+      selectedNodeId: 'approve',
+    })
+    const svg = screen.getByTestId('workflow-canvas')
+    fireEvent.keyDown(svg, { key: 'ArrowRight' })
+    expect(onMoveNode).toHaveBeenCalledTimes(1)
+    const [id, pos] = onMoveNode.mock.calls[0]
+    expect(id).toBe('approve')
+    // Default BFS layout puts 'approve' at (40, 40); snapped right == 60.
+    expect(pos.x - 40).toBe(GRID_SNAP)
+    expect(pos.y).toBe(40)
+  })
+
+  it('Enter opens the inspector for the selected node', () => {
+    const { onOpenInspector } = renderCanvas(singleApproverWorkflow, {
+      selectedNodeId: 'approve',
+    })
+    const svg = screen.getByTestId('workflow-canvas')
+    fireEvent.keyDown(svg, { key: 'Enter' })
+    expect(onOpenInspector).toHaveBeenCalledWith('approve')
+  })
+
+  it('Delete removes the selected node', () => {
+    const { onDeleteNode } = renderCanvas(singleApproverWorkflow, {
+      selectedNodeId: 'approve',
+    })
+    const svg = screen.getByTestId('workflow-canvas')
+    fireEvent.keyDown(svg, { key: 'Delete' })
+    expect(onDeleteNode).toHaveBeenCalledWith('approve')
+  })
+
+  it('Ctrl+E + focus-move + Enter creates an edge', () => {
+    const { onCreateEdge } = renderCanvas(singleApproverWorkflow, {
+      selectedNodeId: 'approve',
+    })
+    const svg = screen.getByTestId('workflow-canvas')
+    // Start edge-draw from selected 'approve'.
+    fireEvent.keyDown(svg, { key: 'e', ctrlKey: true })
+    // Move focus to 'done' (Tab would do this in a browser; simulate via focus event).
+    const target = document.querySelector('[data-node-id="done"]') as SVGGElement
+    fireEvent.focus(target)
+    // Commit with Enter.
+    fireEvent.keyDown(svg, { key: 'Enter' })
+    expect(onCreateEdge).toHaveBeenCalledWith('approve', 'done')
+  })
+
+  it('Escape cancels edge-draw mode', () => {
+    renderCanvas(singleApproverWorkflow, { selectedNodeId: 'approve' })
+    const svg = screen.getByTestId('workflow-canvas')
+    fireEvent.keyDown(svg, { key: 'e', ctrlKey: true })
+    const live = screen.getByTestId('workflow-canvas-live')
+    expect(live.textContent).toMatch(/drawing edge/i)
+    fireEvent.keyDown(svg, { key: 'Escape' })
+    expect(live.textContent).toMatch(/cancelled/i)
+  })
+
+  it('Escape clears selection when not in edge-draw mode', () => {
+    const { onSelectNode } = renderCanvas(singleApproverWorkflow, {
+      selectedNodeId: 'approve',
+    })
+    const svg = screen.getByTestId('workflow-canvas')
+    fireEvent.keyDown(svg, { key: 'Escape' })
+    expect(onSelectNode).toHaveBeenCalledWith(null)
+  })
+
+  it('renders nodes in BFS order so native Tab order traverses the graph', () => {
+    renderCanvas(conditionalByCostWorkflow)
+    const nodes = [...document.querySelectorAll('[data-node-id]')].map(
+      n => n.getAttribute('data-node-id'),
+    )
+    // BFS from 'check-cost': first the root, then rank-1 children, then rank-2, ...
+    expect(nodes[0]).toBe('check-cost')
+    // director + notify-ops are both rank-1 children.
+    expect(nodes.slice(1, 3).sort()).toEqual(['director', 'notify-ops'])
+  })
+})
+
+describe('WorkflowCanvas — edge-draw safety', () => {
+  it('does not commit an edge from a node to itself', () => {
+    const { onCreateEdge } = renderCanvas(singleApproverWorkflow, {
+      selectedNodeId: 'approve',
+    })
+    fireEvent.pointerDown(
+      document.querySelector('[data-handle-for="approve"]')!,
+      { pointerId: 1 },
+    )
+    // Click the same node — should not commit.
+    fireEvent.pointerDown(
+      document.querySelector('[data-node-id="approve"]')!,
+      { pointerId: 2, clientX: 0, clientY: 0 },
+    )
+    expect(onCreateEdge).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
With the reload + persist effects both keyed on calendarId, a calendarId flip from A to B triggered the persist effect once with the NEW id but the STALE workflows value before the reload effect's setState settled. That briefly wrote calendar A's workflows under calendar B's storage key; a follow-up render corrected it, but a component unmount (or quota failure) between the two would leave B corrupted.

Combining { calendarId, workflows } into one state object lets the persist effect guard on state.calendarId === calendarId, skipping the stale-state render entirely.

Regression test spies on localStorage.setItem and asserts no write targeting the new key contains the old calendar's data.

https://claude.ai/code/session_014vuvkCTA8VA3RpPwenpmZS