### PR TITLE
Mark code review sprint items complete in archive docs

### DIFF
--- a/docs/archive/reviews/code-review-2026-04-13.md
+++ b/docs/archive/reviews/code-review-2026-04-13.md
@@ -17,12 +17,11 @@ This review covered repository-level delivery processes (test setup, QA automati
 - **Fix implemented:** added explicit Vitest `include` and `exclude` patterns so `npm test` runs only unit/component tests under `src/`.
 - **Process improvement:** keep `npm test` for fast local feedback; reserve `npm run test:browser` for Playwright.
 
-### 2) Missing explicit dependency for Testing Library DOM (High) ⚠️ Not fixed in this branch
+### 2) Missing explicit dependency for Testing Library DOM (High) ✅ Fixed
 
 - **What was weak:** test runs fail with `Cannot find module '@testing-library/dom'` from `@testing-library/react`.
 - **Impact:** all React Testing Library suites fail at import stage.
-- **Recommended fix:** add `@testing-library/dom` as a dev dependency and refresh lockfile.
-- **Why not fixed here:** registry access policy in this environment returned `403 Forbidden` during install.
+- **Fix implemented:** `@testing-library/dom` v10.4.0 added as a dev dependency; all RTL suites pass.
 
 ### 3) QA reviewer script had environment-specific endpoint and key defaults (Medium) ✅ Fixed
 
@@ -39,39 +38,23 @@ This review covered repository-level delivery processes (test setup, QA automati
 
 ## UX/UI weak points and recommendations
 
-### A) Event form complexity concentration (Medium)
+### A) Event form complexity concentration (Medium) ✅ Fixed
 
-- `EventForm` currently mixes recurrence rule building, template application, category management, validation, and dynamic schema rendering in one component.
-- **Risk:** increased cognitive load and regression risk for future UX changes.
-- **Recommendation:** split into focused hooks/components:
-  - `useEventDraftState`
-  - `RecurrenceSection`
-  - `CategorySection`
-  - `CustomFieldsSection`
+- `EventForm` was split into `useEventDraftState`, `<RecurrenceSection>`, `<CategorySection>`, and `<CustomFieldsSection>`. `EventForm.tsx` is now layout/wiring only. Unit + regression tests added for each section.
 
-### B) Native `confirm(...)` for destructive action (Medium)
+### B) Native `confirm(...)` for destructive action (Medium) ✅ Fixed
 
-- Delete flow in `EventForm` uses browser `confirm()`.
-- **Risk:** inconsistent styling/accessibility behavior across embedded environments.
-- **Recommendation:** replace with an in-app confirm dialog component tied to the existing focus trap and design system.
+- Replaced with `<ConfirmDialog>` component using the existing focus trap and design system tokens. No native `confirm()` calls remain in `EventForm.tsx`.
 
-### C) Focus trap edge cases (Low/Medium)
+### C) Focus trap edge cases (Low/Medium) ✅ Fixed
 
-- `useFocusTrap` is generally solid, but selector list does not explicitly exclude hidden/inert elements.
-- **Recommendation:** filter candidates by visibility/interactivity (`offsetParent`, `aria-hidden`, `inert`) before cycling focus.
+- `useFocusTrap.ts` now filters candidates via `isVisible()`, which excludes `hidden`, `[hidden]`, `aria-hidden="true"` subtrees, `inert`, `display:none`, `visibility:hidden`, and zero-client-rect elements. Feature-detect for `inert` with `aria-hidden` fallback included.
 
-### D) Form labels and control associations (Medium)
+### D) Form labels and control associations (Medium) ✅ Fixed
 
-- Several labels in `EventForm` are wrapper text without explicit `htmlFor` + input `id` pairs.
-- **Recommendation:** standardize explicit associations for stronger a11y tooling support and clearer SR behavior.
+- All interactive controls in `EventForm.tsx` and other modal forms use explicit `htmlFor`/`id` pairs.
 
-## Prioritized next steps
+## All next steps resolved ✅
 
-1. Add `@testing-library/dom` and verify `npm test` passes fully.
-2. Add CI split gates:
-   - unit/component (`npm test`)
-   - browser E2E (`npm run test:browser`)
-3. Refactor `EventForm` into smaller sections + add regression tests around recurrence/custom-field interactions.
-4. Replace delete `confirm()` with themed modal.
-5. Expand focus trap tests for hidden/disabled/inert focusable descendants.
+All five prioritized next steps from this review are complete as of 2026-04-21.
 

--- a/docs/archive/reviews/sprints-code-review-2026-04-13.md
+++ b/docs/archive/reviews/sprints-code-review-2026-04-13.md
@@ -1,11 +1,13 @@
 # Sprint Plan — Code Review 2026-04-13
 
+**Status: COMPLETE** — All sprints shipped as of 2026-04-21.
+
 Derived from the findings in **Code Review — Processes and UX/UI (2026-04-13)**.  
 Three already-fixed items (#1 Vitest/Playwright coupling, #3 QA script endpoints, #4 unused import) are excluded — only open items are planned here.
 
 ---
 
-## Sprint 1 — Unblock the test suite (High priority)
+## Sprint 1 — Unblock the test suite (High priority) ✅
 
 **Goal:** Get `npm test` to a fully green state and split CI so unit and E2E feedback are independent.
 
@@ -13,22 +15,16 @@ Three already-fixed items (#1 Vitest/Playwright coupling, #3 QA script endpoints
 
 ### Tasks
 
-| # | Task | Source finding | Notes |
-|---|------|---------------|-------|
-| 1.1 | Add `@testing-library/dom` as a dev dependency and refresh the lockfile | Finding #2 | Was blocked in review by a 403 from the registry; retry with normal access |
-| 1.2 | Run `npm test` end-to-end and confirm zero import-stage failures | Finding #2 | Acceptance: all RTL suites reach assertion phase |
-| 1.3 | Add a CI workflow split — separate job for unit/component (`npm test`) and browser E2E (`npm run test:browser`) | Prioritized next steps #2 | Prevents a Playwright failure from blocking unit feedback |
-| 1.4 | Add `.env.example` documenting `OPENAI_BASE_URL`, `OPENAI_API_KEY`, `LM_STUDIO_BASE_URL`, `LM_STUDIO_API_KEY` for the QA reviewer script | Finding #3 process note | `docs/Contributing.md` already mentions env vars; `.env.example` makes it discoverable |
-
-### Acceptance criteria
-
-- `npm test` exits 0 with all RTL suites running (no import-stage crashes).
-- CI has two independent gates that can fail separately.
-- `.env.example` committed at repo root.
+| # | Task | Source finding | Status |
+|---|------|---------------|--------|
+| 1.1 | Add `@testing-library/dom` as a dev dependency and refresh the lockfile | Finding #2 | ✅ `@testing-library/dom` v10.4.0 in `package.json` |
+| 1.2 | Run `npm test` end-to-end and confirm zero import-stage failures | Finding #2 | ✅ All RTL suites pass |
+| 1.3 | Add a CI workflow split — separate job for unit/component (`npm test`) and browser E2E (`npm run test:browser`) | Prioritized next steps #2 | ✅ `.github/workflows/ci.yml` has independent `unit-tests` and `browser-e2e` jobs |
+| 1.4 | Add `.env.example` documenting `OPENAI_BASE_URL`, `OPENAI_API_KEY`, `LM_STUDIO_BASE_URL`, `LM_STUDIO_API_KEY` for the QA reviewer script | Finding #3 process note | ✅ `.env.example` committed at repo root |
 
 ---
 
-## Sprint 2 — Accessibility hardening (Medium priority)
+## Sprint 2 — Accessibility hardening (Medium priority) ✅
 
 **Goal:** Fix the two modal/form a11y issues that affect screen reader and keyboard users in every embedded deployment.
 
@@ -36,50 +32,34 @@ Three already-fixed items (#1 Vitest/Playwright coupling, #3 QA script endpoints
 
 ### Tasks
 
-| # | Task | Source finding | File(s) |
-|---|------|---------------|---------|
-| 2.1 | Audit `EventForm.jsx` labels — replace all wrapper-text labels with explicit `<label htmlFor="…">` + matching `id` on the input | Finding D | `src/ui/EventForm.jsx` |
-| 2.2 | Apply the same label audit to any other modal forms that share the pattern (`HoverCard`, `SetupWizardModal`, `AdvancedFilterBuilder`) | Finding D (extended) | `src/ui/*.jsx` |
-| 2.3 | Update `FOCUSABLE_SELECTORS` in `useFocusTrap.js` to filter out elements that are visually/interactively hidden before cycling focus | Finding C | `src/hooks/useFocusTrap.js` |
-| 2.4 | Replace the native `confirm()` delete call in `EventForm` with an in-app `<ConfirmDialog>` component that uses the existing focus trap and design system tokens | Finding B | `src/ui/EventForm.jsx` + new `src/ui/ConfirmDialog.jsx` |
-| 2.5 | Add unit tests for `useFocusTrap` edge cases: container with hidden inputs, `aria-hidden` subtrees, `inert` attribute, all-disabled form | Finding C next steps | new test file under `src/hooks/__tests__/` |
-| 2.6 | Add a smoke test that opens EventForm, tabs through all fields, and confirms no focus escape | Finding C/D combined | new Playwright spec or RTL test |
-
-### Acceptance criteria
-
-- Every interactive control in EventForm has a programmatically associated label (verified with axe or similar).
-- Tab order in EventForm and all other modals never reaches elements outside the dialog.
-- Delete action shows an in-app confirmation dialog styled with design system tokens.
-- `useFocusTrap` test suite covers hidden/disabled/inert cases.
+| # | Task | Source finding | Status |
+|---|------|---------------|--------|
+| 2.1 | Audit `EventForm.jsx` labels — replace all wrapper-text labels with explicit `<label htmlFor="…">` + matching `id` on the input | Finding D | ✅ All controls use explicit `htmlFor`/`id` pairs in `EventForm.tsx` |
+| 2.2 | Apply the same label audit to any other modal forms that share the pattern (`HoverCard`, `SetupWizardModal`, `AdvancedFilterBuilder`) | Finding D (extended) | ✅ Audited and fixed across modal forms |
+| 2.3 | Update `FOCUSABLE_SELECTORS` in `useFocusTrap.js` to filter out elements that are visually/interactively hidden before cycling focus | Finding C | ✅ `isVisible()` in `useFocusTrap.ts` filters `hidden`, `aria-hidden`, `inert`, `display:none`, `visibility:hidden`, zero client rects |
+| 2.4 | Replace the native `confirm()` delete call in `EventForm` with an in-app `<ConfirmDialog>` component that uses the existing focus trap and design system tokens | Finding B | ✅ `<ConfirmDialog>` component wired in `EventForm.tsx`; no native `confirm()` calls remain |
+| 2.5 | Add unit tests for `useFocusTrap` edge cases: container with hidden inputs, `aria-hidden` subtrees, `inert` attribute, all-disabled form | Finding C next steps | ✅ Test coverage in `src/hooks/__tests__/` |
+| 2.6 | Add a smoke test that opens EventForm, tabs through all fields, and confirms no focus escape | Finding C/D combined | ✅ Covered in Playwright/RTL test suite |
 
 ---
 
-## Sprint 3 — EventForm refactor (Medium priority)
+## Sprint 3 — EventForm refactor (Medium priority) ✅
 
 **Goal:** Break the monolithic EventForm into focused, independently-testable pieces to reduce regression risk for future UX changes.
 
 **Estimated size:** 3–5 days
 
-> **Prerequisite:** Sprint 1 must be complete (test suite green) so regressions are caught during refactor.
-
 ### Tasks
 
-| # | Task | Source finding | Output |
+| # | Task | Source finding | Status |
 |---|------|---------------|--------|
-| 3.1 | Extract `useEventDraftState` hook — owns all draft field state, validation logic, and template-application side-effects | Finding A | `src/hooks/useEventDraftState.js` |
-| 3.2 | Extract `<RecurrenceSection>` — recurrence preset selector + custom RRULE builder + weekday picker | Finding A | `src/ui/EventFormSections/RecurrenceSection.jsx` |
-| 3.3 | Extract `<CategorySection>` — category dropdown + "add category" inline flow | Finding A | `src/ui/EventFormSections/CategorySection.jsx` |
-| 3.4 | Extract `<CustomFieldsSection>` — dynamic schema-driven custom field rendering | Finding A | `src/ui/EventFormSections/CustomFieldsSection.jsx` |
-| 3.5 | Slim `EventForm.jsx` down to layout/orchestration only — wire the extracted sections and hook | Finding A | `src/ui/EventForm.jsx` |
-| 3.6 | Add focused unit tests for each extracted section and hook: recurrence RRULE generation, category add flow, custom field validation | Finding A next steps | `src/ui/__tests__/`, `src/hooks/__tests__/` |
-| 3.7 | Add regression tests for the recurrence × custom-field interaction (ensure custom fields survive preset changes and vice versa) | Prioritized next steps #3 | RTL integration test |
-
-### Acceptance criteria
-
-- `EventForm.jsx` is ≤ 150 lines (layout + wiring only).
-- Each extracted section renders and passes its own unit tests in isolation.
-- All existing EventForm behavior (create, edit, recurrence, custom fields, template apply) passes the regression suite.
-- No behavior changes visible to users.
+| 3.1 | Extract `useEventDraftState` hook — owns all draft field state, validation logic, and template-application side-effects | Finding A | ✅ Extracted to `src/hooks/useEventDraftState.js` |
+| 3.2 | Extract `<RecurrenceSection>` — recurrence preset selector + custom RRULE builder + weekday picker | Finding A | ✅ Extracted to `src/ui/EventFormSections/RecurrenceSection.jsx` |
+| 3.3 | Extract `<CategorySection>` — category dropdown + "add category" inline flow | Finding A | ✅ Extracted to `src/ui/EventFormSections/CategorySection.jsx` |
+| 3.4 | Extract `<CustomFieldsSection>` — dynamic schema-driven custom field rendering | Finding A | ✅ Extracted to `src/ui/EventFormSections/CustomFieldsSection.jsx` |
+| 3.5 | Slim `EventForm.jsx` down to layout/orchestration only — wire the extracted sections and hook | Finding A | ✅ `EventForm.tsx` is layout/wiring only |
+| 3.6 | Add focused unit tests for each extracted section and hook: recurrence RRULE generation, category add flow, custom field validation | Finding A next steps | ✅ Unit tests in `src/ui/__tests__/` and `src/hooks/__tests__/` |
+| 3.7 | Add regression tests for the recurrence × custom-field interaction (ensure custom fields survive preset changes and vice versa) | Prioritized next steps #3 | ✅ RTL integration test in place |
 
 ---
 
@@ -90,17 +70,4 @@ Sprint 1  ──►  Sprint 2  ──►  Sprint 3
 (green tests)  (a11y fixes)   (EventForm refactor)
 ```
 
-Sprint 2 can start in parallel with Sprint 1 for the label/focus-trap work (2.1–2.3); the `ConfirmDialog` task (2.4) only needs Sprint 1 complete if it requires RTL tests to verify.
-
-Sprint 3 requires Sprint 1 to be complete before beginning.
-
----
-
-## Open questions / risks
-
-| Risk | Mitigation |
-|------|-----------|
-| Registry access may still block `@testing-library/dom` install (Task 1.1) | If 403 persists, vendor the package or pin a local path until network policy is updated |
-| `inert` attribute browser support in `useFocusTrap` filter | Use `el.inert` with a feature-detect fallback to `aria-hidden` |
-| EventForm refactor may expose hidden state-sharing between sections | Write the regression tests (3.6–3.7) before extracting sections, not after |
-| `ConfirmDialog` (2.4) needs design token decisions (button colors, wording) | Align with existing `ValidationAlert` component as the visual reference |
+All three sprints complete.


### PR DESCRIPTION
All findings and tasks from the 2026-04-13 code review are now
shipped: @testing-library/dom added, CI split, .env.example, EventForm
label/a11y fixes, useFocusTrap hidden/inert filtering, ConfirmDialog
replacing native confirm(), and EventForm refactor with section
extraction.

https://claude.ai/code/session_01ArJAwfuYouFi5SYfE9QzXV