### PR TITLE
fix(workflow): honor empty knownChannels + render standalone \}\} escapes

### DIFF
--- a/src/core/workflow/__tests__/advance.parallel.test.ts
+++ b/src/core/workflow/__tests__/advance.parallel.test.ts
@@ -1,0 +1,298 @@
+/**
+ * Parallel + join interpreter specs — issue #223 Phase 4.
+ *
+ * Covers the concurrent-awaiting contract: a `parallel` node fans out
+ * into independent branches, each of which may pause at its own
+ * approval; actor actions disambiguate via `targetNodeId`; the paired
+ * `join` only releases once the quorum mode is satisfied — or fails
+ * early when the remaining branches can no longer reach it.
+ */
+import { describe, it, expect } from 'vitest'
+import { advance } from '../advance'
+import type { Workflow, WorkflowInstance } from '../workflowSchema'
+
+const AT = '2026-04-21T09:00:00.000Z'
+
+function makeParallel(
+  mode: 'requireAll' | 'requireAny' | 'requireN',
+  n?: number,
+): Workflow {
+  return {
+    id: 'par',
+    version: 1,
+    trigger: 'on_submit',
+    startNodeId: 'fan',
+    nodes: [
+      {
+        id: 'fan',
+        type: 'parallel',
+        branches: ['a', 'b', 'c'],
+        mode,
+        ...(n !== undefined ? { n } : {}),
+      },
+      { id: 'a', type: 'approval', assignTo: 'role:a' },
+      { id: 'b', type: 'approval', assignTo: 'role:b' },
+      { id: 'c', type: 'approval', assignTo: 'role:c' },
+      { id: 'join', type: 'join', pairedWith: 'fan' },
+      { id: 'done',   type: 'terminal', outcome: 'finalized' },
+      { id: 'denied', type: 'terminal', outcome: 'denied' },
+      { id: 'a-denied', type: 'terminal', outcome: 'denied' }, // never reached — denied routes via branch-completed
+    ],
+    edges: [
+      { from: 'a', to: 'join', when: 'branch-completed' },
+      { from: 'b', to: 'join', when: 'branch-completed' },
+      { from: 'c', to: 'join', when: 'branch-completed' },
+      { from: 'join', to: 'done' },
+      // Dangling edges so `a-denied` is reachable from some path —
+      // the interpreter tests below all route through branch-completed.
+      { from: 'join', to: 'denied', when: 'denied' },
+    ],
+  }
+}
+
+describe('advance — parallel fan-out', () => {
+  it('starts and pauses with every branch awaiting its approval', () => {
+    const wf = makeParallel('requireAll')
+    const r = advance({ workflow: wf, instance: null, action: { type: 'start' }, at: AT })
+    expect(r.ok).toBe(true)
+    if (!r.ok) return
+    expect(r.instance.status).toBe('awaiting')
+    expect(r.instance.currentNodeId).toBeNull()
+    expect(r.instance.parallelFrames).toHaveLength(1)
+    const frame = r.instance.parallelFrames![0]
+    expect(frame.branches.map(b => b.activeNodeId)).toEqual(['a', 'b', 'c'])
+    expect(frame.branches.every(b => b.completedSignal === undefined)).toBe(true)
+    // One node_entered per branch approval, plus one for the parallel itself.
+    expect(r.emit.filter(e => e.type === 'node_entered').map(e => 'nodeId' in e && e.nodeId))
+      .toEqual(['fan', 'a', 'b', 'c'])
+  })
+
+  it('rejects an approve without targetNodeId when multiple branches are pending', () => {
+    const wf = makeParallel('requireAll')
+    const s1 = advance({ workflow: wf, instance: null, action: { type: 'start' }, at: AT })
+    if (!s1.ok) throw new Error('precondition')
+    const r = advance({
+      workflow: wf,
+      instance: s1.instance,
+      action: { type: 'approve', actor: 'alice' },
+      at: AT,
+    }) as { ok: false; error: string; instance: WorkflowInstance; emit: readonly unknown[] }
+    expect(r.ok).toBe(false)
+    expect(r.error).toMatch(/branches awaiting/i)
+  })
+})
+
+describe('advance — parallel requireAll', () => {
+  it('waits for every branch, then releases the join to terminal', () => {
+    const wf = makeParallel('requireAll')
+    let inst = startParallel(wf)
+    inst = expectStillAwaiting(approveBranch(wf, inst, 'a'))
+    inst = expectStillAwaiting(approveBranch(wf, inst, 'b'))
+    const final = advance({
+      workflow: wf,
+      instance: inst,
+      action: { type: 'approve', targetNodeId: 'c', actor: 'carol' },
+      at: AT,
+    })
+    expect(final.ok).toBe(true)
+    if (!final.ok) return
+    expect(final.instance.status).toBe('completed')
+    expect(final.instance.outcome).toBe('finalized')
+    expect(final.instance.parallelFrames ?? []).toHaveLength(0)
+  })
+
+  it('fails the workflow when any branch is denied', () => {
+    const wf = makeParallel('requireAll')
+    let inst = startParallel(wf)
+    inst = expectStillAwaiting(approveBranch(wf, inst, 'a'))
+    const r = advance({
+      workflow: wf,
+      instance: inst,
+      action: { type: 'deny', targetNodeId: 'b', actor: 'bob', reason: 'nope' },
+      at: AT,
+    })
+    expect(r.ok).toBe(true)
+    if (!r.ok) return
+    expect(r.instance.status).toBe('failed')
+    expect(r.emit.find(e => e.type === 'workflow_failed')).toBeDefined()
+  })
+})
+
+describe('advance — parallel requireAny', () => {
+  it('short-circuits on the first approval', () => {
+    const wf = makeParallel('requireAny')
+    const inst = startParallel(wf)
+    const r = advance({
+      workflow: wf,
+      instance: inst,
+      action: { type: 'approve', targetNodeId: 'b', actor: 'bob' },
+      at: AT,
+    })
+    expect(r.ok).toBe(true)
+    if (!r.ok) return
+    expect(r.instance.status).toBe('completed')
+    expect(r.instance.outcome).toBe('finalized')
+  })
+
+  it('fails only when every branch has been denied', () => {
+    const wf = makeParallel('requireAny')
+    let inst = startParallel(wf)
+    inst = expectStillAwaiting(denyBranch(wf, inst, 'a'))
+    inst = expectStillAwaiting(denyBranch(wf, inst, 'b'))
+    const r = advance({
+      workflow: wf,
+      instance: inst,
+      action: { type: 'deny', targetNodeId: 'c', reason: 'final' },
+      at: AT,
+    })
+    expect(r.ok).toBe(true)
+    if (!r.ok) return
+    expect(r.instance.status).toBe('failed')
+  })
+})
+
+describe('advance — parallel requireN', () => {
+  it('releases the join once N approvals land, regardless of order', () => {
+    const wf = makeParallel('requireN', 2)
+    let inst = startParallel(wf)
+    inst = expectStillAwaiting(approveBranch(wf, inst, 'c'))
+    const r = advance({
+      workflow: wf,
+      instance: inst,
+      action: { type: 'approve', targetNodeId: 'a', actor: 'alice' },
+      at: AT,
+    })
+    expect(r.ok).toBe(true)
+    if (!r.ok) return
+    expect(r.instance.status).toBe('completed')
+    expect(r.instance.outcome).toBe('finalized')
+  })
+
+  it('fails early once the remaining branches cannot reach N', () => {
+    const wf = makeParallel('requireN', 2)
+    let inst = startParallel(wf)
+    inst = expectStillAwaiting(denyBranch(wf, inst, 'a'))
+    // After one denial, 2 branches remain but we still need 2 positives —
+    // the next denial leaves only 1 branch which can't satisfy N=2.
+    const r = advance({
+      workflow: wf,
+      instance: inst,
+      action: { type: 'deny', targetNodeId: 'b', reason: 'too' },
+      at: AT,
+    })
+    expect(r.ok).toBe(true)
+    if (!r.ok) return
+    expect(r.instance.status).toBe('failed')
+  })
+})
+
+describe('advance — parallel timeout + cancel', () => {
+  it('auto-approve timeout counts a branch positive for quorum', () => {
+    const wf: Workflow = {
+      ...makeParallel('requireAll'),
+      nodes: makeParallel('requireAll').nodes.map(n =>
+        n.id === 'a' && n.type === 'approval'
+          ? { ...n, slaMinutes: 60, onTimeout: 'auto-approve' as const }
+          : n,
+      ),
+    }
+    let inst = startParallel(wf)
+    inst = expectStillAwaiting(advanceOk(wf, inst, { type: 'timeout', targetNodeId: 'a' }))
+    inst = expectStillAwaiting(approveBranch(wf, inst, 'b'))
+    const final = advanceOk(wf, inst, { type: 'approve', targetNodeId: 'c' })
+    expect(final.status).toBe('completed')
+    expect(final.outcome).toBe('finalized')
+  })
+
+  it('cancel closes all pending branches and completes as cancelled', () => {
+    const wf = makeParallel('requireAll')
+    const inst = startParallel(wf)
+    const r = advance({
+      workflow: wf,
+      instance: inst,
+      action: { type: 'cancel', actor: 'owner', reason: 'duplicate' },
+      at: AT,
+    })
+    expect(r.ok).toBe(true)
+    if (!r.ok) return
+    expect(r.instance.status).toBe('completed')
+    expect(r.instance.outcome).toBe('cancelled')
+    expect(r.instance.parallelFrames ?? []).toHaveLength(0)
+    // None of the approval history entries should be left open.
+    expect(r.instance.history.every(h => h.exitedAt !== undefined)).toBe(true)
+  })
+})
+
+describe('advance — parallel with notify inside a branch', () => {
+  it('walks branch notify + condition nodes before pausing', () => {
+    const wf: Workflow = {
+      id: 'par-notify',
+      version: 1,
+      trigger: 'on_submit',
+      startNodeId: 'fan',
+      nodes: [
+        { id: 'fan', type: 'parallel', branches: ['a-notify', 'b-approval'], mode: 'requireAll' },
+        { id: 'a-notify', type: 'notify', channel: 'slack', template: 'branch a' },
+        { id: 'b-approval', type: 'approval', assignTo: 'role:b' },
+        { id: 'join', type: 'join', pairedWith: 'fan' },
+        { id: 'done', type: 'terminal', outcome: 'finalized' },
+      ],
+      edges: [
+        { from: 'a-notify',   to: 'join', when: 'default' },
+        { from: 'b-approval', to: 'join', when: 'branch-completed' },
+        { from: 'join', to: 'done' },
+      ],
+    }
+    const s1 = advance({ workflow: wf, instance: null, action: { type: 'start' }, at: AT })
+    expect(s1.ok).toBe(true)
+    if (!s1.ok) return
+    expect(s1.instance.status).toBe('awaiting')
+    expect(s1.emit.some(e => e.type === 'notify')).toBe(true)
+    // Branch a completed immediately (notify-only), branch b still pending.
+    const frame = s1.instance.parallelFrames![0]
+    expect(frame.branches[0].completedSignal).toBe('default')
+    expect(frame.branches[1].activeNodeId).toBe('b-approval')
+
+    const final = advanceOk(wf, s1.instance, { type: 'approve', targetNodeId: 'b-approval' })
+    expect(final.status).toBe('completed')
+  })
+})
+
+// ─── Helpers ──────────────────────────────────────────────────────────────
+
+function startParallel(wf: Workflow): WorkflowInstance {
+  const r = advance({ workflow: wf, instance: null, action: { type: 'start' }, at: AT })
+  if (!r.ok) throw new Error('start failed')
+  return r.instance
+}
+
+function approveBranch(
+  wf: Workflow,
+  inst: WorkflowInstance,
+  targetNodeId: string,
+): WorkflowInstance {
+  return advanceOk(wf, inst, { type: 'approve', targetNodeId })
+}
+
+function denyBranch(
+  wf: Workflow,
+  inst: WorkflowInstance,
+  targetNodeId: string,
+): WorkflowInstance {
+  return advanceOk(wf, inst, { type: 'deny', targetNodeId, reason: 'nope' })
+}
+
+function advanceOk(
+  wf: Workflow,
+  inst: WorkflowInstance,
+  action: Parameters<typeof advance>[0]['action'],
+): WorkflowInstance {
+  const r = advance({ workflow: wf, instance: inst, action, at: AT })
+  if (!r.ok) throw new Error(`advance failed: ${(r as { error: string }).error}`)
+  return r.instance
+}
+
+function expectStillAwaiting(inst: WorkflowInstance): WorkflowInstance {
+  expect(inst.status).toBe('awaiting')
+  return inst
+}

--- a/src/core/workflow/__tests__/templateInterpolate.test.ts
+++ b/src/core/workflow/__tests__/templateInterpolate.test.ts
@@ -55,6 +55,12 @@ describe('interpolateTemplate — escapes', () => {
     const out = interpolateTemplate('\\{\\{raw\\}\\} vs {{ name }}', { name: 'Alice' })
     expect(out).toBe('{{raw}} vs Alice')
   })
+
+  it('renders standalone \\}\\} escapes even without any {{ token', () => {
+    // Regression: fast-path previously returned unchanged when the only
+    // escapes were closing braces, leaving the backslashes in output.
+    expect(interpolateTemplate('x \\}\\} y', {})).toBe('x }} y')
+  })
 })
 
 describe('interpolateTemplate — errors', () => {

--- a/src/core/workflow/__tests__/templates.test.ts
+++ b/src/core/workflow/__tests__/templates.test.ts
@@ -11,6 +11,7 @@ import {
   twoTierApproverWorkflow,
   conditionalByCostWorkflow,
   slaEscalationWorkflow,
+  parallelSecurityAndFinanceApproval,
   WORKFLOW_TEMPLATES,
 } from '../templates'
 
@@ -182,6 +183,51 @@ describe('slaEscalationWorkflow', () => {
   })
 })
 
