### PR TITLE
Fix broken archive planning links after docs reorg

### DIFF
--- a/docs/archive/planning/GROUPING_SPRINT_EXECUTIVE_SUMMARY.md
+++ b/docs/archive/planning/GROUPING_SPRINT_EXECUTIVE_SUMMARY.md
@@ -2,7 +2,7 @@
 
 **Date:** 2026-04-16 (initial review) · **Updated:** 2026-04-18 (Phase A+B delivery)
 **Status:** ✅ Phases A + B shipped — original scope reshaped; see **Delivery Update** at bottom.
-**Full Analysis:** [INFINITE_GROUPING_VIABILITY_ANALYSIS.md](./INFINITE_GROUPING_VIABILITY_ANALYSIS.md)
+**Full Analysis:** [INFINITE_GROUPING_VIABILITY_ANALYSIS.md](../analysis/INFINITE_GROUPING_VIABILITY_ANALYSIS.md)
 
 > **If you only read one thing, skip to the [Delivery Update](#delivery-update--2026-04-sprint) section.** The body below is preserved as the original pre-implementation risk analysis. It correctly flagged that the 5-day scope was unrealistic; the sprint reshaped into phased delivery (A/B) under GitHub issue #134.
 
@@ -256,7 +256,7 @@ The calendar is a valuable product. Let's build grouping features properly, not 
 ---
 
 **Reviewed by:** Claude Code Agent
-**Full Analysis:** [INFINITE_GROUPING_VIABILITY_ANALYSIS.md](./INFINITE_GROUPING_VIABILITY_ANALYSIS.md)
+**Full Analysis:** [INFINITE_GROUPING_VIABILITY_ANALYSIS.md](../analysis/INFINITE_GROUPING_VIABILITY_ANALYSIS.md)
 **Next Steps:** Stakeholder review + scope decision
 
 ---
@@ -333,7 +333,7 @@ not the default path.**
 
 ### Where to look for the work
 
-- **API surface:** [`GROUPING_API.md`](./GROUPING_API.md) — now includes the
+- **API surface:** [`GROUPING_API.md`](../../GROUPING_API.md) — now includes the
   AssetsView / Assets tab section covering the `assets[]` prop shape, the
   ConfigPanel deep-link, and the cross-group keyboard contract.
 - **Engine:** `src/grouping/groupRows.ts`, `src/hooks/useGrouping.ts`,

--- a/docs/archive/planning/PHASE_3_SPRINT.md
+++ b/docs/archive/planning/PHASE_3_SPRINT.md
@@ -1,7 +1,7 @@
 # Phase 3 Sprint Plan — Multi-Level Grouping (with Phase 2 Catch-up)
 
 **Created:** 2026-04-17
-**Based on:** [Viability Analysis](./INFINITE_GROUPING_VIABILITY_ANALYSIS.md), [Sprint Roadmap](./SPRINT_ROADMAP.md)
+**Based on:** [Viability Analysis](../analysis/INFINITE_GROUPING_VIABILITY_ANALYSIS.md), [Sprint Roadmap](./SPRINT_ROADMAP.md)
 **Branch:** `claude/create-phase-3-sprint-KCf36`
 **Duration:** 7 one-week sprints (Phase 2 catch-up: 3 weeks; Phase 3: 4 weeks)
 **Version target:** `v0.3.0`
@@ -10,7 +10,7 @@
 
 ## Context
 
-The [viability analysis](./INFINITE_GROUPING_VIABILITY_ANALYSIS.md) rejected the original 5-day "unlimited grouping" sprint as unrealistic and recommended Option C — a phased rollout over 7-9 weeks. The [sprint roadmap](./SPRINT_ROADMAP.md) split that vision into Phases 1-3.
+The [viability analysis](../analysis/INFINITE_GROUPING_VIABILITY_ANALYSIS.md) rejected the original 5-day "unlimited grouping" sprint as unrealistic and recommended Option C — a phased rollout over 7-9 weeks. The [sprint roadmap](./SPRINT_ROADMAP.md) split that vision into Phases 1-3.
 
 Current state (verified against `main` on 2026-04-17):
 

--- a/docs/archive/planning/SPRINT_ROADMAP.md
+++ b/docs/archive/planning/SPRINT_ROADMAP.md
@@ -1,7 +1,7 @@
 # Sprint Roadmap: Grouping, Filtering & Sorting — Phased Implementation
 
 **Created:** 2026-04-16
-**Based on:** [Executive Summary](./GROUPING_SPRINT_EXECUTIVE_SUMMARY.md) | [Viability Analysis](./INFINITE_GROUPING_VIABILITY_ANALYSIS.md)
+**Based on:** [Executive Summary](./GROUPING_SPRINT_EXECUTIVE_SUMMARY.md) | [Viability Analysis](../analysis/INFINITE_GROUPING_VIABILITY_ANALYSIS.md)
 **Approach:** Option C — Phased (7-9 weeks, 9 sprints)
 **Sprint Cadence:** 1-week sprints (5 working days)
 

--- a/docs/archive/planning/enhanced-filtering-sprint-plan.md
+++ b/docs/archive/planning/enhanced-filtering-sprint-plan.md
@@ -2,7 +2,7 @@
 
 ## Context
 
-WorksCalendar already has a solid schema-driven filtering system (filterSchema.ts, filterEngine.js, filterState.js, FilterBar.jsx, AdvancedFilterBuilder.jsx, useSavedViews.js). A prior viability analysis (docs/INFINITE_GROUPING_VIABILITY_ANALYSIS.md) recommended **Option B: Enhanced Filtering** as the safest, highest-value next step -- building on the existing solid infrastructure rather than attempting risky grouping work.
+WorksCalendar already has a solid schema-driven filtering system (filterSchema.ts, filterEngine.js, filterState.js, FilterBar.jsx, AdvancedFilterBuilder.jsx, useSavedViews.js). A prior viability analysis (../analysis/INFINITE_GROUPING_VIABILITY_ANALYSIS.md) recommended **Option B: Enhanced Filtering** as the safest, highest-value next step -- building on the existing solid infrastructure rather than attempting risky grouping work.
 
 **Problem**: The filtering system has key gaps that limit power-user workflows:
 - AdvancedFilterBuilder is hard-coded to 3 fields (Category, Person, Title) instead of being schema-driven


### PR DESCRIPTION
### Motivation
- Archive planning docs were left with relative links that no longer resolve after moving `INFINITE_GROUPING_VIABILITY_ANALYSIS.md` into `docs/archive/analysis/`, causing dead links from `docs/archive/planning/`.
- The executive summary also contained an API link that needed to point to the top-level `docs/GROUPING_API.md` from the archive location.
- This change aims to restore navigable references so archived planning documents remain useful for readers tracing design decisions.

### Description
- Updated references to `INFINITE_GROUPING_VIABILITY_ANALYSIS.md` in `docs/archive/planning/GROUPING_SPRINT_EXECUTIVE_SUMMARY.md`, `docs/archive/planning/SPRINT_ROADMAP.md`, `docs/archive/planning/PHASE_3_SPRINT.md`, and `docs/archive/planning/enhanced-filtering-sprint-plan.md` to `../analysis/INFINITE_GROUPING_VIABILITY_ANALYSIS.md`.
- Fixed the API link in `docs/archive/planning/GROUPING_SPRINT_EXECUTIVE_SUMMARY.md` to point to `../../GROUPING_API.md` so it resolves to `docs/GROUPING_API.md` from the archive folder.
- Changes are limited to link path edits in the four archived planning markdown files and do not modify code or behavior.

### Testing
- No automated test-suite changes were required because this is a documentation-only fix; no unit or integration tests were run or affected.
- Verified the replacements and commit with `rg` to search for old link targets and `git diff`/`git status`, and committed the changes (`Fix archived planning doc links after reorg`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e6cad1b230832cb0fb761a97e2eb12)