### PR TITLE
docs: archive TypeScript migration session lessons (2026-04-21)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -26,6 +26,7 @@ This index is the canonical docs entrypoint for the package.
 ## Release, roadmap, and migration docs
 
 - [Roadmap](./Roadmap.md)
+- [TypeScript strict migration](./TypeScriptStrictMigration.md)
 - [Release readiness checklist](./release-readiness.md)
 - [Release notes: v0.1.0 draft](./releases/v0.1.0.md)
 

--- a/docs/TypeScriptStrictMigration.md
+++ b/docs/TypeScriptStrictMigration.md
@@ -1,0 +1,228 @@
+# TypeScript Strict Migration — Staged Roadmap
+
+Plan for migrating the codebase to `strict: true` without the failure mode from the prior attempt (see [typescript-migration-lessons-2026-04-21](./archive/reviews/typescript-migration-lessons-2026-04-21.md)). The plan is staged, each stage has explicit exit criteria, and every stage is independently shippable.
+
+## Baseline (as of 2026-04-21)
+
+`tsconfig.json` currently sets:
+
+```json
+"strict": true,
+"noImplicitAny": false,
+"strictNullChecks": false
+```
+
+Measured in the prior session:
+
+- `noImplicitAny` would produce ~1,973 real implicit-any diagnostics (after filtering module-resolution noise).
+- `strictNullChecks` has **not** been measured. Typical ratio in codebases that ignored nulls is 2–4× the implicit-any count, so a working estimate is 4,000–8,000 sites.
+
+This roadmap covers `noImplicitAny` in stages 0–6 and parks `strictNullChecks` as a separate epic that does **not** start until stage 6 is done.
+
+## Guiding principles
+
+1. **Slice by directory, leaves first.** Migrate pure modules before React; pure React before JSX-heavy views.
+2. **Real types over `any`.** `any` is allowed only with an adjacent comment stating the reason. Track the count; treat growth as a red flag.
+3. **CI ratchet, not a cliff.** Migrated directories are locked in via a side `tsconfig.strict.json` + CI job. New code in migrated directories must typecheck strict. Stops regression without requiring the whole repo to be done.
+4. **No repo-wide text transforms.** `ts-morph` / TS compiler API or hand edits only. No arrow-parameter regexes.
+5. **One slice per PR.** Commit per stable batch. A stage may span multiple PRs.
+6. **Measure before estimating.** Each stage's sizing is updated with real numbers from the stage before it.
+
+## Mechanism
+
+**Side config, not root flip.** Root `tsconfig.json` stays as-is until stage 6. Migration is tracked in `tsconfig.strict.json`:
+
+```jsonc
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noImplicitAny": true
+  },
+  "include": []
+}
+```
+
+`include` grows one slice at a time. A new `npm run typecheck:strict` script runs `tsc -p tsconfig.strict.json`. CI runs the strict typecheck as a blocking job alongside the existing typecheck, so migrated directories cannot regress.
+
+## Stages
+
+### Stage 0 — Baseline & mechanism
+
+**Goal:** land the migration infrastructure with zero code changes.
+
+Tasks:
+- Add `tsconfig.strict.json` with empty `include`.
+- Add `npm run typecheck:strict`.
+- Wire `typecheck:strict` into CI as a blocking job.
+- Run per-directory error counts under `noImplicitAny: true` and publish them in this doc's "Measured per-directory counts" section.
+
+**Exit criteria:**
+- `npm run typecheck:strict` exists and passes (empty include → trivially green).
+- CI runs the strict job on every PR.
+- Per-directory baseline numbers are committed to this doc.
+
+**Sizing:** ~1 day.
+
+---
+
+### Stage 1 — Types slice: `src/types/**` + `src/index.ts`
+
+**Goal:** prove the pattern on the smallest possible slice.
+
+**Exit criteria:**
+- `src/types/**` and `src/index.ts` in `tsconfig.strict.json` include.
+- Zero explicit `any` added.
+- `typecheck:strict` green.
+- Merged to `main`.
+
+**Sizing:** 2–3 days. If this slice takes more than a week, the whole plan needs re-scoping.
+
+---
+
+### Stage 2 — Core & pure engine-adjacent
+
+**Scope:** `src/core/**`, `src/filters/**`, `src/grouping/**`, `src/export/**`, `src/external/**`.
+
+**Rules:**
+- Real types preferred. Explicit `any` requires an adjacent `// any: <reason>` comment.
+- Sub-split by directory if any directory exceeds ~150 diagnostics.
+- Track the running count of explicit `any` sites in this doc.
+
+**Exit criteria:**
+- All listed directories in `tsconfig.strict.json` include.
+- `typecheck:strict` green.
+- Running `any` count within budget (target: ≤ 20 across stage 2 total).
+
+**Sizing:** 2–3 weeks.
+
+**Decision point at end of stage:** compare actual velocity to estimate. If ≥ 2× over, re-scope stages 3–6 before continuing.
+
+---
+
+### Stage 3 — Boundaries: `src/api/**`, `src/providers/**`, `src/hooks/**`
+
+**Why grouped:** these are the external-data seams. Real types here pay off the most for refactor safety.
+
+**Rules:**
+- Third-party untyped responses may use `any` or `unknown` at the boundary, with a wrapper function that types the rest of the flow.
+- React hook return types must be explicit.
+
+**Exit criteria:**
+- All listed directories in `tsconfig.strict.json` include.
+- `typecheck:strict` green.
+- Running `any` count within budget (target: ≤ 20 additional in stage 3).
+
+**Sizing:** 2–3 weeks.
+
+---
+
+### Stage 4 — DECISION POINT: continue into UI?
+
+Before touching `src/ui/**` or `src/views/**`, evaluate:
+
+- Actual cost per diagnostic in stages 2–3 (hours per 100 sites).
+- Bug density correlation with typed vs. untyped code (did any stage 2/3 migration catch a real bug?).
+- Team appetite for the JSX-heavy slice.
+
+Two legitimate paths:
+
+**Path A — continue.** Proceed to stage 5.
+
+**Path B — stop here.** Declare "`noImplicitAny` on non-UI code" as the shipped state. Add a per-directory override in `tsconfig.json` so `src/ui/**` and `src/views/**` remain lax, and document the decision. This captures ~80% of the refactor-safety value.
+
+This decision is explicitly on the plan to prevent the failure mode where scope expansion is assumed rather than chosen.
+
+---
+
+### Stage 5 — UI slice (conditional on Stage 4 → Path A)
+
+**Scope:** `src/ui/**`, `src/views/**`, `WorksCalendar.tsx`, `demo/**`.
+
+**Rules:**
+- Typed event-handler helpers added to `src/types/**` first, if not already present.
+- Component `props` interfaces must be exhaustive — no `[k: string]: any` fallbacks.
+- Sub-split aggressively: expect one PR per ~3–5 view files.
+
+**Exit criteria:**
+- All listed paths in `tsconfig.strict.json` include.
+- `typecheck:strict` green.
+- Running `any` count within budget (target: ≤ 40 additional in stage 5).
+
+**Sizing:** 4–6 weeks.
+
+---
+
+### Stage 6 — Flip the root config
+
+**Goal:** collapse the migration infrastructure.
+
+Tasks:
+- Move `"noImplicitAny": true` into `tsconfig.json`.
+- Delete `tsconfig.strict.json` and `npm run typecheck:strict`.
+- Collapse the CI jobs back to one.
+
+**Exit criteria:**
+- Root `tsc` green with `noImplicitAny: true`.
+- PR merged.
+
+**Sizing:** half a day.
+
+---
+
+### Stage 7 — `strictNullChecks` epic (not in this roadmap)
+
+Does not start until stage 6 is complete. Will get its own staged roadmap, sized against real measurements from the `noImplicitAny` work. Expected 2–4× the effort of stages 1–6 combined.
+
+## Drift control
+
+Once a directory is in `tsconfig.strict.json`:
+
+- CI blocks any PR that introduces `noImplicitAny` violations in that directory.
+- New files in that directory must typecheck strict from day one.
+- Reviewers should reject unexplained `any` additions.
+
+This ratchet is what makes the staged approach safe: we don't have to finish to keep the gains.
+
+## Sprint 3 definition
+
+Minimum viable Sprint 3 = **stages 0, 1, 2.** Delivers:
+
+- Working migration infrastructure.
+- Strict `src/core/**` + pure engine-adjacent modules.
+- Drift control in place for everything migrated.
+
+**Size:** 3–4 weeks for one engineer focused.
+
+Stages 3–6 are explicitly out of scope for Sprint 3. If stage 2 finishes faster than estimated, stage 3 is optional carry-over. Stages 5–6 are separate sprints.
+
+## Measured per-directory counts
+
+_Populated during stage 0. Empty until then._
+
+| Directory | Implicit-any count | Notes |
+|---|---|---|
+| `src/types/**` | _tbd_ | |
+| `src/index.ts` | _tbd_ | |
+| `src/core/**` | _tbd_ | |
+| `src/filters/**` | _tbd_ | |
+| `src/grouping/**` | _tbd_ | |
+| `src/export/**` | _tbd_ | |
+| `src/external/**` | _tbd_ | |
+| `src/api/**` | _tbd_ | |
+| `src/providers/**` | _tbd_ | |
+| `src/hooks/**` | _tbd_ | |
+| `src/ui/**` | _tbd_ | |
+| `src/views/**` | _tbd_ | |
+| `WorksCalendar.tsx` | _tbd_ | |
+| `demo/**` | _tbd_ | |
+
+## Running `any`-budget ledger
+
+_Populated as stages complete._
+
+| Stage | Added `any` count | Running total | Budget |
+|---|---|---|---|
+| 1 | 0 | 0 | 0 |
+| 2 | _tbd_ | _tbd_ | 20 |
+| 3 | _tbd_ | _tbd_ | 40 |
+| 5 | _tbd_ | _tbd_ | 80 |

