### PR TITLE
Docs audit: archive historical planning docs, add status banners (#245)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -27,8 +27,6 @@ This index is the canonical docs entrypoint for the package.
 
 - [Roadmap](./Roadmap.md)
 - [Release readiness checklist](./release-readiness.md)
-- [v0.2 → v0.3 migration guide](./v0.2-to-v0.3-MIGRATION.md)
-- [Phase 4 migration notes](./schedule-phase4-migration-notes.md)
 - [Release notes: v0.1.0 draft](./releases/v0.1.0.md)
 
 ## Engineering reference docs
@@ -37,8 +35,6 @@ This index is the canonical docs entrypoint for the package.
 - [Prompts](./Prompts.md)
 - [HIPAA security notes](./HIPAA-Security.md)
 - [Bundle size audit](./bundle-size-audit.md)
-- [Recurring schedule implementation plan](./recurring-schedule-implementation-plan.md)
-- [Recurring events engine plan](./recurring-events-engine-plan.md)
 
 ## Example references
 

--- a/docs/archive/planning/recurring-events-engine-plan.md
+++ b/docs/archive/planning/recurring-events-engine-plan.md
@@ -1,3 +1,5 @@
+> **Status: HISTORICAL** — Recurring events engine shipped. Do not treat as active work.
+
 # Recurring Events Engine + Template-Based Event/Schedule Creation Plan
 
 This project already has a strong recurrence foundation in the engine layer (`expandOccurrences`, `splitSeries`, `detachOccurrence`, and recurring edit scope resolution). This plan describes what it would take to:

--- a/docs/archive/planning/recurring-schedule-implementation-plan.md
+++ b/docs/archive/planning/recurring-schedule-implementation-plan.md
@@ -1,3 +1,5 @@
+> **Status: HISTORICAL** — Recurring schedule work shipped. Do not treat as active work.
+
 # Recurring Schedule Templates — Implementation Plan
 
 ## Goal

--- a/docs/archive/planning/schedule-phase4-migration-notes.md
+++ b/docs/archive/planning/schedule-phase4-migration-notes.md
@@ -1,3 +1,5 @@
+> **Status: HISTORICAL** — Phase 4 shipped. Retained for reference only.
+
 # Schedule Templates Phase 4 — Migration Notes
 
 Phase 4 introduces optional operational hardening APIs for Add Schedule flows.

--- a/docs/archive/planning/v0.2-to-v0.3-MIGRATION.md
+++ b/docs/archive/planning/v0.2-to-v0.3-MIGRATION.md
@@ -1,3 +1,5 @@
+> **Status: HISTORICAL** — v0.3 shipped. Retained for reference only.
+
 # Migration: v0.2 → v0.3
 
 v0.3 introduces the "infinite grouping" feature surface: multi-level

--- a/docs/archive/planning/workflow-epic-closeout-plan.md
+++ b/docs/archive/planning/workflow-epic-closeout-plan.md
@@ -1,3 +1,5 @@
+> **Status: HISTORICAL** — Epic #219 and all sub-issues (#220–#223) closed 2026-04-21. Do not treat as active work.
+
 # Workflow DSL — Sprint Plan to Close Epic #219
 
 ## Context
@@ -349,11 +351,9 @@ worth the overhead.**
 
 Status:
 
-1. ⏳ Verify #220, #221, #222, #223 are all closed. (Pending — happens
-   once the Sprint 2 PR merges with `Closes #223` in the body.)
-2. ⏳ Post a summary comment on #219 linking each sub-issue's landing
-   PR + commit hashes.
-3. ⏳ Close #219 (auto-closes via PR body).
+1. ✅ #220, #221, #222, #223 all closed (closed 2026-04-21).
+2. ✅ Summary comment posted on #219.
+3. ✅ #219 closed as completed (2026-04-21).
 4. ✅ Updated `README.md` feature list — SLA timers, parallel/join
    approvals with quorum, and pluggable notification channels.
 5. ✅ Added `docs/bundle-size-audit.md` with the post-P4 snapshot;

--- a/docs/archive/reviews/pr-106-followup-checklist.md
+++ b/docs/archive/reviews/pr-106-followup-checklist.md
@@ -1,3 +1,5 @@
+> **Status: COMPLETE** — Issue #98 closed 2026-04-16. All wiring shipped.
+
 # PR 106 follow-up checklist for issue #98
 
 This branch exists to track the remaining wiring work after PR #106.


### PR DESCRIPTION
- Move 5 historical docs from docs/ to docs/archive/planning/: workflow-epic-closeout-plan, recurring-schedule-implementation-plan, recurring-events-engine-plan, v0.2-to-v0.3-MIGRATION, schedule-phase4-migration-notes
- Add HISTORICAL/COMPLETE status banners to all moved docs and to pr-106-followup-checklist.md (issue #98 closed)
- Update workflow-epic-closeout-plan Sprint 3: all 3 pending items now confirmed complete (#219–#223 all closed 2026-04-21)
- Remove moved docs from docs/README.md index; archive link remains

https://claude.ai/code/session_01ArJAwfuYouFi5SYfE9QzXV