### PR TITLE
feat(workflow): SLA timers + timeout escalation (P3)

### DIFF
--- a/src/core/workflow/__tests__/advance.test.ts
+++ b/src/core/workflow/__tests__/advance.test.ts
@@ -298,6 +298,78 @@ describe('advance — history bookkeeping', () => {
   })
 })
 
+describe('advance — timeout action', () => {
+  const slaEscalate: Workflow = {
+    id: 'sla-escalate',
+    version: 1,
+    trigger: 'on_submit',
+    startNodeId: 'a',
+    nodes: [
+      { id: 'a', type: 'approval', assignTo: 'role:manager', slaMinutes: 15, onTimeout: 'escalate' },
+      { id: 'escalated', type: 'approval', assignTo: 'role:director' },
+      { id: 'done', type: 'terminal', outcome: 'finalized' },
+      { id: 'denied', type: 'terminal', outcome: 'denied' },
+    ],
+    edges: [
+      { from: 'a', to: 'done', when: 'approved' },
+      { from: 'a', to: 'denied', when: 'denied' },
+      { from: 'a', to: 'escalated', when: 'timeout' },
+      { from: 'escalated', to: 'done', when: 'approved' },
+      { from: 'escalated', to: 'denied', when: 'denied' },
+    ],
+  }
+
+  it('escalate routes down the timeout edge', () => {
+    const s1 = advance({ workflow: slaEscalate, instance: null, action: { type: 'start' }, at: AT })
+    if (!s1.ok) throw new Error('precondition')
+    const r = advance({
+      workflow: slaEscalate,
+      instance: s1.instance,
+      action: { type: 'timeout' },
+      at: '2026-04-20T10:30:00.000Z',
+    })
+    expect(r.ok).toBe(true)
+    if (!r.ok) return
+    expect(r.instance.currentNodeId).toBe('escalated')
+    const aExit = r.instance.history.find(h => h.nodeId === 'a')
+    expect(aExit?.signal).toBe('timeout')
+    expect(aExit?.reason).toMatch(/SLA timeout/)
+  })
+
+  it('auto-approve reuses the approved edge', () => {
+    const wf: Workflow = {
+      ...slaEscalate,
+      nodes: slaEscalate.nodes.map(n =>
+        n.id === 'a' && n.type === 'approval'
+          ? { ...n, onTimeout: 'auto-approve' as const }
+          : n,
+      ),
+    }
+    const s1 = advance({ workflow: wf, instance: null, action: { type: 'start' }, at: AT })
+    if (!s1.ok) throw new Error('precondition')
+    const r = advance({
+      workflow: wf,
+      instance: s1.instance,
+      action: { type: 'timeout' },
+      at: '2026-04-20T10:30:00.000Z',
+    })
+    expect(r.ok).toBe(true)
+    if (!r.ok) return
+    expect(r.instance.status).toBe('completed')
+    expect(r.instance.outcome).toBe('finalized')
+  })
+
+  it('rejects timeout when not on an awaiting approval', () => {
+    const r = advance({
+      workflow: slaEscalate,
+      instance: null,
+      action: { type: 'timeout' },
+      at: AT,
+    })
+    expect(r.ok).toBe(false)
+  })
+})
+
 describe('advance — purity', () => {
   it('does not mutate the input instance', () => {
     const s1 = advance({ workflow: singleApprover, instance: null, action: { type: 'start' }, at: AT })

--- a/src/core/workflow/__tests__/templates.test.ts
+++ b/src/core/workflow/__tests__/templates.test.ts
@@ -10,6 +10,7 @@ import {
   singleApproverWorkflow,
   twoTierApproverWorkflow,
   conditionalByCostWorkflow,
+  slaEscalationWorkflow,
   WORKFLOW_TEMPLATES,
 } from '../templates'
 
@@ -150,12 +151,44 @@ describe('conditionalByCostWorkflow', () => {
   })
 })
 
+describe('slaEscalationWorkflow', () => {
+  it('manager approve path finalizes without escalation', () => {
+    const s = advance({ workflow: slaEscalationWorkflow, instance: null, action: { type: 'start' }, at: AT })
+    if (!s.ok) throw new Error('start')
+    const r = advance({
+      workflow: slaEscalationWorkflow,
+      instance: s.instance,
+      action: { type: 'approve', actor: 'mgr' },
+      at: AT,
+    })
+    expect(r.ok).toBe(true)
+    if (!r.ok) return
+    expect(r.instance.outcome).toBe('finalized')
+  })
+
+  it('timeout action routes to the director', () => {
+    const s = advance({ workflow: slaEscalationWorkflow, instance: null, action: { type: 'start' }, at: AT })
+    if (!s.ok) throw new Error('start')
+    const r = advance({
+      workflow: slaEscalationWorkflow,
+      instance: s.instance,
+      action: { type: 'timeout' },
+      at: '2026-04-20T10:01:00.000Z',
+    })
+    expect(r.ok).toBe(true)
+    if (!r.ok) return
+    expect(r.instance.status).toBe('awaiting')
+    expect(r.instance.currentNodeId).toBe('director')
+  })
+})
+
 describe('WORKFLOW_TEMPLATES registry', () => {
-  it('includes all three shipped templates in the expected order', () => {
+  it('includes all shipped templates in the expected order', () => {
     expect(WORKFLOW_TEMPLATES).toEqual([
       singleApproverWorkflow,
       twoTierApproverWorkflow,
       conditionalByCostWorkflow,
+      slaEscalationWorkflow,
     ])
   })
 

--- a/src/core/workflow/__tests__/tick.test.ts
+++ b/src/core/workflow/__tests__/tick.test.ts
@@ -158,6 +158,44 @@ describe('tick — inapplicable cases return null', () => {
   })
 })
 
+describe('tick — variables forwarded to advance', () => {
+  it('timeout auto-advance through a condition reads variables', () => {
+    // Timeout routes into a cost-gated branch: cost>500 → denied,
+    // otherwise → ok. Without variables the condition throws and the
+    // workflow fails. With variables it resolves to a terminal.
+    const wf: Workflow = {
+      id: 'sla-cond', version: 1, trigger: 'on_submit', startNodeId: 'a',
+      nodes: [
+        { id: 'a', type: 'approval', assignTo: 'role:m', slaMinutes: 5, onTimeout: 'escalate' },
+        { id: 'cost', type: 'condition', expr: 'event.cost > 500' },
+        { id: 'ok', type: 'terminal', outcome: 'finalized' },
+        { id: 'no', type: 'terminal', outcome: 'denied' },
+      ],
+      edges: [
+        { from: 'a', to: 'ok', when: 'approved' },
+        { from: 'a', to: 'no', when: 'denied' },
+        { from: 'a', to: 'cost', when: 'timeout' },
+        { from: 'cost', to: 'no', when: 'true' },
+        { from: 'cost', to: 'ok', when: 'false' },
+      ],
+    }
+    const s = advance({ workflow: wf, instance: null, action: { type: 'start' }, at: T0 })
+    if (!s.ok) throw new Error('start')
+
+    const rNoVars = tick(wf, s.instance, minutesAfter(T0, 10))
+    if (!rNoVars) throw new Error('expected result')
+    expect(rNoVars.instance.status).toBe('failed')
+
+    const rWithVars = tick(wf, s.instance, minutesAfter(T0, 10), { event: { cost: 1000 } })
+    if (!rWithVars || !rWithVars.ok) throw new Error('expected ok')
+    expect(rWithVars.instance.outcome).toBe('denied')
+
+    const rCheap = tick(wf, s.instance, minutesAfter(T0, 10), { event: { cost: 100 } })
+    if (!rCheap || !rCheap.ok) throw new Error('expected ok')
+    expect(rCheap.instance.outcome).toBe('finalized')
+  })
+})
+
 describe('tick — purity', () => {
   it('does not mutate the input instance', () => {
     const wf = build('escalate')

--- a/src/core/workflow/__tests__/tick.test.ts
+++ b/src/core/workflow/__tests__/tick.test.ts
@@ -1,0 +1,169 @@
+/**
+ * SLA timer tick — unit specs (issue #222 Phase 3).
+ *
+ * `tick()` is a pure timer-driven counterpart to `advance()`. It is
+ * called by the host scheduler; when the active approval step has
+ * exceeded its `slaMinutes`, it fires a synthetic `{ type: 'timeout' }`
+ * action and returns the resulting `AdvanceResult`. Otherwise it
+ * returns `null`.
+ */
+import { describe, it, expect } from 'vitest'
+import { advance, tick } from '../advance'
+import type { Workflow, WorkflowInstance } from '../workflowSchema'
+
+const T0 = '2026-04-20T10:00:00.000Z'
+
+function minutesAfter(iso: string, mins: number): string {
+  return new Date(Date.parse(iso) + mins * 60_000).toISOString()
+}
+
+function build(onTimeout: 'escalate' | 'auto-approve' | 'auto-deny' | undefined): Workflow {
+  return {
+    id: 'sla',
+    version: 1,
+    trigger: 'on_submit',
+    startNodeId: 'a',
+    nodes: [
+      {
+        id: 'a',
+        type: 'approval',
+        assignTo: 'role:manager',
+        slaMinutes: 30,
+        ...(onTimeout ? { onTimeout } : {}),
+      },
+      { id: 'escalated', type: 'approval', assignTo: 'role:director' },
+      { id: 'done',      type: 'terminal', outcome: 'finalized' },
+      { id: 'denied',    type: 'terminal', outcome: 'denied' },
+    ],
+    edges: [
+      { from: 'a', to: 'done',      when: 'approved' },
+      { from: 'a', to: 'denied',    when: 'denied' },
+      { from: 'a', to: 'escalated', when: 'timeout' },
+      { from: 'escalated', to: 'done',   when: 'approved' },
+      { from: 'escalated', to: 'denied', when: 'denied' },
+    ],
+  }
+}
+
+function start(wf: Workflow): WorkflowInstance {
+  const r = advance({ workflow: wf, instance: null, action: { type: 'start' }, at: T0 })
+  if (!r.ok) throw new Error('precondition: start failed')
+  return r.instance
+}
+
+describe('tick — SLA elapsed detection', () => {
+  it('returns null before SLA has elapsed', () => {
+    const wf = build('escalate')
+    const inst = start(wf)
+    const r = tick(wf, inst, minutesAfter(T0, 29))
+    expect(r).toBeNull()
+  })
+
+  it('returns an AdvanceResult once SLA has elapsed', () => {
+    const wf = build('escalate')
+    const inst = start(wf)
+    const r = tick(wf, inst, minutesAfter(T0, 30))
+    expect(r).not.toBeNull()
+    if (!r || !r.ok) throw new Error('expected ok advance')
+    expect(r.instance.status).toBe('awaiting')
+    expect(r.instance.currentNodeId).toBe('escalated')
+  })
+})
+
+describe('tick — onTimeout behaviors', () => {
+  it('escalate walks the timeout edge', () => {
+    const wf = build('escalate')
+    const inst = start(wf)
+    const r = tick(wf, inst, minutesAfter(T0, 45))
+    if (!r || !r.ok) throw new Error('expected ok advance')
+    expect(r.instance.currentNodeId).toBe('escalated')
+    const aExit = r.instance.history.find(h => h.nodeId === 'a')
+    expect(aExit?.signal).toBe('timeout')
+  })
+
+  it('auto-approve walks the approved edge', () => {
+    const wf = build('auto-approve')
+    const inst = start(wf)
+    const r = tick(wf, inst, minutesAfter(T0, 45))
+    if (!r || !r.ok) throw new Error('expected ok advance')
+    expect(r.instance.status).toBe('completed')
+    expect(r.instance.outcome).toBe('finalized')
+    const aExit = r.instance.history.find(h => h.nodeId === 'a')
+    expect(aExit?.signal).toBe('approved')
+  })
+
+  it('auto-deny walks the denied edge', () => {
+    const wf = build('auto-deny')
+    const inst = start(wf)
+    const r = tick(wf, inst, minutesAfter(T0, 45))
+    if (!r || !r.ok) throw new Error('expected ok advance')
+    expect(r.instance.status).toBe('completed')
+    expect(r.instance.outcome).toBe('denied')
+    const aExit = r.instance.history.find(h => h.nodeId === 'a')
+    expect(aExit?.signal).toBe('denied')
+  })
+
+  it('defaults to escalate when onTimeout is unset', () => {
+    const wf = build(undefined)
+    const inst = start(wf)
+    const r = tick(wf, inst, minutesAfter(T0, 45))
+    if (!r || !r.ok) throw new Error('expected ok advance')
+    expect(r.instance.currentNodeId).toBe('escalated')
+  })
+})
+
+describe('tick — inapplicable cases return null', () => {
+  it('returns null when approval has no slaMinutes', () => {
+    const wf: Workflow = {
+      id: 'nosla', version: 1, trigger: 'on_submit', startNodeId: 'a',
+      nodes: [
+        { id: 'a', type: 'approval', assignTo: 'role:x' },
+        { id: 'done', type: 'terminal', outcome: 'finalized' },
+        { id: 'denied', type: 'terminal', outcome: 'denied' },
+      ],
+      edges: [
+        { from: 'a', to: 'done',   when: 'approved' },
+        { from: 'a', to: 'denied', when: 'denied' },
+      ],
+    }
+    const inst = start(wf)
+    expect(tick(wf, inst, minutesAfter(T0, 999))).toBeNull()
+  })
+
+  it('returns null when instance is completed', () => {
+    const wf = build('auto-approve')
+    const inst = start(wf)
+    const completed = tick(wf, inst, minutesAfter(T0, 45))
+    if (!completed || !completed.ok) throw new Error('precondition')
+    const again = tick(wf, completed.instance, minutesAfter(T0, 60))
+    expect(again).toBeNull()
+  })
+
+  it('returns null when the workflow is not awaiting', () => {
+    const wf = build('escalate')
+    const inst: WorkflowInstance = {
+      workflowId: wf.id,
+      workflowVersion: wf.version,
+      status: 'running',
+      currentNodeId: null,
+      history: [],
+    }
+    expect(tick(wf, inst, minutesAfter(T0, 60))).toBeNull()
+  })
+
+  it('returns null for non-finite timestamps', () => {
+    const wf = build('escalate')
+    const inst = start(wf)
+    expect(tick(wf, inst, 'not-a-date')).toBeNull()
+  })
+})
+
+describe('tick — purity', () => {
+  it('does not mutate the input instance', () => {
+    const wf = build('escalate')
+    const inst = start(wf)
+    const snapshot: WorkflowInstance = JSON.parse(JSON.stringify(inst))
+    tick(wf, inst, minutesAfter(T0, 45))
+    expect(inst).toEqual(snapshot)
+  })
+})

--- a/src/core/workflow/__tests__/validate.test.ts
+++ b/src/core/workflow/__tests__/validate.test.ts
@@ -198,6 +198,80 @@ describe('validateWorkflow — rules', () => {
     expect(issues.some(i => i.code === 'expression-syntax')).toBe(true)
   })
 
+  it('flags approvals with onTimeout=escalate but no timeout edge', () => {
+    const wf: Workflow = {
+      id: 'w', version: 1, trigger: 'on_submit', startNodeId: 'a',
+      nodes: [
+        { id: 'a', type: 'approval', assignTo: 'role:x', slaMinutes: 30, onTimeout: 'escalate' },
+        { id: 'done', type: 'terminal', outcome: 'finalized' },
+        { id: 'denied', type: 'terminal', outcome: 'denied' },
+      ],
+      edges: [
+        { from: 'a', to: 'done', when: 'approved' },
+        { from: 'a', to: 'denied', when: 'denied' },
+      ],
+    }
+    const issues = validateWorkflow(wf)
+    expect(issues.some(i => i.code === 'timeout-edge-missing' && i.severity === 'error')).toBe(true)
+  })
+
+  it('accepts auto-approve approvals without a timeout edge', () => {
+    const wf: Workflow = {
+      id: 'w', version: 1, trigger: 'on_submit', startNodeId: 'a',
+      nodes: [
+        { id: 'a', type: 'approval', assignTo: 'role:x', slaMinutes: 30, onTimeout: 'auto-approve' },
+        { id: 'done', type: 'terminal', outcome: 'finalized' },
+        { id: 'denied', type: 'terminal', outcome: 'denied' },
+      ],
+      edges: [
+        { from: 'a', to: 'done', when: 'approved' },
+        { from: 'a', to: 'denied', when: 'denied' },
+      ],
+    }
+    const errors = validateWorkflow(wf).filter(i => i.severity === 'error')
+    expect(errors).toEqual([])
+  })
+
+  it('warns when slaMinutes is set but onTimeout is not', () => {
+    const wf: Workflow = {
+      id: 'w', version: 1, trigger: 'on_submit', startNodeId: 'a',
+      nodes: [
+        { id: 'a', type: 'approval', assignTo: 'role:x', slaMinutes: 30 },
+        { id: 'done', type: 'terminal', outcome: 'finalized' },
+        { id: 'denied', type: 'terminal', outcome: 'denied' },
+        { id: 'esc', type: 'approval', assignTo: 'role:d' },
+      ],
+      edges: [
+        { from: 'a', to: 'done', when: 'approved' },
+        { from: 'a', to: 'denied', when: 'denied' },
+        { from: 'a', to: 'esc', when: 'timeout' },
+        { from: 'esc', to: 'done', when: 'approved' },
+        { from: 'esc', to: 'denied', when: 'denied' },
+      ],
+    }
+    const issues = validateWorkflow(wf)
+    const warn = issues.find(i => i.code === 'sla-without-on-timeout')
+    expect(warn?.severity).toBe('warning')
+  })
+
+  it('flags timeout guard on approval without slaMinutes as illegal', () => {
+    const wf: Workflow = {
+      id: 'w', version: 1, trigger: 'on_submit', startNodeId: 'a',
+      nodes: [
+        { id: 'a', type: 'approval', assignTo: 'role:x' },
+        { id: 'done', type: 'terminal', outcome: 'finalized' },
+        { id: 'denied', type: 'terminal', outcome: 'denied' },
+      ],
+      edges: [
+        { from: 'a', to: 'done', when: 'approved' },
+        { from: 'a', to: 'denied', when: 'denied' },
+        { from: 'a', to: 'denied', when: 'timeout' },
+      ],
+    }
+    const issues = validateWorkflow(wf)
+    expect(issues.some(i => i.code === 'illegal-guard-for-source')).toBe(true)
+  })
+
   it('flags terminals that carry outgoing edges (warning)', () => {
     const wf: Workflow = {
       ...singleApproverWorkflow,

--- a/src/core/workflow/advance.ts
+++ b/src/core/workflow/advance.ts
@@ -327,6 +327,11 @@ function finalize(
  * minutes. Returns `null` in every other case — not awaiting, no
  * `slaMinutes`, no `enteredAt`, or the SLA hasn't elapsed yet.
  *
+ * `variables` are forwarded to `advance()` so condition nodes that the
+ * timeout edge auto-advances into can resolve runtime data (e.g. cost-
+ * based escalation). Callers driving tick from a scheduler should pass
+ * whatever variables they use for normal actor-driven actions.
+ *
  * Pure + side-effect-free: the host drives it with a scheduler
  * (`setInterval`, cron, server-side tick). Two consecutive calls with
  * the same `nowIso` produce the same result.
@@ -335,6 +340,7 @@ export function tick(
   workflow: Workflow,
   instance: WorkflowInstance,
   nowIso: string,
+  variables?: Readonly<Record<string, unknown>>,
 ): AdvanceResult | null {
   const node = activeApprovalNode(workflow, instance)
   if (!node) return null
@@ -354,6 +360,7 @@ export function tick(
     instance,
     action: { type: 'timeout' },
     at: nowIso,
+    ...(variables !== undefined ? { variables } : {}),
   })
 }
 

--- a/src/core/workflow/advance.ts
+++ b/src/core/workflow/advance.ts
@@ -18,6 +18,7 @@ import {
   resolveNextEdge,
   type EdgeGuard,
   type Workflow,
+  type WorkflowApprovalNode,
   type WorkflowHistoryEntry,
   type WorkflowInstance,
   type WorkflowOutcome,
@@ -30,6 +31,7 @@ export type WorkflowAction =
   | { readonly type: 'approve'; readonly actor?: string; readonly reason?: string }
   | { readonly type: 'deny';    readonly actor?: string; readonly reason: string }
   | { readonly type: 'cancel';  readonly actor?: string; readonly reason?: string }
+  | { readonly type: 'timeout' }
 
 // ─── Emitted events ───────────────────────────────────────────────────────
 
@@ -123,6 +125,26 @@ export function advance(input: AdvanceInput): AdvanceResult {
         state.outcome = 'cancelled'
         state.emit.push({ type: 'workflow_completed', outcome: 'cancelled', at })
         break
+
+      case 'timeout': {
+        const node = state.currentNodeId ? findNode(workflow, state.currentNodeId) : undefined
+        if (!node || node.type !== 'approval' || state.status !== 'awaiting') {
+          return finalize(base, state,
+            `timeout requires an awaiting approval node; current="${state.currentNodeId}" status=${state.status}`)
+        }
+        const behavior = node.onTimeout ?? 'escalate'
+        // `escalate` walks a dedicated `timeout` edge; `auto-approve` /
+        // `auto-deny` reuse the standard approved/denied edges so the
+        // workflow author doesn't have to double-wire.
+        const signal: EdgeGuard =
+          behavior === 'escalate'    ? 'timeout'
+          : behavior === 'auto-approve' ? 'approved'
+          : 'denied'
+        exitCurrent(state, signal, at, { reason: `SLA timeout (${behavior})` })
+        if (!followEdge(workflow, state, signal, at)) break
+        autoAdvance(workflow, state, vars, at)
+        break
+      }
     }
   } catch (err) {
     const reason = err instanceof ExpressionError ? err.message : String(err)
@@ -292,4 +314,68 @@ function finalize(
   error: string,
 ): AdvanceResult {
   return { ok: false, error, instance: assemble(base, state), emit: state.emit }
+}
+
+// ─── Tick (SLA timers — issue #222) ──────────────────────────────────────
+
+/**
+ * Pure check: has the currently-awaited approval step exceeded its SLA?
+ *
+ * Returns an `AdvanceResult` (the product of firing a `{ type: 'timeout' }`
+ * action) when the active approval node has `slaMinutes` set AND the
+ * elapsed time since `history[-1].enteredAt` is at least that many
+ * minutes. Returns `null` in every other case — not awaiting, no
+ * `slaMinutes`, no `enteredAt`, or the SLA hasn't elapsed yet.
+ *
+ * Pure + side-effect-free: the host drives it with a scheduler
+ * (`setInterval`, cron, server-side tick). Two consecutive calls with
+ * the same `nowIso` produce the same result.
+ */
+export function tick(
+  workflow: Workflow,
+  instance: WorkflowInstance,
+  nowIso: string,
+): AdvanceResult | null {
+  const node = activeApprovalNode(workflow, instance)
+  if (!node) return null
+  if (typeof node.slaMinutes !== 'number' || node.slaMinutes <= 0) return null
+
+  const enteredAt = latestEnteredAt(instance, node.id)
+  if (!enteredAt) return null
+
+  const enteredMs = Date.parse(enteredAt)
+  const nowMs = Date.parse(nowIso)
+  if (!Number.isFinite(enteredMs) || !Number.isFinite(nowMs)) return null
+  const elapsedMs = nowMs - enteredMs
+  if (elapsedMs < node.slaMinutes * 60_000) return null
+
+  return advance({
+    workflow,
+    instance,
+    action: { type: 'timeout' },
+    at: nowIso,
+  })
+}
+
+function activeApprovalNode(
+  workflow: Workflow,
+  instance: WorkflowInstance,
+): WorkflowApprovalNode | null {
+  if (instance.status !== 'awaiting' || !instance.currentNodeId) return null
+  const node = findNode(workflow, instance.currentNodeId)
+  if (!node || node.type !== 'approval') return null
+  return node
+}
+
+function latestEnteredAt(
+  instance: WorkflowInstance,
+  nodeId: string,
+): string | null {
+  for (let i = instance.history.length - 1; i >= 0; i--) {
+    const entry = instance.history[i]
+    if (entry.nodeId !== nodeId) continue
+    if (entry.exitedAt !== undefined) continue
+    return entry.enteredAt
+  }
+  return null
 }

--- a/src/core/workflow/templates.ts
+++ b/src/core/workflow/templates.ts
@@ -77,9 +77,43 @@ export const conditionalByCostWorkflow: Workflow = {
   ],
 }
 
+/**
+ * Manager approves within 60 minutes, otherwise the request escalates
+ * to a director. Demonstrates Phase-3 SLA timers + timeout edges
+ * (issue #222): `slaMinutes` sets the countdown, `onTimeout: 'escalate'`
+ * picks behavior, and the `timeout` edge routes the escalation.
+ */
+export const slaEscalationWorkflow: Workflow = {
+  id: 'sla-escalation',
+  version: 1,
+  trigger: 'on_submit',
+  startNodeId: 'manager',
+  nodes: [
+    {
+      id: 'manager',
+      type: 'approval',
+      assignTo: 'role:manager',
+      label: 'Manager approval (60m SLA)',
+      slaMinutes: 60,
+      onTimeout: 'escalate',
+    },
+    { id: 'director', type: 'approval', assignTo: 'role:director', label: 'Director escalation' },
+    { id: 'done',     type: 'terminal', outcome: 'finalized' },
+    { id: 'denied',   type: 'terminal', outcome: 'denied' },
+  ],
+  edges: [
+    { from: 'manager',  to: 'done',     when: 'approved' },
+    { from: 'manager',  to: 'denied',   when: 'denied'   },
+    { from: 'manager',  to: 'director', when: 'timeout'  },
+    { from: 'director', to: 'done',     when: 'approved' },
+    { from: 'director', to: 'denied',   when: 'denied'   },
+  ],
+}
+
 /** Ordered list of all shipped templates — drives the ConfigPanel picker. */
 export const WORKFLOW_TEMPLATES: readonly Workflow[] = [
   singleApproverWorkflow,
   twoTierApproverWorkflow,
   conditionalByCostWorkflow,
+  slaEscalationWorkflow,
 ]

--- a/src/core/workflow/validate.ts
+++ b/src/core/workflow/validate.ts
@@ -33,6 +33,8 @@ export type ValidationCode =
   | 'illegal-guard-for-source'
   | 'expression-syntax'
   | 'terminal-has-outgoing'
+  | 'timeout-edge-missing'
+  | 'sla-without-on-timeout'
 
 export interface ValidationIssue {
   readonly code: ValidationCode
@@ -211,6 +213,38 @@ export function validateWorkflow(
     }
   }
 
+  // 13. SLA / timeout wiring on approval nodes (issue #222)
+  for (const node of workflow.nodes) {
+    if (node.type !== 'approval') continue
+    const hasSla = typeof node.slaMinutes === 'number' && node.slaMinutes > 0
+    if (!hasSla) continue
+    if (node.onTimeout === undefined) {
+      // SLA is declared but no behavior is configured — the interpreter
+      // defaults to 'escalate' which would error at runtime if no
+      // timeout edge exists. Warn now so authors catch this in the
+      // builder.
+      issues.push({
+        code: 'sla-without-on-timeout',
+        severity: 'warning',
+        message: `Approval "${node.id}" sets slaMinutes but no onTimeout — defaults to 'escalate'`,
+        nodeId: node.id,
+      })
+    }
+    if ((node.onTimeout ?? 'escalate') === 'escalate') {
+      const hasTimeoutEdge = workflow.edges.some(
+        e => e.from === node.id && e.when === 'timeout',
+      )
+      if (!hasTimeoutEdge) {
+        issues.push({
+          code: 'timeout-edge-missing',
+          severity: 'error',
+          message: `Approval "${node.id}" with onTimeout='escalate' needs an outgoing edge with when: 'timeout'`,
+          nodeId: node.id,
+        })
+      }
+    }
+  }
+
   return issues
 }
 
@@ -258,7 +292,14 @@ function reachableNodeIds(workflow: Workflow): Set<string> {
 function isGuardLegal(node: WorkflowNode, guard: EdgeGuard): boolean {
   switch (node.type) {
     case 'condition': return guard === 'true' || guard === 'false'
-    case 'approval':  return guard === 'approved' || guard === 'denied'
+    case 'approval':
+      if (guard === 'approved' || guard === 'denied') return true
+      // `timeout` is only legal when the approval declares an SLA —
+      // without one, the interpreter can never fire a timeout from
+      // this node, so the edge would be dead code.
+      return guard === 'timeout'
+        && typeof node.slaMinutes === 'number'
+        && node.slaMinutes > 0
     case 'notify':    return guard === 'default'
     case 'terminal':  return false
   }

--- a/src/core/workflow/workflowSchema.ts
+++ b/src/core/workflow/workflowSchema.ts
@@ -74,7 +74,7 @@ export type WorkflowNode =
  * the signal emitted by the previous node:
  *
  *   - `condition`  → 'true' | 'false'
- *   - `approval`   → 'approved' | 'denied'
+ *   - `approval`   → 'approved' | 'denied' | 'timeout' (when slaMinutes set)
  *   - `notify`     → 'default'
  *   - `terminal`   → (no outgoing edges)
  *
@@ -86,6 +86,7 @@ export type EdgeGuard =
   | 'false'
   | 'approved'
   | 'denied'
+  | 'timeout'
   | 'default'
 
 export interface WorkflowEdge {

--- a/src/hooks/__tests__/useWorkflowTicker.test.tsx
+++ b/src/hooks/__tests__/useWorkflowTicker.test.tsx
@@ -91,4 +91,77 @@ describe('useWorkflowTicker', () => {
     )
     expect(onTimeout).not.toHaveBeenCalled()
   })
+
+  it('forwards variables to tick so condition auto-advance can resolve', () => {
+    // Manager approval (5m SLA) → on timeout routes into a condition
+    // node that requires `event.cost`. Without variables the auto-
+    // advance fails; with them it resolves.
+    const condWf: Workflow = {
+      id: 'sla-cond', version: 1, trigger: 'on_submit', startNodeId: 'a',
+      nodes: [
+        { id: 'a', type: 'approval', assignTo: 'role:m', slaMinutes: 5, onTimeout: 'escalate' },
+        { id: 'cost', type: 'condition', expr: 'event.cost > 500' },
+        { id: 'ok', type: 'terminal', outcome: 'finalized' },
+        { id: 'no', type: 'terminal', outcome: 'denied' },
+      ],
+      edges: [
+        { from: 'a', to: 'ok', when: 'approved' },
+        { from: 'a', to: 'no', when: 'denied' },
+        { from: 'a', to: 'cost', when: 'timeout' },
+        { from: 'cost', to: 'no', when: 'true' },
+        { from: 'cost', to: 'ok', when: 'false' },
+      ],
+    }
+    const start = advance({ workflow: condWf, instance: null, action: { type: 'start' }, at: '2026-04-20T09:00:00.000Z' })
+    if (!start.ok) throw new Error('start')
+    vi.setSystemTime(new Date('2026-04-20T10:00:00.000Z'))
+    const onTimeout = vi.fn()
+    renderHook(() =>
+      useWorkflowTicker({
+        workflow: condWf,
+        instance: start.instance,
+        onTimeout,
+        variables: { event: { cost: 1000 } },
+      }),
+    )
+    expect(onTimeout).toHaveBeenCalledTimes(1)
+    const [result] = onTimeout.mock.calls[0]
+    expect(result.ok).toBe(true)
+    expect(result.instance.outcome).toBe('denied')
+  })
+
+  it('dedupes: fires at most once per SLA boundary while instance is stable', () => {
+    const instance = startAt('2026-04-20T09:00:00.000Z')
+    vi.setSystemTime(new Date('2026-04-20T10:30:00.000Z'))
+    const onTimeout = vi.fn()
+    renderHook(() =>
+      useWorkflowTicker({ workflow: wf, instance, onTimeout, intervalMs: 1000 }),
+    )
+    expect(onTimeout).toHaveBeenCalledTimes(1)
+    // Host hasn't persisted yet — the instance prop is still the same.
+    // Subsequent interval ticks must not re-fire the callback.
+    act(() => {
+      vi.advanceTimersByTime(10_000)
+    })
+    expect(onTimeout).toHaveBeenCalledTimes(1)
+  })
+
+  it('re-arms after the instance prop changes to a new SLA boundary', () => {
+    const first = startAt('2026-04-20T09:00:00.000Z')
+    vi.setSystemTime(new Date('2026-04-20T10:30:00.000Z'))
+    const onTimeout = vi.fn()
+    const { rerender } = renderHook(
+      ({ instance }: { instance: WorkflowInstance }) =>
+        useWorkflowTicker({ workflow: wf, instance, onTimeout, intervalMs: 1000 }),
+      { initialProps: { instance: first } },
+    )
+    expect(onTimeout).toHaveBeenCalledTimes(1)
+
+    // Simulate host persisting: advance into the escalated node 'b'
+    // (also has no SLA — tick should now do nothing regardless).
+    const escalated = onTimeout.mock.calls[0][0].instance as WorkflowInstance
+    rerender({ instance: escalated })
+    act(() => { vi.advanceTimersByTime(5000) })
+    expect(onTimeout).toHaveBeenCalledTimes(1)
+  })
 })

--- a/src/hooks/__tests__/useWorkflowTicker.test.tsx
+++ b/src/hooks/__tests__/useWorkflowTicker.test.tsx
@@ -1,0 +1,94 @@
+// @vitest-environment happy-dom
+/**
+ * useWorkflowTicker — hook specs (issue #222).
+ */
+import { renderHook, act } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+import { useWorkflowTicker } from '../useWorkflowTicker'
+import { advance } from '../../core/workflow/advance'
+import type { Workflow, WorkflowInstance } from '../../core/workflow/workflowSchema'
+
+const wf: Workflow = {
+  id: 'sla',
+  version: 1,
+  trigger: 'on_submit',
+  startNodeId: 'a',
+  nodes: [
+    { id: 'a', type: 'approval', assignTo: 'role:m', slaMinutes: 10, onTimeout: 'escalate' },
+    { id: 'b', type: 'approval', assignTo: 'role:d' },
+    { id: 'ok', type: 'terminal', outcome: 'finalized' },
+    { id: 'no', type: 'terminal', outcome: 'denied' },
+  ],
+  edges: [
+    { from: 'a', to: 'ok', when: 'approved' },
+    { from: 'a', to: 'no', when: 'denied' },
+    { from: 'a', to: 'b', when: 'timeout' },
+    { from: 'b', to: 'ok', when: 'approved' },
+    { from: 'b', to: 'no', when: 'denied' },
+  ],
+}
+
+function startAt(iso: string): WorkflowInstance {
+  const r = advance({ workflow: wf, instance: null, action: { type: 'start' }, at: iso })
+  if (!r.ok) throw new Error('start')
+  return r.instance
+}
+
+describe('useWorkflowTicker', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-04-20T10:00:00.000Z'))
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('fires onTimeout immediately when SLA has already elapsed on mount', () => {
+    const instance = startAt('2026-04-20T09:00:00.000Z') // 60m ago; SLA is 10m.
+    vi.setSystemTime(new Date('2026-04-20T10:30:00.000Z'))
+    const onTimeout = vi.fn()
+    renderHook(() => useWorkflowTicker({ workflow: wf, instance, onTimeout }))
+    expect(onTimeout).toHaveBeenCalledTimes(1)
+    const [result] = onTimeout.mock.calls[0]
+    expect(result.ok).toBe(true)
+    expect(result.instance.currentNodeId).toBe('b')
+  })
+
+  it('does not fire when SLA has not elapsed', () => {
+    const instance = startAt('2026-04-20T09:59:00.000Z') // 1m ago; SLA is 10m.
+    const onTimeout = vi.fn()
+    renderHook(() => useWorkflowTicker({ workflow: wf, instance, onTimeout }))
+    expect(onTimeout).not.toHaveBeenCalled()
+  })
+
+  it('fires once an interval tick pushes the elapsed time past the SLA', () => {
+    const instance = startAt('2026-04-20T09:55:00.000Z') // 5m ago
+    const onTimeout = vi.fn()
+    renderHook(() => useWorkflowTicker({ workflow: wf, instance, onTimeout, intervalMs: 1000 }))
+    expect(onTimeout).not.toHaveBeenCalled()
+    // Jump wall-clock past the SLA and let one interval elapse.
+    act(() => {
+      vi.setSystemTime(new Date('2026-04-20T10:06:00.000Z'))
+      vi.advanceTimersByTime(1000)
+    })
+    expect(onTimeout).toHaveBeenCalled()
+  })
+
+  it('is idle when instance is null', () => {
+    const onTimeout = vi.fn()
+    renderHook(() => useWorkflowTicker({ workflow: wf, instance: null, onTimeout }))
+    expect(onTimeout).not.toHaveBeenCalled()
+  })
+
+  it('does not run when enabled=false', () => {
+    const instance = startAt('2026-04-20T09:00:00.000Z')
+    vi.setSystemTime(new Date('2026-04-20T10:30:00.000Z'))
+    const onTimeout = vi.fn()
+    renderHook(() =>
+      useWorkflowTicker({ workflow: wf, instance, onTimeout, enabled: false }),
+    )
+    expect(onTimeout).not.toHaveBeenCalled()
+  })
+})

--- a/src/hooks/useWorkflowTicker.ts
+++ b/src/hooks/useWorkflowTicker.ts
@@ -1,0 +1,70 @@
+/**
+ * useWorkflowTicker — periodic SLA timeout driver (issue #222).
+ *
+ * Calls `tick(workflow, instance, nowIso)` on a fixed interval; when
+ * `tick` returns a non-null `AdvanceResult`, invokes `onTimeout` with
+ * the next instance + emitted events so the host can persist and
+ * re-render. Stops on unmount or when `instance` becomes null.
+ *
+ * Pure at-will scheduling — the host owns persistence, the hook just
+ * detects the SLA boundary. Idle when the workflow has no SLA, the
+ * instance isn't awaiting, or the interval hasn't fired yet.
+ *
+ * Typical wiring:
+ *
+ *     useWorkflowTicker({
+ *       workflow,
+ *       instance: event.meta?.workflowInstance,
+ *       onTimeout: (next, emit) => persist(event.id, next, emit),
+ *     })
+ */
+import { useEffect, useRef } from 'react'
+import { tick, type AdvanceResult, type WorkflowEmitEvent } from '../core/workflow/advance'
+import type { Workflow, WorkflowInstance } from '../core/workflow/workflowSchema'
+
+export interface UseWorkflowTickerOptions {
+  readonly workflow: Workflow | null | undefined
+  readonly instance: WorkflowInstance | null | undefined
+  /**
+   * Called once per crossing of the SLA boundary. Receives the result
+   * of the synthetic `{ type: 'timeout' }` action. Host is responsible
+   * for persisting the new instance and re-rendering.
+   */
+  readonly onTimeout: (
+    result: AdvanceResult,
+    emit: readonly WorkflowEmitEvent[],
+  ) => void
+  /** Polling interval in ms. Default: 30s. */
+  readonly intervalMs?: number
+  /** Set false to pause the ticker (e.g. during modal edits). Default: true. */
+  readonly enabled?: boolean
+}
+
+export function useWorkflowTicker(opts: UseWorkflowTickerOptions): void {
+  const { workflow, instance, onTimeout, intervalMs = 30_000, enabled = true } = opts
+
+  // Hold the latest onTimeout in a ref so the interval doesn't need to
+  // restart when the host passes a fresh callback every render.
+  const cbRef = useRef(onTimeout)
+  cbRef.current = onTimeout
+
+  useEffect(() => {
+    if (!enabled) return
+    if (!workflow || !instance) return
+    if (instance.status !== 'awaiting') return
+
+    const check = (): void => {
+      const result = tick(workflow, instance, new Date().toISOString())
+      if (!result) return
+      cbRef.current(result, result.emit)
+    }
+
+    // Fire once immediately so a page that mounts mid-SLA doesn't have
+    // to wait a full interval before catching an already-elapsed timer.
+    check()
+    const id = setInterval(check, intervalMs)
+    return () => clearInterval(id)
+  }, [workflow, instance, intervalMs, enabled])
+}
+
+export default useWorkflowTicker

--- a/src/hooks/useWorkflowTicker.ts
+++ b/src/hooks/useWorkflowTicker.ts
@@ -10,11 +10,19 @@
  * detects the SLA boundary. Idle when the workflow has no SLA, the
  * instance isn't awaiting, or the interval hasn't fired yet.
  *
+ * Dedupe: each (currentNodeId, enteredAt) tuple is emitted at most
+ * once. If host persistence is slow (or the host ignores the result)
+ * the interval won't re-fire for the same boundary — the callback
+ * only runs again after `instance` changes, which happens when the
+ * host persists the advance and re-renders with the new workflow
+ * state.
+ *
  * Typical wiring:
  *
  *     useWorkflowTicker({
  *       workflow,
  *       instance: event.meta?.workflowInstance,
+ *       variables: { event },
  *       onTimeout: (next, emit) => persist(event.id, next, emit),
  *     })
  */
@@ -34,6 +42,12 @@ export interface UseWorkflowTickerOptions {
     result: AdvanceResult,
     emit: readonly WorkflowEmitEvent[],
   ) => void
+  /**
+   * Variables forwarded to `advance()` so condition nodes downstream of
+   * the timeout edge can resolve runtime data. Pass the same object you
+   * use for normal actor-driven actions.
+   */
+  readonly variables?: Readonly<Record<string, unknown>>
   /** Polling interval in ms. Default: 30s. */
   readonly intervalMs?: number
   /** Set false to pause the ticker (e.g. during modal edits). Default: true. */
@@ -41,21 +55,40 @@ export interface UseWorkflowTickerOptions {
 }
 
 export function useWorkflowTicker(opts: UseWorkflowTickerOptions): void {
-  const { workflow, instance, onTimeout, intervalMs = 30_000, enabled = true } = opts
+  const { workflow, instance, onTimeout, variables, intervalMs = 30_000, enabled = true } = opts
 
-  // Hold the latest onTimeout in a ref so the interval doesn't need to
-  // restart when the host passes a fresh callback every render.
+  // Hold the latest onTimeout + variables in refs so the interval
+  // doesn't need to restart when the host passes a fresh callback or
+  // variables object every render.
   const cbRef = useRef(onTimeout)
   cbRef.current = onTimeout
+  const varsRef = useRef(variables)
+  varsRef.current = variables
+
+  // Keyed by `${currentNodeId}:${enteredAt}` — the SLA boundary
+  // identity for the currently-awaited approval. Once onTimeout fires
+  // for a given key, we don't fire again until the instance prop
+  // changes (i.e. the host persisted our advance) and the effect
+  // re-runs with a fresh closure.
+  const firedKeyRef = useRef<string | null>(null)
 
   useEffect(() => {
     if (!enabled) return
     if (!workflow || !instance) return
     if (instance.status !== 'awaiting') return
 
+    const nodeId = instance.currentNodeId
+    if (!nodeId) return
+    const enteredAt = findEnteredAt(instance, nodeId)
+    if (!enteredAt) return
+    const boundaryKey = `${nodeId}:${enteredAt}`
+    firedKeyRef.current = null
+
     const check = (): void => {
-      const result = tick(workflow, instance, new Date().toISOString())
+      if (firedKeyRef.current === boundaryKey) return
+      const result = tick(workflow, instance, new Date().toISOString(), varsRef.current)
       if (!result) return
+      firedKeyRef.current = boundaryKey
       cbRef.current(result, result.emit)
     }
 
@@ -65,6 +98,16 @@ export function useWorkflowTicker(opts: UseWorkflowTickerOptions): void {
     const id = setInterval(check, intervalMs)
     return () => clearInterval(id)
   }, [workflow, instance, intervalMs, enabled])
+}
+
+function findEnteredAt(instance: WorkflowInstance, nodeId: string): string | null {
+  for (let i = instance.history.length - 1; i >= 0; i--) {
+    const entry = instance.history[i]
+    if (entry.nodeId !== nodeId) continue
+    if (entry.exitedAt !== undefined) continue
+    return entry.enteredAt
+  }
+  return null
 }
 
 export default useWorkflowTicker

--- a/src/index.ts
+++ b/src/index.ts
@@ -45,20 +45,24 @@ export { DEFAULT_CATEGORIES }             from './types/assets.ts';
 export { transitionApproval, legalActionsFrom, LEGAL_TRANSITIONS } from './core/approvals/transitions';
 export type { TransitionInput, TransitionResult, TransitionError, TransitionErrorCode } from './core/approvals/transitions';
 export { verifyAuditChain, appendAuditEntry } from './core/approvals/auditChain';
-export { advance as advanceWorkflow } from './core/workflow/advance';
+export { advance as advanceWorkflow, tick as tickWorkflow } from './core/workflow/advance';
 export type {
   WorkflowAction, WorkflowEmitEvent, AdvanceInput, AdvanceResult,
 } from './core/workflow/advance';
+export { useWorkflowTicker } from './hooks/useWorkflowTicker';
+export type { UseWorkflowTickerOptions } from './hooks/useWorkflowTicker';
 export { evaluate as evaluateExpression, evaluateBool as evaluateExpressionBool, ExpressionError } from './core/workflow/expression';
 export type {
   Workflow, WorkflowNode, WorkflowEdge, WorkflowInstance, WorkflowInstanceStatus,
   WorkflowHistoryEntry, WorkflowOutcome, WorkflowTrigger, EdgeGuard,
   WorkflowConditionNode, WorkflowApprovalNode, WorkflowNotifyNode, WorkflowTerminalNode,
+  TimeoutBehavior,
 } from './core/workflow/workflowSchema';
 export { findNode as findWorkflowNode, resolveNextEdge as resolveWorkflowEdge } from './core/workflow/workflowSchema';
 export {
   WORKFLOW_TEMPLATES,
   singleApproverWorkflow, twoTierApproverWorkflow, conditionalByCostWorkflow,
+  slaEscalationWorkflow,
 } from './core/workflow/templates';
 
 // ── Booking holds (#211) ────────────────────────────────────────────────────

--- a/src/ui/WorkflowBuilderModal.tsx
+++ b/src/ui/WorkflowBuilderModal.tsx
@@ -187,9 +187,14 @@ export function WorkflowBuilderModal(
     [pendingEdge, clearUndo],
   )
 
-  const pendingEdgeSourceType: WorkflowNode['type'] | null = pendingEdge
-    ? draftWorkflow.nodes.find(n => n.id === pendingEdge.from)?.type ?? null
+  const pendingEdgeSource: WorkflowNode | null = pendingEdge
+    ? draftWorkflow.nodes.find(n => n.id === pendingEdge.from) ?? null
     : null
+  const pendingEdgeSourceType = pendingEdgeSource?.type ?? null
+  const pendingEdgeSourceHasSla =
+    pendingEdgeSource?.type === 'approval'
+    && typeof pendingEdgeSource.slaMinutes === 'number'
+    && pendingEdgeSource.slaMinutes > 0
 
   // ─── Save ────────────────────────────────────────────────────────────────
 
@@ -271,6 +276,7 @@ export function WorkflowBuilderModal(
             {pendingEdge && pendingEdgeSourceType && (
               <WorkflowEdgeGuardPicker
                 sourceType={pendingEdgeSourceType}
+                sourceHasSla={pendingEdgeSourceHasSla}
                 onPick={commitPendingEdge}
                 onCancel={() => setPendingEdge(null)}
               />

--- a/src/ui/WorkflowEdgeGuardPicker.tsx
+++ b/src/ui/WorkflowEdgeGuardPicker.tsx
@@ -6,7 +6,7 @@
  * Options are filtered to just those the source node can legally emit:
  *
  *   - `condition`  → true / false / default
- *   - `approval`   → approved / denied / default
+ *   - `approval`   → approved / denied / default (+ `timeout` when slaMinutes set)
  *   - `notify`     → default
  *   - `terminal`   → (no outgoing edges; picker should not be invoked)
  *
@@ -26,6 +26,12 @@ export interface AnchorRect {
 
 export interface WorkflowEdgeGuardPickerProps {
   readonly sourceType: WorkflowNode['type']
+  /**
+   * Whether the source approval has `slaMinutes > 0`. Only consulted
+   * when `sourceType === 'approval'` — the `timeout` option is added
+   * iff true, matching the validator's `isGuardLegal` rule.
+   */
+  readonly sourceHasSla?: boolean
   readonly anchorRect?: AnchorRect
   readonly onPick: (guard: EdgeGuard) => void
   readonly onCancel: () => void
@@ -36,19 +42,26 @@ const GUARD_LABELS: Readonly<Record<EdgeGuard, string>> = {
   'false': 'false',
   'approved': 'approved',
   'denied': 'denied',
+  'timeout': 'timeout (SLA)',
   'default': 'default (fallback)',
 }
 
 /**
  * Exported for unit tests + the canvas (which hides the handle on
  * terminal nodes so this returns [] for defensive callers only).
+ *
+ * `options.hasSla` unlocks the `timeout` option for approval sources.
  */
 export function guardsForSource(
   sourceType: WorkflowNode['type'],
+  options?: { readonly hasSla?: boolean },
 ): readonly EdgeGuard[] {
   switch (sourceType) {
     case 'condition': return ['true', 'false', 'default']
-    case 'approval':  return ['approved', 'denied', 'default']
+    case 'approval':
+      return options?.hasSla
+        ? ['approved', 'denied', 'timeout', 'default']
+        : ['approved', 'denied', 'default']
     case 'notify':    return ['default']
     case 'terminal':  return []
   }
@@ -57,9 +70,9 @@ export function guardsForSource(
 export function WorkflowEdgeGuardPicker(
   props: WorkflowEdgeGuardPickerProps,
 ): JSX.Element | null {
-  const { sourceType, anchorRect, onPick, onCancel } = props
+  const { sourceType, sourceHasSla, anchorRect, onPick, onCancel } = props
   const ref = useRef<HTMLDivElement | null>(null)
-  const guards = guardsForSource(sourceType)
+  const guards = guardsForSource(sourceType, { hasSla: sourceHasSla })
 
   // Escape + click-outside dismissal. Registered only while mounted;
   // parent unmounts the picker after the first pick or cancel.

--- a/src/ui/WorkflowNodeInspector.tsx
+++ b/src/ui/WorkflowNodeInspector.tsx
@@ -216,7 +216,10 @@ function ApprovalFields({
             }
           }}
         />
-        <span className={styles.hint}>Phase-3 feature; stored but not yet enforced.</span>
+        <span className={styles.hint}>
+          When elapsed, the interpreter fires a timeout action using the
+          behavior below. Add a <code>timeout</code> edge for escalate.
+        </span>
       </div>
 
       <div className={styles.field}>

--- a/src/ui/WorkflowSimulator.module.css
+++ b/src/ui/WorkflowSimulator.module.css
@@ -238,3 +238,16 @@
 .historyTable tbody tr:last-child td {
   border-bottom: none;
 }
+
+.clockRow {
+  display: flex;
+  gap: 8px;
+  align-items: baseline;
+  padding: 4px 0;
+}
+
+.clockValue {
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 12px;
+  color: var(--wc-text, #111827);
+}

--- a/src/ui/WorkflowSimulator.tsx
+++ b/src/ui/WorkflowSimulator.tsx
@@ -17,7 +17,7 @@
  *   or failed actions — nothing that short-circuits on invalid variables.
  */
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
-import { advance } from '../core/workflow/advance'
+import { advance, tick } from '../core/workflow/advance'
 import type {
   WorkflowAction,
   WorkflowEmitEvent,
@@ -29,6 +29,12 @@ import type {
 import styles from './WorkflowSimulator.module.css'
 
 export const STEP_CAP = 100
+
+/** Fixed sim-clock epoch so every simulator run starts at the same wall
+ * clock. Real host time is irrelevant in the authoring UI — what matters
+ * is the delta between actions and clock jumps. */
+const SIM_EPOCH_ISO = '2026-01-01T09:00:00.000Z'
+const CLOCK_JUMPS_MINUTES: readonly number[] = [5, 15, 60]
 
 const DEFAULT_VARIABLES = JSON.stringify(
   { event: { cost: 1000 }, actor: { role: 'director' } },
@@ -57,6 +63,7 @@ export function WorkflowSimulator(
   const [denyReason, setDenyReason] = useState<string>('')
   const [stepCount, setStepCount] = useState<number>(0)
   const [lastError, setLastError] = useState<string | null>(null)
+  const [simClockMs, setSimClockMs] = useState<number>(Date.parse(SIM_EPOCH_ISO))
   const seqRef = useRef<number>(0)
 
   const { variables, parseError } = useMemo(() => {
@@ -102,7 +109,8 @@ export function WorkflowSimulator(
 
   const dispatch = useCallback((action: WorkflowAction): void => {
     if (atCap) return
-    const result = advance({ workflow, instance, action, variables })
+    const at = new Date(simClockMs).toISOString()
+    const result = advance({ workflow, instance, action, variables, at })
     // Count every action the user fires, even failed ones — pathological
     // graphs can generate a stream of `ok:false` that still deserves a cap.
     setStepCount(n => n + 1)
@@ -112,7 +120,23 @@ export function WorkflowSimulator(
       return [...prev, ...additions]
     })
     setLastError(result.ok === false ? result.error : null)
-  }, [workflow, instance, variables, atCap])
+  }, [workflow, instance, variables, atCap, simClockMs])
+
+  const advanceClock = useCallback((minutes: number): void => {
+    if (atCap) return
+    const nextMs = simClockMs + minutes * 60_000
+    setSimClockMs(nextMs)
+    if (!instance) return
+    const result = tick(workflow, instance, new Date(nextMs).toISOString())
+    if (!result) return
+    setStepCount(n => n + 1)
+    setInstance(result.instance)
+    setEmitLog(prev => {
+      const additions = result.emit.map(e => ({ seq: seqRef.current++, event: e }))
+      return [...prev, ...additions]
+    })
+    setLastError(result.ok === false ? result.error : null)
+  }, [workflow, instance, simClockMs, atCap])
 
   const reset = useCallback((): void => {
     setInstance(null)
@@ -120,6 +144,7 @@ export function WorkflowSimulator(
     setDenyReason('')
     setStepCount(0)
     setLastError(null)
+    setSimClockMs(Date.parse(SIM_EPOCH_ISO))
     seqRef.current = 0
   }, [])
 
@@ -227,6 +252,33 @@ export function WorkflowSimulator(
           placeholder="Required to enable Deny"
           onChange={e => setDenyReason(e.target.value)}
         />
+      </div>
+
+      <div className={styles.section} data-testid="sim-clock">
+        <h4 className={styles.sectionTitle}>Sim clock</h4>
+        <div className={styles.clockRow}>
+          <span className={styles.clockValue} data-testid="sim-clock-value">
+            {new Date(simClockMs).toISOString()}
+          </span>
+        </div>
+        <div className={styles.actions}>
+          {CLOCK_JUMPS_MINUTES.map(m => (
+            <button
+              key={m}
+              type="button"
+              className={styles.buttonSecondary}
+              onClick={() => advanceClock(m)}
+              disabled={atCap}
+              data-testid={`sim-advance-${m}m`}
+            >
+              +{m}m
+            </button>
+          ))}
+        </div>
+        <span className={styles.hint}>
+          Advances the simulator clock. If the current approval has
+          an SLA and the elapsed time crosses it, a timeout action fires.
+        </span>
       </div>
 
       {atCap && (

--- a/src/ui/__tests__/WorkflowEdgeGuardPicker.test.tsx
+++ b/src/ui/__tests__/WorkflowEdgeGuardPicker.test.tsx
@@ -21,6 +21,45 @@ describe('guardsForSource', () => {
   it('terminal → empty list', () => {
     expect(guardsForSource('terminal')).toEqual([])
   })
+  it('approval with SLA → includes timeout', () => {
+    expect(guardsForSource('approval', { hasSla: true })).toEqual([
+      'approved', 'denied', 'timeout', 'default',
+    ])
+  })
+  it('approval without SLA → no timeout', () => {
+    expect(guardsForSource('approval', { hasSla: false })).toEqual([
+      'approved', 'denied', 'default',
+    ])
+  })
+  it('hasSla only affects approval sources', () => {
+    expect(guardsForSource('condition', { hasSla: true })).toEqual(['true', 'false', 'default'])
+    expect(guardsForSource('notify',    { hasSla: true })).toEqual(['default'])
+  })
+})
+
+describe('WorkflowEdgeGuardPicker — timeout option', () => {
+  it('shows timeout button when sourceHasSla is true', () => {
+    render(
+      <WorkflowEdgeGuardPicker
+        sourceType="approval"
+        sourceHasSla
+        onPick={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    )
+    expect(document.querySelector('[data-guard="timeout"]')).toBeInTheDocument()
+  })
+
+  it('hides timeout button when sourceHasSla is false', () => {
+    render(
+      <WorkflowEdgeGuardPicker
+        sourceType="approval"
+        onPick={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    )
+    expect(document.querySelector('[data-guard="timeout"]')).toBeNull()
+  })
 })
 
 describe('WorkflowEdgeGuardPicker — rendering', () => {

--- a/src/ui/__tests__/WorkflowSimulator.test.tsx
+++ b/src/ui/__tests__/WorkflowSimulator.test.tsx
@@ -286,3 +286,46 @@ describe('WorkflowSimulator — onActiveNodeChange', () => {
     expect(onActiveNodeChange).toHaveBeenLastCalledWith(null)
   })
 })
+
+describe('WorkflowSimulator — sim clock', () => {
+  const slaWorkflow: Workflow = {
+    id: 'sla', version: 1, trigger: 'on_submit', startNodeId: 'm',
+    nodes: [
+      { id: 'm', type: 'approval', assignTo: 'role:manager', slaMinutes: 30, onTimeout: 'escalate' },
+      { id: 'd', type: 'approval', assignTo: 'role:director' },
+      { id: 'ok', type: 'terminal', outcome: 'finalized' },
+      { id: 'no', type: 'terminal', outcome: 'denied' },
+    ],
+    edges: [
+      { from: 'm', to: 'ok', when: 'approved' },
+      { from: 'm', to: 'no', when: 'denied' },
+      { from: 'm', to: 'd', when: 'timeout' },
+      { from: 'd', to: 'ok', when: 'approved' },
+      { from: 'd', to: 'no', when: 'denied' },
+    ],
+  }
+
+  it('renders advance-clock buttons', () => {
+    render(<WorkflowSimulator workflow={slaWorkflow} />)
+    expect(screen.getByTestId('sim-advance-5m')).toBeInTheDocument()
+    expect(screen.getByTestId('sim-advance-15m')).toBeInTheDocument()
+    expect(screen.getByTestId('sim-advance-60m')).toBeInTheDocument()
+  })
+
+  it('advancing the clock past SLA fires timeout and escalates', () => {
+    render(<WorkflowSimulator workflow={slaWorkflow} />)
+    start()
+    expect(screen.getByTestId('sim-current-node').textContent).toMatch(/@ m/)
+    // Two 15m jumps = 30m; tick then fires the timeout and moves to 'd'.
+    fireEvent.click(screen.getByTestId('sim-advance-15m'))
+    fireEvent.click(screen.getByTestId('sim-advance-15m'))
+    expect(screen.getByTestId('sim-current-node').textContent).toMatch(/@ d/)
+  })
+
+  it('advancing the clock under SLA does not fire timeout', () => {
+    render(<WorkflowSimulator workflow={slaWorkflow} />)
+    start()
+    fireEvent.click(screen.getByTestId('sim-advance-5m'))
+    expect(screen.getByTestId('sim-current-node').textContent).toMatch(/@ m/)
+  })
+})

--- a/src/views/AuditDrawer.module.css
+++ b/src/views/AuditDrawer.module.css
@@ -55,6 +55,22 @@
 .stageTag[data-stage="finalized"]      { background: color-mix(in srgb, var(--wc-success, #059669) 20%, transparent); color: var(--wc-success, #059669); }
 .stageTag[data-stage="requested"]      { background: color-mix(in srgb, var(--wc-accent, #2563eb) 15%, transparent); color: var(--wc-accent, #2563eb); }
 
+.slaPill {
+  display: inline-block;
+  margin-left: 8px;
+  font-size: 10px;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  padding: 2px 8px;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--wc-accent, #2563eb) 15%, transparent);
+  color: var(--wc-accent, #2563eb);
+}
+.slaPill[data-sla-expired="true"] {
+  background: color-mix(in srgb, var(--wc-danger, #dc2626) 15%, transparent);
+  color: var(--wc-danger, #dc2626);
+}
+
 .closeBtn {
   background: transparent;
   border: none;

--- a/src/views/AuditDrawer.tsx
+++ b/src/views/AuditDrawer.tsx
@@ -6,10 +6,11 @@
  * append entries via the onApprovalAction callback (calendar emits, host
  * persists, re-renders with updated history).
  */
-import { useEffect, useRef } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { X } from 'lucide-react';
 import styles from './AuditDrawer.module.css';
 import ApprovalActionMenu from '../ui/ApprovalActionMenu';
+import { findNode } from '../core/workflow/workflowSchema';
 
 /**
  * Formats an ISO timestamp as a locale-aware date + time string. Returns the
@@ -35,8 +36,50 @@ const ACTION_LABELS = {
   finalize:  'Finalized',
 };
 
-export default function AuditDrawer({ event, onClose, approvalsConfig, onAction }: any) {
+/**
+ * Compute SLA pill data from a workflow definition + running instance.
+ * Returns null when inapplicable (no instance, not awaiting, no SLA, or
+ * the active node isn't in the workflow anymore).
+ */
+function computeSlaPill(workflow, workflowInstance, nowMs) {
+  if (!workflow || !workflowInstance) return null;
+  if (workflowInstance.status !== 'awaiting') return null;
+  const nodeId = workflowInstance.currentNodeId;
+  if (!nodeId) return null;
+  const node = findNode(workflow, nodeId);
+  if (!node || node.type !== 'approval') return null;
+  if (typeof node.slaMinutes !== 'number' || node.slaMinutes <= 0) return null;
+  const history = workflowInstance.history ?? [];
+  let enteredAt = null;
+  for (let i = history.length - 1; i >= 0; i--) {
+    const h = history[i];
+    if (h.nodeId === nodeId && h.exitedAt === undefined) { enteredAt = h.enteredAt; break; }
+  }
+  if (!enteredAt) return null;
+  const enteredMs = Date.parse(enteredAt);
+  if (!Number.isFinite(enteredMs)) return null;
+  const slaMs = node.slaMinutes * 60_000;
+  const remainingMs = enteredMs + slaMs - nowMs;
+  return {
+    remainingMs,
+    slaMinutes: node.slaMinutes,
+    onTimeout: node.onTimeout ?? 'escalate',
+    expired: remainingMs <= 0,
+  };
+}
+
+function formatRemaining(ms) {
+  const abs = Math.abs(ms);
+  const totalMinutes = Math.max(0, Math.round(abs / 60_000));
+  if (totalMinutes < 60) return `${totalMinutes}m`;
+  const h = Math.floor(totalMinutes / 60);
+  const m = totalMinutes % 60;
+  return m === 0 ? `${h}h` : `${h}h ${m}m`;
+}
+
+export default function AuditDrawer({ event, onClose, approvalsConfig, onAction, workflow }: any) {
   const closeRef = useRef(null);
+  const [nowMs, setNowMs] = useState(() => Date.now());
 
   useEffect(() => {
     if (!event) return;
@@ -45,6 +88,17 @@ export default function AuditDrawer({ event, onClose, approvalsConfig, onAction 
     window.addEventListener('keydown', onKey);
     return () => window.removeEventListener('keydown', onKey);
   }, [event, onClose]);
+
+  // Re-render once per 30s so the SLA countdown stays current while the
+  // drawer is open. Only runs when an SLA pill is actually visible —
+  // cheaper than a global interval.
+  const workflowInstance = event?.meta?.workflowInstance;
+  const sla = computeSlaPill(workflow, workflowInstance, nowMs);
+  useEffect(() => {
+    if (!sla) return;
+    const id = setInterval(() => setNowMs(Date.now()), 30_000);
+    return () => clearInterval(id);
+  }, [sla !== null]);
 
   if (!event) return null;
 
@@ -69,6 +123,18 @@ export default function AuditDrawer({ event, onClose, approvalsConfig, onAction 
             {stageData?.stage && (
               <span className={styles.stageTag} data-stage={stageData.stage}>
                 {stageData.stage.replace('_', ' ')}
+              </span>
+            )}
+            {sla && (
+              <span
+                className={styles.slaPill}
+                data-testid="audit-sla-pill"
+                data-sla-expired={sla.expired ? 'true' : 'false'}
+                title={`SLA ${sla.slaMinutes}m · onTimeout=${sla.onTimeout}`}
+              >
+                {sla.expired
+                  ? `SLA elapsed +${formatRemaining(sla.remainingMs)}`
+                  : `SLA ${formatRemaining(sla.remainingMs)} left`}
               </span>
             )}
             {stageData?.stage && typeof onAction === 'function' && (

--- a/src/views/__tests__/AuditDrawer.test.tsx
+++ b/src/views/__tests__/AuditDrawer.test.tsx
@@ -167,3 +167,66 @@ describe('AuditDrawer — inline approval actions', () => {
     expect(onAction).toHaveBeenCalledWith('revoke');
   });
 });
+
+describe('AuditDrawer — SLA countdown pill (#222)', () => {
+  const workflow = {
+    id: 'sla-esc',
+    version: 1,
+    trigger: 'on_submit',
+    startNodeId: 'm',
+    nodes: [
+      { id: 'm', type: 'approval', assignTo: 'role:manager', slaMinutes: 60, onTimeout: 'escalate' },
+      { id: 'ok', type: 'terminal', outcome: 'finalized' },
+      { id: 'no', type: 'terminal', outcome: 'denied' },
+    ],
+    edges: [
+      { from: 'm', to: 'ok', when: 'approved' },
+      { from: 'm', to: 'no', when: 'denied' },
+    ],
+  };
+
+  function makeEvent(enteredAt: string, status = 'awaiting') {
+    return {
+      id: 'ev-sla',
+      title: 'SLA test',
+      meta: {
+        workflowInstance: {
+          workflowId: 'sla-esc',
+          workflowVersion: 1,
+          status,
+          currentNodeId: 'm',
+          history: [{ nodeId: 'm', enteredAt }],
+        },
+      },
+    };
+  }
+
+  it('shows countdown pill when SLA has not elapsed', () => {
+    vi.setSystemTime(new Date('2026-04-20T10:30:00.000Z'));
+    render(<AuditDrawer event={makeEvent('2026-04-20T10:00:00.000Z')} onClose={vi.fn()} workflow={workflow} />);
+    const pill = screen.getByTestId('audit-sla-pill');
+    expect(pill).toBeInTheDocument();
+    expect(pill.getAttribute('data-sla-expired')).toBe('false');
+    expect(pill.textContent).toMatch(/SLA.*left/i);
+    vi.useRealTimers();
+  });
+
+  it('shows expired pill when SLA has elapsed', () => {
+    vi.setSystemTime(new Date('2026-04-20T11:30:00.000Z'));
+    render(<AuditDrawer event={makeEvent('2026-04-20T10:00:00.000Z')} onClose={vi.fn()} workflow={workflow} />);
+    const pill = screen.getByTestId('audit-sla-pill');
+    expect(pill.getAttribute('data-sla-expired')).toBe('true');
+    expect(pill.textContent).toMatch(/elapsed/i);
+    vi.useRealTimers();
+  });
+
+  it('omits the pill when no workflow prop is passed', () => {
+    render(<AuditDrawer event={makeEvent('2026-04-20T10:00:00.000Z')} onClose={vi.fn()} />);
+    expect(screen.queryByTestId('audit-sla-pill')).toBeNull();
+  });
+
+  it('omits the pill when instance is not awaiting', () => {
+    render(<AuditDrawer event={makeEvent('2026-04-20T10:00:00.000Z', 'completed')} onClose={vi.fn()} workflow={workflow} />);
+    expect(screen.queryByTestId('audit-sla-pill')).toBeNull();
+  });
+});


### PR DESCRIPTION
Closes #222.

Phase-3 SLA timers for the workflow DSL — the last missing runtime
behavior from the #219 epic.

## Summary

- **Schema**: `EdgeGuard` grows a `timeout` variant so approvals with
  `slaMinutes` can fan out to an escalation lane alongside
  `approved` / `denied`.
- **Interpreter**: new `{ type: 'timeout' }` action on `advance()`,
  plus a pure `tick(workflow, instance, nowIso)` that fires it when
  the active approval's SLA has elapsed. `onTimeout='escalate'`
  walks the `timeout` edge; `auto-approve` / `auto-deny` reuse the
  standard `approved` / `denied` edges so authors don't have to
  double-wire.
- **Validator**: two new rules — `timeout-edge-missing` (error when
  `escalate` has no timeout outgoing edge) and
  `sla-without-on-timeout` (warning). Tightens
  `illegal-guard-for-source` so `timeout` is only legal on
  approvals with `slaMinutes > 0`.
- **Template**: `slaEscalationWorkflow` demonstrates the full
  wiring end-to-end.
- **Builder UI**: edge-guard picker adds a `timeout` option whenever
  the source approval has an SLA; node inspector drops the "not yet
  enforced" copy; simulator ships an advance-clock control that
  fires `tick()`.
- **AuditDrawer**: optional SLA countdown pill when the caller
  passes a workflow definition + a running instance.
- **Host integration**: public API gains `tickWorkflow` + a
  `useWorkflowTicker` hook that polls `tick()` on an interval and
  invokes a host callback once per SLA boundary crossing.

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npx vitest run` — 1750 pass / 1 todo / 0 fail (123 files)
- [x] `npm run build` — dist generated, main entry 2.04 kB gzip,
      lazy `WorkflowBuilderModal` chunk 12.40 kB gzip
- [x] New specs: `tick.test.ts`, `useWorkflowTicker.test.tsx`
- [x] Extended specs: `advance.test.ts`, `validate.test.ts`,
      `templates.test.ts`, `WorkflowEdgeGuardPicker.test.tsx`,
      `WorkflowSimulator.test.tsx`, `AuditDrawer.test.tsx`

https://claude.ai/code/session_01XMTn2Dr9Xzgd5ZKTWDx3dK