+describe('parallelSecurityAndFinanceApproval', () => {
+  it('fans out to two approvals and finalizes when both approve', () => {
+    const s = advance({ workflow: parallelSecurityAndFinanceApproval, instance: null, action: { type: 'start' }, at: AT })
+    expect(s.ok).toBe(true)
+    if (!s.ok) return
+    expect(s.instance.status).toBe('awaiting')
+    expect(s.instance.parallelFrames?.[0].branches.map(b => b.activeNodeId))
+      .toEqual(['security-approval', 'finance-approval'])
+
+    const s2 = advance({
+      workflow: parallelSecurityAndFinanceApproval,
+      instance: s.instance,
+      action: { type: 'approve', targetNodeId: 'security-approval', actor: 'sec' },
+      at: AT,
+    })
+    if (!s2.ok) throw new Error('security approve')
+    expect(s2.instance.status).toBe('awaiting')
+
+    const final = advance({
+      workflow: parallelSecurityAndFinanceApproval,
+      instance: s2.instance,
+      action: { type: 'approve', targetNodeId: 'finance-approval', actor: 'fin' },
+      at: AT,
+    })
+    expect(final.ok).toBe(true)
+    if (!final.ok) return
+    expect(final.instance.outcome).toBe('finalized')
+    expect(final.emit.map(e => e.type)).toContain('notify')
+  })
+
+  it('fails when a branch denies (requireAll)', () => {
+    const s = advance({ workflow: parallelSecurityAndFinanceApproval, instance: null, action: { type: 'start' }, at: AT })
+    if (!s.ok) throw new Error('start')
+    const r = advance({
+      workflow: parallelSecurityAndFinanceApproval,
+      instance: s.instance,
+      action: { type: 'deny', targetNodeId: 'security-approval', reason: 'policy' },
+      at: AT,
+    })
+    expect(r.ok).toBe(true)
+    if (!r.ok) return
+    expect(r.instance.status).toBe('failed')
+  })
+})
+
 describe('WORKFLOW_TEMPLATES registry', () => {
   it('includes all shipped templates in the expected order', () => {
     expect(WORKFLOW_TEMPLATES).toEqual([
@@ -189,6 +235,7 @@ describe('WORKFLOW_TEMPLATES registry', () => {
       twoTierApproverWorkflow,
       conditionalByCostWorkflow,
       slaEscalationWorkflow,
+      parallelSecurityAndFinanceApproval,
     ])
   })
 

--- a/src/core/workflow/__tests__/validate.test.ts
+++ b/src/core/workflow/__tests__/validate.test.ts
@@ -335,6 +335,14 @@ describe('validateWorkflow — notify channel + template rules (issue #223)', ()
     expect(issues.some(i => i.code === 'unknown-channel')).toBe(false)
   })
 
+  it('skips unknown-channel check when knownChannels is an empty array', () => {
+    // Regression: callers passing a not-yet-populated registry should
+    // not see every notify node flagged as unknown.
+    const wf = withNotify('hi', 'anything-goes')
+    const issues = validateWorkflow(wf, { knownChannels: [] })
+    expect(issues.some(i => i.code === 'unknown-channel')).toBe(false)
+  })
+
   it('accepts a notify with a registered channel cleanly', () => {
     const wf = withNotify('hi', 'slack')
     const issues = validateWorkflow(wf, { knownChannels: ['slack'] })

--- a/src/core/workflow/__tests__/validate.test.ts
+++ b/src/core/workflow/__tests__/validate.test.ts
@@ -520,6 +520,67 @@ describe('validateWorkflow — parallel / join (issue #223)', () => {
     const issues = validateWorkflow(parallelWf())
     expect(issues.some(i => i.code === 'dead-end-node' && i.nodeId === 'fan')).toBe(false)
   })
+
+  // Regression: reachability should treat foreign parallel/join nodes
+  // as dead ends, matching walkBranchForward's runtime behavior —
+  // otherwise a branch can appear to rejoin at validation time yet
+  // deterministically fail at runtime once it enters the nested
+  // parallel path.
+  it('treats a foreign parallel node inside a branch as a dead-end for rejoin', () => {
+    // Branch "a"'s only forward path goes through `inner-fan`, a
+    // foreign parallel. Runtime would fail on entry to inner-fan, so
+    // validation must agree that this branch never reaches the paired
+    // join — even though `inner-fan → join` looks reachable on paper.
+    const wf: Workflow = {
+      id: 'nested', version: 1, trigger: 'on_submit', startNodeId: 'fan',
+      nodes: [
+        { id: 'fan', type: 'parallel', branches: ['a', 'b'], mode: 'requireAll' },
+        // Branch "a": notify whose only outgoing edge enters the foreign parallel.
+        { id: 'a', type: 'notify', channel: 'slack' },
+        { id: 'inner-fan', type: 'parallel', branches: ['x'], mode: 'requireAll' },
+        { id: 'x', type: 'approval', assignTo: 'role:x' },
+        { id: 'inner-join', type: 'join', pairedWith: 'inner-fan' },
+        // Branch "b": clean rejoin so we know the rejoin error is about "a".
+        { id: 'b', type: 'approval', assignTo: 'role:b' },
+        { id: 'join', type: 'join', pairedWith: 'fan' },
+        { id: 'done', type: 'terminal', outcome: 'finalized' },
+      ],
+      edges: [
+        { from: 'a', to: 'inner-fan' },
+        { from: 'inner-fan', to: 'join' },
+        { from: 'x', to: 'inner-join', when: 'branch-completed' },
+        { from: 'inner-join', to: 'join' },
+        { from: 'b', to: 'join', when: 'branch-completed' },
+        { from: 'join', to: 'done' },
+      ],
+    } as Workflow
+    const issues = validateWorkflow(wf)
+    expect(issues.some(
+      i => i.code === 'parallel-branches-rejoin' && /branch "a"/.test(i.message),
+    )).toBe(true)
+  })
+
+  // Regression: notify nodes exit with `default` at runtime;
+  // `resolveNextEdge` only falls back to a `branch-completed` edge for
+  // approved/denied/timeout signals. A notify → branch-completed edge
+  // would pass validation but deadlock at runtime — the guard must be
+  // illegal on notify sources.
+  it('flags a notify edge guarded by branch-completed as illegal', () => {
+    const wf: Workflow = {
+      id: 'bad-notify', version: 1, trigger: 'on_submit', startNodeId: 'n',
+      nodes: [
+        { id: 'n', type: 'notify', channel: 'slack' },
+        { id: 'done', type: 'terminal', outcome: 'finalized' },
+      ],
+      edges: [
+        { from: 'n', to: 'done', when: 'branch-completed' },
+      ],
+    } as Workflow
+    const issues = validateWorkflow(wf)
+    expect(issues.some(
+      i => i.code === 'illegal-guard-for-source' && i.nodeId === 'n',
+    )).toBe(true)
+  })
 })
 
 describe('validateExpressionSyntax', () => {

--- a/src/core/workflow/__tests__/validate.test.ts
+++ b/src/core/workflow/__tests__/validate.test.ts
@@ -398,6 +398,130 @@ describe('validateTemplateSyntax', () => {
   })
 })
 
+describe('validateWorkflow — parallel / join (issue #223)', () => {
+  function parallelWf(overrides: {
+    parallelBranches?: readonly string[]
+    mode?: 'requireAll' | 'requireAny' | 'requireN'
+    n?: number
+    pairedJoinId?: string
+    edgeOverrides?: readonly { readonly from: string; readonly to: string; readonly when?: string }[]
+    removeJoin?: boolean
+    extraJoins?: readonly { id: string; pairedWith: string }[]
+  } = {}): Workflow {
+    const pairedJoinId = overrides.pairedJoinId ?? 'join'
+    const base: Workflow = {
+      id: 'par', version: 1, trigger: 'on_submit', startNodeId: 'fan',
+      nodes: [
+        {
+          id: 'fan', type: 'parallel',
+          branches: overrides.parallelBranches ?? ['a', 'b'],
+          mode: overrides.mode ?? 'requireAll',
+          ...(overrides.n !== undefined ? { n: overrides.n } : {}),
+        },
+        { id: 'a', type: 'approval', assignTo: 'role:a' },
+        { id: 'b', type: 'approval', assignTo: 'role:b' },
+        ...(overrides.removeJoin ? [] : [{ id: pairedJoinId, type: 'join' as const, pairedWith: 'fan' }]),
+        ...(overrides.extraJoins ?? []).map(j => ({ ...j, type: 'join' as const })),
+        { id: 'done', type: 'terminal', outcome: 'finalized' },
+      ],
+      edges: (overrides.edgeOverrides as readonly { from: string; to: string; when?: string }[] | undefined) ?? [
+        { from: 'a', to: pairedJoinId, when: 'branch-completed' },
+        { from: 'b', to: pairedJoinId, when: 'branch-completed' },
+        { from: pairedJoinId, to: 'done' },
+      ],
+    } as Workflow
+    return base
+  }
+
+  it('accepts a simple parallel + join template', () => {
+    const issues = validateWorkflow(parallelWf())
+    const errors = issues.filter(i => i.severity === 'error')
+    expect(errors).toEqual([])
+  })
+
+  it('flags parallel with no paired join', () => {
+    const issues = validateWorkflow(parallelWf({
+      removeJoin: true,
+      edgeOverrides: [
+        { from: 'a', to: 'done' },
+        { from: 'b', to: 'done' },
+      ],
+    }))
+    expect(issues.some(i => i.code === 'parallel-join-unpaired')).toBe(true)
+  })
+
+  it('flags parallel paired with two joins', () => {
+    const issues = validateWorkflow(parallelWf({
+      extraJoins: [{ id: 'join2', pairedWith: 'fan' }],
+    }))
+    expect(issues.some(
+      i => i.code === 'parallel-join-unpaired' && /2 joins/i.test(i.message),
+    )).toBe(true)
+  })
+
+  it('flags a join pointing at a non-existent parallel', () => {
+    const wf: Workflow = {
+      ...parallelWf(),
+      nodes: [
+        ...parallelWf().nodes,
+        { id: 'orphan-join', type: 'join', pairedWith: 'ghost' },
+      ],
+    }
+    const issues = validateWorkflow(wf)
+    expect(issues.some(
+      i => i.code === 'parallel-join-unpaired' && i.nodeId === 'orphan-join',
+    )).toBe(true)
+  })
+
+  it('flags branches that do not rejoin at the paired join', () => {
+    const wf: Workflow = parallelWf({
+      // Branch "a" exits to a terminal instead of rejoining.
+      edgeOverrides: [
+        { from: 'a', to: 'done', when: 'approved' },
+        { from: 'a', to: 'done', when: 'denied' },
+        { from: 'b', to: 'join', when: 'branch-completed' },
+        { from: 'join', to: 'done' },
+      ],
+    })
+    const issues = validateWorkflow(wf)
+    expect(issues.some(
+      i => i.code === 'parallel-branches-rejoin' && /branch "a"/.test(i.message),
+    )).toBe(true)
+  })
+
+  it('flags requireN without a valid n', () => {
+    const tooLow = validateWorkflow(parallelWf({ mode: 'requireN', n: 0 }))
+    expect(tooLow.some(i => i.code === 'parallel-require-n-bounds')).toBe(true)
+    const tooHigh = validateWorkflow(parallelWf({ mode: 'requireN', n: 5 }))
+    expect(tooHigh.some(i => i.code === 'parallel-require-n-bounds')).toBe(true)
+    const missing = validateWorkflow(parallelWf({ mode: 'requireN' }))
+    expect(missing.some(i => i.code === 'parallel-require-n-bounds')).toBe(true)
+  })
+
+  it('accepts requireN with n within branch count', () => {
+    const issues = validateWorkflow(parallelWf({ mode: 'requireN', n: 2 }))
+    const errors = issues.filter(i => i.severity === 'error')
+    expect(errors).toEqual([])
+  })
+
+  it('flags a parallel with zero declared branches', () => {
+    const issues = validateWorkflow(parallelWf({ parallelBranches: [] }))
+    expect(issues.some(i => i.code === 'parallel-branches-empty')).toBe(true)
+  })
+
+  it('flags a parallel branch entry that is not a node', () => {
+    const issues = validateWorkflow(parallelWf({ parallelBranches: ['a', 'ghost'] }))
+    expect(issues.some(
+      i => i.code === 'parallel-branches-rejoin' && /ghost/.test(i.message),
+    )).toBe(true)
+  })
+
+  it('does not flag a parallel node as a dead-end (no outgoing edges)', () => {
+    const issues = validateWorkflow(parallelWf())
+    expect(issues.some(i => i.code === 'dead-end-node' && i.nodeId === 'fan')).toBe(false)
+  })
+})
+
 describe('validateExpressionSyntax', () => {
   it('returns null for clean expressions (even with unbound vars)', () => {
     expect(validateExpressionSyntax('event.cost > 500')).toBeNull()

--- a/src/core/workflow/advance.ts
+++ b/src/core/workflow/advance.ts
@@ -1,5 +1,5 @@
 /**
- * Workflow interpreter — issue #219, Phase 1.
+ * Workflow interpreter — issue #219, Phases 1–4.
  *
  * Pure function that advances a `WorkflowInstance` by one actor action.
  * The host persists the returned instance; every state change is
@@ -11,6 +11,15 @@
  * `approval` (→ `awaiting`) or `terminal` (→ `completed`). This keeps
  * the actor-facing state machine simple: exactly one "stop" node is
  * active between actions.
+ *
+ * Parallel scopes (Phase 4, issue #223): entering a `parallel` node
+ * pushes a frame onto `instance.parallelFrames` and walks each branch
+ * forward until it hits an approval (stored as the branch's
+ * `activeNodeId`) or its paired `join`. Approve/deny/timeout actions
+ * carry `targetNodeId` to disambiguate which branch they advance. The
+ * paired join releases once the frame's `mode` quorum is satisfied —
+ * which may fail-fast if the remaining branches can no longer reach
+ * the required count (e.g. `requireAll` with one denial).
  */
 import { evaluateBool, ExpressionError } from './expression'
 import { interpolateTemplate, TemplateError } from './templateInterpolate'
@@ -18,21 +27,32 @@ import {
   findNode,
   resolveNextEdge,
   type EdgeGuard,
+  type ParallelBranchState,
+  type ParallelMode,
   type Workflow,
   type WorkflowApprovalNode,
   type WorkflowHistoryEntry,
   type WorkflowInstance,
   type WorkflowOutcome,
+  type WorkflowParallelFrame,
+  type WorkflowParallelNode,
 } from './workflowSchema'
 
 // ─── Actions ──────────────────────────────────────────────────────────────
 
+/**
+ * Actor-supplied input to `advance()`. Approval variants accept an
+ * optional `targetNodeId` that identifies which branch's approval the
+ * action applies to while a parallel scope is in flight. When the
+ * workflow is linear (no parallel frame) `targetNodeId` is ignored —
+ * the action targets the single `currentNodeId`.
+ */
 export type WorkflowAction =
   | { readonly type: 'start' }
-  | { readonly type: 'approve'; readonly actor?: string; readonly reason?: string }
-  | { readonly type: 'deny';    readonly actor?: string; readonly reason: string }
+  | { readonly type: 'approve'; readonly actor?: string; readonly reason?: string; readonly targetNodeId?: string }
+  | { readonly type: 'deny';    readonly actor?: string; readonly reason: string;  readonly targetNodeId?: string }
   | { readonly type: 'cancel';  readonly actor?: string; readonly reason?: string }
-  | { readonly type: 'timeout' }
+  | { readonly type: 'timeout'; readonly targetNodeId?: string }
 
 // ─── Emitted events ───────────────────────────────────────────────────────
 
@@ -70,12 +90,28 @@ export type AdvanceResult =
 
 // ─── Internal mutable state during a single advance call ─────────────────
 
+interface MutableBranchState {
+  readonly branchEntryId: string
+  activeNodeId: string | null
+  completedAt?: string
+  completedSignal?: EdgeGuard
+}
+
+interface MutableParallelFrame {
+  readonly parallelId: string
+  readonly joinId: string
+  readonly mode: ParallelMode
+  readonly n?: number
+  readonly branches: MutableBranchState[]
+}
+
 interface RunState {
   history: WorkflowHistoryEntry[]
   emit: WorkflowEmitEvent[]
   currentNodeId: string | null
   status: WorkflowInstance['status']
   outcome?: WorkflowOutcome
+  parallelFrames: MutableParallelFrame[]
 }
 
 // ─── Public API ───────────────────────────────────────────────────────────
@@ -93,6 +129,7 @@ export function advance(input: AdvanceInput): AdvanceResult {
     currentNodeId: base.currentNodeId,
     status: base.status,
     outcome: base.outcome,
+    parallelFrames: (base.parallelFrames ?? []).map(cloneFrame),
   }
 
   // Early exits — already terminal / failed.
@@ -114,12 +151,20 @@ export function advance(input: AdvanceInput): AdvanceResult {
       case 'approve':
       case 'deny': {
         const reason = action.type === 'deny' ? action.reason : undefined
+        const signal: EdgeGuard = action.type === 'approve' ? 'approved' : 'denied'
+        if (state.parallelFrames.length > 0) {
+          const err = applyBranchAction(
+            workflow, state, vars, signal, at,
+            { actor: action.actor, reason, targetNodeId: action.targetNodeId },
+          )
+          if (err) return finalize(base, state, err)
+          break
+        }
         const node = state.currentNodeId ? findNode(workflow, state.currentNodeId) : undefined
         if (!node || node.type !== 'approval' || state.status !== 'awaiting') {
           return finalize(base, state,
             `${action.type} requires an awaiting approval node; current="${state.currentNodeId}" status=${state.status}`)
         }
-        const signal: EdgeGuard = action.type === 'approve' ? 'approved' : 'denied'
         exitCurrent(state, signal, at, { actor: action.actor, reason })
         if (!followEdge(workflow, state, signal, at)) break
         autoAdvance(workflow, state, vars, at)
@@ -130,6 +175,18 @@ export function advance(input: AdvanceInput): AdvanceResult {
         if (state.currentNodeId) {
           exitCurrent(state, 'default', at, { actor: action.actor, reason: action.reason })
         }
+        // Close any still-open branch history entries so the audit trail
+        // doesn't leave dangling "entered without exit" rows.
+        for (const frame of state.parallelFrames) {
+          for (const branch of frame.branches) {
+            if (branch.activeNodeId) {
+              closeHistoryFor(state, branch.activeNodeId, 'default', at,
+                { actor: action.actor, reason: action.reason })
+              branch.activeNodeId = null
+            }
+          }
+        }
+        state.parallelFrames = []
         state.status = 'completed'
         state.currentNodeId = null
         state.outcome = 'cancelled'
@@ -137,6 +194,11 @@ export function advance(input: AdvanceInput): AdvanceResult {
         break
 
       case 'timeout': {
+        if (state.parallelFrames.length > 0) {
+          const err = applyBranchTimeout(workflow, state, vars, at, action.targetNodeId)
+          if (err) return finalize(base, state, err)
+          break
+        }
         const node = state.currentNodeId ? findNode(workflow, state.currentNodeId) : undefined
         if (!node || node.type !== 'approval' || state.status !== 'awaiting') {
           return finalize(base, state,
@@ -200,6 +262,37 @@ function enter(
   state.status = node.type === 'approval' ? 'awaiting' : 'running'
 }
 
+/**
+ * Close the latest open history entry matching `nodeId`. Used when a
+ * branch exits an approval out-of-band (i.e. while `currentNodeId` is
+ * a different branch's node) — `exitCurrent` assumes the latest
+ * unclosed row is the one to close, which is wrong under parallel
+ * scope. Iterates from the tail for O(n) worst case, which matches the
+ * linear interpreter's cost.
+ */
+function closeHistoryFor(
+  state: RunState,
+  nodeId: string,
+  signal: EdgeGuard,
+  at: string,
+  meta?: { actor?: string; reason?: string },
+): void {
+  for (let i = state.history.length - 1; i >= 0; i--) {
+    const entry = state.history[i]
+    if (entry.nodeId !== nodeId) continue
+    if (entry.exitedAt !== undefined) continue
+    state.history[i] = {
+      ...entry,
+      exitedAt: at,
+      signal,
+      ...(meta?.actor  !== undefined ? { actor:  meta.actor  } : {}),
+      ...(meta?.reason !== undefined ? { reason: meta.reason } : {}),
+    }
+    state.emit.push({ type: 'node_exited', nodeId, at, signal })
+    return
+  }
+}
+
 function exitCurrent(
   state: RunState,
   signal: EdgeGuard,
@@ -251,6 +344,11 @@ function followEdge(
 /**
  * Walk condition / notify nodes until the current node is an approval
  * or terminal. Bounded by the workflow's node count to prevent cycles.
+ *
+ * When the cursor lands on a `parallel` node, fans out into the frame
+ * and leaves the branches in their "await an approval or reach the
+ * paired join" state — after which the linear auto-advance returns;
+ * further progress comes from actor actions on branch approvals.
  */
 function autoAdvance(
   workflow: Workflow,
@@ -258,7 +356,7 @@ function autoAdvance(
   vars: Readonly<Record<string, unknown>>,
   at: string,
 ): void {
-  const limit = workflow.nodes.length + 1
+  const limit = workflow.nodes.length * 2 + 4
   for (let step = 0; step < limit; step++) {
     if (state.status !== 'running') return
     const node = state.currentNodeId ? findNode(workflow, state.currentNodeId) : undefined
@@ -287,20 +385,37 @@ function autoAdvance(
     }
 
     if (node.type === 'notify') {
-      const message = node.template !== undefined
-        ? interpolateTemplate(node.template, vars)
-        : undefined
-      state.emit.push({
-        type: 'notify',
-        nodeId: node.id,
-        channel: node.channel,
-        at,
-        ...(node.template !== undefined ? { template: node.template } : {}),
-        ...(message !== undefined ? { message } : {}),
-      })
+      emitNotify(state, node, vars, at)
       exitCurrent(state, 'default', at)
       if (!followEdge(workflow, state, 'default', at)) return
       continue
+    }
+
+    if (node.type === 'parallel') {
+      enterParallel(workflow, state, vars, node, at)
+      // `enterParallel` either released the paired join (and advanced
+      // past it — cursor now resumes after the join) or left us
+      // awaiting branches (status='awaiting', currentNodeId=null). In
+      // either case, fall through the loop and let the next iteration
+      // pick up the new cursor or return.
+      if (state.status !== 'running') return
+      continue
+    }
+
+    if (node.type === 'join') {
+      // A `join` should only ever be entered by the parallel interpreter
+      // after quorum is satisfied. Reaching one via ordinary auto-advance
+      // means the workflow is structurally broken (e.g. an edge pointing
+      // at the join outside a parallel scope). Fail loudly instead of
+      // quietly falling through.
+      state.status = 'failed'
+      state.emit.push({
+        type: 'workflow_failed',
+        nodeId: node.id,
+        reason: `Join "${node.id}" entered outside a parallel scope`,
+        at,
+      })
+      return
     }
   }
 
@@ -313,6 +428,481 @@ function autoAdvance(
   })
 }
 
+function emitNotify(
+  state: RunState,
+  node: { id: string; channel: string; template?: string },
+  vars: Readonly<Record<string, unknown>>,
+  at: string,
+): void {
+  const message = node.template !== undefined
+    ? interpolateTemplate(node.template, vars)
+    : undefined
+  state.emit.push({
+    type: 'notify',
+    nodeId: node.id,
+    channel: node.channel,
+    at,
+    ...(node.template !== undefined ? { template: node.template } : {}),
+    ...(message !== undefined ? { message } : {}),
+  })
+}
+
+// ─── Parallel / join (Phase 4, issue #223) ────────────────────────────────
+
+/**
+ * Enter a `parallel` node: push a frame and walk each branch forward
+ * until it either awaits an approval or reaches the paired join. If
+ * every branch short-circuits to the join in one pass and quorum is
+ * satisfied, release the join immediately so the caller's autoAdvance
+ * loop picks up the post-join cursor.
+ */
+function enterParallel(
+  workflow: Workflow,
+  state: RunState,
+  vars: Readonly<Record<string, unknown>>,
+  node: WorkflowParallelNode,
+  at: string,
+): void {
+  const join = findPairedJoin(workflow, node.id)
+  if (!join) {
+    state.status = 'failed'
+    state.emit.push({
+      type: 'workflow_failed',
+      nodeId: node.id,
+      reason: `Parallel "${node.id}" has no paired join`,
+      at,
+    })
+    return
+  }
+
+  // Close the parallel node's own history entry. The fan-out is its
+  // exit event — signal 'default' is neutral (no branch has completed
+  // anything yet; this just means the parallel finished initializing).
+  exitCurrent(state, 'default', at)
+
+  const frame: MutableParallelFrame = {
+    parallelId: node.id,
+    joinId: join.id,
+    mode: node.mode,
+    ...(node.n !== undefined ? { n: node.n } : {}),
+    branches: node.branches.map<MutableBranchState>(entryId => ({
+      branchEntryId: entryId,
+      activeNodeId: null,
+    })),
+  }
+  state.parallelFrames.push(frame)
+  // currentNodeId is cleared for the duration of the parallel scope —
+  // the "active node" concept is per-branch from here on.
+  state.currentNodeId = null
+
+  // Walk each branch to its first pause point.
+  for (let i = 0; i < frame.branches.length; i++) {
+    initBranch(workflow, state, vars, frame, i, at)
+    if (state.status === 'failed') return
+  }
+
+  // If every branch short-circuited straight to the join (no approval
+  // in any path) AND quorum is satisfied, release the join so the
+  // caller's autoAdvance can continue past it.
+  settleFrame(workflow, state, vars, at)
+}
+
+function findPairedJoin(
+  workflow: Workflow,
+  parallelId: string,
+): { readonly id: string } | undefined {
+  for (const n of workflow.nodes) {
+    if (n.type === 'join' && n.pairedWith === parallelId) return n
+  }
+  return undefined
+}
+
+/**
+ * Initialize a single branch: enter the branch's entry node, then walk
+ * forward until we pause (awaiting an approval) or hit the paired
+ * join. A degenerate branch whose entry IS the paired join completes
+ * immediately without pushing a history row (validator forbids this
+ * shape; the interpreter tolerates it defensively).
+ */
+function initBranch(
+  workflow: Workflow,
+  state: RunState,
+  vars: Readonly<Record<string, unknown>>,
+  frame: MutableParallelFrame,
+  branchIdx: number,
+  at: string,
+): void {
+  const branch = frame.branches[branchIdx]
+  if (branch.branchEntryId === frame.joinId) {
+    branch.activeNodeId = null
+    branch.completedAt = at
+    branch.completedSignal = 'default'
+    return
+  }
+  enter(workflow, state, branch.branchEntryId, at)
+  walkBranchForward(workflow, state, vars, frame, branchIdx, at)
+}
+
+/**
+ * Drive `state.currentNodeId` forward through condition / notify nodes
+ * until it lands on an approval (→ pause branch) or the next outgoing
+ * edge would land on the frame's paired join (→ mark branch complete
+ * without entering the join). Writes the pause/complete state into the
+ * branch record instead of `state.currentNodeId`.
+ *
+ * `lastSignal` is the signal emitted by the branch's final non-join
+ * node; it's copied into `completedSignal` as the branch's quorum vote.
+ */
+function walkBranchForward(
+  workflow: Workflow,
+  state: RunState,
+  vars: Readonly<Record<string, unknown>>,
+  frame: MutableParallelFrame,
+  branchIdx: number,
+  at: string,
+): void {
+  const branch = frame.branches[branchIdx]
+  const limit = workflow.nodes.length * 2 + 4
+  let lastSignal: EdgeGuard = 'default'
+
+  for (let step = 0; step < limit; step++) {
+    const nodeId = state.currentNodeId
+    if (!nodeId) return
+    const node = findNode(workflow, nodeId)
+    if (!node) return
+
+    if (node.type === 'approval') {
+      branch.activeNodeId = nodeId
+      state.status = 'awaiting'
+      state.currentNodeId = null
+      return
+    }
+
+    if (node.type === 'terminal') {
+      // A terminal inside a parallel branch is a structural bug — the
+      // branch can't rejoin. Validator forbids this; the interpreter
+      // fails loudly instead of silently completing the workflow.
+      failWorkflow(state, node.id,
+        `Terminal "${node.id}" reached inside parallel branch "${branch.branchEntryId}"`,
+        at)
+      return
+    }
+
+    if (node.type === 'parallel' || node.type === 'join') {
+      // Nested parallel scopes are out of scope for Phase 4 — a branch
+      // that hits another parallel (or a foreign join) is treated as a
+      // structural error.
+      failWorkflow(state, nodeId,
+        `Unsupported ${node.type} node "${nodeId}" inside a parallel branch`, at)
+      return
+    }
+
+    if (node.type === 'condition') {
+      const truthy = evaluateBool(node.expr, vars)
+      lastSignal = truthy ? 'true' : 'false'
+      closeHistoryFor(state, nodeId, lastSignal, at)
+      if (!stepBranchOutOf(workflow, state, frame, branch, nodeId, lastSignal, at)) return
+      if (state.currentNodeId === null) return
+      continue
+    }
+
+    if (node.type === 'notify') {
+      emitNotify(state, node, vars, at)
+      lastSignal = 'default'
+      closeHistoryFor(state, nodeId, lastSignal, at)
+      if (!stepBranchOutOf(workflow, state, frame, branch, nodeId, lastSignal, at)) return
+      if (state.currentNodeId === null) return
+      continue
+    }
+  }
+
+  failWorkflow(state, branch.activeNodeId ?? branch.branchEntryId,
+    `Branch "${branch.branchEntryId}" exceeded step limit — check for cycles`, at)
+}
+
+/**
+ * Step out of `fromNodeId` (already exited) toward the edge matching
+ * `signal`. If the target IS the paired join, mark the branch complete
+ * without emitting a join `node_entered` — the join is entered once
+ * canonically by `releaseJoin`. Returns `false` only on a routing
+ * failure (state already marked failed).
+ */
+function stepBranchOutOf(
+  workflow: Workflow,
+  state: RunState,
+  frame: MutableParallelFrame,
+  branch: MutableBranchState,
+  fromNodeId: string,
+  signal: EdgeGuard,
+  at: string,
+): boolean {
+  const edge = resolveNextEdge(workflow, fromNodeId, signal)
+  if (!edge) {
+    failWorkflow(state, fromNodeId,
+      `No edge from "${fromNodeId}" for signal "${signal}"`, at)
+    return false
+  }
+  if (edge.to === frame.joinId) {
+    branch.activeNodeId = null
+    branch.completedAt = at
+    branch.completedSignal = signal
+    state.currentNodeId = null
+    return true
+  }
+  enter(workflow, state, edge.to, at)
+  return true
+}
+
+function failWorkflow(
+  state: RunState,
+  nodeId: string,
+  reason: string,
+  at: string,
+): void {
+  state.status = 'failed'
+  state.emit.push({ type: 'workflow_failed', nodeId, reason, at })
+}
+
+/**
+ * Find the (frameIdx, branchIdx) for a parallel-scope action. When
+ * `targetNodeId` is omitted and exactly one branch in the innermost
+ * frame is pending, default to that branch — otherwise require
+ * disambiguation.
+ *
+ * Nested frames are searched outermost-first, but since we don't
+ * currently support nested parallel scopes, in practice there's always
+ * exactly one frame.
+ */
+function locateBranch(
+  state: RunState,
+  targetNodeId: string | undefined,
+): { frameIdx: number; branchIdx: number } | { error: string } {
+  if (targetNodeId !== undefined) {
+    for (let f = 0; f < state.parallelFrames.length; f++) {
+      const frame = state.parallelFrames[f]
+      for (let b = 0; b < frame.branches.length; b++) {
+        if (frame.branches[b].activeNodeId === targetNodeId) {
+          return { frameIdx: f, branchIdx: b }
+        }
+      }
+    }
+    return { error: `no pending branch awaiting node "${targetNodeId}"` }
+  }
+
+  const pending: Array<{ frameIdx: number; branchIdx: number }> = []
+  for (let f = 0; f < state.parallelFrames.length; f++) {
+    const frame = state.parallelFrames[f]
+    for (let b = 0; b < frame.branches.length; b++) {
+      if (frame.branches[b].activeNodeId) pending.push({ frameIdx: f, branchIdx: b })
+    }
+  }
+  if (pending.length === 1) return pending[0]
+  if (pending.length === 0) return { error: 'no branch is awaiting an action' }
+  return { error: `${pending.length} branches awaiting — supply targetNodeId` }
+}
+
+function applyBranchAction(
+  workflow: Workflow,
+  state: RunState,
+  vars: Readonly<Record<string, unknown>>,
+  signal: EdgeGuard,
+  at: string,
+  meta: { actor?: string; reason?: string; targetNodeId?: string },
+): string | null {
+  const located = locateBranch(state, meta.targetNodeId)
+  if ('error' in located) return located.error
+
+  const frame = state.parallelFrames[located.frameIdx]
+  const branch = frame.branches[located.branchIdx]
+  const approvalId = branch.activeNodeId!
+
+  // Close the approval's open history entry with the branch's signal
+  // (we can't use `exitCurrent` — currentNodeId is null in parallel).
+  closeHistoryFor(state, approvalId, signal, at,
+    { actor: meta.actor, reason: meta.reason })
+  branch.activeNodeId = null
+
+  if (!stepBranchOutOf(workflow, state, frame, branch, approvalId, signal, at)) {
+    return null
+  }
+  if (state.currentNodeId !== null) {
+    walkBranchForward(workflow, state, vars, frame, located.branchIdx, at)
+    if (state.status === 'failed') return null
+  }
+
+  settleAndResume(workflow, state, vars, at)
+  return null
+}
+
+function applyBranchTimeout(
+  workflow: Workflow,
+  state: RunState,
+  vars: Readonly<Record<string, unknown>>,
+  at: string,
+  targetNodeId: string | undefined,
+): string | null {
+  const located = locateBranch(state, targetNodeId)
+  if ('error' in located) return located.error
+
+  const frame = state.parallelFrames[located.frameIdx]
+  const branch = frame.branches[located.branchIdx]
+  const approvalId = branch.activeNodeId!
+  const approval = findNode(workflow, approvalId)
+  if (!approval || approval.type !== 'approval') {
+    return `branch target "${approvalId}" is not an approval node`
+  }
+  const behavior = approval.onTimeout ?? 'escalate'
+  const signal: EdgeGuard =
+    behavior === 'escalate'      ? 'timeout'
+    : behavior === 'auto-approve' ? 'approved'
+    : 'denied'
+  closeHistoryFor(state, approvalId, signal, at,
+    { reason: `SLA timeout (${behavior})` })
+  branch.activeNodeId = null
+
+  if (!stepBranchOutOf(workflow, state, frame, branch, approvalId, signal, at)) {
+    return null
+  }
+  if (state.currentNodeId !== null) {
+    walkBranchForward(workflow, state, vars, frame, located.branchIdx, at)
+    if (state.status === 'failed') return null
+  }
+
+  settleAndResume(workflow, state, vars, at)
+  return null
+}
+
+/**
+ * After a branch transitions, settle the innermost frame (maybe
+ * release the join) and, if a join was released, resume linear
+ * auto-advance from the post-join cursor. `settleFrame` alone leaves
+ * `status='running'` with a fresh cursor when it pops a frame — we
+ * need to keep walking to reach the next approval / terminal.
+ */
+function settleAndResume(
+  workflow: Workflow,
+  state: RunState,
+  vars: Readonly<Record<string, unknown>>,
+  at: string,
+): void {
+  settleFrame(workflow, state, vars, at)
+  if (state.status === 'running' && state.currentNodeId !== null) {
+    autoAdvance(workflow, state, vars, at)
+  }
+}
+
+/**
+ * After each branch transition, check if the innermost frame can
+ * release its join. If quorum is satisfied, pop + release. If quorum
+ * is now unreachable (e.g. `requireAll` saw a denial), fail the
+ * workflow. Otherwise the branch stays awaiting.
+ *
+ * Loops because releasing a join may land the cursor on another
+ * parallel (nested case, currently unsupported but defensive) or on
+ * condition/notify/approval/terminal nodes — the outer autoAdvance
+ * picks up from there.
+ */
+function settleFrame(
+  workflow: Workflow,
+  state: RunState,
+  vars: Readonly<Record<string, unknown>>,
+  at: string,
+): void {
+  while (state.parallelFrames.length > 0 && state.status !== 'failed') {
+    const frame = state.parallelFrames[state.parallelFrames.length - 1]
+    const verdict = checkQuorum(frame)
+    if (verdict === 'pending') {
+      state.status = 'awaiting'
+      return
+    }
+    if (verdict === 'failed') {
+      state.status = 'failed'
+      state.emit.push({
+        type: 'workflow_failed',
+        nodeId: frame.parallelId,
+        reason: `Parallel "${frame.parallelId}" quorum (${frame.mode}) unreachable`,
+        at,
+      })
+      return
+    }
+    // Satisfied — release the paired join.
+    state.parallelFrames.pop()
+    releaseJoin(workflow, state, vars, frame, at)
+    // After releasing, `currentNodeId` now points past the join. Let
+    // autoAdvance continue in the caller; settleFrame is invoked again
+    // if that auto-advance itself lands on another parallel.
+    return
+  }
+}
+
+type QuorumVerdict = 'satisfied' | 'failed' | 'pending'
+
+function checkQuorum(frame: MutableParallelFrame): QuorumVerdict {
+  const total = frame.branches.length
+  let positive = 0
+  let negative = 0
+  let pending = 0
+  for (const b of frame.branches) {
+    if (b.completedSignal === undefined) { pending++; continue }
+    if (isPositiveSignal(b.completedSignal)) positive++
+    else negative++
+  }
+
+  switch (frame.mode) {
+    case 'requireAll':
+      if (negative > 0) return 'failed'
+      if (positive === total) return 'satisfied'
+      return 'pending'
+    case 'requireAny':
+      if (positive > 0) return 'satisfied'
+      if (negative === total) return 'failed'
+      return 'pending'
+    case 'requireN': {
+      const required = Math.max(1, Math.min(total, frame.n ?? 1))
+      if (positive >= required) return 'satisfied'
+      if (positive + pending < required) return 'failed'
+      return 'pending'
+    }
+  }
+}
+
+function isPositiveSignal(signal: EdgeGuard): boolean {
+  // `approved` / `true` / `default` / `branch-completed` are treated
+  // as "this branch succeeded". `denied` / `timeout` / `false` are
+  // negative. The distinction matters for `requireN` + `requireAll`
+  // where one denial can doom the whole frame.
+  return signal === 'approved'
+    || signal === 'true'
+    || signal === 'default'
+    || signal === 'branch-completed'
+}
+
+/**
+ * Release the paired join: record one `node_entered`/`node_exited`
+ * pair for the join itself, then move `state.currentNodeId` to the
+ * node past the join via its default edge. Branches that reached the
+ * join earlier set `completedSignal` on themselves but did NOT emit a
+ * `node_entered` for the join — this is the only place we do.
+ */
+function releaseJoin(
+  workflow: Workflow,
+  state: RunState,
+  _vars: Readonly<Record<string, unknown>>,
+  frame: MutableParallelFrame,
+  at: string,
+): void {
+  enter(workflow, state, frame.joinId, at)
+  exitCurrent(state, 'default', at)
+  const next = resolveNextEdge(workflow, frame.joinId, 'default')
+  if (!next) {
+    failWorkflow(state, frame.joinId,
+      `No edge from join "${frame.joinId}" (need a default edge)`, at)
+    return
+  }
+  enter(workflow, state, next.to, at)
+  state.status = 'running'
+}
+
 function assemble(base: WorkflowInstance, state: RunState): WorkflowInstance {
   return {
     workflowId: base.workflowId,
@@ -321,6 +911,39 @@ function assemble(base: WorkflowInstance, state: RunState): WorkflowInstance {
     currentNodeId: state.currentNodeId,
     history: state.history,
     ...(state.outcome !== undefined ? { outcome: state.outcome } : {}),
+    ...(state.parallelFrames.length > 0
+      ? { parallelFrames: state.parallelFrames.map(freezeFrame) }
+      : {}),
+  }
+}
+
+function cloneFrame(frame: WorkflowParallelFrame): MutableParallelFrame {
+  return {
+    parallelId: frame.parallelId,
+    joinId: frame.joinId,
+    mode: frame.mode,
+    ...(frame.n !== undefined ? { n: frame.n } : {}),
+    branches: frame.branches.map(b => ({
+      branchEntryId: b.branchEntryId,
+      activeNodeId: b.activeNodeId,
+      ...(b.completedAt !== undefined ? { completedAt: b.completedAt } : {}),
+      ...(b.completedSignal !== undefined ? { completedSignal: b.completedSignal } : {}),
+    })),
+  }
+}
+
+function freezeFrame(frame: MutableParallelFrame): WorkflowParallelFrame {
+  return {
+    parallelId: frame.parallelId,
+    joinId: frame.joinId,
+    mode: frame.mode,
+    ...(frame.n !== undefined ? { n: frame.n } : {}),
+    branches: frame.branches.map<ParallelBranchState>(b => ({
+      branchEntryId: b.branchEntryId,
+      activeNodeId: b.activeNodeId,
+      ...(b.completedAt !== undefined ? { completedAt: b.completedAt } : {}),
+      ...(b.completedSignal !== undefined ? { completedSignal: b.completedSignal } : {}),
+    })),
   }
 }
 

--- a/src/core/workflow/templateInterpolate.ts
+++ b/src/core/workflow/templateInterpolate.ts
@@ -45,8 +45,6 @@ export function interpolateTemplate(
   template: string,
   variables: Readonly<Record<string, unknown>>,
 ): string {
-  if (template.indexOf('{{') < 0 && template.indexOf('\\{\\{') < 0) return template
-
   let out = ''
   let i = 0
   while (i < template.length) {

--- a/src/core/workflow/templates.ts
+++ b/src/core/workflow/templates.ts
@@ -110,10 +110,46 @@ export const slaEscalationWorkflow: Workflow = {
   ],
 }
 
+/**
+ * Fires security + finance approvals in parallel and only finalizes
+ * when both return. Demonstrates Phase-4 parallel/join nodes (issue
+ * #223): the `fanout` node spawns two branches whose `branch-completed`
+ * edges converge on the paired `rejoin` node, which then notifies and
+ * terminates. A single denial on either branch flips the quorum and
+ * fails the workflow.
+ */
+export const parallelSecurityAndFinanceApproval: Workflow = {
+  id: 'parallel-security-and-finance',
+  version: 1,
+  trigger: 'on_submit',
+  startNodeId: 'fanout',
+  nodes: [
+    {
+      id: 'fanout',
+      type: 'parallel',
+      branches: ['security-approval', 'finance-approval'],
+      mode: 'requireAll',
+      label: 'Security + Finance approvals',
+    },
+    { id: 'security-approval', type: 'approval', assignTo: 'role:security', label: 'Security review' },
+    { id: 'finance-approval',  type: 'approval', assignTo: 'role:finance',  label: 'Finance review'  },
+    { id: 'rejoin', type: 'join', pairedWith: 'fanout', label: 'Join approvals' },
+    { id: 'notify-ops', type: 'notify', channel: 'slack', template: 'Booking approved by security + finance' },
+    { id: 'done',   type: 'terminal', outcome: 'finalized' },
+  ],
+  edges: [
+    { from: 'security-approval', to: 'rejoin', when: 'branch-completed' },
+    { from: 'finance-approval',  to: 'rejoin', when: 'branch-completed' },
+    { from: 'rejoin', to: 'notify-ops' },
+    { from: 'notify-ops', to: 'done' },
+  ],
+}
+
 /** Ordered list of all shipped templates — drives the ConfigPanel picker. */
 export const WORKFLOW_TEMPLATES: readonly Workflow[] = [
   singleApproverWorkflow,
   twoTierApproverWorkflow,
   conditionalByCostWorkflow,
   slaEscalationWorkflow,
+  parallelSecurityAndFinanceApproval,
 ]

--- a/src/core/workflow/validate.ts
+++ b/src/core/workflow/validate.ts
@@ -39,6 +39,10 @@ export type ValidationCode =
   | 'template-syntax'
   | 'unknown-channel'
   | 'empty-channel'
+  | 'parallel-join-unpaired'
+  | 'parallel-branches-rejoin'
+  | 'parallel-require-n-bounds'
+  | 'parallel-branches-empty'
 
 export interface ValidationIssue {
   readonly code: ValidationCode
@@ -131,9 +135,12 @@ export function validateWorkflow(
     }
   }
 
-  // 6. sink safety — non-terminal node with no outgoing edges
+  // 6. sink safety — non-terminal node with no outgoing edges.
+  //    Parallels are exempt: they fan out via the `branches` array,
+  //    not via edges, so "no outgoing edge" is the expected shape.
   for (const node of workflow.nodes) {
     if (node.type === 'terminal') continue
+    if (node.type === 'parallel') continue
     const hasOut = workflow.edges.some(e => e.from === node.id)
     if (!hasOut) {
       issues.push({
@@ -262,7 +269,98 @@ export function validateWorkflow(
     }
   }
 
-  // 14. notify templates + channels (issue #223)
+  // 14. parallel / join pairing, branch bounds, rejoin reachability (issue #223)
+  const parallels = workflow.nodes.filter(
+    (n): n is Extract<WorkflowNode, { type: 'parallel' }> => n.type === 'parallel',
+  )
+  const joins = workflow.nodes.filter(
+    (n): n is Extract<WorkflowNode, { type: 'join' }> => n.type === 'join',
+  )
+
+  for (const par of parallels) {
+    const paired = joins.filter(j => j.pairedWith === par.id)
+    if (paired.length === 0) {
+      issues.push({
+        code: 'parallel-join-unpaired',
+        severity: 'error',
+        message: `Parallel "${par.id}" has no paired join (need a join with pairedWith="${par.id}")`,
+        nodeId: par.id,
+      })
+    } else if (paired.length > 1) {
+      issues.push({
+        code: 'parallel-join-unpaired',
+        severity: 'error',
+        message: `Parallel "${par.id}" is paired with ${paired.length} joins (need exactly one)`,
+        nodeId: par.id,
+      })
+    }
+
+    if (par.branches.length === 0) {
+      issues.push({
+        code: 'parallel-branches-empty',
+        severity: 'error',
+        message: `Parallel "${par.id}" declares no branches`,
+        nodeId: par.id,
+      })
+    } else {
+      for (const entryId of par.branches) {
+        if (!findNode(workflow, entryId)) {
+          issues.push({
+            code: 'parallel-branches-rejoin',
+            severity: 'error',
+            message: `Parallel "${par.id}" branch entry "${entryId}" is not a node`,
+            nodeId: par.id,
+          })
+        }
+      }
+    }
+
+    if (par.mode === 'requireN') {
+      const n = par.n
+      if (typeof n !== 'number' || n < 1 || n > par.branches.length) {
+        issues.push({
+          code: 'parallel-require-n-bounds',
+          severity: 'error',
+          message: `Parallel "${par.id}" mode 'requireN' needs 1 ≤ n ≤ ${par.branches.length}; got ${String(n)}`,
+          nodeId: par.id,
+        })
+      }
+    }
+
+    // Every branch must eventually reach the paired join (not a
+    // terminal or dead end). Use forward BFS along outgoing edges from
+    // each branch entry, stopping at the join. Treat nested parallels
+    // as opaque — they're already flagged as unsupported elsewhere.
+    const pairedJoin = paired[0]
+    if (pairedJoin) {
+      const targetJoinId = pairedJoin.id
+      for (const entryId of par.branches) {
+        if (!findNode(workflow, entryId)) continue
+        if (!branchReachesJoin(workflow, entryId, targetJoinId)) {
+          issues.push({
+            code: 'parallel-branches-rejoin',
+            severity: 'error',
+            message: `Parallel "${par.id}" branch "${entryId}" does not rejoin at "${targetJoinId}"`,
+            nodeId: par.id,
+          })
+        }
+      }
+    }
+  }
+
+  for (const j of joins) {
+    const paired = parallels.find(p => p.id === j.pairedWith)
+    if (!paired) {
+      issues.push({
+        code: 'parallel-join-unpaired',
+        severity: 'error',
+        message: `Join "${j.id}" references missing parallel "${j.pairedWith}"`,
+        nodeId: j.id,
+      })
+    }
+  }
+
+  // 15. notify templates + channels (issue #223)
   for (const node of workflow.nodes) {
     if (node.type !== 'notify') continue
 
@@ -339,19 +437,55 @@ function reachableNodeIds(workflow: Workflow): Set<string> {
   return reachable
 }
 
+/**
+ * Forward reachability check: from `entryId` can we reach `joinId`
+ * without passing through a terminal? Used to gate
+ * `parallel-branches-rejoin`. Limits depth to the node count so cycles
+ * don't hang the validator.
+ */
+function branchReachesJoin(
+  workflow: Workflow,
+  entryId: string,
+  joinId: string,
+): boolean {
+  const visited = new Set<string>()
+  const queue: string[] = [entryId]
+  while (queue.length > 0) {
+    const id = queue.shift()!
+    if (visited.has(id)) continue
+    visited.add(id)
+    if (id === joinId) return true
+    const node = findNode(workflow, id)
+    // Terminals and nested parallels are dead ends for rejoin purposes.
+    if (!node || node.type === 'terminal') continue
+    for (const e of workflow.edges) {
+      if (e.from !== id) continue
+      if (!visited.has(e.to)) queue.push(e.to)
+    }
+  }
+  return false
+}
+
 function isGuardLegal(node: WorkflowNode, guard: EdgeGuard): boolean {
   switch (node.type) {
     case 'condition': return guard === 'true' || guard === 'false'
     case 'approval':
       if (guard === 'approved' || guard === 'denied') return true
+      if (guard === 'branch-completed') return true
       // `timeout` is only legal when the approval declares an SLA —
       // without one, the interpreter can never fire a timeout from
       // this node, so the edge would be dead code.
       return guard === 'timeout'
         && typeof node.slaMinutes === 'number'
         && node.slaMinutes > 0
-    case 'notify':    return guard === 'default'
+    case 'notify':    return guard === 'default' || guard === 'branch-completed'
     case 'terminal':  return false
+    // `parallel` only branches via `branches: string[]`; outgoing edges
+    // if any are treated as post-join fallbacks, which isn't how the
+    // schema is meant to be used. Enforce default-only here; branches
+    // are authored inside the node, not via edges.
+    case 'parallel':  return guard === 'default'
+    case 'join':      return guard === 'default'
   }
 }
 

--- a/src/core/workflow/validate.ts
+++ b/src/core/workflow/validate.ts
@@ -62,7 +62,7 @@ export function validateWorkflow(
   options: ValidateWorkflowOptions = {},
 ): readonly ValidationIssue[] {
   const issues: ValidationIssue[] = []
-  const knownChannels = options.knownChannels
+  const knownChannels = options.knownChannels && options.knownChannels.length > 0
     ? new Set(options.knownChannels)
     : null
 

--- a/src/core/workflow/validate.ts
+++ b/src/core/workflow/validate.ts
@@ -456,8 +456,13 @@ function branchReachesJoin(
     visited.add(id)
     if (id === joinId) return true
     const node = findNode(workflow, id)
-    // Terminals and nested parallels are dead ends for rejoin purposes.
+    // Terminals and (foreign) parallel/join nodes are dead ends for
+    // rejoin purposes — `walkBranchForward` fails the workflow if a
+    // branch lands on any of these, so a path through one cannot
+    // legitimately reach the paired join. The `id === joinId` check
+    // above already excludes the paired join itself.
     if (!node || node.type === 'terminal') continue
+    if (node.type === 'parallel' || node.type === 'join') continue
     for (const e of workflow.edges) {
       if (e.from !== id) continue
       if (!visited.has(e.to)) queue.push(e.to)
@@ -478,7 +483,7 @@ function isGuardLegal(node: WorkflowNode, guard: EdgeGuard): boolean {
       return guard === 'timeout'
         && typeof node.slaMinutes === 'number'
         && node.slaMinutes > 0
-    case 'notify':    return guard === 'default' || guard === 'branch-completed'
+    case 'notify':    return guard === 'default'
     case 'terminal':  return false
     // `parallel` only branches via `branches: string[]`; outgoing edges
     // if any are treated as post-join fallbacks, which isn't how the

--- a/src/core/workflow/workflowSchema.ts
+++ b/src/core/workflow/workflowSchema.ts
@@ -12,9 +12,9 @@
  *   - `notify`    — fires a `WorkflowEmitEvent` and falls through.
  *   - `terminal`  — ends the flow with a final outcome.
  *
- * Phase 4 will add `parallel`. Phase 3 will honor `slaMinutes` /
- * `onTimeout`; those fields are schema-present here so templates can
- * carry them forward without a migration.
+ * Phase 4 adds:
+ *   - `parallel`  — fans out into multiple branches simultaneously.
+ *   - `join`      — collects branch outcomes with a quorum policy.
  */
 
 // ─── Trigger ──────────────────────────────────────────────────────────────
@@ -61,11 +61,43 @@ export interface WorkflowTerminalNode {
   readonly label?: string
 }
 
+// ─── Parallel / join (Phase 4, issue #223) ────────────────────────────────
+
+/**
+ * Parallel fan-out modes. Determine when the paired join releases.
+ *
+ *  - `requireAll` — every branch must approve; a single deny fails.
+ *  - `requireAny` — first approval short-circuits; remaining branches are abandoned.
+ *  - `requireN`   — at least `n` approvals release; if the remaining branches can't reach `n`, fail early.
+ */
+export type ParallelMode = 'requireAll' | 'requireAny' | 'requireN'
+
+export interface WorkflowParallelNode {
+  readonly id: string
+  readonly type: 'parallel'
+  /** Entry node id for each branch — each must path to the paired join. */
+  readonly branches: readonly string[]
+  readonly mode: ParallelMode
+  /** Required approvals when `mode === 'requireN'`. Must satisfy `1 ≤ n ≤ branches.length`. */
+  readonly n?: number
+  readonly label?: string
+}
+
+export interface WorkflowJoinNode {
+  readonly id: string
+  readonly type: 'join'
+  /** Id of the paired `parallel` node. Runtime enforces one-to-one pairing. */
+  readonly pairedWith: string
+  readonly label?: string
+}
+
 export type WorkflowNode =
   | WorkflowConditionNode
   | WorkflowApprovalNode
   | WorkflowNotifyNode
   | WorkflowTerminalNode
+  | WorkflowParallelNode
+  | WorkflowJoinNode
 
 // ─── Edges ────────────────────────────────────────────────────────────────
 
@@ -76,7 +108,13 @@ export type WorkflowNode =
  *   - `condition`  → 'true' | 'false'
  *   - `approval`   → 'approved' | 'denied' | 'timeout' (when slaMinutes set)
  *   - `notify`     → 'default'
+ *   - `parallel`   → (branches are addressed via `branches: string[]`, not edges)
+ *   - `join`       → 'default'
  *   - `terminal`   → (no outgoing edges)
+ *
+ * Branch-to-join edges use `when: 'branch-completed'` so the validator
+ * can distinguish them from ordinary approvals (whose outcomes are
+ * rolled up into the parallel frame).
  *
  * An edge with no `when` is a default transition, taken when no guarded
  * edge matches. At most one default edge per source node.
@@ -87,6 +125,7 @@ export type EdgeGuard =
   | 'approved'
   | 'denied'
   | 'timeout'
+  | 'branch-completed'
   | 'default'
 
 export interface WorkflowEdge {
@@ -123,11 +162,41 @@ export interface WorkflowHistoryEntry {
   readonly reason?: string
 }
 
+/**
+ * Per-branch state inside a parallel frame. Each entry describes where
+ * one branch is sitting right now: `activeNodeId` is the approval it's
+ * currently awaiting (or null while auto-advancing / after completion).
+ */
+export interface ParallelBranchState {
+  readonly branchEntryId: string
+  readonly activeNodeId: string | null
+  /** Set once the branch has reached the paired join. */
+  readonly completedAt?: string
+  /** Signal the branch emitted when exiting into the join ('approved' / 'denied' / 'default'). */
+  readonly completedSignal?: EdgeGuard
+}
+
+/**
+ * Runtime state for one `parallel` node currently in flight. Hosts see
+ * one frame per nested parallel scope; the outermost frame is `[0]`.
+ */
+export interface WorkflowParallelFrame {
+  readonly parallelId: string
+  readonly joinId: string
+  readonly mode: ParallelMode
+  readonly n?: number
+  readonly branches: readonly ParallelBranchState[]
+}
+
 export interface WorkflowInstance {
   readonly workflowId: string
   readonly workflowVersion: number
   readonly status: WorkflowInstanceStatus
-  /** The node that is currently active (awaiting approval / running). */
+  /**
+   * The node that is currently active (awaiting approval / running).
+   * Null while a parallel frame is in flight — the per-branch activity
+   * is tracked in `parallelFrames` instead.
+   */
   readonly currentNodeId: string | null
   readonly history: readonly WorkflowHistoryEntry[]
   /**
@@ -136,6 +205,11 @@ export interface WorkflowInstance {
    * the history to learn the result.
    */
   readonly outcome?: WorkflowOutcome
+  /**
+   * Active parallel frames, outermost first. Empty / undefined when
+   * the workflow is linear.
+   */
+  readonly parallelFrames?: readonly WorkflowParallelFrame[]
 }
 
 // ─── Layout (Phase 2 visual builder — side-car, NOT part of Workflow) ─────
@@ -163,8 +237,18 @@ export function findNode(
 }
 
 /**
- * Return the next node id for a given source + emitted signal.
- * Priority: exact `when` match > `default` edge > undefined.
+ * Return the edge matching a source + emitted signal, using the
+ * priority order:
+ *
+ *   1. exact `when === signal` match
+ *   2. `when === 'branch-completed'` when the signal is a branch-
+ *      terminating one (`approved` / `denied` / `timeout`), so branches
+ *      inside a parallel scope can route to the paired join without
+ *      double-wiring both outcomes.
+ *   3. default edge (`when === undefined` or `when === 'default'`)
+ *
+ * Returns undefined when nothing matches — callers treat that as a
+ * workflow failure.
  */
 export function resolveNextEdge(
   workflow: Workflow,
@@ -172,12 +256,21 @@ export function resolveNextEdge(
   signal: EdgeGuard,
 ): WorkflowEdge | undefined {
   let defaultEdge: WorkflowEdge | undefined
+  let branchCompletedEdge: WorkflowEdge | undefined
   for (const edge of workflow.edges) {
     if (edge.from !== fromNodeId) continue
     if (edge.when === signal) return edge
-    if (edge.when === undefined || edge.when === 'default') {
+    if (edge.when === 'branch-completed') {
+      branchCompletedEdge = edge
+    } else if (edge.when === undefined || edge.when === 'default') {
       defaultEdge = edge
     }
+  }
+  if (
+    branchCompletedEdge &&
+    (signal === 'approved' || signal === 'denied' || signal === 'timeout')
+  ) {
+    return branchCompletedEdge
   }
   return defaultEdge
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -70,13 +70,15 @@ export type {
   Workflow, WorkflowNode, WorkflowEdge, WorkflowInstance, WorkflowInstanceStatus,
   WorkflowHistoryEntry, WorkflowOutcome, WorkflowTrigger, EdgeGuard,
   WorkflowConditionNode, WorkflowApprovalNode, WorkflowNotifyNode, WorkflowTerminalNode,
+  WorkflowParallelNode, WorkflowJoinNode, ParallelMode,
+  ParallelBranchState, WorkflowParallelFrame,
   TimeoutBehavior,
 } from './core/workflow/workflowSchema';
 export { findNode as findWorkflowNode, resolveNextEdge as resolveWorkflowEdge } from './core/workflow/workflowSchema';
 export {
   WORKFLOW_TEMPLATES,
   singleApproverWorkflow, twoTierApproverWorkflow, conditionalByCostWorkflow,
-  slaEscalationWorkflow,
+  slaEscalationWorkflow, parallelSecurityAndFinanceApproval,
 } from './core/workflow/templates';
 
 // ── Booking holds (#211) ────────────────────────────────────────────────────

--- a/src/ui/WorkflowBuilderModal.module.css
+++ b/src/ui/WorkflowBuilderModal.module.css
@@ -122,6 +122,40 @@
   background: var(--wc-bg, #ffffff);
 }
 
+.palette {
+  display: flex;
+  gap: 6px;
+  flex-wrap: wrap;
+  padding-bottom: 8px;
+  border-bottom: 1px solid var(--wc-border, #d1d5db);
+  margin-bottom: 8px;
+}
+
+.paletteLabel {
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+  color: var(--wc-muted, #6b7280);
+  align-self: center;
+  margin-right: 4px;
+}
+
+.paletteButton {
+  padding: 4px 8px;
+  font-size: 11px;
+  font-weight: 500;
+  background: var(--wc-bg, #ffffff);
+  color: var(--wc-text, #111827);
+  border: 1px solid var(--wc-border, #d1d5db);
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.paletteButton:hover {
+  background: var(--wc-bg-muted, #f3f4f6);
+}
+
 .sidePane {
   display: flex;
   flex-direction: column;

--- a/src/ui/WorkflowBuilderModal.tsx
+++ b/src/ui/WorkflowBuilderModal.tsx
@@ -41,6 +41,7 @@ import type {
   WorkflowLayout,
   WorkflowNode,
 } from '../core/workflow/workflowSchema'
+import { NODE_HEIGHT } from '../core/workflow/layout'
 import { WorkflowCanvas } from './WorkflowCanvas'
 import { WorkflowNodeInspector } from './WorkflowNodeInspector'
 import { WorkflowEdgeGuardPicker } from './WorkflowEdgeGuardPicker'
@@ -104,6 +105,10 @@ export function WorkflowBuilderModal(
   const selectedNode: WorkflowNode | undefined = selectedNodeId
     ? draftWorkflow.nodes.find(n => n.id === selectedNodeId)
     : undefined
+  const parallelNodeIds = useMemo(
+    () => draftWorkflow.nodes.filter(n => n.type === 'parallel').map(n => n.id),
+    [draftWorkflow.nodes],
+  )
 
   // ─── Snapshot helper: cleared on non-delete mutations ────────────────────
   const clearUndo = useCallback(() => setUndoSnap(null), [])
@@ -166,6 +171,27 @@ export function WorkflowBuilderModal(
     setDraftLayout(undoSnap.layout)
     setUndoSnap(null)
   }, [undoSnap])
+
+  const handleAddNode = useCallback(
+    (type: WorkflowNode['type']) => {
+      const id = nextNodeId(draftWorkflow, type)
+      const node = seedNode(id, type)
+      // Drop the new node just below the lowest existing row so it's
+      // visible without overlapping. If the layout is empty, use (0, 0).
+      const existing = Object.values(draftLayout.positions)
+      const maxY = existing.reduce((m, p) => Math.max(m, p.y), -NODE_HEIGHT)
+      const pos = { x: 0, y: maxY + NODE_HEIGHT + 24 }
+      setDraftWorkflow(prev => ({ ...prev, nodes: [...prev.nodes, node] }))
+      setDraftLayout(prev => ({
+        ...prev,
+        positions: { ...prev.positions, [id]: pos },
+      }))
+      setSelectedNodeId(id)
+      setSidePane('inspector')
+      clearUndo()
+    },
+    [draftWorkflow, draftLayout, clearUndo],
+  )
 
   // ─── Edge creation → guard picker → commit ───────────────────────────────
 
@@ -259,6 +285,20 @@ export function WorkflowBuilderModal(
 
         <div className={styles.body}>
           <div className={styles.canvasPane}>
+            <div className={styles.palette} role="toolbar" aria-label="Add node">
+              <span className={styles.paletteLabel}>Add node</span>
+              {NODE_PALETTE.map(type => (
+                <button
+                  key={type}
+                  type="button"
+                  className={styles.paletteButton}
+                  data-testid={`wb-add-${type}`}
+                  onClick={() => handleAddNode(type)}
+                >
+                  + {type}
+                </button>
+              ))}
+            </div>
             <WorkflowCanvas
               workflow={draftWorkflow}
               layout={draftLayout}
@@ -311,6 +351,7 @@ export function WorkflowBuilderModal(
                   <WorkflowNodeInspector
                     node={selectedNode}
                     onChange={handleNodeChange}
+                    parallelNodeIds={parallelNodeIds}
                   />
                 )
                 : (
@@ -388,4 +429,50 @@ function groupIssuesByNode(
     acc[i.nodeId].push(i)
   }
   return acc
+}
+
+// ─── Palette helpers ─────────────────────────────────────────────────────
+
+const NODE_PALETTE: readonly WorkflowNode['type'][] = [
+  'approval',
+  'condition',
+  'notify',
+  'parallel',
+  'join',
+  'terminal',
+]
+
+/**
+ * Mint a fresh node id that doesn't collide with existing nodes.
+ * Format: `<type>-<n>` with `n` bumped until unique. Kept simple so
+ * authors can immediately see which kind of node they just added.
+ */
+function nextNodeId(
+  workflow: Workflow,
+  type: WorkflowNode['type'],
+): string {
+  const taken = new Set(workflow.nodes.map(n => n.id))
+  for (let i = 1; i < 1_000; i++) {
+    const candidate = `${type}-${i}`
+    if (!taken.has(candidate)) return candidate
+  }
+  // Unreachable for any realistic workflow; keep TS happy.
+  return `${type}-${workflow.nodes.length + 1}`
+}
+
+function seedNode(id: string, type: WorkflowNode['type']): WorkflowNode {
+  switch (type) {
+    case 'approval':
+      return { id, type, assignTo: 'role:approver' }
+    case 'condition':
+      return { id, type, expr: 'true' }
+    case 'notify':
+      return { id, type, channel: 'slack' }
+    case 'parallel':
+      return { id, type, branches: [], mode: 'requireAll' }
+    case 'join':
+      return { id, type, pairedWith: '' }
+    case 'terminal':
+      return { id, type, outcome: 'finalized' }
+  }
 }

--- a/src/ui/WorkflowBuilderModal.tsx
+++ b/src/ui/WorkflowBuilderModal.tsx
@@ -196,8 +196,30 @@ export function WorkflowBuilderModal(
   // ─── Edge creation → guard picker → commit ───────────────────────────────
 
   const handleCreateEdge = useCallback(
-    (from: string, to: string) => setPendingEdge({ from, to }),
-    [],
+    (from: string, to: string) => {
+      // Parallel nodes fan out via `node.branches`, NOT outgoing edges
+      // (the runtime's `enterParallel` reads only `branches` and
+      // ignores edges from a parallel source). Mutate the source's
+      // branches array directly instead of opening the guard picker —
+      // any edge appended here would be dead at runtime and would
+      // leave the parallel stuck on `parallel-branches-empty`.
+      const src = draftWorkflow.nodes.find(n => n.id === from)
+      if (src?.type === 'parallel') {
+        if (src.branches.includes(to)) return
+        setDraftWorkflow(prev => ({
+          ...prev,
+          nodes: prev.nodes.map(n =>
+            n.id === from && n.type === 'parallel'
+              ? { ...n, branches: [...n.branches, to] }
+              : n,
+          ),
+        }))
+        clearUndo()
+        return
+      }
+      setPendingEdge({ from, to })
+    },
+    [draftWorkflow, clearUndo],
   )
 
   const commitPendingEdge = useCallback(

--- a/src/ui/WorkflowCanvas.module.css
+++ b/src/ui/WorkflowCanvas.module.css
@@ -56,6 +56,8 @@
 .nodeKindCondition .nodeRect { fill: #fefce8; }
 .nodeKindNotify .nodeRect { fill: #f3e8ff; }
 .nodeKindTerminal .nodeRect { fill: #f3f4f6; }
+.nodeKindParallel .nodeRect { fill: #ecfeff; stroke-dasharray: 6 3; }
+.nodeKindJoin     .nodeRect { fill: #cffafe; stroke-dasharray: 6 3; }
 
 .nodeKind {
   font: 10px var(--wc-font, system-ui, sans-serif);

--- a/src/ui/WorkflowCanvas.tsx
+++ b/src/ui/WorkflowCanvas.tsx
@@ -76,6 +76,8 @@ function displayLabel(node: WorkflowNode): string {
     case 'condition': return node.expr
     case 'notify':    return node.channel
     case 'terminal':  return node.outcome
+    case 'parallel':  return `parallel (${node.mode}${node.n !== undefined ? `, n=${node.n}` : ''})`
+    case 'join':      return `join → ${node.pairedWith}`
   }
 }
 
@@ -386,6 +388,8 @@ export function WorkflowCanvas(props: WorkflowCanvasProps): JSX.Element {
             node.type === 'approval'  ? styles.nodeKindApproval  :
             node.type === 'condition' ? styles.nodeKindCondition :
             node.type === 'notify'    ? styles.nodeKindNotify    :
+            node.type === 'parallel'  ? styles.nodeKindParallel  :
+            node.type === 'join'      ? styles.nodeKindJoin      :
                                         styles.nodeKindTerminal
           const classes = [
             styles.node,

--- a/src/ui/WorkflowEdgeGuardPicker.tsx
+++ b/src/ui/WorkflowEdgeGuardPicker.tsx
@@ -6,8 +6,11 @@
  * Options are filtered to just those the source node can legally emit:
  *
  *   - `condition`  → true / false / default
- *   - `approval`   → approved / denied / default (+ `timeout` when slaMinutes set)
- *   - `notify`     → default
+ *   - `approval`   → approved / denied / branch-completed / default
+ *                     (+ `timeout` when slaMinutes set)
+ *   - `notify`     → branch-completed / default
+ *   - `parallel`   → default (fan-out is authored via `branches`, not edges)
+ *   - `join`       → default (joins always continue along the single post-join edge)
  *   - `terminal`   → (no outgoing edges; picker should not be invoked)
  *
  * Dismissal: Escape or click-outside calls `onCancel`. Picking an
@@ -43,6 +46,7 @@ const GUARD_LABELS: Readonly<Record<EdgeGuard, string>> = {
   'approved': 'approved',
   'denied': 'denied',
   'timeout': 'timeout (SLA)',
+  'branch-completed': 'branch-completed',
   'default': 'default (fallback)',
 }
 
@@ -60,9 +64,11 @@ export function guardsForSource(
     case 'condition': return ['true', 'false', 'default']
     case 'approval':
       return options?.hasSla
-        ? ['approved', 'denied', 'timeout', 'default']
-        : ['approved', 'denied', 'default']
-    case 'notify':    return ['default']
+        ? ['approved', 'denied', 'timeout', 'branch-completed', 'default']
+        : ['approved', 'denied', 'branch-completed', 'default']
+    case 'notify':    return ['branch-completed', 'default']
+    case 'parallel':  return ['default']
+    case 'join':      return ['default']
     case 'terminal':  return []
   }
 }

--- a/src/ui/WorkflowEdgeGuardPicker.tsx
+++ b/src/ui/WorkflowEdgeGuardPicker.tsx
@@ -8,7 +8,9 @@
  *   - `condition`  → true / false / default
  *   - `approval`   → approved / denied / branch-completed / default
  *                     (+ `timeout` when slaMinutes set)
- *   - `notify`     → branch-completed / default
+ *   - `notify`     → default (notify nodes always exit on the default
+ *                     edge; `branch-completed` only resolves for
+ *                     approved/denied/timeout signals at runtime)
  *   - `parallel`   → default (fan-out is authored via `branches`, not edges)
  *   - `join`       → default (joins always continue along the single post-join edge)
  *   - `terminal`   → (no outgoing edges; picker should not be invoked)
@@ -66,7 +68,7 @@ export function guardsForSource(
       return options?.hasSla
         ? ['approved', 'denied', 'timeout', 'branch-completed', 'default']
         : ['approved', 'denied', 'branch-completed', 'default']
-    case 'notify':    return ['branch-completed', 'default']
+    case 'notify':    return ['default']
     case 'parallel':  return ['default']
     case 'join':      return ['default']
     case 'terminal':  return []

--- a/src/ui/WorkflowNodeInspector.module.css
+++ b/src/ui/WorkflowNodeInspector.module.css
@@ -86,3 +86,14 @@
 .errorInput {
   border-color: var(--wc-danger, #b91c1c);
 }
+
+.list {
+  margin: 0;
+  padding: 0 0 0 16px;
+  font-size: 12px;
+  color: var(--wc-text, #111827);
+}
+
+.listItem {
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+}

--- a/src/ui/WorkflowNodeInspector.tsx
+++ b/src/ui/WorkflowNodeInspector.tsx
@@ -13,12 +13,15 @@
 import { useEffect, useRef, useState } from 'react'
 import { validateExpressionSyntax } from '../core/workflow/validate'
 import type {
+  ParallelMode,
   TimeoutBehavior,
   WorkflowApprovalNode,
   WorkflowConditionNode,
+  WorkflowJoinNode,
   WorkflowNode,
   WorkflowNotifyNode,
   WorkflowOutcome,
+  WorkflowParallelNode,
   WorkflowTerminalNode,
 } from '../core/workflow/workflowSchema'
 import styles from './WorkflowNodeInspector.module.css'
@@ -31,17 +34,30 @@ const TIMEOUT_BEHAVIORS: readonly TimeoutBehavior[] = [
   'auto-deny',
 ]
 
+const PARALLEL_MODES: readonly ParallelMode[] = [
+  'requireAll',
+  'requireAny',
+  'requireN',
+]
+
 const OUTCOMES: readonly WorkflowOutcome[] = ['finalized', 'denied', 'cancelled']
 
 export interface WorkflowNodeInspectorProps {
   readonly node: WorkflowNode
   readonly onChange: (patch: Partial<WorkflowNode>) => void
+  /**
+   * Ids of every `parallel` node in the workflow, for the join
+   * inspector's `pairedWith` dropdown. Optional: when absent, the
+   * dropdown falls back to a free-text input so the inspector can still
+   * be used in isolation (tests, storybook, etc.).
+   */
+  readonly parallelNodeIds?: readonly string[]
 }
 
 export function WorkflowNodeInspector(
   props: WorkflowNodeInspectorProps,
 ): JSX.Element {
-  const { node, onChange } = props
+  const { node, onChange, parallelNodeIds } = props
   return (
     <section
       className={styles.panel}
@@ -65,6 +81,16 @@ export function WorkflowNodeInspector(
       )}
       {node.type === 'terminal' && (
         <TerminalFields node={node} onChange={onChange} />
+      )}
+      {node.type === 'parallel' && (
+        <ParallelFields node={node} onChange={onChange} />
+      )}
+      {node.type === 'join' && (
+        <JoinFields
+          node={node}
+          onChange={onChange}
+          parallelNodeIds={parallelNodeIds}
+        />
       )}
     </section>
   )
@@ -292,6 +318,118 @@ function TerminalFields({
       >
         {OUTCOMES.map(o => <option key={o} value={o}>{o}</option>)}
       </select>
+    </div>
+  )
+}
+
+function ParallelFields({
+  node,
+  onChange,
+}: {
+  node: WorkflowParallelNode
+  onChange: (patch: Partial<WorkflowParallelNode>) => void
+}): JSX.Element {
+  return (
+    <>
+      <div className={styles.field}>
+        <label className={styles.label} htmlFor="wc-node-mode">Mode</label>
+        <select
+          id="wc-node-mode"
+          className={styles.select}
+          value={node.mode}
+          onChange={e => {
+            const mode = e.target.value as ParallelMode
+            // Drop `n` unless we're in requireN — keeps persisted
+            // graphs free of stale quorum counts after a mode swap.
+            onChange(mode === 'requireN' ? { mode } : { mode, n: undefined })
+          }}
+        >
+          {PARALLEL_MODES.map(m => <option key={m} value={m}>{m}</option>)}
+        </select>
+      </div>
+
+      {node.mode === 'requireN' && (
+        <div className={styles.field}>
+          <label className={styles.label} htmlFor="wc-node-n">N (required approvals)</label>
+          <input
+            id="wc-node-n"
+            className={styles.input}
+            type="text"
+            inputMode="numeric"
+            pattern="[0-9]*"
+            value={node.n ?? ''}
+            onChange={e => {
+              const raw = e.target.value
+              if (raw === '') return onChange({ n: undefined })
+              if (!/^\d+$/.test(raw)) return
+              const parsed = Number(raw)
+              if (Number.isFinite(parsed) && parsed >= 1) {
+                onChange({ n: parsed })
+              }
+            }}
+          />
+          <span className={styles.hint}>
+            Must be between 1 and the number of branches.
+          </span>
+        </div>
+      )}
+
+      <div className={styles.field}>
+        <label className={styles.label}>Branches</label>
+        <ul className={styles.list} data-testid="wc-parallel-branches">
+          {node.branches.length === 0
+            ? <li className={styles.hint}>No branches yet.</li>
+            : node.branches.map(b => (
+              <li key={b} className={styles.listItem}>{b}</li>
+            ))}
+        </ul>
+        <span className={styles.hint}>
+          Branches are authored by picking entry nodes on the canvas.
+        </span>
+      </div>
+    </>
+  )
+}
+
+function JoinFields({
+  node,
+  onChange,
+  parallelNodeIds,
+}: {
+  node: WorkflowJoinNode
+  onChange: (patch: Partial<WorkflowJoinNode>) => void
+  parallelNodeIds?: readonly string[]
+}): JSX.Element {
+  const useDropdown = parallelNodeIds !== undefined
+  return (
+    <div className={styles.field}>
+      <label className={styles.label} htmlFor="wc-node-paired">Paired parallel</label>
+      {useDropdown ? (
+        <select
+          id="wc-node-paired"
+          className={styles.select}
+          value={node.pairedWith}
+          onChange={e => onChange({ pairedWith: e.target.value })}
+        >
+          {/* Show the current value first so a stale pairing still renders. */}
+          {!parallelNodeIds!.includes(node.pairedWith) && (
+            <option value={node.pairedWith}>{node.pairedWith} (missing)</option>
+          )}
+          {parallelNodeIds!.map(id => (
+            <option key={id} value={id}>{id}</option>
+          ))}
+        </select>
+      ) : (
+        <input
+          id="wc-node-paired"
+          className={styles.input}
+          value={node.pairedWith}
+          onChange={e => onChange({ pairedWith: e.target.value })}
+        />
+      )}
+      <span className={styles.hint}>
+        Join releases once the paired parallel's quorum is met.
+      </span>
     </div>
   )
 }

--- a/src/ui/__tests__/WorkflowBuilderModal.test.tsx
+++ b/src/ui/__tests__/WorkflowBuilderModal.test.tsx
@@ -224,6 +224,68 @@ describe('WorkflowBuilderModal — add node palette', () => {
     expect(document.querySelector('[data-node-id="approval-1"]')).toBeInTheDocument()
     expect(document.querySelector('[data-node-id="approval-2"]')).toBeInTheDocument()
   })
+
+  // Regression: drawing an edge from a parallel source must persist
+  // the target into the source's `branches` array — the runtime's
+  // `enterParallel` reads only `branches` and ignores outgoing edges,
+  // so a normal-edge append would leave the parallel stuck on
+  // `parallel-branches-empty` even after the user "wired" it.
+  it('drawing an edge from a parallel source persists the target into node.branches (no edge appended, no picker)', () => {
+    renderModal()
+    fireEvent.click(screen.getByTestId('wb-add-parallel'))
+    // Select the new parallel so the inspector renders its branches list.
+    fireEvent.pointerDown(
+      document.querySelector('[data-node-id="parallel-1"]')!,
+      { pointerId: 0, clientX: 0, clientY: 0 },
+    )
+    expect(screen.getByTestId('wc-parallel-branches').textContent ?? '').not.toContain('done')
+    // Source = the new parallel, Target = the existing 'done' terminal.
+    fireEvent.pointerDown(
+      document.querySelector('[data-handle-for="parallel-1"]')!,
+      { pointerId: 1 },
+    )
+    fireEvent.pointerDown(
+      document.querySelector('[data-node-id="done"]')!,
+      { pointerId: 2, clientX: 0, clientY: 0 },
+    )
+    // No picker should appear — parallel has no edge guards to choose.
+    expect(screen.queryByTestId('workflow-edge-guard-picker')).toBeNull()
+    // Re-select the parallel and verify the inspector now lists 'done'
+    // in its branches panel — i.e. the target was persisted into
+    // node.branches, not appended as a dead outgoing edge.
+    fireEvent.pointerDown(
+      document.querySelector('[data-node-id="parallel-1"]')!,
+      { pointerId: 3, clientX: 0, clientY: 0 },
+    )
+    expect(screen.getByTestId('wc-parallel-branches').textContent).toContain('done')
+    // And the canvas has NOT drawn a parallel→done edge path.
+    expect(
+      document.querySelector('[data-edge-from="parallel-1"][data-edge-to="done"]'),
+    ).toBeNull()
+  })
+
+  it('redrawing the same parallel→target edge does not duplicate the branch entry', () => {
+    renderModal()
+    fireEvent.click(screen.getByTestId('wb-add-parallel'))
+    for (let i = 0; i < 2; i++) {
+      fireEvent.pointerDown(
+        document.querySelector('[data-handle-for="parallel-1"]')!,
+        { pointerId: 1 },
+      )
+      fireEvent.pointerDown(
+        document.querySelector('[data-node-id="done"]')!,
+        { pointerId: 2, clientX: 0, clientY: 0 },
+      )
+    }
+    fireEvent.pointerDown(
+      document.querySelector('[data-node-id="parallel-1"]')!,
+      { pointerId: 3, clientX: 0, clientY: 0 },
+    )
+    const branches = screen.getByTestId('wc-parallel-branches')
+    const entries = branches.querySelectorAll('li')
+    const doneCount = [...entries].filter(li => (li.textContent ?? '').includes('done')).length
+    expect(doneCount).toBe(1)
+  })
 })
 
 describe('WorkflowBuilderModal — delete + undo', () => {

--- a/src/ui/__tests__/WorkflowBuilderModal.test.tsx
+++ b/src/ui/__tests__/WorkflowBuilderModal.test.tsx
@@ -189,6 +189,43 @@ describe('WorkflowBuilderModal — edge creation → guard picker', () => {
   })
 })
 
+describe('WorkflowBuilderModal — add node palette', () => {
+  it('renders a button for every node type', () => {
+    renderModal()
+    for (const t of ['approval', 'condition', 'notify', 'parallel', 'join', 'terminal']) {
+      expect(screen.getByTestId(`wb-add-${t}`)).toBeInTheDocument()
+    }
+  })
+
+  it('clicking + parallel adds a parallel node and selects it', () => {
+    renderModal()
+    fireEvent.click(screen.getByTestId('wb-add-parallel'))
+    const added = document.querySelector('[data-node-id="parallel-1"]')
+    expect(added).toBeInTheDocument()
+    expect(added?.className).toMatch(/nodeKindParallel/)
+    // Inspector shows the parallel form (mode dropdown).
+    expect(screen.getByLabelText(/mode/i)).toBeInTheDocument()
+  })
+
+  it('clicking + join adds a join node and the paired-parallel dropdown lists existing parallels', () => {
+    renderModal()
+    fireEvent.click(screen.getByTestId('wb-add-parallel'))
+    fireEvent.click(screen.getByTestId('wb-add-join'))
+    const select = screen.getByLabelText(/paired parallel/i) as HTMLSelectElement
+    expect(select.tagName).toBe('SELECT')
+    const ids = [...select.options].map(o => o.value)
+    expect(ids).toContain('parallel-1')
+  })
+
+  it('id minting avoids colliding with existing ids', () => {
+    renderModal()
+    fireEvent.click(screen.getByTestId('wb-add-approval'))
+    fireEvent.click(screen.getByTestId('wb-add-approval'))
+    expect(document.querySelector('[data-node-id="approval-1"]')).toBeInTheDocument()
+    expect(document.querySelector('[data-node-id="approval-2"]')).toBeInTheDocument()
+  })
+})
+
 describe('WorkflowBuilderModal — delete + undo', () => {
   it('Delete removes the node; Undo restores it exactly', () => {
     const { onSave } = renderModal(conditionalByCostWorkflow)

--- a/src/ui/__tests__/WorkflowCanvas.test.tsx
+++ b/src/ui/__tests__/WorkflowCanvas.test.tsx
@@ -8,6 +8,7 @@ import { GRID_SNAP } from '../../core/workflow/layout'
 import {
   singleApproverWorkflow,
   conditionalByCostWorkflow,
+  parallelSecurityAndFinanceApproval,
 } from '../../core/workflow/templates'
 import type { Workflow, WorkflowLayout } from '../../core/workflow/workflowSchema'
 
@@ -188,6 +189,28 @@ describe('WorkflowCanvas — keyboard', () => {
     expect(nodes[0]).toBe('check-cost')
     // director + notify-ops are both rank-1 children.
     expect(nodes.slice(1, 3).sort()).toEqual(['director', 'notify-ops'])
+  })
+})
+
+describe('WorkflowCanvas — parallel + join rendering', () => {
+  it('renders the parallel fan-out node with its mode in the label', () => {
+    renderCanvas(parallelSecurityAndFinanceApproval)
+    const fan = document.querySelector('[data-node-id="fanout"]')!
+    expect(fan.getAttribute('aria-label')).toMatch(/parallel node/i)
+    expect(fan.className).toMatch(/nodeKindParallel/)
+  })
+
+  it('renders the join node with a join kind class', () => {
+    renderCanvas(parallelSecurityAndFinanceApproval)
+    const join = document.querySelector('[data-node-id="rejoin"]')!
+    expect(join.className).toMatch(/nodeKindJoin/)
+    expect(join.getAttribute('aria-label')).toMatch(/join node/i)
+  })
+
+  it('both parallel and join expose a source handle for edge-draw', () => {
+    renderCanvas(parallelSecurityAndFinanceApproval)
+    expect(document.querySelector('[data-handle-for="fanout"]')).toBeInTheDocument()
+    expect(document.querySelector('[data-handle-for="rejoin"]')).toBeInTheDocument()
   })
 })
 

--- a/src/ui/__tests__/WorkflowEdgeGuardPicker.test.tsx
+++ b/src/ui/__tests__/WorkflowEdgeGuardPicker.test.tsx
@@ -17,8 +17,8 @@ describe('guardsForSource', () => {
       'approved', 'denied', 'branch-completed', 'default',
     ])
   })
-  it('notify → branch-completed / default', () => {
-    expect(guardsForSource('notify')).toEqual(['branch-completed', 'default'])
+  it('notify → default only (notify always exits via default at runtime)', () => {
+    expect(guardsForSource('notify')).toEqual(['default'])
   })
   it('parallel → default only (branches author via the node, not edges)', () => {
     expect(guardsForSource('parallel')).toEqual(['default'])
@@ -41,7 +41,7 @@ describe('guardsForSource', () => {
   })
   it('hasSla only affects approval sources', () => {
     expect(guardsForSource('condition', { hasSla: true })).toEqual(['true', 'false', 'default'])
-    expect(guardsForSource('notify',    { hasSla: true })).toEqual(['branch-completed', 'default'])
+    expect(guardsForSource('notify',    { hasSla: true })).toEqual(['default'])
   })
 })
 
@@ -100,7 +100,7 @@ describe('WorkflowEdgeGuardPicker — rendering', () => {
     expect(document.querySelector('[data-guard="true"]')).toBeNull()
   })
 
-  it('renders branch-completed + default for a notify source', () => {
+  it('renders only default for a notify source', () => {
     render(
       <WorkflowEdgeGuardPicker
         sourceType="notify"
@@ -108,9 +108,9 @@ describe('WorkflowEdgeGuardPicker — rendering', () => {
         onCancel={vi.fn()}
       />,
     )
-    const guards = [...document.querySelectorAll('[data-guard]')]
-      .map(b => b.getAttribute('data-guard'))
-    expect(guards).toEqual(['branch-completed', 'default'])
+    const buttons = document.querySelectorAll('[data-guard]')
+    expect(buttons.length).toBe(1)
+    expect(buttons[0].getAttribute('data-guard')).toBe('default')
   })
 
   it('renders only default for a parallel source', () => {

--- a/src/ui/__tests__/WorkflowEdgeGuardPicker.test.tsx
+++ b/src/ui/__tests__/WorkflowEdgeGuardPicker.test.tsx
@@ -12,28 +12,36 @@ describe('guardsForSource', () => {
   it('condition → true / false / default', () => {
     expect(guardsForSource('condition')).toEqual(['true', 'false', 'default'])
   })
-  it('approval → approved / denied / default', () => {
-    expect(guardsForSource('approval')).toEqual(['approved', 'denied', 'default'])
+  it('approval → approved / denied / branch-completed / default', () => {
+    expect(guardsForSource('approval')).toEqual([
+      'approved', 'denied', 'branch-completed', 'default',
+    ])
   })
-  it('notify → default only', () => {
-    expect(guardsForSource('notify')).toEqual(['default'])
+  it('notify → branch-completed / default', () => {
+    expect(guardsForSource('notify')).toEqual(['branch-completed', 'default'])
+  })
+  it('parallel → default only (branches author via the node, not edges)', () => {
+    expect(guardsForSource('parallel')).toEqual(['default'])
+  })
+  it('join → default only', () => {
+    expect(guardsForSource('join')).toEqual(['default'])
   })
   it('terminal → empty list', () => {
     expect(guardsForSource('terminal')).toEqual([])
   })
   it('approval with SLA → includes timeout', () => {
     expect(guardsForSource('approval', { hasSla: true })).toEqual([
-      'approved', 'denied', 'timeout', 'default',
+      'approved', 'denied', 'timeout', 'branch-completed', 'default',
     ])
   })
   it('approval without SLA → no timeout', () => {
     expect(guardsForSource('approval', { hasSla: false })).toEqual([
-      'approved', 'denied', 'default',
+      'approved', 'denied', 'branch-completed', 'default',
     ])
   })
   it('hasSla only affects approval sources', () => {
     expect(guardsForSource('condition', { hasSla: true })).toEqual(['true', 'false', 'default'])
-    expect(guardsForSource('notify',    { hasSla: true })).toEqual(['default'])
+    expect(guardsForSource('notify',    { hasSla: true })).toEqual(['branch-completed', 'default'])
   })
 })
 
@@ -77,7 +85,7 @@ describe('WorkflowEdgeGuardPicker — rendering', () => {
     expect(document.querySelector('[data-guard="approved"]')).toBeNull()
   })
 
-  it('renders approved/denied/default for an approval source', () => {
+  it('renders approved/denied/branch-completed/default for an approval source', () => {
     render(
       <WorkflowEdgeGuardPicker
         sourceType="approval"
@@ -87,14 +95,41 @@ describe('WorkflowEdgeGuardPicker — rendering', () => {
     )
     expect(document.querySelector('[data-guard="approved"]')).toBeInTheDocument()
     expect(document.querySelector('[data-guard="denied"]')).toBeInTheDocument()
+    expect(document.querySelector('[data-guard="branch-completed"]')).toBeInTheDocument()
     expect(document.querySelector('[data-guard="default"]')).toBeInTheDocument()
     expect(document.querySelector('[data-guard="true"]')).toBeNull()
   })
 
-  it('renders only default for a notify source', () => {
+  it('renders branch-completed + default for a notify source', () => {
     render(
       <WorkflowEdgeGuardPicker
         sourceType="notify"
+        onPick={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    )
+    const guards = [...document.querySelectorAll('[data-guard]')]
+      .map(b => b.getAttribute('data-guard'))
+    expect(guards).toEqual(['branch-completed', 'default'])
+  })
+
+  it('renders only default for a parallel source', () => {
+    render(
+      <WorkflowEdgeGuardPicker
+        sourceType="parallel"
+        onPick={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    )
+    const buttons = document.querySelectorAll('[data-guard]')
+    expect(buttons.length).toBe(1)
+    expect(buttons[0].getAttribute('data-guard')).toBe('default')
+  })
+
+  it('renders only default for a join source', () => {
+    render(
+      <WorkflowEdgeGuardPicker
+        sourceType="join"
         onPick={vi.fn()}
         onCancel={vi.fn()}
       />,

--- a/src/ui/__tests__/WorkflowNodeInspector.test.tsx
+++ b/src/ui/__tests__/WorkflowNodeInspector.test.tsx
@@ -8,8 +8,10 @@ import { WorkflowNodeInspector } from '../WorkflowNodeInspector'
 import type {
   WorkflowApprovalNode,
   WorkflowConditionNode,
+  WorkflowJoinNode,
   WorkflowNode,
   WorkflowNotifyNode,
+  WorkflowParallelNode,
   WorkflowTerminalNode,
 } from '../../core/workflow/workflowSchema'
 
@@ -267,5 +269,102 @@ describe('WorkflowNodeInspector — terminal', () => {
     render(<WorkflowNodeInspector node={node} onChange={onChange} />)
     fireEvent.change(screen.getByLabelText(/outcome/i), { target: { value: 'cancelled' } })
     expect(onChange).toHaveBeenLastCalledWith({ outcome: 'cancelled' })
+  })
+})
+
+describe('WorkflowNodeInspector — parallel', () => {
+  const baseNode: WorkflowParallelNode = {
+    id: 'fan',
+    type: 'parallel',
+    branches: ['a', 'b'],
+    mode: 'requireAll',
+  }
+
+  it('edits mode', () => {
+    const onChange = vi.fn()
+    render(<WorkflowNodeInspector node={baseNode} onChange={onChange} />)
+    fireEvent.change(screen.getByLabelText(/mode/i), { target: { value: 'requireAny' } })
+    expect(onChange).toHaveBeenLastCalledWith({ mode: 'requireAny', n: undefined })
+  })
+
+  it('does not render the N input outside requireN', () => {
+    render(<WorkflowNodeInspector node={baseNode} onChange={vi.fn()} />)
+    expect(screen.queryByLabelText(/n \(required/i)).toBeNull()
+  })
+
+  it('renders the N input and parses valid digits when mode is requireN', () => {
+    const node: WorkflowParallelNode = { ...baseNode, mode: 'requireN', n: 1 }
+    const spy = vi.fn()
+    render(<Harness initial={node} spy={spy} />)
+    fireEvent.change(screen.getByLabelText(/n \(required/i), { target: { value: '2' } })
+    expect(spy).toHaveBeenLastCalledWith({ n: 2 })
+  })
+
+  it('clears N when emptied', () => {
+    const node: WorkflowParallelNode = { ...baseNode, mode: 'requireN', n: 2 }
+    const spy = vi.fn()
+    render(<Harness initial={node} spy={spy} />)
+    fireEvent.change(screen.getByLabelText(/n \(required/i), { target: { value: '' } })
+    expect(spy).toHaveBeenLastCalledWith({ n: undefined })
+  })
+
+  it('ignores n < 1', () => {
+    const node: WorkflowParallelNode = { ...baseNode, mode: 'requireN', n: 2 }
+    const spy = vi.fn()
+    render(<Harness initial={node} spy={spy} />)
+    fireEvent.change(screen.getByLabelText(/n \(required/i), { target: { value: '0' } })
+    expect(spy).not.toHaveBeenCalledWith(expect.objectContaining({ n: 0 }))
+  })
+
+  it('lists each declared branch entry id', () => {
+    render(<WorkflowNodeInspector node={baseNode} onChange={vi.fn()} />)
+    const list = screen.getByTestId('wc-parallel-branches')
+    expect(list.textContent).toContain('a')
+    expect(list.textContent).toContain('b')
+  })
+})
+
+describe('WorkflowNodeInspector — join', () => {
+  const baseNode: WorkflowJoinNode = {
+    id: 'rejoin',
+    type: 'join',
+    pairedWith: 'fan',
+  }
+
+  it('renders a free-text input when no parallelNodeIds are supplied', () => {
+    const onChange = vi.fn()
+    render(<WorkflowNodeInspector node={baseNode} onChange={onChange} />)
+    const input = screen.getByLabelText(/paired parallel/i) as HTMLInputElement
+    expect(input.tagName).toBe('INPUT')
+    fireEvent.change(input, { target: { value: 'other' } })
+    expect(onChange).toHaveBeenLastCalledWith({ pairedWith: 'other' })
+  })
+
+  it('renders a dropdown when parallelNodeIds are supplied', () => {
+    const onChange = vi.fn()
+    render(
+      <WorkflowNodeInspector
+        node={baseNode}
+        onChange={onChange}
+        parallelNodeIds={['fan', 'other']}
+      />,
+    )
+    const select = screen.getByLabelText(/paired parallel/i) as HTMLSelectElement
+    expect(select.tagName).toBe('SELECT')
+    fireEvent.change(select, { target: { value: 'other' } })
+    expect(onChange).toHaveBeenLastCalledWith({ pairedWith: 'other' })
+  })
+
+  it('preserves a stale pairedWith as a disabled-looking missing option', () => {
+    render(
+      <WorkflowNodeInspector
+        node={{ ...baseNode, pairedWith: 'gone' }}
+        onChange={vi.fn()}
+        parallelNodeIds={['fan']}
+      />,
+    )
+    const select = screen.getByLabelText(/paired parallel/i) as HTMLSelectElement
+    expect(select.value).toBe('gone')
+    expect(select.textContent).toContain('(missing)')
   })
 })


### PR DESCRIPTION
Two review fixes on #223 Sprint 2a:

- validateWorkflow: treat knownChannels=[] as "skip check" to match the
  documented semantics. Previously any truthy array enabled validation,
  so a not-yet-populated registry flagged every notify node.
- interpolateTemplate: drop the fast-path that short-circuited when
  neither `{{` nor `\{\{` appeared. A template like "x \}\} y" only
  contains closing-brace escapes, so the guard left the backslashes in
  the output. The char-by-char loop is cheap enough to run
  unconditionally — no shortcut needed.