### PR TITLE
fix(workflow): honor empty knownChannels + render standalone \}\} esc…

### DIFF
--- a/src/core/workflow/__tests__/templateInterpolate.test.ts
+++ b/src/core/workflow/__tests__/templateInterpolate.test.ts
@@ -55,6 +55,12 @@ describe('interpolateTemplate — escapes', () => {
     const out = interpolateTemplate('\\{\\{raw\\}\\} vs {{ name }}', { name: 'Alice' })
     expect(out).toBe('{{raw}} vs Alice')
   })
+
+  it('renders standalone \\}\\} escapes even without any {{ token', () => {
+    // Regression: fast-path previously returned unchanged when the only
+    // escapes were closing braces, leaving the backslashes in output.
+    expect(interpolateTemplate('x \\}\\} y', {})).toBe('x }} y')
+  })
 })
 
 describe('interpolateTemplate — errors', () => {

--- a/src/core/workflow/__tests__/validate.test.ts
+++ b/src/core/workflow/__tests__/validate.test.ts
@@ -335,6 +335,14 @@ describe('validateWorkflow — notify channel + template rules (issue #223)', ()
     expect(issues.some(i => i.code === 'unknown-channel')).toBe(false)
   })
 
+  it('skips unknown-channel check when knownChannels is an empty array', () => {
+    // Regression: callers passing a not-yet-populated registry should
+    // not see every notify node flagged as unknown.
+    const wf = withNotify('hi', 'anything-goes')
+    const issues = validateWorkflow(wf, { knownChannels: [] })
+    expect(issues.some(i => i.code === 'unknown-channel')).toBe(false)
+  })
+
   it('accepts a notify with a registered channel cleanly', () => {
     const wf = withNotify('hi', 'slack')
     const issues = validateWorkflow(wf, { knownChannels: ['slack'] })

--- a/src/core/workflow/templateInterpolate.ts
+++ b/src/core/workflow/templateInterpolate.ts
@@ -45,8 +45,6 @@ export function interpolateTemplate(
   template: string,
   variables: Readonly<Record<string, unknown>>,
 ): string {
-  if (template.indexOf('{{') < 0 && template.indexOf('\\{\\{') < 0) return template
-
   let out = ''
   let i = 0
   while (i < template.length) {

--- a/src/core/workflow/validate.ts
+++ b/src/core/workflow/validate.ts
@@ -62,7 +62,7 @@ export function validateWorkflow(
   options: ValidateWorkflowOptions = {},
 ): readonly ValidationIssue[] {
   const issues: ValidationIssue[] = []
-  const knownChannels = options.knownChannels
+  const knownChannels = options.knownChannels && options.knownChannels.length > 0
     ? new Set(options.knownChannels)
     : null
 


### PR DESCRIPTION
…apes

Two review fixes on #223 Sprint 2a:

- validateWorkflow: treat knownChannels=[] as "skip check" to match the documented semantics. Previously any truthy array enabled validation, so a not-yet-populated registry flagged every notify node.
- interpolateTemplate: drop the fast-path that short-circuited when neither `{{` nor `\{\{` appeared. A template like "x \}\} y" only contains closing-brace escapes, so the guard left the backslashes in the output. The char-by-char loop is cheap enough to run unconditionally — no shortcut needed.