--- a/docs/archive/README.md
+++ b/docs/archive/README.md
@@ -27,6 +27,7 @@ This directory stores historical planning notes, one-off analyses, and dated rev
 - [pr-106-followup-checklist](./reviews/pr-106-followup-checklist.md) — ✅ Completed
 - [code-review-2026-04-13](./reviews/code-review-2026-04-13.md) — ✅ Completed
 - [sprints-code-review-2026-04-13](./reviews/sprints-code-review-2026-04-13.md) — ✅ Completed
+- [typescript-migration-lessons-2026-04-21](./reviews/typescript-migration-lessons-2026-04-21.md) — 🗄️ Archived
 
 ## Analysis artifacts
 

--- a/docs/archive/reviews/typescript-migration-lessons-2026-04-21.md
+++ b/docs/archive/reviews/typescript-migration-lessons-2026-04-21.md
@@ -1,0 +1,58 @@
+# TypeScript Migration — Session Lessons (2026-04-21)
+
+Retrospective on a Claude Code session that cleanly shipped PR #261 (test fixes) and then attempted a repo-wide `noImplicitAny` migration in the same session. The migration attempt was abandoned before landing. This doc captures what the session did well, where it went off the rails, and the playbook to use next time Sprint 3 is picked up.
+
+## Phases of the session
+
+### Phase A — PR/test cleanup (rating: 8/10)
+
+- Landed a targeted test fix, with a correct explanation of why a `useMemo` placement affected `toThrow()` in the React component under test.
+- Verified CI status after the push.
+- Correctly identified stale review threads and resolved them.
+- Moved through the PR flow in a reasonable order.
+
+This phase reads like solid senior-engineer cleanup work.
+
+### Phase B — `noImplicitAny` migration attempt (rating: 4/10)
+
+- Measured the problem up front: ~6,639 TypeScript errors under `noImplicitAny`, narrowed to ~1,973 real implicit-any diagnostics after filtering out local module-resolution errors.
+- Clustered the errors by area (core/engine vs UI) — correct instinct.
+- Then chose a **repo-wide mechanical strategy**: annotate implicit anys with `: any` via bulk text transforms across the whole codebase.
+- Once that produced syntax errors, the session shifted into repair-on-top-of-repair rather than resetting to a known-good checkpoint.
+- The attempt never produced a green `tsc` pass and was not committed to this branch.
+
+## What went well
+
+- Measured before acting (error counts, by-file clustering).
+- Separated local module errors from real implicit-any errors instead of treating the raw count as truth.
+- Kept probing reality (running `tsc`) rather than declaring success.
+- Caught that a subagent had likely reverted `tsconfig` mid-run.
+
+## What went poorly
+
+- **Scope was too wide for a single step.** A ~2k-diagnostic migration across mixed core + UI code is not a one-session task.
+- **Bulk text transforms on TypeScript syntax are brittle.** Arrow-parameter regexes in particular do not survive contact with real code (destructuring, generics, default params, JSX in `.tsx`, etc.).
+- **"Make implicit any explicit any everywhere" was treated as mechanically safe.** It is not: each edit is a syntactic change on typed code, and the aggregate blast radius is hundreds of files.
+- **No small success boundary was locked down before mass editing.** There was no narrow `tsconfig` include, no per-directory slice, no per-batch commit cadence — so when things broke there was no green checkpoint to return to.
+
+## Signal to watch for
+
+The moment a session shifts from _reasoned software change_ to _bulk mutation plus damage control_ is the moment to stop, reset, and re-scope. In this session that transition happened immediately after the scope measurement — right when the scope measurement should have caused a re-plan.
+
+## Playbook for the next attempt
+
+1. **Dedicated branch.** Start Sprint 3 on its own branch off current `main`.
+2. **Narrow the `tsconfig` surface, don't flip the whole repo.** Enable `noImplicitAny` against a narrow `include` set, or use a secondary `tsconfig.strict.json` that only covers the slice being migrated. Expand the include set slice by slice.
+3. **Slice by directory, core-out.** Suggested order:
+   1. `src/engine/**`, `src/core/**`, adapters, pure helpers.
+   2. Hooks and filters.
+   3. Then selected UI folders (`src/views/**`, `src/ui/**`) one at a time.
+4. **Prefer real types over `: any`.** Reserve explicit `any` for a small, tracked list of edge cases (e.g. third-party untyped boundaries). Every `any` left behind should be recorded with a reason.
+5. **No regex-based global rewrites for arrow params or destructured signatures.** Use `ts-morph` / the TypeScript compiler API, or hand-edit per file. If a transform can't be justified per-file, don't run it repo-wide.
+6. **Run `tsc` after every small batch**, not at the end.
+7. **Commit every stable green chunk.** The next attempt's recovery story is "reset to the last green commit," not "repair the repair."
+8. **Only expand scope after one clean green slice has landed on `main`.**
+
+## Recommended next step for this repo
+
+This branch (`claude/typescript-migration-lessons-zSxnq`) captures the lessons and nothing else — the working tree matches `main`. When Sprint 3 is picked up, start fresh from `main` on a new branch, and apply the playbook above. Do not resume from the abandoned mass-annotation attempt.


### PR DESCRIPTION
Retrospective on the noImplicitAny migration attempt that was abandoned
before landing. Captures what the session did well (measurement,
slicing, reality checks) and where it went off track (repo-wide bulk
text transforms, no narrow tsconfig surface, no per-batch commit
cadence). Includes a playbook for the next Sprint 3 attempt: core-out
directory slicing, ts-morph over regex, and green-checkpoint commits.