### PR TITLE
perf(config): lazy-load ApprovalFlowsTab to keep Phase 2 out of main …

### DIFF
--- a/docs/bundle-size-audit.md
+++ b/docs/bundle-size-audit.md
@@ -1,23 +1,56 @@
-# Bundle size audit (2026-04-14)
+# Bundle size audit (2026-04-20 — Phase 2 visual builder)
 
 ## What was checked
 
-- Ran a production build (`npm run build`) to inspect emitted chunk sizes.
-- Verified the Excel export path is fully lazy: base UI click handler lazy-loads export code, and public API export uses a lazy wrapper.
-- Attempted to run `vite-bundle-visualizer`, but npm registry access is blocked in this environment (`403 Forbidden`).
+- Ran a production build (`npm run build`) before and after Phase 2 to
+  measure the main-chunk delta attributable to the visual workflow
+  builder.
+- Verified the Phase 2 code paths stay lazy:
+  - `ApprovalFlowsTab` (ConfigPanel's entry into the builder) is
+    `React.lazy`-imported, so `WORKFLOW_TEMPLATES`, `useSavedWorkflows`,
+    and the tab's render tree only download when the owner opens the
+    Approval Flows tab.
+  - `WorkflowBuilderModal` is a second-tier lazy import inside
+    `ApprovalFlowsTab`, so the SVG canvas, validator, layout engine,
+    and simulator only download when the author actually opens a draft.
 
 ## Current build output snapshot
 
-From `npm run build` after this change:
+### Pre-Phase-2 baseline (commit `82af954`)
 
-- `dist/index-DxbOqCiJ.js`: **493.90 kB** (gzip **117.14 kB**)
-- `dist/excelExport-DUhHt3G1.js`: **1.17 kB** (gzip **0.66 kB**)
-- `dist/works-calendar.es.js` bootstrap: **3.65 kB** (gzip **1.56 kB**)
+- `dist/index--97GcyGz.js`: **814.36 kB** (gzip **187.66 kB**)
+- `dist/excelExport-BAkhDACy.js`: 1.17 kB (gzip 0.66 kB)
+- `dist/works-calendar.es.js` bootstrap: 3.84 kB (gzip 1.64 kB)
+- `dist/style.css`: 168.34 kB (gzip 26.42 kB)
+
+### After Phase 2 (commit `79f97a7` + lazy-split of `ApprovalFlowsTab`)
+
+- `dist/index-Bxr5v1SQ.js`: **815.05 kB** (gzip **187.90 kB**) — **+0.24 kB gzip**
+- `dist/ApprovalFlowsTab-*.js`: 12.79 kB (gzip 3.13 kB) — new lazy chunk
+- `dist/WorkflowBuilderModal-*.js`: 57.71 kB (gzip 14.70 kB) — new lazy chunk
+- `dist/excelExport-*.js`: 1.17 kB (gzip 0.66 kB)
+- `dist/works-calendar.es.js` bootstrap: 3.86 kB (gzip 1.65 kB)
+- `dist/style.css`: 180.95 kB (gzip 28.51 kB) — **+2.09 kB gzip**
 
 ## Audit conclusion
 
-- `xlsx` is no longer reachable via any static import path from the main entrypoint.
-- Excel export is loaded on demand via dynamic import, so optional export code is excluded from the base runtime path and fetched only when needed.
+- **Main chunk delta from Phase 2: +0.24 kB gzipped.** Inside the
+  plan's ≤2 kB gzip budget for the main chunk.
+- The full visual builder (validator + layout engine + canvas +
+  inspector + picker + simulator + builder modal + tab UI + templates
+  + persistence hook) lives entirely in two lazy chunks totalling
+  17.83 kB gzipped, fetched only when the Approval Flows tab opens.
+- CSS delta is +2.09 kB gzipped — from the per-component CSS modules
+  introduced by Phase 2. Vite's library build emits a single
+  `style.css`, so the Phase 2 styles can't be split into a separate
+  file without reshaping the build config; they are a one-time cost
+  on first load regardless of whether the tab opens.
+
+## Earlier baseline (2026-04-14, Excel-export lazy audit)
+
+Prior pass verified `xlsx` is no longer reachable via any static
+import path from the main entrypoint and that Excel export is loaded
+on demand via dynamic import.
 
 ## Follow-up when network-restricted policy is lifted
 
@@ -31,3 +64,6 @@ Then confirm:
 
 1. `lucide-react` contribution is tree-shaken to only used icons.
 2. No `xlsx` code appears in the initial app/library chunk(s).
+3. The `ApprovalFlowsTab` and `WorkflowBuilderModal` chunks contain
+   the expected Phase 2 modules (templates, validate, layout, canvas,
+   inspector, picker, simulator, hook) and nothing else.

--- a/src/ui/ApprovalFlowsTab.tsx
+++ b/src/ui/ApprovalFlowsTab.tsx
@@ -1,0 +1,262 @@
+/**
+ * ApprovalFlowsTab — ConfigPanel's entry point into the Phase 2
+ * visual workflow builder.
+ *
+ * Split into its own module (and lazy-loaded from ConfigPanel) so
+ * the templates catalog, the per-calendar persistence hook, and the
+ * visual builder itself never touch the main app chunk. A host that
+ * never opens ConfigPanel → Approval Flows pays zero runtime cost
+ * for Phase 2.
+ */
+import { lazy, Suspense, useState } from 'react';
+import { Pencil, Plus, Trash2 } from 'lucide-react';
+import { createId } from '../core/createId';
+import { WORKFLOW_TEMPLATES } from '../core/workflow/templates';
+import { useSavedWorkflows } from '../hooks/useSavedWorkflows';
+import type { SavedWorkflow } from '../hooks/useSavedWorkflows';
+import type { Workflow, WorkflowLayout } from '../core/workflow/workflowSchema';
+import styles from './ConfigPanel.module.css';
+
+// Lazy-loaded so the SVG canvas, validator, layout engine and
+// simulator only download when the author actually opens a draft.
+const WorkflowBuilderModal = lazy(() => import('./WorkflowBuilderModal'));
+
+interface ApprovalFlowsTabProps {
+  readonly calendarId: string;
+}
+
+/**
+ * Edit state for the Approval Flows tab. When non-null, the lazy-loaded
+ * WorkflowBuilderModal is mounted against this draft. Two modes:
+ *
+ *   - `new`   — the Save handler calls `saveWorkflow(...)` to persist as
+ *               a fresh entry. Used for "Create blank" and "Edit from
+ *               template" (fork-on-edit).
+ *   - `saved` — the Save handler calls `updateWorkflow(id, ...)` in-place
+ *               so the existing entry's version bumps correctly.
+ */
+type ApprovalFlowsEdit =
+  | { readonly kind: 'new'; readonly name: string; readonly workflow: Workflow; readonly layout: WorkflowLayout }
+  | { readonly kind: 'saved'; readonly savedId: string; readonly name: string; readonly workflow: Workflow; readonly layout: WorkflowLayout };
+
+/** Minimal validator-clean seed: one approval + finalize/deny terminals. */
+function buildBlankWorkflow(): Workflow {
+  return {
+    id: createId('wf'),
+    version: 1,
+    trigger: 'on_submit',
+    startNodeId: 'approve-1',
+    nodes: [
+      { id: 'approve-1', type: 'approval', assignTo: 'role:approver', label: 'Approve' },
+      { id: 'done',      type: 'terminal', outcome: 'finalized' },
+      { id: 'denied',    type: 'terminal', outcome: 'denied' },
+    ],
+    edges: [
+      { from: 'approve-1', to: 'done',   when: 'approved' },
+      { from: 'approve-1', to: 'denied', when: 'denied'   },
+    ],
+  };
+}
+
+/** Fork a shipped template: deep-clone + fresh id so edits can't mutate the original. */
+function forkTemplate(template: Workflow): Workflow {
+  return {
+    id: createId('wf'),
+    version: 1,
+    trigger: template.trigger,
+    startNodeId: template.startNodeId,
+    nodes: template.nodes.map(n => ({ ...n })),
+    edges: template.edges.map(e => ({ ...e })),
+  };
+}
+
+function emptyLayoutFor(wf: Workflow): WorkflowLayout {
+  return { workflowId: wf.id, workflowVersion: wf.version, positions: {} };
+}
+
+export function ApprovalFlowsTab({ calendarId }: ApprovalFlowsTabProps) {
+  const { workflows: saved, saveWorkflow, updateWorkflow, deleteWorkflow } =
+    useSavedWorkflows(calendarId);
+  const [editing, setEditing] = useState<ApprovalFlowsEdit | null>(null);
+  const [confirmDel, setConfirmDel] = useState<string | null>(null);
+
+  const editTemplate = (template: Workflow): void => {
+    const wf = forkTemplate(template);
+    setEditing({
+      kind: 'new',
+      name: `${template.id} (forked)`,
+      workflow: wf,
+      layout: emptyLayoutFor(wf),
+    });
+  };
+
+  const editSaved = (s: SavedWorkflow): void => {
+    setEditing({ kind: 'saved', savedId: s.id, name: s.name, workflow: s.workflow, layout: s.layout });
+  };
+
+  const createBlank = (): void => {
+    const wf = buildBlankWorkflow();
+    setEditing({ kind: 'new', name: 'New workflow', workflow: wf, layout: emptyLayoutFor(wf) });
+  };
+
+  const handleSave = (wf: Workflow, layout: WorkflowLayout): void => {
+    if (!editing) return;
+    if (editing.kind === 'new') {
+      saveWorkflow(editing.name, wf, layout);
+    } else {
+      updateWorkflow(editing.savedId, { workflow: wf, layout });
+    }
+    setEditing(null);
+  };
+
+  return (
+    <div className={styles.section}>
+      <p className={styles.sectionDesc}>
+        Author approval workflows visually — fork a starter template, build a new flow from
+        scratch, or tweak one you saved earlier. Saved flows persist per calendar in this browser.
+      </p>
+
+      <div>
+        <h4 style={{ margin: '0 0 6px', fontSize: 12, textTransform: 'uppercase', letterSpacing: '0.05em' }}>
+          Starter templates
+        </h4>
+        <ul style={{ listStyle: 'none', padding: 0, margin: 0, display: 'flex', flexDirection: 'column', gap: 6 }}>
+          {WORKFLOW_TEMPLATES.map(t => (
+            <li
+              key={t.id}
+              data-template-id={t.id}
+              style={{
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'space-between',
+                padding: '6px 8px',
+                border: '1px solid var(--wc-border)',
+                borderRadius: 4,
+                background: 'var(--wc-surface)',
+              }}
+            >
+              <div style={{ display: 'flex', flexDirection: 'column' }}>
+                <span style={{ fontSize: 13, fontWeight: 500 }}>{t.id}</span>
+                <span style={{ fontSize: 11, color: 'var(--wc-text-muted)' }}>
+                  {t.nodes.length} nodes · {t.edges.length} edges
+                </span>
+              </div>
+              <button
+                className={styles.addFieldBtn}
+                style={{ marginTop: 0 }}
+                onClick={() => editTemplate(t)}
+                data-testid={`edit-template-${t.id}`}
+              >
+                <Pencil size={12} /> Edit
+              </button>
+            </li>
+          ))}
+        </ul>
+      </div>
+
+      <div>
+        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', margin: '0 0 6px' }}>
+          <h4 style={{ margin: 0, fontSize: 12, textTransform: 'uppercase', letterSpacing: '0.05em' }}>
+            My workflows
+          </h4>
+          <button
+            className={styles.addFieldBtn}
+            style={{ marginTop: 0 }}
+            onClick={createBlank}
+            data-testid="create-blank-workflow"
+          >
+            <Plus size={12} /> Create blank workflow
+          </button>
+        </div>
+        {saved.length === 0
+          ? (
+            <p style={{ fontSize: 12, color: 'var(--wc-text-muted)', margin: 0 }}>
+              No saved workflows yet.
+            </p>
+          )
+          : (
+            <ul
+              style={{ listStyle: 'none', padding: 0, margin: 0, display: 'flex', flexDirection: 'column', gap: 6 }}
+              data-testid="saved-workflow-list"
+            >
+              {saved.map(s => (
+                <li
+                  key={s.id}
+                  data-saved-id={s.id}
+                  style={{
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'space-between',
+                    padding: '6px 8px',
+                    border: '1px solid var(--wc-border)',
+                    borderRadius: 4,
+                    background: 'var(--wc-surface)',
+                  }}
+                >
+                  <div style={{ display: 'flex', flexDirection: 'column' }}>
+                    <span style={{ fontSize: 13, fontWeight: 500 }}>{s.name}</span>
+                    <span style={{ fontSize: 11, color: 'var(--wc-text-muted)' }}>
+                      v{s.workflow.version} · {s.workflow.nodes.length} nodes · {s.workflow.edges.length} edges
+                    </span>
+                  </div>
+                  <div style={{ display: 'flex', gap: 4 }}>
+                    <button
+                      className={styles.addFieldBtn}
+                      style={{ marginTop: 0 }}
+                      onClick={() => editSaved(s)}
+                      data-testid={`edit-saved-${s.id}`}
+                    >
+                      <Pencil size={12} /> Edit
+                    </button>
+                    {confirmDel === s.id
+                      ? (
+                        <>
+                          <button
+                            className={styles.removeBtn}
+                            onClick={() => { deleteWorkflow(s.id); setConfirmDel(null); }}
+                            data-testid={`confirm-delete-saved-${s.id}`}
+                          >
+                            Confirm
+                          </button>
+                          <button
+                            className={styles.addFieldBtn}
+                            style={{ marginTop: 0 }}
+                            onClick={() => setConfirmDel(null)}
+                          >
+                            Cancel
+                          </button>
+                        </>
+                      )
+                      : (
+                        <button
+                          className={styles.removeBtn}
+                          onClick={() => setConfirmDel(s.id)}
+                          aria-label={`Delete ${s.name}`}
+                          data-testid={`delete-saved-${s.id}`}
+                        >
+                          <Trash2 size={12} />
+                        </button>
+                      )}
+                  </div>
+                </li>
+              ))}
+            </ul>
+          )}
+      </div>
+
+      {editing && (
+        <Suspense fallback={<div role="status">Loading builder…</div>}>
+          <WorkflowBuilderModal
+            workflow={editing.workflow}
+            layout={editing.layout}
+            title={`Editing: ${editing.name}`}
+            onSave={handleSave}
+            onClose={() => setEditing(null)}
+          />
+        </Suspense>
+      )}
+    </div>
+  );
+}
+
+export default ApprovalFlowsTab;

--- a/src/ui/ConfigPanel.tsx
+++ b/src/ui/ConfigPanel.tsx
@@ -1,17 +1,10 @@
 import { lazy, Suspense, useEffect, useMemo, useRef, useState } from 'react';
 import { X, Plus, Trash2, Check, Camera, Pencil, ArrowUp, ArrowDown, ChevronDown } from 'lucide-react';
-import { createId } from '../core/createId';
-import { WORKFLOW_TEMPLATES } from '../core/workflow/templates';
-import { useSavedWorkflows } from '../hooks/useSavedWorkflows';
-import type {
-  Workflow,
-  WorkflowLayout,
-} from '../core/workflow/workflowSchema';
-import type { SavedWorkflow } from '../hooks/useSavedWorkflows';
 
-// Lazy-loaded so the visual builder (SVG canvas + simulator +
-// validator) doesn't land in the main bundle.
-const WorkflowBuilderModal = lazy(() => import('./WorkflowBuilderModal'));
+// Lazy-loaded so Phase 2's workflow templates + persistence hook +
+// visual builder modal never touch the main chunk for hosts that
+// don't open the Approval Flows tab.
+const ApprovalFlowsTab = lazy(() => import('./ApprovalFlowsTab'));
 import {
   FIELD_TYPES,
   APPROVAL_STAGE_IDS,
@@ -241,7 +234,11 @@ export default function ConfigPanel({
             />
           )}
           {tab === 'approvals'   && <ApprovalsTab   config={config} onUpdate={onUpdate} />}
-          {tab === 'approvalFlows' && <ApprovalFlowsTab calendarId={calendarId} />}
+          {tab === 'approvalFlows' && (
+            <Suspense fallback={<div role="status">Loading…</div>}>
+              <ApprovalFlowsTab calendarId={calendarId} />
+            </Suspense>
+          )}
           {tab === 'conflicts'   && <ConflictsTab   config={config} onUpdate={onUpdate} />}
           {tab === 'requestForm' && <RequestFormTab config={config} onUpdate={onUpdate} />}
           {tab === 'access'      && <AccessTab      config={config} onUpdate={onUpdate} />}
@@ -1611,246 +1608,6 @@ const STAGE_LABELS = {
  *   approvals.rules   — per-stage `{ allow: ApprovalAction[], prefix }`.
  *   approvals.labels  — per-action button copy shown to approvers.
  */
-// ─── Approval Flows tab (Phase 2 visual builder host) ───────────────────
-
-interface ApprovalFlowsTabProps {
-  readonly calendarId: string;
-}
-
-/**
- * Edit state for the Approval Flows tab. When non-null, the lazy-loaded
- * WorkflowBuilderModal is mounted against this draft. Two modes:
- *
- *   - `new`   — the Save handler calls `saveWorkflow(...)` to persist as
- *               a fresh entry. Used for "Create blank" and "Edit from
- *               template" (fork-on-edit).
- *   - `saved` — the Save handler calls `updateWorkflow(id, ...)` in-place
- *               so the existing entry's version bumps correctly.
- */
-type ApprovalFlowsEdit =
-  | { readonly kind: 'new'; readonly name: string; readonly workflow: Workflow; readonly layout: WorkflowLayout }
-  | { readonly kind: 'saved'; readonly savedId: string; readonly name: string; readonly workflow: Workflow; readonly layout: WorkflowLayout };
-
-/** Minimal validator-clean seed: one approval + finalize/deny terminals. */
-function buildBlankWorkflow(): Workflow {
-  return {
-    id: createId('wf'),
-    version: 1,
-    trigger: 'on_submit',
-    startNodeId: 'approve-1',
-    nodes: [
-      { id: 'approve-1', type: 'approval', assignTo: 'role:approver', label: 'Approve' },
-      { id: 'done',      type: 'terminal', outcome: 'finalized' },
-      { id: 'denied',    type: 'terminal', outcome: 'denied' },
-    ],
-    edges: [
-      { from: 'approve-1', to: 'done',   when: 'approved' },
-      { from: 'approve-1', to: 'denied', when: 'denied'   },
-    ],
-  };
-}
-
-/** Fork a shipped template: deep-clone + fresh id so edits can't mutate the original. */
-function forkTemplate(template: Workflow): Workflow {
-  return {
-    id: createId('wf'),
-    version: 1,
-    trigger: template.trigger,
-    startNodeId: template.startNodeId,
-    nodes: template.nodes.map(n => ({ ...n })),
-    edges: template.edges.map(e => ({ ...e })),
-  };
-}
-
-function emptyLayoutFor(wf: Workflow): WorkflowLayout {
-  return { workflowId: wf.id, workflowVersion: wf.version, positions: {} };
-}
-
-export function ApprovalFlowsTab({ calendarId }: ApprovalFlowsTabProps) {
-  const { workflows: saved, saveWorkflow, updateWorkflow, deleteWorkflow } =
-    useSavedWorkflows(calendarId);
-  const [editing, setEditing] = useState<ApprovalFlowsEdit | null>(null);
-  const [confirmDel, setConfirmDel] = useState<string | null>(null);
-
-  const editTemplate = (template: Workflow): void => {
-    const wf = forkTemplate(template);
-    setEditing({
-      kind: 'new',
-      name: `${template.id} (forked)`,
-      workflow: wf,
-      layout: emptyLayoutFor(wf),
-    });
-  };
-
-  const editSaved = (s: SavedWorkflow): void => {
-    setEditing({ kind: 'saved', savedId: s.id, name: s.name, workflow: s.workflow, layout: s.layout });
-  };
-
-  const createBlank = (): void => {
-    const wf = buildBlankWorkflow();
-    setEditing({ kind: 'new', name: 'New workflow', workflow: wf, layout: emptyLayoutFor(wf) });
-  };
-
-  const handleSave = (wf: Workflow, layout: WorkflowLayout): void => {
-    if (!editing) return;
-    if (editing.kind === 'new') {
-      saveWorkflow(editing.name, wf, layout);
-    } else {
-      updateWorkflow(editing.savedId, { workflow: wf, layout });
-    }
-    setEditing(null);
-  };
-
-  return (
-    <div className={styles.section}>
-      <p className={styles.sectionDesc}>
-        Author approval workflows visually — fork a starter template, build a new flow from
-        scratch, or tweak one you saved earlier. Saved flows persist per calendar in this browser.
-      </p>
-
-      <div>
-        <h4 style={{ margin: '0 0 6px', fontSize: 12, textTransform: 'uppercase', letterSpacing: '0.05em' }}>
-          Starter templates
-        </h4>
-        <ul style={{ listStyle: 'none', padding: 0, margin: 0, display: 'flex', flexDirection: 'column', gap: 6 }}>
-          {WORKFLOW_TEMPLATES.map(t => (
-            <li
-              key={t.id}
-              data-template-id={t.id}
-              style={{
-                display: 'flex',
-                alignItems: 'center',
-                justifyContent: 'space-between',
-                padding: '6px 8px',
-                border: '1px solid var(--wc-border)',
-                borderRadius: 4,
-                background: 'var(--wc-surface)',
-              }}
-            >
-              <div style={{ display: 'flex', flexDirection: 'column' }}>
-                <span style={{ fontSize: 13, fontWeight: 500 }}>{t.id}</span>
-                <span style={{ fontSize: 11, color: 'var(--wc-text-muted)' }}>
-                  {t.nodes.length} nodes · {t.edges.length} edges
-                </span>
-              </div>
-              <button
-                className={styles.addFieldBtn}
-                style={{ marginTop: 0 }}
-                onClick={() => editTemplate(t)}
-                data-testid={`edit-template-${t.id}`}
-              >
-                <Pencil size={12} /> Edit
-              </button>
-            </li>
-          ))}
-        </ul>
-      </div>
-
-      <div>
-        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', margin: '0 0 6px' }}>
-          <h4 style={{ margin: 0, fontSize: 12, textTransform: 'uppercase', letterSpacing: '0.05em' }}>
-            My workflows
-          </h4>
-          <button
-            className={styles.addFieldBtn}
-            style={{ marginTop: 0 }}
-            onClick={createBlank}
-            data-testid="create-blank-workflow"
-          >
-            <Plus size={12} /> Create blank workflow
-          </button>
-        </div>
-        {saved.length === 0
-          ? (
-            <p style={{ fontSize: 12, color: 'var(--wc-text-muted)', margin: 0 }}>
-              No saved workflows yet.
-            </p>
-          )
-          : (
-            <ul
-              style={{ listStyle: 'none', padding: 0, margin: 0, display: 'flex', flexDirection: 'column', gap: 6 }}
-              data-testid="saved-workflow-list"
-            >
-              {saved.map(s => (
-                <li
-                  key={s.id}
-                  data-saved-id={s.id}
-                  style={{
-                    display: 'flex',
-                    alignItems: 'center',
-                    justifyContent: 'space-between',
-                    padding: '6px 8px',
-                    border: '1px solid var(--wc-border)',
-                    borderRadius: 4,
-                    background: 'var(--wc-surface)',
-                  }}
-                >
-                  <div style={{ display: 'flex', flexDirection: 'column' }}>
-                    <span style={{ fontSize: 13, fontWeight: 500 }}>{s.name}</span>
-                    <span style={{ fontSize: 11, color: 'var(--wc-text-muted)' }}>
-                      v{s.workflow.version} · {s.workflow.nodes.length} nodes · {s.workflow.edges.length} edges
-                    </span>
-                  </div>
-                  <div style={{ display: 'flex', gap: 4 }}>
-                    <button
-                      className={styles.addFieldBtn}
-                      style={{ marginTop: 0 }}
-                      onClick={() => editSaved(s)}
-                      data-testid={`edit-saved-${s.id}`}
-                    >
-                      <Pencil size={12} /> Edit
-                    </button>
-                    {confirmDel === s.id
-                      ? (
-                        <>
-                          <button
-                            className={styles.removeBtn}
-                            onClick={() => { deleteWorkflow(s.id); setConfirmDel(null); }}
-                            data-testid={`confirm-delete-saved-${s.id}`}
-                          >
-                            Confirm
-                          </button>
-                          <button
-                            className={styles.addFieldBtn}
-                            style={{ marginTop: 0 }}
-                            onClick={() => setConfirmDel(null)}
-                          >
-                            Cancel
-                          </button>
-                        </>
-                      )
-                      : (
-                        <button
-                          className={styles.removeBtn}
-                          onClick={() => setConfirmDel(s.id)}
-                          aria-label={`Delete ${s.name}`}
-                          data-testid={`delete-saved-${s.id}`}
-                        >
-                          <Trash2 size={12} />
-                        </button>
-                      )}
-                  </div>
-                </li>
-              ))}
-            </ul>
-          )}
-      </div>
-
-      {editing && (
-        <Suspense fallback={<div role="status">Loading builder…</div>}>
-          <WorkflowBuilderModal
-            workflow={editing.workflow}
-            layout={editing.layout}
-            title={`Editing: ${editing.name}`}
-            onSave={handleSave}
-            onClose={() => setEditing(null)}
-          />
-        </Suspense>
-      )}
-    </div>
-  );
-}
-
 export function ApprovalsTab({ config, onUpdate }: any) {
   const approvals = config.approvals ?? {};
   const enabled   = !!approvals.enabled;


### PR DESCRIPTION
…chunk

Extracted the Approval Flows tab body into its own module and swapped the static import in ConfigPanel for React.lazy + Suspense. Previously WORKFLOW_TEMPLATES, useSavedWorkflows, and the tab render tree were pulled into the main chunk every time ConfigPanel shipped, costing ~3 kB gzipped whether or not anyone opened the tab.

Now Phase 2 adds only +0.24 kB gzip to the main chunk (well under the plan's 2 kB budget). The full builder — validator, layout engine, canvas, inspector, picker, simulator, modal shell, templates, persistence hook — lives in two lazy chunks totalling 17.83 kB gzip that download only when the owner opens the tab.

Audit doc updated with before/after measurements.

https://claude.ai/code/session_014vuvkCTA8VA3RpPwenpmZS