### PR TITLE
docs(workflow): fold Sprint 3 close-out into the P4 branch (#219)

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ WorksCalendar is an embeddable React calendar focused on **real scheduling workf
 - External intake form component (`CalendarExternalForm`)
 - Themeable UI with optional packaged themes
 - Data adapter pattern for backend-agnostic integrations
-- Declarative approval workflows (conditions, multi-tier approvals, notifications) with a sandboxed expression language
+- Declarative approval workflows with a sandboxed expression language — multi-tier approvals, SLA timers + escalation, parallel branches with quorum joins (`requireAll` / `requireAny` / `requireN`), and pluggable notification channels (Slack, email, webhook, or your own adapter)
 - **Written in strict TypeScript**; ships with generated `.d.ts` so consumer types stay in lockstep with the implementation
 
 ## New here? Start with the [Setup guide](./docs/Setup.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -36,6 +36,7 @@ This index is the canonical docs entrypoint for the package.
 - [Grouping API](./GROUPING_API.md)
 - [Prompts](./Prompts.md)
 - [HIPAA security notes](./HIPAA-Security.md)
+- [Bundle size audit](./bundle-size-audit.md)
 - [Recurring schedule implementation plan](./recurring-schedule-implementation-plan.md)
 - [Recurring events engine plan](./recurring-events-engine-plan.md)
 

--- a/docs/Workflow.md
+++ b/docs/Workflow.md
@@ -16,8 +16,9 @@ it in lockstep with the existing approval state machine.
   inspector, guard picker, validator, simulator, persistence.
   Accessible at ConfigPanel → Approval Flows.
 - **Phase 3 (#222)** — SLA timers on approval nodes with
-  `onTimeout: 'escalate' | 'deny' | 'approve'` behavior, driven by a
-  host-side `tickWorkflow()` call (see `useWorkflowTicker`).
+  `onTimeout: 'escalate' | 'auto-approve' | 'auto-deny'` behavior,
+  driven by a host-side `tickWorkflow()` call (see
+  `useWorkflowTicker`).
 - **Phase 4 (#223)** — `parallel` + `join` nodes with
   `requireAll` / `requireAny` / `requireN` quorum modes, plus a
   pluggable channel registry (`createChannelRegistry`) with built-in

--- a/docs/Workflow.md
+++ b/docs/Workflow.md
@@ -1,11 +1,28 @@
 # Workflow DSL
 
-_Phase 1 — JSON-only interpreter. Issue #219._
+_Epic #219 — phases 1–4 all shipped (JSON interpreter, visual builder,
+SLA timers, parallel/channels)._
 
 WorksCalendar ships a declarative, versioned approval workflow engine that
 supersedes the hard-coded single/two-tier approval flow. Owners describe
 the flow as a JSON graph of nodes and edges; a pure interpreter advances
 it in lockstep with the existing approval state machine.
+
+## What shipped across phases 1–4
+
+- **Phase 1** — the JSON schema, expression evaluator, interpreter,
+  approval integration, and starter templates (below).
+- **Phase 2 (#220, #221)** — in-app visual builder: SVG canvas,
+  inspector, guard picker, validator, simulator, persistence.
+  Accessible at ConfigPanel → Approval Flows.
+- **Phase 3 (#222)** — SLA timers on approval nodes with
+  `onTimeout: 'escalate' | 'deny' | 'approve'` behavior, driven by a
+  host-side `tickWorkflow()` call (see `useWorkflowTicker`).
+- **Phase 4 (#223)** — `parallel` + `join` nodes with
+  `requireAll` / `requireAny` / `requireN` quorum modes, plus a
+  pluggable channel registry (`createChannelRegistry`) with built-in
+  Slack / email / webhook adapters and Mustache-style template
+  interpolation for notify payloads.
 
 ## What shipped in Phase 1
 
@@ -34,8 +51,10 @@ it in lockstep with the existing approval state machine.
 | Type        | Purpose                                    | Exit signal            |
 |-------------|--------------------------------------------|------------------------|
 | `condition` | Branch on an expression                    | `'true'` / `'false'`   |
-| `approval`  | Wait for approve/deny from an assignee     | `'approved'` / `'denied'` |
-| `notify`    | Fire a `notify` emit event, then fall through | `'default'`        |
+| `approval`  | Wait for approve/deny from an assignee (optional SLA + `onTimeout`) | `'approved'` / `'denied'` / `'timeout'` |
+| `notify`    | Dispatch via a channel adapter, then fall through | `'default'`     |
+| `parallel`  | Fan out to N branches; quorum is set by `mode` (`requireAll` / `requireAny` / `requireN`) | — (branches rejoin at the paired `join`) |
+| `join`      | Gate the paired parallel's continuation until quorum is met | `'default'` |
 | `terminal`  | End the flow with an `outcome`             | — (no outgoing edges)  |
 
 Edge resolution prefers an exact `when` match over a `default` edge
@@ -138,21 +157,14 @@ nodes can fan out without the workflow engine caring about transport.
 | `singleApproverWorkflow`       | One approval → finalized or denied.                       |
 | `twoTierApproverWorkflow`      | Manager → director chain, IHC-style.                      |
 | `conditionalByCostWorkflow`    | Cheap requests finalize; `event.cost > 500` requires a director then notifies ops. |
+| `slaEscalationWorkflow`        | Manager approval with a 60-minute SLA that escalates to a director on timeout (#222). |
+| `parallelSecurityAndFinanceApproval` | Fan out to security + finance approvals in parallel, rejoin once both vote, notify ops, finalize (#223). |
 
 Import from `works-calendar/workflow`:
 
 ```ts
 import { WORKFLOW_TEMPLATES } from 'works-calendar'
 ```
-
-## Planned phases
-
-- **Phase 2** — visual `WorkflowBuilder` editor in ConfigPanel (drag-drop
-  canvas, node inspector, JSON import/export).
-- **Phase 3** — SLA timers + escalation; scheduled `tick` action fed by
-  host-side cron/queue.
-- **Phase 4** — `parallel` node (N-of-M approvals), pluggable notify
-  channels.
 
 ## Related
 

--- a/docs/bundle-size-audit.md
+++ b/docs/bundle-size-audit.md
@@ -1,0 +1,86 @@
+# Bundle size audit (2026-04-21 — Phase 4 workflow close-out)
+
+Post-merge snapshot for the workflow DSL close-out (epic #219). Covers
+the runtime additions from #222 (SLA timers + escalation) and #223
+(parallel/join nodes, channel registry, notify dispatch, template
+interpolation) on top of the Phase-2 visual builder baseline.
+
+Prior snapshot: [Phase 2 baseline (archived)](./archive/analysis/bundle-size-audit.md).
+
+## What was checked
+
+- Ran `npm run build` on the tip of `claude/workflow-p4-parallel`
+  (commit `8b25faf`) after the Codex review fixes landed.
+- Verified the Phase-2 lazy boundaries still hold:
+  - `ApprovalFlowsTab` is `React.lazy`-imported from ConfigPanel.
+  - `WorkflowBuilderModal` is a second-tier lazy import inside
+    `ApprovalFlowsTab`; the SVG canvas, validator, layout engine,
+    inspector, guard picker, simulator, parallel/join forms, and
+    per-type CSS modules only download when the author opens a draft.
+- Confirmed the P3/P4 additions land in the library's main chunk
+  (`dist/index-*.js`) because `src/index.ts` re-exports the engine,
+  channel factories, validator, and templates as public API.
+
+## Current build output snapshot
+
+### Post-P4 (commit `8b25faf`)
+
+- `dist/index-DWst08WI.js`: **898.31 kB** (gzip **209.83 kB**)
+- `dist/WorkflowBuilderModal-l6Z1_J2-.js`: 50.31 kB (gzip 12.48 kB)
+- `dist/ApprovalFlowsTab-BAXXubUJ.js`: 10.86 kB (gzip 2.81 kB)
+- `dist/excelExport-BtyGrHgh.js`: 1.17 kB (gzip 0.66 kB)
+- `dist/works-calendar.es.js` bootstrap: 5.37 kB (gzip 2.21 kB)
+- `dist/works-calendar.umd.js`: 620.66 kB (gzip 178.47 kB)
+- `dist/style.css`: 182.95 kB (gzip 28.86 kB)
+
+### Delta vs. Phase-2 baseline
+
+| Chunk | Phase 2 (gzip) | Phase 4 (gzip) | Δ |
+| --- | --- | --- | --- |
+| `index-*.js` (main) | 187.90 kB | 209.83 kB | **+21.93 kB** |
+| `WorkflowBuilderModal-*.js` | 14.70 kB | 12.48 kB | −2.22 kB |
+| `ApprovalFlowsTab-*.js` | 3.13 kB | 2.81 kB | −0.32 kB |
+| `style.css` | 28.51 kB | 28.86 kB | +0.35 kB |
+| `works-calendar.es.js` bootstrap | 1.65 kB | 2.21 kB | +0.56 kB |
+
+## Audit conclusion
+
+- **Main chunk grew by ~22 kB gzipped across P3 + P4** — larger than
+  the ≤2 kB budget used for the visual builder in Phase 2, but that
+  budget was scoped to the builder UI. P3/P4 add *runtime* surface
+  that is public API by design:
+  - SLA timer state + `tick()` + timeout/escalate semantics (#222).
+  - Parallel frame machinery (`enterParallel`, `walkBranchForward`,
+    `settleFrame`, branch quorum) + `join` resolution (#223).
+  - Channel registry, dispatch pipeline, 3 built-in adapters (Slack,
+    email, webhook), + template interpolation (#223).
+  - New validator rules, templates, and `useWorkflowTicker` hook.
+  Callers that do not import the workflow API continue to tree-shake
+  these out of their own bundles.
+- **The visual builder chunks shrank slightly** despite gaining
+  parallel/join inspector forms, the node palette, and canvas kind
+  styling — the previous `esbuild`→`oxc` toolchain switch is the
+  likely source of the win.
+- **CSS delta is +0.35 kB gzipped** — the parallel/join node kind
+  classes and the add-node palette styles.
+- The `WorkflowBuilderModal` chunk stays well under the 25 kB gzip
+  budget called out in the close-out plan (12.48 kB actual).
+
+## Follow-up when network-restricted policy is lifted
+
+Run the visualizer for a full treemap breakdown:
+
+```bash
+npx vite-bundle-visualizer
+```
+
+Then confirm:
+
+1. `lucide-react` contribution stays tree-shaken to only used icons.
+2. No `xlsx` code appears in the initial app/library chunk(s).
+3. The `ApprovalFlowsTab` and `WorkflowBuilderModal` chunks contain
+   the expected Phase-2 + P4 modules (templates, validate, layout,
+   canvas, inspector, picker, simulator, parallel/join inspector
+   forms, palette) and nothing else.
+4. The main-chunk P3/P4 delta is dominated by `src/core/workflow/`
+   (advance, channels, templateInterpolate, validate) as expected.

--- a/docs/workflow-epic-closeout-plan.md
+++ b/docs/workflow-epic-closeout-plan.md
@@ -343,19 +343,25 @@ Open PR, body "Closes #223."
 
 ## Sprint 3 — Close the epic · Closes #219
 
-**Effort: ~½ day. Fresh branch: `claude/workflow-epic-close` (only if
-docs/readme updates remain).**
+**Folded into the Sprint 2 PR on `claude/workflow-p4-parallel` — the
+docs updates are small enough that a separate PR + branch was not
+worth the overhead.**
 
-If Sprint 2's PR body says `Closes #219`, this sprint collapses to a
-GitHub close-out:
+Status:
 
-1. Verify #220, #221, #222, #223 are all closed.
-2. Post a summary comment on #219 linking each sub-issue's landing
+1. ⏳ Verify #220, #221, #222, #223 are all closed. (Pending — happens
+   once the Sprint 2 PR merges with `Closes #223` in the body.)
+2. ⏳ Post a summary comment on #219 linking each sub-issue's landing
    PR + commit hashes.
-3. Close #219 (auto-closes via PR body, or manually).
-4. Update the `README.md` feature list — workflow engine ships with
-   SLA timers, parallel approvals, and pluggable channels.
-5. Update `docs/bundle-size-audit.md` with the final post-P4 snapshot.
+3. ⏳ Close #219 (auto-closes via PR body).
+4. ✅ Updated `README.md` feature list — SLA timers, parallel/join
+   approvals with quorum, and pluggable notification channels.
+5. ✅ Added `docs/bundle-size-audit.md` with the post-P4 snapshot;
+   the Phase-2 audit is preserved under `docs/archive/analysis/` as
+   the prior baseline.
+6. ✅ Updated `docs/Workflow.md` — removed "Planned phases", marked
+   all four phases as shipped, and refreshed the node-type and
+   starter-template tables for P3/P4 additions.
 
 ---
 


### PR DESCRIPTION
The plan's Sprint 3 was docs-only, so landing it on the existing `claude/workflow-p4-parallel` branch avoids a second PR.

- README.md — swapped the single-line workflow blurb for one that names SLA timers, parallel branches with quorum joins, and the pluggable notification channels.
- docs/Workflow.md — removed the stale "Planned phases" section that still listed P2–P4 as upcoming, added a "phases 1–4 all shipped" summary, extended the node-type table with parallel/join and the approval `timeout` signal, and added the slaEscalation + parallelSecurityAndFinance templates.
- docs/bundle-size-audit.md — fresh post-P4 snapshot with deltas against the Phase-2 baseline; Phase-2 audit stays archived under docs/archive/analysis/ as the prior reference.
- docs/README.md — linked the new bundle audit under Engineering ref.
- docs/workflow-epic-closeout-plan.md — marked items 4–6 of Sprint 3 complete; the GitHub close-out (verify sub-issues, #219 summary comment, close) will happen once the PR merges.