### PR TITLE
feat(workflow): WorkflowNodeInspector per-type editor

### DIFF
--- a/src/ui/WorkflowNodeInspector.module.css
+++ b/src/ui/WorkflowNodeInspector.module.css
@@ -1,0 +1,88 @@
+.panel {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  padding: 12px;
+  background: var(--wc-bg, #ffffff);
+  border: 1px solid var(--wc-border, #d1d5db);
+  border-radius: 6px;
+  min-width: 240px;
+}
+
+.header {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 8px;
+  border-bottom: 1px solid var(--wc-border, #d1d5db);
+  padding-bottom: 6px;
+}
+
+.headerTitle {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--wc-text, #111827);
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+}
+
+.headerKind {
+  font-size: 11px;
+  color: var(--wc-muted, #6b7280);
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.label {
+  font-size: 11px;
+  font-weight: 500;
+  color: var(--wc-text, #111827);
+}
+
+.hint {
+  font-size: 11px;
+  color: var(--wc-muted, #6b7280);
+}
+
+.input,
+.select,
+.textarea {
+  padding: 6px 8px;
+  font-size: 12px;
+  font-family: inherit;
+  color: var(--wc-text, #111827);
+  background: var(--wc-bg, #ffffff);
+  border: 1px solid var(--wc-border, #d1d5db);
+  border-radius: 4px;
+}
+
+.textarea {
+  min-height: 60px;
+  resize: vertical;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+}
+
+.input:focus,
+.select:focus,
+.textarea:focus {
+  outline: none;
+  border-color: var(--wc-accent, #2563eb);
+}
+
+.input:disabled {
+  background: var(--wc-bg-muted, #f3f4f6);
+  color: var(--wc-muted, #6b7280);
+}
+
+.error {
+  font-size: 11px;
+  color: var(--wc-danger, #b91c1c);
+}
+
+.errorInput {
+  border-color: var(--wc-danger, #b91c1c);
+}

--- a/src/ui/WorkflowNodeInspector.tsx
+++ b/src/ui/WorkflowNodeInspector.tsx
@@ -118,18 +118,32 @@ function ConditionFields({
 }): JSX.Element {
   // Debounced syntax check: store the latest draft value and run
   // `validateExpressionSyntax` only after the user pauses typing.
+  //
+  // The initial `error` is seeded synchronously so there's no "no
+  // error" flash between mount and the first effect pass.
   const [draftExpr, setDraftExpr] = useState<string>(node.expr)
-  const [error, setError] = useState<string | null>(null)
+  const [error, setError] = useState<string | null>(
+    () => validateExpressionSyntax(node.expr),
+  )
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
-  // Keep the draft in sync when the parent swaps to a different node
-  // or replaces the expression from outside.
+  // Only sync on a genuine node swap (`node.id` changes). Syncing on
+  // `node.expr` would re-validate on every controlled re-render — in
+  // normal usage the parent merges each keystroke back in, which
+  // would short-circuit the 150ms debounce and badger mid-type.
+  // On swap we also flush the pending timer so a late validation
+  // from the previous node can't stomp the new node's error state.
   useEffect(() => {
+    if (debounceRef.current) {
+      clearTimeout(debounceRef.current)
+      debounceRef.current = null
+    }
     setDraftExpr(node.expr)
     setError(validateExpressionSyntax(node.expr))
-  }, [node.id, node.expr])
+  // eslint-disable-next-line react-hooks/exhaustive-deps -- see comment above
+  }, [node.id])
 
-  // Flush the pending timer on unmount.
+  // Safety net: cancel any pending validation on unmount.
   useEffect(() => () => {
     if (debounceRef.current) clearTimeout(debounceRef.current)
   }, [])

--- a/src/ui/WorkflowNodeInspector.tsx
+++ b/src/ui/WorkflowNodeInspector.tsx
@@ -1,0 +1,280 @@
+/**
+ * WorkflowNodeInspector — per-type editor for a single workflow node.
+ *
+ * Pure controlled component: the caller owns the draft `node` and
+ * receives patches via `onChange`. Patches are shallow — the parent
+ * merges them into the underlying `Workflow.nodes[]` entry.
+ *
+ * Condition expressions are syntax-checked via `validateExpressionSyntax`
+ * with a short debounce (150ms) so the user isn't badgered mid-keystroke.
+ * Everything else is direct binding; validation of guards / signal
+ * coverage lives in the top-level `validateWorkflow` pass.
+ */
+import { useEffect, useRef, useState } from 'react'
+import { validateExpressionSyntax } from '../core/workflow/validate'
+import type {
+  TimeoutBehavior,
+  WorkflowApprovalNode,
+  WorkflowConditionNode,
+  WorkflowNode,
+  WorkflowNotifyNode,
+  WorkflowOutcome,
+  WorkflowTerminalNode,
+} from '../core/workflow/workflowSchema'
+import styles from './WorkflowNodeInspector.module.css'
+
+const EXPR_DEBOUNCE_MS = 150
+
+const TIMEOUT_BEHAVIORS: readonly TimeoutBehavior[] = [
+  'escalate',
+  'auto-approve',
+  'auto-deny',
+]
+
+const OUTCOMES: readonly WorkflowOutcome[] = ['finalized', 'denied', 'cancelled']
+
+export interface WorkflowNodeInspectorProps {
+  readonly node: WorkflowNode
+  readonly onChange: (patch: Partial<WorkflowNode>) => void
+}
+
+export function WorkflowNodeInspector(
+  props: WorkflowNodeInspectorProps,
+): JSX.Element {
+  const { node, onChange } = props
+  return (
+    <section
+      className={styles.panel}
+      aria-label={`Inspector for ${node.type} node ${node.id}`}
+    >
+      <header className={styles.header}>
+        <span className={styles.headerTitle}>{node.type}</span>
+        <span className={styles.headerKind}>#{node.id}</span>
+      </header>
+
+      <CommonFields node={node} onChange={onChange} />
+
+      {node.type === 'condition' && (
+        <ConditionFields node={node} onChange={onChange} />
+      )}
+      {node.type === 'approval' && (
+        <ApprovalFields node={node} onChange={onChange} />
+      )}
+      {node.type === 'notify' && (
+        <NotifyFields node={node} onChange={onChange} />
+      )}
+      {node.type === 'terminal' && (
+        <TerminalFields node={node} onChange={onChange} />
+      )}
+    </section>
+  )
+}
+
+export default WorkflowNodeInspector
+
+// ─── Field groups ──────────────────────────────────────────────────────────
+
+function CommonFields({
+  node,
+  onChange,
+}: {
+  node: WorkflowNode
+  onChange: (patch: Partial<WorkflowNode>) => void
+}): JSX.Element {
+  return (
+    <>
+      <div className={styles.field}>
+        <label className={styles.label} htmlFor="wc-node-id">Node ID</label>
+        <input
+          id="wc-node-id"
+          className={styles.input}
+          value={node.id}
+          disabled
+          readOnly
+        />
+        <span className={styles.hint}>IDs are fixed after creation.</span>
+      </div>
+
+      <div className={styles.field}>
+        <label className={styles.label} htmlFor="wc-node-label">Label</label>
+        <input
+          id="wc-node-label"
+          className={styles.input}
+          value={node.label ?? ''}
+          placeholder="Shown on the canvas"
+          onChange={e => onChange({ label: e.target.value } as Partial<WorkflowNode>)}
+        />
+      </div>
+    </>
+  )
+}
+
+function ConditionFields({
+  node,
+  onChange,
+}: {
+  node: WorkflowConditionNode
+  onChange: (patch: Partial<WorkflowConditionNode>) => void
+}): JSX.Element {
+  // Debounced syntax check: store the latest draft value and run
+  // `validateExpressionSyntax` only after the user pauses typing.
+  const [draftExpr, setDraftExpr] = useState<string>(node.expr)
+  const [error, setError] = useState<string | null>(null)
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  // Keep the draft in sync when the parent swaps to a different node
+  // or replaces the expression from outside.
+  useEffect(() => {
+    setDraftExpr(node.expr)
+    setError(validateExpressionSyntax(node.expr))
+  }, [node.id, node.expr])
+
+  // Flush the pending timer on unmount.
+  useEffect(() => () => {
+    if (debounceRef.current) clearTimeout(debounceRef.current)
+  }, [])
+
+  const handleChange = (value: string): void => {
+    setDraftExpr(value)
+    onChange({ expr: value })
+    if (debounceRef.current) clearTimeout(debounceRef.current)
+    debounceRef.current = setTimeout(() => {
+      setError(validateExpressionSyntax(value))
+    }, EXPR_DEBOUNCE_MS)
+  }
+
+  return (
+    <div className={styles.field}>
+      <label className={styles.label} htmlFor="wc-node-expr">Expression</label>
+      <textarea
+        id="wc-node-expr"
+        className={[styles.textarea, error ? styles.errorInput : ''].filter(Boolean).join(' ')}
+        value={draftExpr}
+        onChange={e => handleChange(e.target.value)}
+        aria-invalid={error ? 'true' : 'false'}
+        aria-describedby="wc-node-expr-hint"
+        rows={3}
+        spellCheck={false}
+      />
+      <span id="wc-node-expr-hint" className={error ? styles.error : styles.hint}>
+        {error ?? 'Evaluated against action variables — e.g. event.cost > 500'}
+      </span>
+    </div>
+  )
+}
+
+function ApprovalFields({
+  node,
+  onChange,
+}: {
+  node: WorkflowApprovalNode
+  onChange: (patch: Partial<WorkflowApprovalNode>) => void
+}): JSX.Element {
+  return (
+    <>
+      <div className={styles.field}>
+        <label className={styles.label} htmlFor="wc-node-assignTo">Assign to</label>
+        <input
+          id="wc-node-assignTo"
+          className={styles.input}
+          value={node.assignTo}
+          placeholder="role:director, user:alice, …"
+          onChange={e => onChange({ assignTo: e.target.value })}
+        />
+      </div>
+
+      <div className={styles.field}>
+        <label className={styles.label} htmlFor="wc-node-sla">SLA minutes (optional)</label>
+        <input
+          id="wc-node-sla"
+          className={styles.input}
+          type="text"
+          inputMode="numeric"
+          pattern="[0-9]*"
+          value={node.slaMinutes ?? ''}
+          onChange={e => {
+            const raw = e.target.value
+            if (raw === '') return onChange({ slaMinutes: undefined })
+            if (!/^\d+$/.test(raw)) return
+            const parsed = Number(raw)
+            if (Number.isFinite(parsed) && parsed >= 0) {
+              onChange({ slaMinutes: parsed })
+            }
+          }}
+        />
+        <span className={styles.hint}>Phase-3 feature; stored but not yet enforced.</span>
+      </div>
+
+      <div className={styles.field}>
+        <label className={styles.label} htmlFor="wc-node-onTimeout">On timeout</label>
+        <select
+          id="wc-node-onTimeout"
+          className={styles.select}
+          value={node.onTimeout ?? ''}
+          onChange={e => {
+            const v = e.target.value as TimeoutBehavior | ''
+            onChange({ onTimeout: v === '' ? undefined : v })
+          }}
+        >
+          <option value="">(none)</option>
+          {TIMEOUT_BEHAVIORS.map(b => <option key={b} value={b}>{b}</option>)}
+        </select>
+      </div>
+    </>
+  )
+}
+
+function NotifyFields({
+  node,
+  onChange,
+}: {
+  node: WorkflowNotifyNode
+  onChange: (patch: Partial<WorkflowNotifyNode>) => void
+}): JSX.Element {
+  return (
+    <>
+      <div className={styles.field}>
+        <label className={styles.label} htmlFor="wc-node-channel">Channel</label>
+        <input
+          id="wc-node-channel"
+          className={styles.input}
+          value={node.channel}
+          placeholder="slack, email, webhook, …"
+          onChange={e => onChange({ channel: e.target.value })}
+        />
+      </div>
+
+      <div className={styles.field}>
+        <label className={styles.label} htmlFor="wc-node-template">Template (optional)</label>
+        <input
+          id="wc-node-template"
+          className={styles.input}
+          value={node.template ?? ''}
+          onChange={e => onChange({ template: e.target.value || undefined })}
+        />
+      </div>
+    </>
+  )
+}
+
+function TerminalFields({
+  node,
+  onChange,
+}: {
+  node: WorkflowTerminalNode
+  onChange: (patch: Partial<WorkflowTerminalNode>) => void
+}): JSX.Element {
+  return (
+    <div className={styles.field}>
+      <label className={styles.label} htmlFor="wc-node-outcome">Outcome</label>
+      <select
+        id="wc-node-outcome"
+        className={styles.select}
+        value={node.outcome}
+        onChange={e => onChange({ outcome: e.target.value as WorkflowOutcome })}
+      >
+        {OUTCOMES.map(o => <option key={o} value={o}>{o}</option>)}
+      </select>
+    </div>
+  )
+}

--- a/src/ui/__tests__/WorkflowNodeInspector.test.tsx
+++ b/src/ui/__tests__/WorkflowNodeInspector.test.tsx
@@ -1,0 +1,213 @@
+// @vitest-environment happy-dom
+import { useState } from 'react'
+import { render, screen, fireEvent, act } from '@testing-library/react'
+import { describe, it, expect, vi } from 'vitest'
+import '@testing-library/jest-dom'
+
+import { WorkflowNodeInspector } from '../WorkflowNodeInspector'
+import type {
+  WorkflowApprovalNode,
+  WorkflowConditionNode,
+  WorkflowNode,
+  WorkflowNotifyNode,
+  WorkflowTerminalNode,
+} from '../../core/workflow/workflowSchema'
+
+/**
+ * Stateful harness. The inspector is a controlled component; its
+ * value props only reflect new state if the parent re-renders with
+ * the updated node. Routing patches through React state also ensures
+ * React emits `change` events consistently even when the coerced DOM
+ * value would otherwise be identical across fires.
+ */
+function Harness<T extends WorkflowNode>({
+  initial,
+  spy,
+}: { initial: T; spy: (patch: Partial<T>) => void }): JSX.Element {
+  const [node, setNode] = useState<T>(initial)
+  return (
+    <WorkflowNodeInspector
+      node={node}
+      onChange={patch => {
+        spy(patch as Partial<T>)
+        setNode(prev => ({ ...prev, ...patch }) as T)
+      }}
+    />
+  )
+}
+
+describe('WorkflowNodeInspector — common fields', () => {
+  it('renders the node id as read-only', () => {
+    const node: WorkflowApprovalNode = {
+      id: 'approve',
+      type: 'approval',
+      assignTo: 'role:x',
+    }
+    render(<WorkflowNodeInspector node={node} onChange={vi.fn()} />)
+    const idField = screen.getByLabelText(/node id/i) as HTMLInputElement
+    expect(idField.value).toBe('approve')
+    expect(idField).toBeDisabled()
+  })
+
+  it('emits a patch when the label changes', () => {
+    const onChange = vi.fn()
+    const node: WorkflowApprovalNode = {
+      id: 'approve',
+      type: 'approval',
+      assignTo: 'role:x',
+    }
+    render(<WorkflowNodeInspector node={node} onChange={onChange} />)
+    fireEvent.change(screen.getByLabelText(/^label$/i), {
+      target: { value: 'My approval' },
+    })
+    expect(onChange).toHaveBeenLastCalledWith({ label: 'My approval' })
+  })
+})
+
+describe('WorkflowNodeInspector — approval', () => {
+  const baseNode: WorkflowApprovalNode = {
+    id: 'approve',
+    type: 'approval',
+    assignTo: 'role:director',
+  }
+
+  it('edits assignTo', () => {
+    const onChange = vi.fn()
+    render(<WorkflowNodeInspector node={baseNode} onChange={onChange} />)
+    fireEvent.change(screen.getByLabelText(/assign to/i), {
+      target: { value: 'user:alice' },
+    })
+    expect(onChange).toHaveBeenLastCalledWith({ assignTo: 'user:alice' })
+  })
+
+  it('parses slaMinutes as a number, clears on empty', () => {
+    const spy = vi.fn()
+    render(<Harness initial={baseNode} spy={spy} />)
+    const field = screen.getByLabelText(/sla minutes/i)
+    fireEvent.change(field, { target: { value: '30' } })
+    expect(spy).toHaveBeenLastCalledWith({ slaMinutes: 30 })
+    fireEvent.change(field, { target: { value: '' } })
+    expect(spy).toHaveBeenLastCalledWith({ slaMinutes: undefined })
+  })
+
+  it('ignores negative or non-numeric slaMinutes', () => {
+    const spy = vi.fn()
+    render(<Harness initial={baseNode} spy={spy} />)
+    const field = screen.getByLabelText(/sla minutes/i)
+    fireEvent.change(field, { target: { value: '-5' } })
+    expect(spy).not.toHaveBeenCalledWith(expect.objectContaining({ slaMinutes: -5 }))
+  })
+
+  it('edits onTimeout to a known behavior', () => {
+    const onChange = vi.fn()
+    render(<WorkflowNodeInspector node={baseNode} onChange={onChange} />)
+    fireEvent.change(screen.getByLabelText(/on timeout/i), {
+      target: { value: 'auto-approve' },
+    })
+    expect(onChange).toHaveBeenLastCalledWith({ onTimeout: 'auto-approve' })
+  })
+
+  it('clears onTimeout when set to the blank option', () => {
+    const onChange = vi.fn()
+    const node: WorkflowApprovalNode = { ...baseNode, onTimeout: 'escalate' }
+    render(<WorkflowNodeInspector node={node} onChange={onChange} />)
+    fireEvent.change(screen.getByLabelText(/on timeout/i), { target: { value: '' } })
+    expect(onChange).toHaveBeenLastCalledWith({ onTimeout: undefined })
+  })
+})
+
+describe('WorkflowNodeInspector — condition', () => {
+  const makeNode = (expr: string): WorkflowConditionNode => ({
+    id: 'c',
+    type: 'condition',
+    expr,
+  })
+
+  it('emits every keystroke to onChange', () => {
+    const onChange = vi.fn()
+    render(<WorkflowNodeInspector node={makeNode('event.cost > 500')} onChange={onChange} />)
+    fireEvent.change(screen.getByLabelText(/expression/i), {
+      target: { value: 'event.cost > 1000' },
+    })
+    expect(onChange).toHaveBeenLastCalledWith({ expr: 'event.cost > 1000' })
+  })
+
+  it('shows no syntax error for a valid expression', () => {
+    vi.useFakeTimers()
+    try {
+      render(<WorkflowNodeInspector node={makeNode('event.cost > 500')} onChange={vi.fn()} />)
+      const hint = screen.getByText(/evaluated against action variables/i)
+      expect(hint).toBeInTheDocument()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('surfaces a syntax error after the debounce for invalid input', () => {
+    vi.useFakeTimers()
+    try {
+      render(<WorkflowNodeInspector node={makeNode('event.cost > 500')} onChange={vi.fn()} />)
+      fireEvent.change(screen.getByLabelText(/expression/i), {
+        target: { value: 'event.cost >' },
+      })
+      // Before the debounce fires, no error is visible.
+      expect(screen.queryByText(/syntax|unexpected|empty/i)).toBeNull()
+      act(() => { vi.advanceTimersByTime(200) })
+      const textarea = screen.getByLabelText(/expression/i) as HTMLTextAreaElement
+      expect(textarea.getAttribute('aria-invalid')).toBe('true')
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('flags empty expressions as errors', () => {
+    vi.useFakeTimers()
+    try {
+      render(<WorkflowNodeInspector node={makeNode('event.cost > 500')} onChange={vi.fn()} />)
+      fireEvent.change(screen.getByLabelText(/expression/i), {
+        target: { value: '' },
+      })
+      act(() => { vi.advanceTimersByTime(200) })
+      expect(screen.getByText(/empty/i)).toBeInTheDocument()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+})
+
+describe('WorkflowNodeInspector — notify', () => {
+  const node: WorkflowNotifyNode = {
+    id: 'n',
+    type: 'notify',
+    channel: 'slack',
+  }
+
+  it('edits channel', () => {
+    const onChange = vi.fn()
+    render(<WorkflowNodeInspector node={node} onChange={onChange} />)
+    fireEvent.change(screen.getByLabelText(/channel/i), { target: { value: 'email' } })
+    expect(onChange).toHaveBeenLastCalledWith({ channel: 'email' })
+  })
+
+  it('clears template to undefined when emptied', () => {
+    const onChange = vi.fn()
+    const withTemplate: WorkflowNotifyNode = { ...node, template: 'foo' }
+    render(<WorkflowNodeInspector node={withTemplate} onChange={onChange} />)
+    fireEvent.change(screen.getByLabelText(/template/i), { target: { value: '' } })
+    expect(onChange).toHaveBeenLastCalledWith({ template: undefined })
+  })
+})
+
+describe('WorkflowNodeInspector — terminal', () => {
+  it('edits outcome to a known value', () => {
+    const onChange = vi.fn()
+    const node: WorkflowTerminalNode = {
+      id: 't',
+      type: 'terminal',
+      outcome: 'finalized',
+    }
+    render(<WorkflowNodeInspector node={node} onChange={onChange} />)
+    fireEvent.change(screen.getByLabelText(/outcome/i), { target: { value: 'cancelled' } })
+    expect(onChange).toHaveBeenLastCalledWith({ outcome: 'cancelled' })
+  })
+})

--- a/src/ui/__tests__/WorkflowNodeInspector.test.tsx
+++ b/src/ui/__tests__/WorkflowNodeInspector.test.tsx
@@ -173,6 +173,64 @@ describe('WorkflowNodeInspector — condition', () => {
       vi.useRealTimers()
     }
   })
+
+  // Regression: controlled parents that merge each keystroke back into `node.expr`
+  // must not bypass the 150ms debounce. A prior version synced on `[node.id, node.expr]`
+  // and validated synchronously on every re-render, badgering the user mid-type.
+  it('does not validate synchronously when a controlled parent echoes expr back', () => {
+    vi.useFakeTimers()
+    try {
+      const spy = vi.fn()
+      render(<Harness initial={makeNode('event.cost > 500')} spy={spy} />)
+      const textarea = screen.getByLabelText(/expression/i) as HTMLTextAreaElement
+      // Type a syntactically invalid fragment. The Harness merges it into state,
+      // which causes the inspector to re-render with node.expr === the bad value.
+      fireEvent.change(textarea, { target: { value: 'event.cost >' } })
+      // Pre-debounce: the textarea should NOT yet be marked invalid.
+      expect(textarea.getAttribute('aria-invalid')).toBe('false')
+      act(() => { vi.advanceTimersByTime(200) })
+      // Post-debounce: now the error surfaces.
+      expect(textarea.getAttribute('aria-invalid')).toBe('true')
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  // Regression: swapping to a different condition node must flush any pending
+  // validation from the previous node — otherwise a late-firing timer writes
+  // the previous node's error text into the new node's hint slot.
+  it('cancels a pending validation when the selected condition node changes', () => {
+    vi.useFakeTimers()
+    try {
+      function Swapper(): JSX.Element {
+        const [which, setWhich] = useState<'bad' | 'good'>('bad')
+        const node: WorkflowConditionNode = which === 'bad'
+          ? { id: 'bad', type: 'condition', expr: 'event.cost > 500' }
+          : { id: 'good', type: 'condition', expr: 'event.cost > 500' }
+        return (
+          <>
+            <button onClick={() => setWhich('good')}>swap</button>
+            <WorkflowNodeInspector node={node} onChange={vi.fn()} />
+          </>
+        )
+      }
+      render(<Swapper />)
+      // Type invalid expr on the 'bad' node — schedules a 150ms debounced
+      // validation that would mark the textarea invalid.
+      fireEvent.change(screen.getByLabelText(/expression/i), {
+        target: { value: 'event.cost >' },
+      })
+      // Before the debounce fires, swap to a different node. The pending
+      // timer must be flushed so it doesn't stomp the new node's error state.
+      fireEvent.click(screen.getByText('swap'))
+      act(() => { vi.advanceTimersByTime(200) })
+      const textarea = screen.getByLabelText(/expression/i) as HTMLTextAreaElement
+      expect(textarea.value).toBe('event.cost > 500')
+      expect(textarea.getAttribute('aria-invalid')).toBe('false')
+    } finally {
+      vi.useRealTimers()
+    }
+  })
 })
 
 describe('WorkflowNodeInspector — notify', () => {


### PR DESCRIPTION
Pure controlled component: caller owns draft node, shallow patches flow back via onChange. Per-type fields match the Phase 2 plan:

  - common    : read-only id, editable label
  - condition : expr textarea with debounced (150ms) syntax check via
                validateExpressionSyntax; ignores variable-binding
                errors (non-object / undefined-variable) that are
                expected at edit time
  - approval  : assignTo, slaMinutes (numeric text), onTimeout
                (escalate | auto-approve | auto-deny)
  - notify    : channel, template (empty → undefined so it survives
                the JSON round-trip cleanly)
  - terminal  : outcome (finalized | denied | cancelled)

https://claude.ai/code/session_014vuvkCTA8VA3RpPwenpmZS