### PR TITLE
Add Type annotations to hooks/tests and expand strict typecheck allowlist

### DIFF
--- a/scripts/typecheck-strict.mjs
+++ b/scripts/typecheck-strict.mjs
@@ -26,6 +26,18 @@ const MIGRATED_PATHS = [
   'src/core/',
   'src/grouping/',
   'src/filters/',
+  // Stage 3 (Sprint 1)
+  'src/api/',
+  'src/hooks/useGroupingRows.ts',
+  'src/hooks/__tests__/useGrouping.test.ts',
+  // Stage 3 (Sprint 2)
+  'src/hooks/useEventOptions.ts',
+  'src/hooks/useFeedEvents.ts',
+  'src/hooks/useFetchEvents.ts',
+  'src/hooks/useKeyboardShortcuts.ts',
+  'src/hooks/useOwnerConfig.ts',
+  'src/hooks/useSourceAggregator.ts',
+  'src/hooks/useTouchSwipe.ts',
 ];
 
 // Implicit-any diagnostic codes. See:

--- a/src/api/v1/__tests__/adapters.test.ts
+++ b/src/api/v1/__tests__/adapters.test.ts
@@ -102,7 +102,8 @@ describe('RestAdapter.loadRange', () => {
   });
 
   it('uses custom startParam and endParam', async () => {
-    const stub = vi.fn().mockResolvedValue({ ok: true, json: async () => [] });
+    const noEvents: CalendarEventV1[] = [];
+    const stub = vi.fn().mockResolvedValue({ ok: true, json: async () => noEvents });
     const origFetch = globalThis.fetch;
     globalThis.fetch = stub as typeof fetch;
     try {
@@ -235,7 +236,8 @@ describe('RestAdapter.exportFeed', () => {
 
 describe('RestAdapter schedule template scaffolding', () => {
   it('GETs schedule templates', async () => {
-    const stub = vi.fn().mockResolvedValue({ ok: true, json: async () => [{ id: 'sched-1', name: 'Clinic', entries: [] }] });
+    const templatesResponse = [{ id: 'sched-1', name: 'Clinic', entries: [] as unknown[] }];
+    const stub = vi.fn().mockResolvedValue({ ok: true, json: async () => templatesResponse });
     const origFetch = globalThis.fetch;
     globalThis.fetch = stub as typeof fetch;
     try {
@@ -249,7 +251,8 @@ describe('RestAdapter schedule template scaffolding', () => {
   });
 
   it('POSTs schedule template instantiation request', async () => {
-    const stub = vi.fn().mockResolvedValue({ ok: true, json: async () => ({ templateId: 'sched-1', generated: [] }) });
+    const instantiationResponse = { templateId: 'sched-1', generated: [] as CalendarEventV1[] };
+    const stub = vi.fn().mockResolvedValue({ ok: true, json: async () => instantiationResponse });
     const origFetch = globalThis.fetch;
     globalThis.fetch = stub as typeof fetch;
     try {
@@ -265,7 +268,8 @@ describe('RestAdapter schedule template scaffolding', () => {
   });
 
   it('PATCHes a schedule template', async () => {
-    const stub = vi.fn().mockResolvedValue({ ok: true, json: async () => ({ id: 'sched-1', name: 'Updated', entries: [] }) });
+    const updatedTemplate = { id: 'sched-1', name: 'Updated', entries: [] as unknown[] };
+    const stub = vi.fn().mockResolvedValue({ ok: true, json: async () => updatedTemplate });
     const origFetch = globalThis.fetch;
     globalThis.fetch = stub as typeof fetch;
     try {

--- a/src/hooks/__tests__/useGrouping.test.ts
+++ b/src/hooks/__tests__/useGrouping.test.ts
@@ -8,7 +8,9 @@ const rows = [
   { id: 3, emp: { role: 'Doctor' } },
 ];
 
-const fieldAccessor = (row) => row.emp?.role ?? null;
+type GroupingTestRow = (typeof rows)[number];
+
+const fieldAccessor = (row: GroupingTestRow) => row.emp?.role ?? null;
 
 describe('useGrouping', () => {
   it('returns identity flatRows when groupBy is null', () => {
@@ -23,7 +25,7 @@ describe('useGrouping', () => {
     );
     expect(result.current.isGrouped).toBe(true);
     expect(result.current.groupOrder).toEqual(['Nurse', 'Doctor']);
-    const headers = result.current.flatRows.filter(r => r._type === 'groupHeader');
+    const headers = result.current.flatRows.filter((r) => r._type === 'groupHeader');
     expect(headers.length).toBe(2);
   });
 
@@ -33,7 +35,7 @@ describe('useGrouping', () => {
     );
     act(() => result.current.toggleGroup('Nurse'));
     expect(result.current.collapsedGroups.has('Nurse')).toBe(true);
-    const nurseMembers = result.current.flatRows.filter(r => !r._type && r.emp?.role === 'Nurse');
+    const nurseMembers = result.current.flatRows.filter((r) => !r._type && r.emp?.role === 'Nurse');
     expect(nurseMembers.length).toBe(0);
   });
 

--- a/src/hooks/useEventOptions.ts
+++ b/src/hooks/useEventOptions.ts
@@ -4,7 +4,7 @@
  */
 import { useState, useCallback } from 'react';
 
-function load(calendarId) {
+function load(calendarId: string): string[] {
   try {
     const raw = localStorage.getItem(`wc-options-${calendarId}`);
     return JSON.parse(raw)?.categories ?? [];
@@ -13,16 +13,16 @@ function load(calendarId) {
   }
 }
 
-function save(calendarId, categories) {
+function save(calendarId: string, categories: string[]): void {
   try {
     localStorage.setItem(`wc-options-${calendarId}`, JSON.stringify({ categories }));
   } catch {}
 }
 
-export function useEventOptions(calendarId) {
+export function useEventOptions(calendarId: string) {
   const [categories, setCategories] = useState(() => load(calendarId));
 
-  const addCategory = useCallback((cat) => {
+  const addCategory = useCallback((cat: string) => {
     const trimmed = String(cat).trim();
     if (!trimmed) return;
     setCategories(prev => {
@@ -33,7 +33,7 @@ export function useEventOptions(calendarId) {
     });
   }, [calendarId]);
 
-  const removeCategory = useCallback((cat) => {
+  const removeCategory = useCallback((cat: string) => {
     setCategories(prev => {
       const next = prev.filter(c => c !== cat);
       save(calendarId, next);

--- a/src/hooks/useFeedEvents.ts
+++ b/src/hooks/useFeedEvents.ts
@@ -11,9 +11,18 @@
 import { useState, useEffect } from 'react';
 import { fetchAndParseICS } from '../core/icalParser';
 
-export function useFeedEvents(icalFeeds) {
-  const [feedEvents, setFeedEvents] = useState([]);
-  const [feedErrors, setFeedErrors] = useState([]);
+type ICalFeedInput = {
+  url: string;
+  label?: string;
+  refreshInterval?: number;
+};
+
+type FeedEvent = Record<string, any> & { _feedLabel: string };
+type FeedError = { feed: ICalFeedInput; err: unknown };
+
+export function useFeedEvents(icalFeeds: ICalFeedInput[] = []) {
+  const [feedEvents, setFeedEvents] = useState<FeedEvent[]>([]);
+  const [feedErrors, setFeedErrors] = useState<FeedError[]>([]);
 
   useEffect(() => {
     if (!icalFeeds?.length) {
@@ -24,17 +33,18 @@ export function useFeedEvents(icalFeeds) {
     let cancelled = false;
 
     async function fetchAll() {
-      const results = [];
-      const errors  = [];
+      const results: FeedEvent[] = [];
+      const errors: FeedError[] = [];
 
-      await Promise.allSettled(icalFeeds.map(async feed => {
+      await Promise.allSettled(icalFeeds.map(async (feed: ICalFeedInput) => {
         try {
-          const evs = await fetchAndParseICS(feed.url);
+          const evs = await fetchAndParseICS(feed.url) as Array<Record<string, any>>;
           const label = feed.label ?? feed.url;
-          results.push(...evs.map(ev => ({ ...ev, _feedLabel: label })));
-        } catch (err: any) {
+          results.push(...evs.map((ev) => ({ ...ev, _feedLabel: label })));
+        } catch (err: unknown) {
           errors.push({ feed, err });
-          console.warn('[WorksCalendar] iCal feed error:', feed.url, err.message);
+          const message = err instanceof Error ? err.message : String(err);
+          console.warn('[WorksCalendar] iCal feed error:', feed.url, message);
         }
       }));
 
@@ -47,7 +57,7 @@ export function useFeedEvents(icalFeeds) {
     fetchAll();
 
     // Set up per-feed refresh timers
-    const timers = icalFeeds.map(feed => {
+    const timers = icalFeeds.map((feed: ICalFeedInput) => {
       const interval = feed.refreshInterval ?? 300_000; // 5 minutes
       return setInterval(fetchAll, interval);
     });

--- a/src/hooks/useFetchEvents.ts
+++ b/src/hooks/useFetchEvents.ts
@@ -15,7 +15,7 @@ import {
 } from 'date-fns';
 
 /** Compute the visible [start, end] range for a given view + date. */
-function visibleRange(view, currentDate, weekStartDay: 0 | 1 | 2 | 3 | 4 | 5 | 6 = 0) {
+function visibleRange(view: string, currentDate: Date, weekStartDay: 0 | 1 | 2 | 3 | 4 | 5 | 6 = 0) {
   switch (view) {
     case 'week':
       return {
@@ -36,11 +36,18 @@ function visibleRange(view, currentDate, weekStartDay: 0 | 1 | 2 | 3 | 4 | 5 | 6
   }
 }
 
-export function useFetchEvents(fetchEvents, view, currentDate, weekStartDay: 0 | 1 | 2 | 3 | 4 | 5 | 6 = 0) {
-  const [fetchedEvents, setFetchedEvents] = useState([]);
+type FetchEventsFn<T> = (args: { start: Date; end: Date; signal: AbortSignal }) => Promise<T[]>;
+
+export function useFetchEvents<T extends Record<string, any>>(
+  fetchEvents: FetchEventsFn<T> | null | undefined,
+  view: string,
+  currentDate: Date,
+  weekStartDay: 0 | 1 | 2 | 3 | 4 | 5 | 6 = 0,
+) {
+  const [fetchedEvents, setFetchedEvents] = useState<T[]>([]);
   const [loading, setLoading]             = useState(false);
-  const [error, setError]                 = useState(null);
-  const abortRef = useRef(null);
+  const [error, setError]                 = useState<unknown>(null);
+  const abortRef = useRef<AbortController | null>(null);
 
   // Stable range key so the effect only fires when the range actually changes
   const range = useMemo(
@@ -63,12 +70,15 @@ export function useFetchEvents(fetchEvents, view, currentDate, weekStartDay: 0 |
     setError(null);
 
     fetchEvents({ start: range.start, end: range.end, signal: ctrl.signal })
-      .then(raw => {
+      .then((raw: T[]) => {
         if (ctrl.signal.aborted) return;
         setFetchedEvents(Array.isArray(raw) ? raw : []);
       })
-      .catch(err => {
-        if (ctrl.signal.aborted || err?.name === 'AbortError') return;
+      .catch((err: unknown) => {
+        const errorName = typeof err === 'object' && err && 'name' in err
+          ? String((err as { name?: unknown }).name)
+          : '';
+        if (ctrl.signal.aborted || errorName === 'AbortError') return;
         console.error('[WorksCalendar] fetchEvents error:', err);
         setError(err);
         setFetchedEvents([]);

--- a/src/hooks/useGroupingRows.ts
+++ b/src/hooks/useGroupingRows.ts
@@ -1,20 +1,22 @@
 import { useState, useMemo, useCallback } from 'react';
 import { groupRows } from '../grouping/groupRows';
 
-export function useGrouping(rows, options: {
+type GroupingOptions<T> = {
   groupBy?: unknown
-  fieldAccessor?: unknown
+  fieldAccessor?: ((row: T) => unknown) | Array<(row: T) => unknown>
   groupHeaderHeight?: number
-} = {}) {
+};
+
+export function useGrouping<T extends Record<string, any>>(rows: T[], options: GroupingOptions<T> = {}) {
   const { groupBy, fieldAccessor, groupHeaderHeight = 36 } = options;
   const [collapsedGroups, setCollapsedGroups] = useState<Set<string>>(() => new Set());
 
   const { flatRows, groupOrder } = useMemo(() => {
-    if (!groupBy) return { flatRows: rows, groupOrder: [] };
+    if (!groupBy) return { flatRows: rows as Array<T | Record<string, any>>, groupOrder: [] };
     return groupRows(rows, { groupBy, fieldAccessor: fieldAccessor as any, collapsedGroups, groupHeaderHeight });
   }, [rows, groupBy, fieldAccessor, collapsedGroups, groupHeaderHeight]);
 
-  const toggleGroup = useCallback((key) => {
+  const toggleGroup = useCallback((key: string) => {
     setCollapsedGroups(prev => {
       const next = new Set(prev);
       if (next.has(key)) next.delete(key);

--- a/src/hooks/useKeyboardShortcuts.ts
+++ b/src/hooks/useKeyboardShortcuts.ts
@@ -24,13 +24,14 @@ const VIEW_KEYS = {
   '4': 'agenda',
   '5': 'schedule',
   '6': 'assets',
-};
+} as const;
+type CalendarView = typeof VIEW_KEYS[keyof typeof VIEW_KEYS];
 
-function isTypingTarget(el) {
+function isTypingTarget(el: Element | null): boolean {
   if (!el) return false;
   const tag = el.tagName;
   if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT') return true;
-  if (el.isContentEditable) return true;
+  if (el instanceof HTMLElement && el.isContentEditable) return true;
   return false;
 }
 
@@ -46,13 +47,19 @@ function hasOpenModal() {
  * @param {() => void} api.openHelp
  * @param {boolean} [api.enabled=true]
  */
-export function useKeyboardShortcuts(api) {
+export function useKeyboardShortcuts(api: {
+  setView?: (view: string) => void;
+  navigate?: (direction: number) => void;
+  goToToday?: () => void;
+  openHelp?: () => void;
+  enabled?: boolean;
+}) {
   const { setView, navigate, goToToday, openHelp, enabled = true } = api;
 
   useEffect(() => {
     if (!enabled) return;
 
-    function handler(e) {
+    function handler(e: KeyboardEvent) {
       if (e.ctrlKey || e.metaKey || e.altKey) return;
       if (isTypingTarget(document.activeElement)) return;
       if (hasOpenModal()) return;
@@ -60,7 +67,7 @@ export function useKeyboardShortcuts(api) {
       // View switches: digits 1..6
       if (Object.prototype.hasOwnProperty.call(VIEW_KEYS, e.key)) {
         e.preventDefault();
-        setView?.(VIEW_KEYS[e.key]);
+        setView?.(VIEW_KEYS[e.key as keyof typeof VIEW_KEYS]);
         return;
       }
 

--- a/src/hooks/useOwnerConfig.ts
+++ b/src/hooks/useOwnerConfig.ts
@@ -4,22 +4,29 @@
 import { useState, useCallback, useEffect, useRef } from 'react';
 import { loadConfig, saveConfig, DEFAULT_CONFIG } from '../core/configSchema';
 
-async function sha256(text) {
+type OwnerConfig = Record<string, any>;
+
+async function sha256(text: string): Promise<string> {
   const buf = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(text));
   return Array.from(new Uint8Array(buf)).map(b => b.toString(16).padStart(2,'0')).join('');
 }
 
-export function useOwnerConfig({ calendarId, ownerPassword, onConfigSave, devMode = false }) {
-  const [config,        setConfig]        = useState(() => loadConfig(calendarId));
+export function useOwnerConfig({ calendarId, ownerPassword, onConfigSave, devMode = false }: {
+  calendarId: string;
+  ownerPassword?: string;
+  onConfigSave?: (config: OwnerConfig) => void;
+  devMode?: boolean;
+}) {
+  const [config,        setConfig]        = useState<OwnerConfig>(() => loadConfig(calendarId));
   const [isOwner,       setIsOwner]       = useState(devMode);
   const [configOpen,    setConfigOpen]    = useState(false);
-  const [configInitialTab, setConfigInitialTab] = useState(null);
-  const [smartViewEditId, setSmartViewEditId] = useState(null);
+  const [configInitialTab, setConfigInitialTab] = useState<string | null>(null);
+  const [smartViewEditId, setSmartViewEditId] = useState<string | null>(null);
   const [authError,     setAuthError]     = useState('');
   const [isAuthLoading, setIsAuthLoading] = useState(false);
   const pendingNotifyRef = useRef(false);
 
-  const authenticate = useCallback(async (password) => {
+  const authenticate = useCallback(async (password: string) => {
     if (!ownerPassword) {
       setIsOwner(true);
       setConfigOpen(true);
@@ -46,7 +53,7 @@ export function useOwnerConfig({ calendarId, ownerPassword, onConfigSave, devMod
     }
   }, [ownerPassword]);
 
-  const updateConfig = useCallback((updater) => {
+  const updateConfig = useCallback((updater: OwnerConfig | ((prev: OwnerConfig) => OwnerConfig)) => {
     setConfig(prev => {
       const next = typeof updater === 'function' ? updater(prev) : { ...prev, ...updater };
       saveConfig(calendarId, next);
@@ -75,7 +82,7 @@ export function useOwnerConfig({ calendarId, ownerPassword, onConfigSave, devMod
   // Deep-link helper: open ConfigPanel focused on a specific tab id. Used by
   // view toolbars (e.g. AssetsView's "Edit assets") so owners can jump
   // straight to the relevant registry without hunting through tabs.
-  const openConfigToTab = useCallback((tabId, opts: any = {}) => {
+  const openConfigToTab = useCallback((tabId: string | null, opts: { smartViewEditId?: string | null } = {}) => {
     setConfigInitialTab(tabId ?? null);
     setSmartViewEditId(opts.smartViewEditId ?? null);
     setConfigOpen(true);

--- a/src/hooks/useSourceAggregator.ts
+++ b/src/hooks/useSourceAggregator.ts
@@ -18,7 +18,18 @@
 import { useMemo } from 'react';
 import { useFeedEvents } from './useFeedEvents';
 
-export function useSourceAggregator({ icalFeedsProp = [], sourceStore }) {
+type FeedLike = Record<string, any> & { url?: string; label?: string; refreshInterval?: number };
+type SourceEvent = Record<string, any>;
+type CsvSource = { id: string; label?: string; enabled?: boolean; events?: SourceEvent[] };
+type SourceStoreLike = {
+  activeIcsSources: FeedLike[];
+  activeCsvSources: CsvSource[];
+};
+
+export function useSourceAggregator({ icalFeedsProp = [], sourceStore }: {
+  icalFeedsProp?: FeedLike[];
+  sourceStore: SourceStoreLike;
+}) {
   // Merge prop-level feeds + store-managed ICS feeds for the polling hook.
   // We use a stable JSON key so that referentially-new but semantically-identical
   // arrays do not trigger unnecessary re-fetches.
@@ -29,7 +40,7 @@ export function useSourceAggregator({ icalFeedsProp = [], sourceStore }) {
   );
 
   const allIcsFeeds = useMemo(
-    () => [...(icalFeedsProp ?? []), ...sourceStore.activeIcsSources],
+    () => [...(icalFeedsProp ?? []), ...sourceStore.activeIcsSources].filter((f): f is FeedLike & { url: string } => typeof f.url === 'string'),
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [allIcsFeedsKey],
   );
@@ -39,7 +50,7 @@ export function useSourceAggregator({ icalFeedsProp = [], sourceStore }) {
   // Tag ICS events with source metadata
   const taggedFeedEvents = useMemo(
     () =>
-      feedEvents.map(ev => ({
+      feedEvents.map((ev) => ({
         ...ev,
         _sourceId:    ev._feedLabel ?? 'ics',
         _sourceLabel: ev._feedLabel,
@@ -50,15 +61,15 @@ export function useSourceAggregator({ icalFeedsProp = [], sourceStore }) {
   // CSV source events — already parsed, just merge when the source is enabled
   const csvEvents = useMemo(
     () =>
-      sourceStore.activeCsvSources.flatMap(src =>
-        (src.events ?? []).map(ev => ({
+      sourceStore.activeCsvSources.flatMap((src) =>
+        (src.events ?? []).map((ev) => ({
           ...ev,
           _sourceId:    src.id,
           _sourceLabel: src.label,
         })),
       ),
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [JSON.stringify(sourceStore.activeCsvSources.map(s => ({ id: s.id, enabled: s.enabled, count: s.events?.length })))],
+    [JSON.stringify(sourceStore.activeCsvSources.map((s) => ({ id: s.id, enabled: s.enabled, count: s.events?.length })))],
   );
 
   const events = useMemo(

--- a/src/hooks/useTouchSwipe.ts
+++ b/src/hooks/useTouchSwipe.ts
@@ -1,8 +1,8 @@
-import { useEffect, useRef } from 'react';
+import { useEffect, useRef, type RefObject } from 'react';
 
 const INTERACTIVE_TAGS = new Set(['INPUT', 'TEXTAREA', 'SELECT', 'BUTTON', 'A']);
 
-function isInteractiveElement(node) {
+function isInteractiveElement(node: EventTarget | null): boolean {
   if (!(node instanceof Element)) return false;
   if (INTERACTIVE_TAGS.has(node.tagName)) return true;
   return node.closest('[contenteditable="true"], [data-no-swipe="true"]') != null;
@@ -23,14 +23,22 @@ export function useTouchSwipe({
   minDistance = 48,
   maxOffAxis = 72,
   maxDurationMs = 700,
+}: {
+  targetRef: RefObject<HTMLElement | null>;
+  enabled?: boolean;
+  onSwipeLeft?: () => void;
+  onSwipeRight?: () => void;
+  minDistance?: number;
+  maxOffAxis?: number;
+  maxDurationMs?: number;
 }) {
-  const gestureRef = useRef(null);
+  const gestureRef = useRef<{ x: number; y: number; ts: number } | null>(null);
 
   useEffect(() => {
     const el = targetRef?.current;
     if (!enabled || !el) return undefined;
 
-    const handleTouchStart = (e) => {
+    const handleTouchStart = (e: TouchEvent) => {
       if (e.touches.length !== 1) {
         gestureRef.current = null;
         return;
@@ -47,7 +55,7 @@ export function useTouchSwipe({
       };
     };
 
-    const handleTouchEnd = (e) => {
+    const handleTouchEnd = (e: TouchEvent) => {
       const start = gestureRef.current;
       gestureRef.current = null;
       if (!start || e.changedTouches.length === 0) return;


### PR DESCRIPTION
### Motivation
- Harden several hook implementations and tests for the staged `noImplicitAny` TypeScript migration by adding explicit types and safer runtime checks.
- Make runtime behavior clearer and reduce accidental any/unknown flows in feed/fetch/grouping/owner logic.
- Include newly-migrated files in the strict-typecheck allowlist so the incremental migration ratchet reflects landed work.

### Description
- Added new entries to `MIGRATED_PATHS` in `scripts/typecheck-strict.mjs` to mark `src/api/`, `src/hooks/*` files as migrated.
- Introduced explicit type annotations and generics across multiple hooks: `useFeedEvents`, `useFetchEvents`, `useGrouping`, `useOwnerConfig`, `useSourceAggregator`, `useEventOptions`, `useTouchSwipe`, and `useKeyboardShortcuts`, plus related helper types and runtime guards.
- Improved error handling and narrowing for unknown errors, AbortController typing, and touch/keyboard target checks; refined several array/object typings and return types.
- Updated tests (`adapters.test.ts`, `useGrouping.test.ts`) to use typed fixtures and clearer mock return values to satisfy stricter type rules.

### Testing
- Ran the unit test suite with `vitest` and updated tests; the test run completed successfully.
- Ran the strict typecheck via the TypeScript project (`npx tsc -p tsconfig.strict.json` or `node scripts/typecheck-strict.mjs`) and verified no disallowed implicit-any diagnostics for the migrated paths.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e72bd1a4e0832cbbdcdffb0fec9be5)