### PR TITLE
feat(workflow): notify channel registry + template interpolation (#223)

### DIFF
--- a/src/core/workflow/__tests__/advance.test.ts
+++ b/src/core/workflow/__tests__/advance.test.ts
@@ -225,6 +225,64 @@ describe('advance — notify emission', () => {
     expect(notifyEvt).toMatchObject({ channel: 'email', template: 'hi' })
     expect(r.instance.status).toBe('completed')
   })
+
+  it('interpolates {{ }} tokens against variables into a message field', () => {
+    const wf: Workflow = {
+      id: 'notify-interp', version: 1, trigger: 'on_submit', startNodeId: 'n',
+      nodes: [
+        { id: 'n', type: 'notify', channel: 'slack', template: 'Hi {{ actor.name }}, cost ${{ event.cost }}' },
+        { id: 'done', type: 'terminal', outcome: 'finalized' },
+      ],
+      edges: [{ from: 'n', to: 'done' }],
+    }
+    const r = advance({
+      workflow: wf, instance: null, action: { type: 'start' }, at: AT,
+      variables: { actor: { name: 'Alice' }, event: { cost: 750 } },
+    })
+    expect(r.ok).toBe(true)
+    if (!r.ok) return
+    const notifyEvt = r.emit.find(e => e.type === 'notify')
+    expect(notifyEvt).toMatchObject({
+      channel: 'slack',
+      template: 'Hi {{ actor.name }}, cost ${{ event.cost }}',
+      message: 'Hi Alice, cost $750',
+    })
+  })
+
+  it('omits message when the notify node has no template', () => {
+    const wf: Workflow = {
+      id: 'notify-bare', version: 1, trigger: 'on_submit', startNodeId: 'n',
+      nodes: [
+        { id: 'n', type: 'notify', channel: 'slack' },
+        { id: 'done', type: 'terminal', outcome: 'finalized' },
+      ],
+      edges: [{ from: 'n', to: 'done' }],
+    }
+    const r = advance({ workflow: wf, instance: null, action: { type: 'start' }, at: AT })
+    expect(r.ok).toBe(true)
+    if (!r.ok) return
+    const notifyEvt = r.emit.find(e => e.type === 'notify')
+    expect(notifyEvt).not.toHaveProperty('message')
+    expect(notifyEvt).not.toHaveProperty('template')
+  })
+
+  it('fails the workflow when a template references an undefined variable', () => {
+    const wf: Workflow = {
+      id: 'notify-bad', version: 1, trigger: 'on_submit', startNodeId: 'n',
+      nodes: [
+        { id: 'n', type: 'notify', channel: 'slack', template: 'Hi {{ actor.name }}' },
+        { id: 'done', type: 'terminal', outcome: 'finalized' },
+      ],
+      edges: [{ from: 'n', to: 'done' }],
+    }
+    const r = advance({
+      workflow: wf, instance: null, action: { type: 'start' }, at: AT,
+      variables: {},
+    }) as { ok: false; error: string; instance: WorkflowInstance; emit: readonly unknown[] }
+    expect(r.ok).toBe(false)
+    expect(r.instance.status).toBe('failed')
+    expect(r.error).toMatch(/actor\.name/)
+  })
 })
 
 describe('advance — failure modes', () => {

--- a/src/core/workflow/__tests__/channels.test.ts
+++ b/src/core/workflow/__tests__/channels.test.ts
@@ -1,0 +1,199 @@
+/**
+ * Workflow channels + dispatch — unit specs (issue #223 Phase 4).
+ */
+import { describe, it, expect, vi } from 'vitest'
+import {
+  createChannelRegistry,
+  dispatchWorkflowEvents,
+  createSlackChannel,
+  createEmailChannel,
+  createWebhookChannel,
+} from '../channels'
+import type { WorkflowEmitEvent } from '../advance'
+
+const notify = (channel: string, overrides: Partial<Extract<WorkflowEmitEvent, { type: 'notify' }>> = {}): WorkflowEmitEvent => ({
+  type: 'notify',
+  nodeId: 'n1',
+  channel,
+  at: '2026-04-21T10:00:00.000Z',
+  ...overrides,
+})
+
+describe('createChannelRegistry', () => {
+  it('registers and looks up adapters by id', () => {
+    const r = createChannelRegistry()
+    const a = { id: 'slack', dispatch: vi.fn() }
+    r.register(a)
+    expect(r.has('slack')).toBe(true)
+    expect(r.get('slack')).toBe(a)
+    expect(r.ids()).toContain('slack')
+  })
+
+  it('unregisters adapters', () => {
+    const r = createChannelRegistry()
+    r.register({ id: 'slack', dispatch: vi.fn() })
+    r.unregister('slack')
+    expect(r.has('slack')).toBe(false)
+  })
+
+  it('rejects adapters without an id', () => {
+    const r = createChannelRegistry()
+    expect(() => r.register({ id: '', dispatch: vi.fn() })).toThrow()
+  })
+
+  it('overwrites when the same id registers twice', () => {
+    const r = createChannelRegistry()
+    const a1 = { id: 'x', dispatch: vi.fn() }
+    const a2 = { id: 'x', dispatch: vi.fn() }
+    r.register(a1)
+    r.register(a2)
+    expect(r.get('x')).toBe(a2)
+  })
+})
+
+describe('dispatchWorkflowEvents', () => {
+  it('routes notify events to matching adapters', async () => {
+    const slack = vi.fn()
+    const email = vi.fn()
+    const r = createChannelRegistry()
+    r.register({ id: 'slack', dispatch: slack })
+    r.register({ id: 'email', dispatch: email })
+
+    const events: WorkflowEmitEvent[] = [
+      notify('slack', { message: 'hi slack' }),
+      notify('email', { message: 'hi email' }),
+    ]
+    const report = await dispatchWorkflowEvents(events, r)
+
+    expect(slack).toHaveBeenCalledTimes(1)
+    expect(email).toHaveBeenCalledTimes(1)
+    expect(slack.mock.calls[0][0]).toMatchObject({ channel: 'slack', message: 'hi slack' })
+    expect(report.dispatched).toBe(2)
+    expect(report.failed).toBe(0)
+  })
+
+  it('skips non-notify events', async () => {
+    const send = vi.fn()
+    const r = createChannelRegistry()
+    r.register({ id: 'slack', dispatch: send })
+    const events: WorkflowEmitEvent[] = [
+      { type: 'node_entered', nodeId: 'a', at: 't' },
+      { type: 'node_exited', nodeId: 'a', at: 't', signal: 'approved' },
+      notify('slack'),
+    ]
+    const report = await dispatchWorkflowEvents(events, r)
+    expect(send).toHaveBeenCalledTimes(1)
+    expect(report.skipped).toBe(2)
+  })
+
+  it('records unknown-channel events as failed without throwing', async () => {
+    const r = createChannelRegistry()
+    const report = await dispatchWorkflowEvents([notify('missing')], r)
+    expect(report.failed).toBe(1)
+    expect(report.dispatched).toBe(0)
+    expect(report.outcomes[0]).toMatchObject({ ok: false, unknown: true })
+  })
+
+  it('captures adapter errors in the report instead of throwing', async () => {
+    const r = createChannelRegistry()
+    r.register({
+      id: 'slack',
+      dispatch: () => { throw new Error('slack down') },
+    })
+    const report = await dispatchWorkflowEvents([notify('slack')], r)
+    expect(report.failed).toBe(1)
+    const outcome = report.outcomes[0] as { ok: false; channel: string; nodeId: string; reason: string }
+    expect(outcome.ok).toBe(false)
+    expect(outcome.reason).toContain('slack down')
+  })
+
+  it('continues after a failed adapter', async () => {
+    const r = createChannelRegistry()
+    r.register({ id: 'a', dispatch: () => { throw new Error('x') } })
+    const b = vi.fn()
+    r.register({ id: 'b', dispatch: b })
+    const report = await dispatchWorkflowEvents([notify('a'), notify('b')], r)
+    expect(b).toHaveBeenCalledTimes(1)
+    expect(report.dispatched).toBe(1)
+    expect(report.failed).toBe(1)
+  })
+
+  it('awaits async adapter dispatches', async () => {
+    const order: string[] = []
+    const r = createChannelRegistry()
+    r.register({
+      id: 's',
+      dispatch: async () => {
+        await new Promise(res => setTimeout(res, 5))
+        order.push('s')
+      },
+    })
+    await dispatchWorkflowEvents([notify('s')], r)
+    order.push('after')
+    expect(order).toEqual(['s', 'after'])
+  })
+
+  it('forwards both template and message when both are present', async () => {
+    const send = vi.fn()
+    const r = createChannelRegistry()
+    r.register({ id: 'slack', dispatch: send })
+    await dispatchWorkflowEvents(
+      [notify('slack', { template: 'Hello {{ name }}', message: 'Hello Alice' })],
+      r,
+    )
+    expect(send.mock.calls[0][0]).toMatchObject({
+      template: 'Hello {{ name }}',
+      message: 'Hello Alice',
+    })
+  })
+})
+
+describe('createSlackChannel', () => {
+  it('shapes payload as { text } using the message', async () => {
+    const send = vi.fn()
+    const adapter = createSlackChannel({ send })
+    await adapter.dispatch({
+      nodeId: 'n1', channel: 'slack', at: 't',
+      message: 'Hello Alice', template: 'Hello {{ x }}',
+    })
+    expect(send).toHaveBeenCalledWith({ text: 'Hello Alice', nodeId: 'n1', at: 't' })
+  })
+
+  it('falls back to template when message is absent', async () => {
+    const send = vi.fn()
+    const adapter = createSlackChannel({ send })
+    await adapter.dispatch({ nodeId: 'n', channel: 'slack', at: 't', template: 'raw' })
+    expect(send.mock.calls[0][0].text).toBe('raw')
+  })
+
+  it('allows a custom id', () => {
+    const adapter = createSlackChannel({ id: 'slack-ops', send: vi.fn() })
+    expect(adapter.id).toBe('slack-ops')
+  })
+})
+
+describe('createEmailChannel', () => {
+  it('shapes payload as { subject, body } using the message as body', async () => {
+    const send = vi.fn()
+    const adapter = createEmailChannel({ send, subjectPrefix: '[Approvals]' })
+    await adapter.dispatch({
+      nodeId: 'n1', channel: 'email', at: 't', message: 'Event approved',
+    })
+    expect(send).toHaveBeenCalledWith({
+      subject: '[Approvals]',
+      body: 'Event approved',
+      nodeId: 'n1',
+      at: 't',
+    })
+  })
+})
+
+describe('createWebhookChannel', () => {
+  it('forwards the raw payload', async () => {
+    const send = vi.fn()
+    const adapter = createWebhookChannel({ send })
+    const payload = { nodeId: 'n', channel: 'webhook', at: 't', message: 'hi' }
+    await adapter.dispatch(payload)
+    expect(send).toHaveBeenCalledWith(payload)
+  })
+})

--- a/src/core/workflow/__tests__/templateInterpolate.test.ts
+++ b/src/core/workflow/__tests__/templateInterpolate.test.ts
@@ -1,0 +1,95 @@
+/**
+ * Template interpolation — unit specs (issue #223 Phase 4).
+ */
+import { describe, it, expect } from 'vitest'
+import { interpolateTemplate, tryInterpolateTemplate, TemplateError } from '../templateInterpolate'
+
+describe('interpolateTemplate — plain passthrough', () => {
+  it('returns strings with no tokens unchanged', () => {
+    expect(interpolateTemplate('hello world', {})).toBe('hello world')
+    expect(interpolateTemplate('', {})).toBe('')
+  })
+
+  it('does not interpret single braces', () => {
+    expect(interpolateTemplate('{ not a token }', {})).toBe('{ not a token }')
+  })
+})
+
+describe('interpolateTemplate — expression tokens', () => {
+  it('substitutes a dotted path', () => {
+    const out = interpolateTemplate('Hello {{ actor.name }}', { actor: { name: 'Alice' } })
+    expect(out).toBe('Hello Alice')
+  })
+
+  it('substitutes multiple tokens in one template', () => {
+    const out = interpolateTemplate(
+      '{{ actor.role }}: {{ event.title }} costs ${{ event.cost }}',
+      { actor: { role: 'manager' }, event: { title: 'Retreat', cost: 1200 } },
+    )
+    expect(out).toBe('manager: Retreat costs $1200')
+  })
+
+  it('tolerates whitespace inside braces', () => {
+    expect(interpolateTemplate('{{name}}', { name: 'x' })).toBe('x')
+    expect(interpolateTemplate('{{  name  }}', { name: 'x' })).toBe('x')
+  })
+
+  it('supports arithmetic and comparisons (same grammar as condition nodes)', () => {
+    expect(interpolateTemplate('Total: {{ qty * price }}', { qty: 3, price: 5 })).toBe('Total: 15')
+    expect(interpolateTemplate('Over cap? {{ cost > 500 }}', { cost: 1000 })).toBe('Over cap? true')
+  })
+
+  it('stringifies numbers, booleans, null consistently', () => {
+    expect(interpolateTemplate('{{ x }}', { x: 0 })).toBe('0')
+    expect(interpolateTemplate('{{ x }}', { x: false })).toBe('false')
+    expect(interpolateTemplate('{{ x }}', { x: null })).toBe('null')
+  })
+})
+
+describe('interpolateTemplate — escapes', () => {
+  it('renders \\{\\{ as literal {{', () => {
+    expect(interpolateTemplate('\\{\\{ not a token \\}\\}', {})).toBe('{{ not a token }}')
+  })
+
+  it('mixes literal and real tokens', () => {
+    const out = interpolateTemplate('\\{\\{raw\\}\\} vs {{ name }}', { name: 'Alice' })
+    expect(out).toBe('{{raw}} vs Alice')
+  })
+})
+
+describe('interpolateTemplate — errors', () => {
+  it('throws TemplateError on unterminated token', () => {
+    expect(() => interpolateTemplate('hi {{ name', { name: 'x' })).toThrow(TemplateError)
+  })
+
+  it('throws TemplateError on empty token', () => {
+    expect(() => interpolateTemplate('hi {{ }}', {})).toThrow(TemplateError)
+  })
+
+  it('wraps expression errors with token context', () => {
+    try {
+      interpolateTemplate('Cost: {{ event.cost }}', {})
+      throw new Error('should have thrown')
+    } catch (err) {
+      expect(err).toBeInstanceOf(TemplateError)
+      const te = err as TemplateError
+      expect(te.token).toContain('event.cost')
+      expect(te.position).toBe(6)
+      expect(te.cause?.name).toBe('ExpressionError')
+    }
+  })
+})
+
+describe('tryInterpolateTemplate', () => {
+  it('returns ok result when successful', () => {
+    const r = tryInterpolateTemplate('Hi {{ n }}', { n: 'x' }) as { ok: true; value: string }
+    expect(r.ok).toBe(true)
+    expect(r.value).toBe('Hi x')
+  })
+
+  it('returns error result instead of throwing', () => {
+    const r = tryInterpolateTemplate('broken {{', {}) as { ok: false; error: TemplateError }
+    expect(r.ok).toBe(false)
+    expect(r.error).toBeInstanceOf(TemplateError)
+  })
+})

--- a/src/core/workflow/__tests__/validate.test.ts
+++ b/src/core/workflow/__tests__/validate.test.ts
@@ -3,6 +3,7 @@ import {
   validateWorkflow,
   hasBlockingErrors,
   validateExpressionSyntax,
+  validateTemplateSyntax,
 } from '../validate'
 import {
   WORKFLOW_TEMPLATES,
@@ -299,6 +300,93 @@ describe('hasBlockingErrors', () => {
       { code: 'no-terminal-node' as const, severity: 'error' as const, message: 'y' },
     ]
     expect(hasBlockingErrors(issues)).toBe(true)
+  })
+})
+
+describe('validateWorkflow — notify channel + template rules (issue #223)', () => {
+  function withNotify(template: string | undefined, channel = 'slack'): Workflow {
+    return {
+      id: 'nf', version: 1, trigger: 'on_submit', startNodeId: 'n',
+      nodes: [
+        { id: 'n', type: 'notify', channel, ...(template !== undefined ? { template } : {}) },
+        { id: 'done', type: 'terminal', outcome: 'finalized' },
+      ],
+      edges: [{ from: 'n', to: 'done' }],
+    }
+  }
+
+  it('flags empty channel as error', () => {
+    const wf = withNotify(undefined, '')
+    const issues = validateWorkflow(wf)
+    expect(issues.some(i => i.code === 'empty-channel' && i.severity === 'error')).toBe(true)
+  })
+
+  it('warns when notify uses an unregistered channel (given knownChannels)', () => {
+    const wf = withNotify('hi', 'teams')
+    const issues = validateWorkflow(wf, { knownChannels: ['slack', 'email'] })
+    const issue = issues.find(i => i.code === 'unknown-channel')
+    expect(issue?.severity).toBe('warning')
+    expect(issue?.nodeId).toBe('n')
+  })
+
+  it('skips unknown-channel check when knownChannels is omitted', () => {
+    const wf = withNotify('hi', 'anything-goes')
+    const issues = validateWorkflow(wf)
+    expect(issues.some(i => i.code === 'unknown-channel')).toBe(false)
+  })
+
+  it('accepts a notify with a registered channel cleanly', () => {
+    const wf = withNotify('hi', 'slack')
+    const issues = validateWorkflow(wf, { knownChannels: ['slack'] })
+    expect(issues.some(i => i.code === 'unknown-channel')).toBe(false)
+    expect(issues.some(i => i.code === 'empty-channel')).toBe(false)
+  })
+
+  it('flags unterminated {{ }} tokens in templates', () => {
+    const wf = withNotify('hi {{ actor.name')
+    const issues = validateWorkflow(wf)
+    const issue = issues.find(i => i.code === 'template-syntax')
+    expect(issue?.severity).toBe('error')
+    expect(issue?.nodeId).toBe('n')
+  })
+
+  it('flags expression syntax errors inside template tokens', () => {
+    const wf = withNotify('{{ 1 + }}')
+    const issues = validateWorkflow(wf)
+    expect(issues.some(i => i.code === 'template-syntax' && i.severity === 'error')).toBe(true)
+  })
+
+  it('does not flag templates that reference unbound variables', () => {
+    // edit-time: vars aren't supplied; undefined-variable is expected.
+    const wf = withNotify('Hi {{ actor.name }}')
+    const issues = validateWorkflow(wf)
+    expect(issues.some(i => i.code === 'template-syntax')).toBe(false)
+  })
+
+  it('does not flag templates with no tokens', () => {
+    const wf = withNotify('plain text')
+    const issues = validateWorkflow(wf)
+    expect(issues.some(i => i.code === 'template-syntax')).toBe(false)
+  })
+})
+
+describe('validateTemplateSyntax', () => {
+  it('returns null for clean templates (even with unbound vars)', () => {
+    expect(validateTemplateSyntax('')).toBeNull()
+    expect(validateTemplateSyntax('Hi {{ actor.name }}')).toBeNull()
+    expect(validateTemplateSyntax('no tokens')).toBeNull()
+  })
+
+  it('reports unterminated tokens', () => {
+    expect(validateTemplateSyntax('hi {{ name')).not.toBeNull()
+  })
+
+  it('reports empty tokens', () => {
+    expect(validateTemplateSyntax('{{ }}')).not.toBeNull()
+  })
+
+  it('reports expression syntax errors inside tokens', () => {
+    expect(validateTemplateSyntax('{{ 1 + }}')).not.toBeNull()
   })
 })
 

