### PR TITLE
feat(workflow): WorkflowEdgeGuardPicker popover

### DIFF
--- a/src/ui/WorkflowEdgeGuardPicker.module.css
+++ b/src/ui/WorkflowEdgeGuardPicker.module.css
@@ -1,0 +1,40 @@
+.menu {
+  z-index: 540;
+  min-width: 160px;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  padding: 4px;
+  background: var(--wc-bg, #fff);
+  border: 1px solid var(--wc-border, #d1d5db);
+  border-radius: 6px;
+  box-shadow: var(--wc-shadow, 0 6px 18px rgba(0, 0, 0, 0.12));
+}
+
+.menuItem {
+  padding: 6px 10px;
+  text-align: left;
+  font-size: 13px;
+  font-weight: 500;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  background: transparent;
+  color: var(--wc-text, #111827);
+  border: 1px solid transparent;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.menuItem:hover,
+.menuItem:focus-visible {
+  background: var(--wc-bg-muted, #f3f4f6);
+  outline: none;
+}
+
+.menuItem[data-guard='true'] {
+  color: var(--wc-accent, #16a34a);
+}
+
+.menuItem[data-guard='false'],
+.menuItem[data-guard='denied'] {
+  color: var(--wc-danger, #b91c1c);
+}

--- a/src/ui/WorkflowEdgeGuardPicker.tsx
+++ b/src/ui/WorkflowEdgeGuardPicker.tsx
@@ -1,0 +1,136 @@
+/**
+ * WorkflowEdgeGuardPicker — popover shown after a new edge is drawn
+ * in the builder canvas. The user picks a guard (`true`/`false`,
+ * `approved`/`denied`, `default`), the modal commits the edge.
+ *
+ * Options are filtered to just those the source node can legally emit:
+ *
+ *   - `condition`  → true / false / default
+ *   - `approval`   → approved / denied / default
+ *   - `notify`     → default
+ *   - `terminal`   → (no outgoing edges; picker should not be invoked)
+ *
+ * Dismissal: Escape or click-outside calls `onCancel`. Picking an
+ * option calls `onPick(guard)` — the host decides whether to persist.
+ */
+import { useEffect, useRef, type CSSProperties } from 'react'
+import type { EdgeGuard, WorkflowNode } from '../core/workflow/workflowSchema'
+import styles from './WorkflowEdgeGuardPicker.module.css'
+
+export interface AnchorRect {
+  readonly left: number
+  readonly top: number
+  readonly bottom: number
+  readonly right: number
+}
+
+export interface WorkflowEdgeGuardPickerProps {
+  readonly sourceType: WorkflowNode['type']
+  readonly anchorRect?: AnchorRect
+  readonly onPick: (guard: EdgeGuard) => void
+  readonly onCancel: () => void
+}
+
+const GUARD_LABELS: Readonly<Record<EdgeGuard, string>> = {
+  'true': 'true',
+  'false': 'false',
+  'approved': 'approved',
+  'denied': 'denied',
+  'default': 'default (fallback)',
+}
+
+/**
+ * Exported for unit tests + the canvas (which hides the handle on
+ * terminal nodes so this returns [] for defensive callers only).
+ */
+export function guardsForSource(
+  sourceType: WorkflowNode['type'],
+): readonly EdgeGuard[] {
+  switch (sourceType) {
+    case 'condition': return ['true', 'false', 'default']
+    case 'approval':  return ['approved', 'denied', 'default']
+    case 'notify':    return ['default']
+    case 'terminal':  return []
+  }
+}
+
+export function WorkflowEdgeGuardPicker(
+  props: WorkflowEdgeGuardPickerProps,
+): JSX.Element | null {
+  const { sourceType, anchorRect, onPick, onCancel } = props
+  const ref = useRef<HTMLDivElement | null>(null)
+  const guards = guardsForSource(sourceType)
+
+  // Escape + click-outside dismissal. Registered only while mounted;
+  // parent unmounts the picker after the first pick or cancel.
+  useEffect(() => {
+    if (guards.length === 0) return
+    const onKey = (e: KeyboardEvent): void => {
+      if (e.key === 'Escape') {
+        e.stopPropagation()
+        onCancel()
+      }
+    }
+    const onDown = (e: MouseEvent): void => {
+      if (ref.current && !ref.current.contains(e.target as Node)) {
+        onCancel()
+      }
+    }
+    window.addEventListener('keydown', onKey)
+    window.addEventListener('mousedown', onDown)
+    return () => {
+      window.removeEventListener('keydown', onKey)
+      window.removeEventListener('mousedown', onDown)
+    }
+  }, [guards.length, onCancel])
+
+  // Initial focus on the first option so keyboard users can commit
+  // with Enter immediately. `terminal` returns early above, so this
+  // only runs when there's at least one option.
+  useEffect(() => {
+    if (guards.length === 0) return
+    const first = ref.current?.querySelector<HTMLButtonElement>(
+      'button[data-guard]',
+    )
+    first?.focus()
+  }, [guards.length])
+
+  if (guards.length === 0) return null
+
+  const style: CSSProperties | undefined = anchorRect
+    ? {
+      position: 'fixed',
+      top: anchorRect.bottom + 4,
+      left: anchorRect.left,
+    }
+    : undefined
+
+  return (
+    <div
+      ref={ref}
+      role="menu"
+      aria-label="Pick edge guard"
+      className={styles.menu}
+      data-testid="workflow-edge-guard-picker"
+      style={style}
+    >
+      {guards.map(g => (
+        <button
+          key={g}
+          type="button"
+          role="menuitem"
+          className={styles.menuItem}
+          data-guard={g}
+          onClick={e => {
+            e.stopPropagation()
+            onPick(g)
+          }}
+        >
+          {GUARD_LABELS[g]}
+        </button>
+      ))}
+    </div>
+  )
+}
+
+export default WorkflowEdgeGuardPicker

--- a/src/ui/__tests__/WorkflowEdgeGuardPicker.test.tsx
+++ b/src/ui/__tests__/WorkflowEdgeGuardPicker.test.tsx
@@ -1,0 +1,162 @@
+// @vitest-environment happy-dom
+import { render, screen, fireEvent } from '@testing-library/react'
+import { describe, it, expect, vi } from 'vitest'
+import '@testing-library/jest-dom'
+
+import {
+  WorkflowEdgeGuardPicker,
+  guardsForSource,
+} from '../WorkflowEdgeGuardPicker'
+
+describe('guardsForSource', () => {
+  it('condition → true / false / default', () => {
+    expect(guardsForSource('condition')).toEqual(['true', 'false', 'default'])
+  })
+  it('approval → approved / denied / default', () => {
+    expect(guardsForSource('approval')).toEqual(['approved', 'denied', 'default'])
+  })
+  it('notify → default only', () => {
+    expect(guardsForSource('notify')).toEqual(['default'])
+  })
+  it('terminal → empty list', () => {
+    expect(guardsForSource('terminal')).toEqual([])
+  })
+})
+
+describe('WorkflowEdgeGuardPicker — rendering', () => {
+  it('renders one button per valid guard for a condition source', () => {
+    render(
+      <WorkflowEdgeGuardPicker
+        sourceType="condition"
+        onPick={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    )
+    expect(document.querySelector('[data-guard="true"]')).toBeInTheDocument()
+    expect(document.querySelector('[data-guard="false"]')).toBeInTheDocument()
+    expect(document.querySelector('[data-guard="default"]')).toBeInTheDocument()
+    expect(document.querySelector('[data-guard="approved"]')).toBeNull()
+  })
+
+  it('renders approved/denied/default for an approval source', () => {
+    render(
+      <WorkflowEdgeGuardPicker
+        sourceType="approval"
+        onPick={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    )
+    expect(document.querySelector('[data-guard="approved"]')).toBeInTheDocument()
+    expect(document.querySelector('[data-guard="denied"]')).toBeInTheDocument()
+    expect(document.querySelector('[data-guard="default"]')).toBeInTheDocument()
+    expect(document.querySelector('[data-guard="true"]')).toBeNull()
+  })
+
+  it('renders only default for a notify source', () => {
+    render(
+      <WorkflowEdgeGuardPicker
+        sourceType="notify"
+        onPick={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    )
+    const buttons = document.querySelectorAll('[data-guard]')
+    expect(buttons.length).toBe(1)
+    expect(buttons[0].getAttribute('data-guard')).toBe('default')
+  })
+
+  it('renders nothing for a terminal source (defensive)', () => {
+    const { container } = render(
+      <WorkflowEdgeGuardPicker
+        sourceType="terminal"
+        onPick={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    )
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('focuses the first guard button on mount', () => {
+    render(
+      <WorkflowEdgeGuardPicker
+        sourceType="approval"
+        onPick={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    )
+    const first = document.querySelector('[data-guard="approved"]')
+    expect(document.activeElement).toBe(first)
+  })
+})
+
+describe('WorkflowEdgeGuardPicker — interactions', () => {
+  it('clicking an option calls onPick with the chosen guard', () => {
+    const onPick = vi.fn()
+    render(
+      <WorkflowEdgeGuardPicker
+        sourceType="condition"
+        onPick={onPick}
+        onCancel={vi.fn()}
+      />,
+    )
+    fireEvent.click(document.querySelector('[data-guard="false"]')!)
+    expect(onPick).toHaveBeenCalledWith('false')
+  })
+
+  it('Escape key calls onCancel', () => {
+    const onCancel = vi.fn()
+    render(
+      <WorkflowEdgeGuardPicker
+        sourceType="condition"
+        onPick={vi.fn()}
+        onCancel={onCancel}
+      />,
+    )
+    fireEvent.keyDown(window, { key: 'Escape' })
+    expect(onCancel).toHaveBeenCalledTimes(1)
+  })
+
+  it('click outside calls onCancel', () => {
+    const onCancel = vi.fn()
+    render(
+      <>
+        <button data-testid="outside">outside</button>
+        <WorkflowEdgeGuardPicker
+          sourceType="condition"
+          onPick={vi.fn()}
+          onCancel={onCancel}
+        />
+      </>,
+    )
+    fireEvent.mouseDown(screen.getByTestId('outside'))
+    expect(onCancel).toHaveBeenCalledTimes(1)
+  })
+
+  it('click inside the menu does NOT dismiss', () => {
+    const onCancel = vi.fn()
+    render(
+      <WorkflowEdgeGuardPicker
+        sourceType="approval"
+        onPick={vi.fn()}
+        onCancel={onCancel}
+      />,
+    )
+    fireEvent.mouseDown(document.querySelector('[data-guard="approved"]')!)
+    expect(onCancel).not.toHaveBeenCalled()
+  })
+
+  it('anchors to the provided rect via fixed positioning', () => {
+    render(
+      <WorkflowEdgeGuardPicker
+        sourceType="condition"
+        anchorRect={{ left: 120, top: 40, bottom: 60, right: 180 }}
+        onPick={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    )
+    const menu = screen.getByTestId('workflow-edge-guard-picker') as HTMLElement
+    expect(menu.style.position).toBe('fixed')
+    expect(menu.style.top).toBe('64px')
+    expect(menu.style.left).toBe('120px')
+  })
+})


### PR DESCRIPTION
Popover that surfaces after an edge is drawn in the builder canvas, so the user can assign its guard without hand-editing JSON. Guard options are filtered to just those the source node legally emits:

  - condition  → true / false / default
  - approval   → approved / denied / default
  - notify     → default
  - terminal   → (picker renders nothing; caller blocks invocation)

The `default` option is offered even on condition/approval so a user can set up a fallback that satisfies the signal-coverage validator rule without requiring both exact guards.

Patterns mirror ApprovalActionMenu: fixed-position anchored menu with Escape + click-outside dismissal, role=menu, first-option initial focus so keyboard users can commit with Enter immediately.

14 unit tests cover per-source guard lists, click/keyboard dismissal, and anchor positioning.

https://claude.ai/code/session_014vuvkCTA8VA3RpPwenpmZS