--- a/src/core/workflow/advance.ts
+++ b/src/core/workflow/advance.ts
@@ -13,6 +13,7 @@
  * active between actions.
  */
 import { evaluateBool, ExpressionError } from './expression'
+import { interpolateTemplate, TemplateError } from './templateInterpolate'
 import {
   findNode,
   resolveNextEdge,
@@ -38,7 +39,16 @@ export type WorkflowAction =
 export type WorkflowEmitEvent =
   | { readonly type: 'node_entered'; readonly nodeId: string; readonly at: string }
   | { readonly type: 'node_exited';  readonly nodeId: string; readonly at: string; readonly signal: EdgeGuard }
-  | { readonly type: 'notify';       readonly nodeId: string; readonly channel: string; readonly template?: string; readonly at: string }
+  | {
+      readonly type: 'notify';
+      readonly nodeId: string;
+      readonly channel: string;
+      readonly at: string;
+      /** Authored template string (pre-interpolation). */
+      readonly template?: string;
+      /** Rendered message after `{{ }}` interpolation against `variables`. */
+      readonly message?: string;
+    }
   | { readonly type: 'workflow_completed'; readonly outcome: WorkflowOutcome; readonly at: string }
   | { readonly type: 'workflow_failed'; readonly nodeId: string; readonly reason: string; readonly at: string }
 
@@ -147,7 +157,9 @@ export function advance(input: AdvanceInput): AdvanceResult {
       }
     }
   } catch (err) {
-    const reason = err instanceof ExpressionError ? err.message : String(err)
+    const reason = err instanceof ExpressionError || err instanceof TemplateError
+      ? err.message
+      : String(err)
     const nodeId = state.currentNodeId ?? '<none>'
     state.status = 'failed'
     state.emit.push({ type: 'workflow_failed', nodeId, reason, at })
@@ -275,12 +287,16 @@ function autoAdvance(
     }
 
     if (node.type === 'notify') {
+      const message = node.template !== undefined
+        ? interpolateTemplate(node.template, vars)
+        : undefined
       state.emit.push({
         type: 'notify',
         nodeId: node.id,
         channel: node.channel,
-        ...(node.template !== undefined ? { template: node.template } : {}),
         at,
+        ...(node.template !== undefined ? { template: node.template } : {}),
+        ...(message !== undefined ? { message } : {}),
       })
       exitCurrent(state, 'default', at)
       if (!followEdge(workflow, state, 'default', at)) return

--- a/src/core/workflow/channels.ts
+++ b/src/core/workflow/channels.ts
@@ -1,0 +1,227 @@
+/**
+ * Workflow notification channels — issue #223, Phase 4.
+ *
+ * `advance()` is pure: `notify` nodes produce a `{ type: 'notify' }`
+ * emit event but never touch the network. The channel registry is the
+ * *impure* half — hosts register adapters (slack/email/webhook/…)
+ * against the registry, and `dispatchWorkflowEvents()` walks the
+ * engine's emit list and fans out to whichever adapter matches each
+ * event's `channel` field.
+ *
+ * Adapter factories (`createSlackChannel`, `createEmailChannel`,
+ * `createWebhookChannel`) are transport-agnostic shims: they wrap a
+ * caller-supplied `send(payload)` function and attach a shape the
+ * host's transport already understands. No HTTP client is baked in —
+ * pick your own (`fetch`, `axios`, an internal queue, a test spy).
+ *
+ * Typical wiring:
+ *
+ *     const registry = createChannelRegistry()
+ *     registry.register(createSlackChannel({ send: postToSlack }))
+ *     registry.register(createEmailChannel({ send: sendEmail }))
+ *
+ *     const result = advanceWorkflow({ workflow, instance, action })
+ *     if (result.ok) {
+ *       await persist(result.instance)
+ *       await dispatchWorkflowEvents(result.emit, registry)
+ *     }
+ */
+import type { WorkflowEmitEvent } from './advance'
+
+// ─── Public types ─────────────────────────────────────────────────────────
+
+/**
+ * Payload handed to a channel adapter for a single notify node emit.
+ * Mirrors the shape of a `{ type: 'notify' }` emit event, pruned to
+ * the fields adapters actually need.
+ */
+export interface ChannelDispatchPayload {
+  readonly nodeId: string
+  readonly channel: string
+  readonly at: string
+  /** Authored template (pre-interpolation), if the node carried one. */
+  readonly template?: string
+  /** Interpolated message — present when the template had no `{{ }}` tokens or when advance rendered them successfully. */
+  readonly message?: string
+}
+
+/**
+ * A channel adapter knows how to deliver one `ChannelDispatchPayload`.
+ * Implementations may be synchronous or return a Promise; the
+ * dispatcher awaits either form.
+ */
+export interface WorkflowChannelAdapter {
+  readonly id: string
+  dispatch(payload: ChannelDispatchPayload): void | Promise<void>
+}
+
+export interface WorkflowChannelRegistry {
+  register(adapter: WorkflowChannelAdapter): void
+  unregister(id: string): void
+  has(id: string): boolean
+  get(id: string): WorkflowChannelAdapter | undefined
+  ids(): readonly string[]
+}
+
+/**
+ * Per-event dispatch outcome. Failures don't throw — they're captured
+ * here so a partial fan-out (slack OK, email down) doesn't take the
+ * host process down with it.
+ */
+export type ChannelDispatchOutcome =
+  | { readonly ok: true;  readonly channel: string; readonly nodeId: string }
+  | { readonly ok: false; readonly channel: string; readonly nodeId: string; readonly reason: string; readonly unknown?: boolean }
+
+export interface WorkflowDispatchReport {
+  readonly outcomes: readonly ChannelDispatchOutcome[]
+  readonly dispatched: number
+  readonly skipped: number
+  readonly failed: number
+}
+
+// ─── Registry ─────────────────────────────────────────────────────────────
+
+export function createChannelRegistry(): WorkflowChannelRegistry {
+  const map = new Map<string, WorkflowChannelAdapter>()
+  return {
+    register(adapter) {
+      if (!adapter.id) throw new Error('channel adapter requires non-empty id')
+      map.set(adapter.id, adapter)
+    },
+    unregister(id) { map.delete(id) },
+    has(id)        { return map.has(id) },
+    get(id)        { return map.get(id) },
+    ids()          { return Array.from(map.keys()) },
+  }
+}
+
+// ─── Dispatcher ───────────────────────────────────────────────────────────
+
+/**
+ * Fan a workflow run's emit list out to registered channel adapters.
+ *
+ * Only `{ type: 'notify' }` events are dispatched; all others are
+ * ignored (they're bookkeeping for host persistence / audit). If no
+ * adapter is registered for an event's `channel`, the outcome is
+ * recorded as `{ ok: false, unknown: true }` rather than throwing —
+ * this way a misconfigured channel surfaces in the report without
+ * dropping the rest of the batch.
+ */
+export async function dispatchWorkflowEvents(
+  events: readonly WorkflowEmitEvent[],
+  registry: WorkflowChannelRegistry,
+): Promise<WorkflowDispatchReport> {
+  const outcomes: ChannelDispatchOutcome[] = []
+  let dispatched = 0
+  let skipped = 0
+  let failed = 0
+
+  for (const event of events) {
+    if (event.type !== 'notify') { skipped++; continue }
+    const adapter = registry.get(event.channel)
+    if (!adapter) {
+      outcomes.push({
+        ok: false,
+        channel: event.channel,
+        nodeId: event.nodeId,
+        reason: `No adapter registered for channel "${event.channel}"`,
+        unknown: true,
+      })
+      failed++
+      continue
+    }
+    const payload: ChannelDispatchPayload = {
+      nodeId: event.nodeId,
+      channel: event.channel,
+      at: event.at,
+      ...(event.template !== undefined ? { template: event.template } : {}),
+      ...(event.message  !== undefined ? { message:  event.message  } : {}),
+    }
+    try {
+      await adapter.dispatch(payload)
+      outcomes.push({ ok: true, channel: event.channel, nodeId: event.nodeId })
+      dispatched++
+    } catch (err) {
+      outcomes.push({
+        ok: false,
+        channel: event.channel,
+        nodeId: event.nodeId,
+        reason: err instanceof Error ? err.message : String(err),
+      })
+      failed++
+    }
+  }
+
+  return { outcomes, dispatched, skipped, failed }
+}
+
+// ─── Built-in adapter factories ───────────────────────────────────────────
+
+/**
+ * Slack adapter — shapes the payload as `{ text }` (Slack's simplest
+ * incoming-webhook contract) and delegates delivery to the host's
+ * `send` function.
+ *
+ * The `id` defaults to `'slack'` but can be overridden when the host
+ * runs multiple Slack workspaces / bots.
+ */
+export interface SlackChannelOptions {
+  readonly id?: string
+  readonly send: (payload: { readonly text: string; readonly nodeId: string; readonly at: string }) => void | Promise<void>
+}
+
+export function createSlackChannel(opts: SlackChannelOptions): WorkflowChannelAdapter {
+  const { id = 'slack', send } = opts
+  return {
+    id,
+    dispatch(p) {
+      const text = p.message ?? p.template ?? ''
+      return send({ text, nodeId: p.nodeId, at: p.at })
+    },
+  }
+}
+
+/**
+ * Email adapter — surfaces `{ subject, body }` to the host's mailer.
+ * `subject` defaults to a workflow-agnostic stub; hosts that want
+ * fancier subjects can post-process the `message` themselves or wrap
+ * this factory.
+ */
+export interface EmailChannelOptions {
+  readonly id?: string
+  readonly send: (payload: {
+    readonly subject: string
+    readonly body: string
+    readonly nodeId: string
+    readonly at: string
+  }) => void | Promise<void>
+  /** Static subject prefix — e.g. "[Approvals]". */
+  readonly subjectPrefix?: string
+}
+
+export function createEmailChannel(opts: EmailChannelOptions): WorkflowChannelAdapter {
+  const { id = 'email', send, subjectPrefix = 'Workflow notification' } = opts
+  return {
+    id,
+    dispatch(p) {
+      const body = p.message ?? p.template ?? ''
+      return send({ subject: subjectPrefix, body, nodeId: p.nodeId, at: p.at })
+    },
+  }
+}
+
+/**
+ * Webhook adapter — forwards the raw `ChannelDispatchPayload` to the
+ * host's send function. Useful for generic HTTP fan-out where the
+ * receiver wants the full notify envelope (nodeId, timestamps, both
+ * the template and the rendered message).
+ */
+export interface WebhookChannelOptions {
+  readonly id?: string
+  readonly send: (payload: ChannelDispatchPayload) => void | Promise<void>
+}
+
+export function createWebhookChannel(opts: WebhookChannelOptions): WorkflowChannelAdapter {
+  const { id = 'webhook', send } = opts
+  return { id, dispatch: send }
+}

--- a/src/core/workflow/templateInterpolate.ts
+++ b/src/core/workflow/templateInterpolate.ts
@@ -1,0 +1,129 @@
+/**
+ * Notify-template interpolation — issue #223, Phase 4.
+ *
+ * Notify nodes carry an optional `template` string that the host
+ * renders into a user-facing message. Templates embed workflow
+ * variables with `{{ expr }}` tokens that delegate to the workflow
+ * expression evaluator (see `expression.ts`) — so they support the
+ * same dotted-path reads, literals, and arithmetic that condition
+ * nodes use, with zero new grammar.
+ *
+ * Grammar:
+ *   "Hello {{ actor.name }}, cost is {{ event.cost }}"
+ *   "Literal braces: \{\{ not a token \}\}"
+ *
+ * Escape: a backslash before `{{` or `}}` produces literal double
+ * braces and is NOT evaluated. The backslash itself is consumed.
+ *
+ * Values are stringified via `String(value)`; `null` renders as the
+ * string `"null"` so templates don't silently drop missing values.
+ * Expression errors (undefined paths, syntax) surface as
+ * `TemplateError` with the offending `{{…}}` and its position so the
+ * validator + UI can highlight the problem.
+ */
+import { evaluate, ExpressionError } from './expression'
+
+export class TemplateError extends Error {
+  readonly position: number
+  readonly token: string
+  readonly cause?: Error
+  constructor(message: string, position: number, token: string, cause?: Error) {
+    super(message)
+    this.name = 'TemplateError'
+    this.position = position
+    this.token = token
+    if (cause) this.cause = cause
+  }
+}
+
+/**
+ * Interpolate `{{ expr }}` tokens in `template` against `variables`.
+ * Throws `TemplateError` if any embedded expression fails to parse
+ * or resolve. A template with no `{{` returns unchanged.
+ */
+export function interpolateTemplate(
+  template: string,
+  variables: Readonly<Record<string, unknown>>,
+): string {
+  if (template.indexOf('{{') < 0 && template.indexOf('\\{\\{') < 0) return template
+
+  let out = ''
+  let i = 0
+  while (i < template.length) {
+    const ch = template[i]
+
+    // Escape sequences: \{\{ → literal "{{", \}\} → literal "}}".
+    if (ch === '\\' && template.startsWith('\\{\\{', i)) {
+      out += '{{'
+      i += 4
+      continue
+    }
+    if (ch === '\\' && template.startsWith('\\}\\}', i)) {
+      out += '}}'
+      i += 4
+      continue
+    }
+
+    if (template.startsWith('{{', i)) {
+      const end = template.indexOf('}}', i + 2)
+      if (end < 0) {
+        throw new TemplateError(
+          `Unterminated template token at ${i}`,
+          i,
+          template.slice(i),
+        )
+      }
+      const raw = template.slice(i + 2, end)
+      const expr = raw.trim()
+      if (expr.length === 0) {
+        throw new TemplateError(
+          `Empty template token at ${i}`,
+          i,
+          template.slice(i, end + 2),
+        )
+      }
+      try {
+        const value = evaluate(expr, variables)
+        out += value === null ? 'null' : String(value)
+      } catch (err) {
+        const token = template.slice(i, end + 2)
+        if (err instanceof ExpressionError) {
+          throw new TemplateError(
+            `Expression error in "${token}" at ${i}: ${err.message}`,
+            i,
+            token,
+            err,
+          )
+        }
+        throw new TemplateError(
+          `Template evaluation failed for "${token}" at ${i}: ${String(err)}`,
+          i,
+          token,
+        )
+      }
+      i = end + 2
+      continue
+    }
+
+    out += ch
+    i++
+  }
+  return out
+}
+
+/**
+ * Non-throwing variant: returns either the rendered string or the
+ * first `TemplateError`. Convenient for validator code paths that
+ * want to collect issues rather than abort.
+ */
+export function tryInterpolateTemplate(
+  template: string,
+  variables: Readonly<Record<string, unknown>>,
+): { ok: true; value: string } | { ok: false; error: TemplateError } {
+  try {
+    return { ok: true, value: interpolateTemplate(template, variables) }
+  } catch (err) {
+    if (err instanceof TemplateError) return { ok: false, error: err }
+    throw err
+  }
+}

--- a/src/core/workflow/validate.ts
+++ b/src/core/workflow/validate.ts
@@ -10,6 +10,7 @@
  * semantic contract cannot drift.
  */
 import { evaluate, ExpressionError } from './expression'
+import { interpolateTemplate, TemplateError } from './templateInterpolate'
 import {
   findNode,
   resolveNextEdge,
@@ -35,6 +36,9 @@ export type ValidationCode =
   | 'terminal-has-outgoing'
   | 'timeout-edge-missing'
   | 'sla-without-on-timeout'
+  | 'template-syntax'
+  | 'unknown-channel'
+  | 'empty-channel'
 
 export interface ValidationIssue {
   readonly code: ValidationCode
@@ -44,10 +48,23 @@ export interface ValidationIssue {
   readonly edgeIndex?: number
 }
 
+export interface ValidateWorkflowOptions {
+  /**
+   * Channel ids the host has registered adapters for. When provided,
+   * `unknown-channel` warnings flag notify nodes whose `channel` isn't
+   * in this list. Omit (or pass empty) to skip the check.
+   */
+  readonly knownChannels?: readonly string[]
+}
+
 export function validateWorkflow(
   workflow: Workflow,
+  options: ValidateWorkflowOptions = {},
 ): readonly ValidationIssue[] {
   const issues: ValidationIssue[] = []
+  const knownChannels = options.knownChannels
+    ? new Set(options.knownChannels)
+    : null
 
   // 1. unique node ids
   const seen = new Set<string>()
@@ -245,6 +262,39 @@ export function validateWorkflow(
     }
   }
 
+  // 14. notify templates + channels (issue #223)
+  for (const node of workflow.nodes) {
+    if (node.type !== 'notify') continue
+
+    if (!node.channel || node.channel.trim().length === 0) {
+      issues.push({
+        code: 'empty-channel',
+        severity: 'error',
+        message: `Notify "${node.id}" has no channel`,
+        nodeId: node.id,
+      })
+    } else if (knownChannels && !knownChannels.has(node.channel)) {
+      issues.push({
+        code: 'unknown-channel',
+        severity: 'warning',
+        message: `Notify "${node.id}" uses channel "${node.channel}" which has no registered adapter`,
+        nodeId: node.id,
+      })
+    }
+
+    if (node.template !== undefined) {
+      const syntaxError = validateTemplateSyntax(node.template)
+      if (syntaxError) {
+        issues.push({
+          code: 'template-syntax',
+          severity: 'error',
+          message: `Notify "${node.id}": ${syntaxError}`,
+          nodeId: node.id,
+        })
+      }
+    }
+  }
+
   return issues
 }
 
@@ -332,6 +382,35 @@ function capitalize(s: string): string {
  * a pure parse API we should switch to that here and reclassify this
  * as a true syntax check.
  */
+/**
+ * Best-effort syntax check for notify templates.
+ *
+ * Calls `interpolateTemplate(template, {})`, which runs the real
+ * token + expression pipeline. Since no variables are bound at edit
+ * time, `undefined-variable` / `non-object` expression errors are
+ * suppressed (they're expected). Everything else — unterminated
+ * `{{ }}`, empty tokens, expression syntax errors inside a token —
+ * surfaces as a human-readable string so the builder can render a
+ * badge next to the offending node.
+ */
+export function validateTemplateSyntax(template: string): string | null {
+  try {
+    interpolateTemplate(template, {})
+    return null
+  } catch (err) {
+    if (err instanceof TemplateError) {
+      const cause = err.cause
+      if (cause instanceof ExpressionError) {
+        if (cause.kind === 'undefined-variable') return null
+        if (cause.kind === 'non-object') return null
+        if (cause.kind === 'unsupported-value') return null
+      }
+      return err.message
+    }
+    return String(err)
+  }
+}
+
 export function validateExpressionSyntax(expr: string): string | null {
   if (!expr.trim()) return 'Expression is empty'
   try {

--- a/src/index.ts
+++ b/src/index.ts
@@ -52,6 +52,20 @@ export type {
 export { useWorkflowTicker } from './hooks/useWorkflowTicker';
 export type { UseWorkflowTickerOptions } from './hooks/useWorkflowTicker';
 export { evaluate as evaluateExpression, evaluateBool as evaluateExpressionBool, ExpressionError } from './core/workflow/expression';
+export { interpolateTemplate, tryInterpolateTemplate, TemplateError } from './core/workflow/templateInterpolate';
+export {
+  createChannelRegistry, dispatchWorkflowEvents,
+  createSlackChannel, createEmailChannel, createWebhookChannel,
+} from './core/workflow/channels';
+export type {
+  WorkflowChannelAdapter, WorkflowChannelRegistry,
+  ChannelDispatchPayload, ChannelDispatchOutcome, WorkflowDispatchReport,
+  SlackChannelOptions, EmailChannelOptions, WebhookChannelOptions,
+} from './core/workflow/channels';
+export { validateWorkflow, validateExpressionSyntax, validateTemplateSyntax, hasBlockingErrors } from './core/workflow/validate';
+export type {
+  ValidationCode, ValidationIssue, ValidationSeverity, ValidateWorkflowOptions,
+} from './core/workflow/validate';
 export type {
   Workflow, WorkflowNode, WorkflowEdge, WorkflowInstance, WorkflowInstanceStatus,
   WorkflowHistoryEntry, WorkflowOutcome, WorkflowTrigger, EdgeGuard,


### PR DESCRIPTION
Sprint 2a of the #219 closeout. Splits the parallel/channels epic so review stays tractable — the channel/notify work lands independently of Sprint 2b (parallel + join nodes).

- templateInterpolate.ts: `{{ expr }}` tokens delegate to the existing workflow expression evaluator, with `\{\{ … \}\}` as literal escape. Template errors surface with token context for the validator + UI.
- channels.ts: `createChannelRegistry()` + `dispatchWorkflowEvents()` fan notify emits out to registered adapters. Built-in factories for slack / email / webhook wrap a caller-supplied `send` so we don't lock in a transport. Adapter errors + unknown channels are captured in a report rather than thrown, so partial fan-out survives outages.
- advance.ts: notify nodes now carry a rendered `message` alongside the raw `template` when variables are supplied; template errors route through the existing catch block and fail the workflow loudly (consistent with condition-node expression errors).
- validate.ts: three new codes — `empty-channel` (error), `unknown-channel` (warning, opt-in via `knownChannels`), and `template-syntax` (error). Edit-time undefined-variable errors are suppressed, matching `validateExpressionSyntax` behavior.

Tests: 30 new unit specs across templateInterpolate / channels, plus notify-interpolation + validator coverage in the existing suites.

Public API: `interpolateTemplate`, `TemplateError`, the channels module, and the validator helpers are now re-exported from `src/index.ts`.