### PR TITLE
chore(ts): Stage 3 — explicit return types on migrated hooks + mark done

### DIFF
--- a/docs/TypeScriptStrictMigration.md
+++ b/docs/TypeScriptStrictMigration.md
@@ -110,9 +110,11 @@ Tasks:
 
 **Decision point outcome:** actual velocity ≫ estimate (well under 2× over — more like 10× under). Stages 3–6 continue as planned; no re-scoping required.
 
+**Stage 3 confirms Stage 2's velocity pattern.** Stage 3 landed in ~2 days against a 2–3 week estimate, same 10× under-estimate ratio. Pattern suggests original sizing treated `noImplicitAny` and `strictNullChecks` as a bundle; for `noImplicitAny` alone, cost per diagnostic is ~0.5 minute when the diagnostics are mechanical parameter annotations.
+
 ---
 
-### Stage 3 — Boundaries: `src/api/**`, `src/providers/**`, `src/hooks/**`
+### Stage 3 — Boundaries: `src/api/**`, `src/providers/**`, `src/hooks/**` — ✅ Completed 2026-04-21
 
 **Why grouped:** these are the external-data seams. Real types here pay off the most for refactor safety.
 
@@ -120,12 +122,27 @@ Tasks:
 - Third-party untyped responses may use `any` or `unknown` at the boundary, with a wrapper function that types the rest of the flow.
 - React hook return types must be explicit.
 
-**Exit criteria:**
-- All listed directories added to `MIGRATED_PATHS` in `scripts/typecheck-strict.mjs`.
-- `typecheck:strict` green.
-- Running `any` count within budget (target: ≤ 20 additional in stage 3).
+**What shipped:**
+- Five commits landing the three directories across four sprints plus a follow-up:
+  - `7c9622a` — sprint 2: simple hooks (`useGroupingRows`, `useEventOptions`, `useFeedEvents`, `useFetchEvents`, `useKeyboardShortcuts`, `useOwnerConfig`, `useSourceAggregator`, `useTouchSwipe`) + `src/api/**`.
+  - `9e9fd04` / `799045a` — sprint 3: heavy hooks (`useDrag`, `useSavedViews`, `useSourceStore`) + review-comment follow-ups on source and saved-view shapes.
+  - `c498f2a` — sprint 4: undo-test hardening + `useDrag` typing.
+  - `9d5d918` — Stage 3b: remaining hooks (`useCalendar`, `useEventDraftState`, `useFeedStore`, `useFocusTrap`, `useOccurrences`, `usePermissions`, `useRealtimeEvents`, `useSyncedCalendar`, `useTouchDnd`) + `src/providers/**` + 7 free strict-clean hooks added to the allowlist.
+  - Follow-up on `claude/typescript-migration-lessons-zSxnq` — explicit return types on the 14 hooks that had shipped with inferred returns.
+- `MIGRATED_PATHS` now at 38 entries covering `src/api/`, `src/providers/`, and every non-test file under `src/hooks/`. Zero unmigrated hooks remain.
+- Advisory `tsc -p tsconfig.json` green throughout — the Stage 2 "run both" rule held; no regressions to unmigrated UI/view callers.
 
-**Sizing:** 2–3 weeks.
+**Exit criteria — met:**
+- All listed directories in `MIGRATED_PATHS`. ✅
+- `typecheck:strict` green across 38 paths. ✅
+- `any` delta **+17** across `src/hooks/**` (+28 added, −11 removed in `useSavedViews`); `src/api/` +0; `src/providers/` +0. Total = 17, under 20-site budget. ✅
+
+**Lessons learned:**
+- **Inferred hook returns are a readable trap.** The initial 11-hook sprint (PR #266/#267) shipped without explicit return types; inference produced correct types in practice but obscured the public contract from readers and hid the rule violation until review. `React hook return types must be explicit` is now a pre-commit check item, not a style preference.
+- **`Set<T>` setter types from `useState` need care.** `setConfigOpen` is a `Dispatch<SetStateAction<boolean>>`, not `(b: boolean) => void` — the latter would reject the functional-update form in consumer code. Typing useState setters in return-type manifests uses the React types directly.
+- **Boundary-structural types compose.** `useSourceAggregator` passes its filtered feeds through `useFeedEvents` — declaring its own `feedErrors` type inline (rather than importing `FeedError` from `useFeedEvents`) kept the two hooks decoupled while still strict-clean.
+
+**Sizing outcome:** estimated 2–3 weeks. Actual: ~2 days across Codex sprints + follow-up (including the extra cleanup pass). Ratio matches Stage 2's ~10× under-estimate for `noImplicitAny`-alone work.
 
 ---
 
@@ -247,7 +264,7 @@ _Populated as stages complete._
 |---|---|---|---|
 | 1 | 0 | 0 | 0 |
 | 2 | +11 (production) | 11 | 20 |
-| 3 | _tbd_ | _tbd_ | 40 |
+| 3 | +17 (production) | 28 | 40 |
 | 5 | _tbd_ | _tbd_ | 80 |
 
 ### Stage 2 `any` accounting (2026-04-21)
@@ -266,3 +283,19 @@ Measurement: count of `any` tokens matching `/:\s*any\b|:\s*any\[\]|<any>|\bas a
 Most of the Stage 2 `any` additions — +6 in `core`, +1 in `grouping`, +4 in `filters` — are at the public-API seam with unmigrated UI/test callers: `Record<string, any>` return types (`parseICS`, `buildOpenShiftEvent`, `buildOpenShiftPatch`, `loadConfig`), `[k: string]: any` index signatures (`LayoutEvent`, `ThemeObject`, `Preset`), and `Record<string, any>` on `Accessor` / `FilterItem`. These are deliberate boundary-protection as described in the third "Lesson learned" above; they will be tightened back to `unknown` when the relevant UI slice migrates in Stage 5. The initial landing introduced +1; the fix commit `cd18a03` added +10 more after the advisory `tsc` regression surfaced which seams needed loosening.
 
 Test files (`__tests__/**`) added `any` annotations on stub/helper callbacks (e.g. `(r: any) => r.emp?.role`) — not counted against the production budget, but worth tracking: ~10 added. These will be revisited when individual test modules are tightened in later stages (or never, if we accept stub events as an explicit escape-hatch pattern in tests).
+
+### Stage 3 `any` accounting (2026-04-21)
+
+Measurement: same regex as Stage 2, applied to `src/api/**`, `src/providers/**`, `src/hooks/*.ts` (non-test), before Stage 3 open (`88822d6`) vs after the follow-up return-type pass.
+
+| Directory | Before | After | Delta |
+|---|---|---|---|
+| `src/api/**` | n/a | 0 | 0 |
+| `src/providers/**` | 0 | 0 | 0 |
+| `src/hooks/**` (migrated files) | 35 | 52 | **+17** |
+| **Total** | 35 | 52 | **+17** |
+
+Hook-side additions are concentrated where boundaries meet unmigrated callers:
+- `useCalendar` (+5), `useEventDraftState` (+6), `useOccurrences` (+3), `useTouchDnd` (+5), `useFocusTrap` (+2), `useSourceAggregator` (+2), `useGroupingRows` (+3) — explicit boundary `any` on event/config/payload shapes that flow into unmigrated `src/views/**` or `WorksCalendar.tsx`, plus `Record<string, any>` fragments inside explicit hook return types.
+- `useFeedEvents` (+1), `useFetchEvents` (+1) — `Record<string, any>` on feed/fetched events so downstream renderers can keep their ad-hoc fields without forcing narrowing.
+- `useSavedViews` (−11) — net removal: old code had 18 `any` sites; the migration tightened most of them to `unknown` or concrete shapes while leaving `Record<string, any>` at the serialise/deserialise seam only.

--- a/src/hooks/useDrag.ts
+++ b/src/hooks/useDrag.ts
@@ -88,7 +88,17 @@ function dateFromDayAndMinutes(day: Date, minutes: number): Date {
 
 export function useDrag<TEvent extends DragEventBase = NormalizedEvent>(
   { pxPerHour, dayStart, dayEnd }: { pxPerHour: number; dayStart: number; dayEnd: number },
-) {
+): {
+  ghost: DragGhost<TEvent>;
+  draggedId: TEvent['id'] | null;
+  startMove: (ev: TEvent, e: DragPointer, gridEl: DragGridElement, days: Date[], gutterWidth: number) => void;
+  startResize: (ev: TEvent, e: DragPointer, gridEl: DragGridElement, days: Date[], gutterWidth: number) => void;
+  startResizeTop: (ev: TEvent, e: DragPointer, gridEl: DragGridElement, days: Date[], gutterWidth: number) => void;
+  startCreate: (e: DragPointer, gridEl: DragGridElement, days: Date[], gutterWidth: number) => void;
+  onPointerMove: (e: DragPointer) => void;
+  onPointerUp: () => DragResult<TEvent> | null;
+  cancel: () => void;
+} {
   const ghostRef = useRef<DragGhost<TEvent>>(null);
   const [ghost, setDisplayGhost] = useState<DragGhost<TEvent>>(null);
   const s = useRef<DragState<TEvent> | null>(null); // mutable drag state

--- a/src/hooks/useEventOptions.ts
+++ b/src/hooks/useEventOptions.ts
@@ -19,7 +19,11 @@ function save(calendarId: string, categories: string[]): void {
   } catch {}
 }
 
-export function useEventOptions(calendarId: string) {
+export function useEventOptions(calendarId: string): {
+  categories: string[];
+  addCategory: (cat: string) => void;
+  removeCategory: (cat: string) => void;
+} {
   const [categories, setCategories] = useState(() => load(calendarId));
 
   const addCategory = useCallback((cat: string) => {

--- a/src/hooks/useFeedEvents.ts
+++ b/src/hooks/useFeedEvents.ts
@@ -20,7 +20,10 @@ type ICalFeedInput = {
 type FeedEvent = Record<string, any> & { _feedLabel: string };
 type FeedError = { feed: ICalFeedInput; err: unknown };
 
-export function useFeedEvents(icalFeeds: ICalFeedInput[] = []) {
+export function useFeedEvents(icalFeeds: ICalFeedInput[] = []): {
+  feedEvents: FeedEvent[];
+  feedErrors: FeedError[];
+} {
   const [feedEvents, setFeedEvents] = useState<FeedEvent[]>([]);
   const [feedErrors, setFeedErrors] = useState<FeedError[]>([]);
 

--- a/src/hooks/useFetchEvents.ts
+++ b/src/hooks/useFetchEvents.ts
@@ -43,7 +43,11 @@ export function useFetchEvents<T extends Record<string, any>>(
   view: string,
   currentDate: Date,
   weekStartDay: 0 | 1 | 2 | 3 | 4 | 5 | 6 = 0,
-) {
+): {
+  fetchedEvents: T[];
+  loading: boolean;
+  error: unknown;
+} {
   const [fetchedEvents, setFetchedEvents] = useState<T[]>([]);
   const [loading, setLoading]             = useState(false);
   const [error, setError]                 = useState<unknown>(null);

--- a/src/hooks/useGroupingRows.ts
+++ b/src/hooks/useGroupingRows.ts
@@ -7,7 +7,15 @@ type GroupingOptions<T> = {
   groupHeaderHeight?: number
 };
 
-export function useGrouping<T extends Record<string, any>>(rows: T[], options: GroupingOptions<T> = {}) {
+export function useGrouping<T extends Record<string, any>>(rows: T[], options: GroupingOptions<T> = {}): {
+  flatRows: Array<Record<string, any>>;
+  groupOrder: string[];
+  collapsedGroups: Set<string>;
+  toggleGroup: (key: string) => void;
+  expandAll: () => void;
+  collapseAll: () => void;
+  isGrouped: boolean;
+} {
   const { groupBy, fieldAccessor, groupHeaderHeight = 36 } = options;
   const [collapsedGroups, setCollapsedGroups] = useState<Set<string>>(() => new Set());
 

--- a/src/hooks/useKeyboardShortcuts.ts
+++ b/src/hooks/useKeyboardShortcuts.ts
@@ -53,7 +53,7 @@ export function useKeyboardShortcuts(api: {
   goToToday?: () => void;
   openHelp?: () => void;
   enabled?: boolean;
-}) {
+}): void {
   const { setView, navigate, goToToday, openHelp, enabled = true } = api;
 
   useEffect(() => {

--- a/src/hooks/useOwnerConfig.ts
+++ b/src/hooks/useOwnerConfig.ts
@@ -1,7 +1,7 @@
 /**
  * useOwnerConfig.js — Owner authentication + config state.
  */
-import { useState, useCallback, useEffect, useRef } from 'react';
+import { useState, useCallback, useEffect, useRef, type Dispatch, type SetStateAction } from 'react';
 import { loadConfig, saveConfig, DEFAULT_CONFIG } from '../core/configSchema';
 
 type OwnerConfig = Record<string, any>;
@@ -16,7 +16,21 @@ export function useOwnerConfig({ calendarId, ownerPassword, onConfigSave, devMod
   ownerPassword?: string;
   onConfigSave?: (config: OwnerConfig) => void;
   devMode?: boolean;
-}) {
+}): {
+  config: OwnerConfig;
+  isOwner: boolean;
+  configOpen: boolean;
+  setConfigOpen: Dispatch<SetStateAction<boolean>>;
+  configInitialTab: string | null;
+  smartViewEditId: string | null;
+  authError: string;
+  isAuthLoading: boolean;
+  authenticate: (password: string) => Promise<boolean>;
+  updateConfig: (updater: OwnerConfig | ((prev: OwnerConfig) => OwnerConfig)) => void;
+  closeConfig: () => void;
+  openGear: () => void;
+  openConfigToTab: (tabId: string | null, opts?: { smartViewEditId?: string | null }) => void;
+} {
   const [config,        setConfig]        = useState<OwnerConfig>(() => loadConfig(calendarId));
   const [isOwner,       setIsOwner]       = useState(devMode);
   const [configOpen,    setConfigOpen]    = useState(false);

--- a/src/hooks/usePermissions.ts
+++ b/src/hooks/usePermissions.ts
@@ -10,7 +10,7 @@
 export const ROLES = /** @type {const} */ (['admin', 'user', 'readonly']);
 type Role = 'admin' | 'user' | 'readonly';
 
-const CAPS: Record<Role, {
+export type PermissionCaps = {
   canAddEvent: boolean;
   canEditEvent: boolean;
   canDeleteEvent: boolean;
@@ -18,7 +18,9 @@ const CAPS: Record<Role, {
   canManagePeople: boolean;
   canManageOptions: boolean;
   canManageSavedViews: boolean;
-}> = {
+};
+
+const CAPS: Record<Role, PermissionCaps> = {
   admin: {
     canAddEvent:         true,
     canEditEvent:        true,
@@ -48,6 +50,6 @@ const CAPS: Record<Role, {
   },
 };
 
-export function usePermissions(role: string = 'admin') {
+export function usePermissions(role: string = 'admin'): PermissionCaps {
   return CAPS[(role in CAPS ? role : 'admin') as Role];
 }

--- a/src/hooks/useSavedViews.ts
+++ b/src/hooks/useSavedViews.ts
@@ -286,7 +286,27 @@ export function deserializeFilters(saved: Record<string, any> | null | undefined
  * @param {string} calendarId
  * @returns {{ views, saveView, updateView, resaveView, deleteView }}
  */
-export function useSavedViews(calendarId: string) {
+export function useSavedViews(calendarId: string): {
+  views: SavedView[];
+  saveView: (name: string, filters: Record<string, unknown>, opts?: SaveViewOptions) => SavedView;
+  updateView: (id: string, patch: Partial<SavedView>) => void;
+  resaveView: (
+    id: string,
+    filters: Record<string, unknown>,
+    viewName?: string | null,
+    groupBy?: GroupByInput,
+    opts?: {
+      sort?: unknown;
+      showAllGroups?: unknown;
+      sortBy?: unknown;
+      zoomLevel?: unknown;
+      collapsedGroups?: unknown;
+      selectedBaseIds?: unknown;
+    },
+  ) => void;
+  deleteView: (id: string) => void;
+  toggleStripVisibility: (id: string) => void;
+} {
   const [views, setViews] = useState<SavedView[]>(() => loadViews(calendarId));
 
   // Re-load when calendarId changes

--- a/src/hooks/useSourceAggregator.ts
+++ b/src/hooks/useSourceAggregator.ts
@@ -29,7 +29,10 @@ type SourceStoreLike = {
 export function useSourceAggregator({ icalFeedsProp = [], sourceStore }: {
   icalFeedsProp?: FeedLike[];
   sourceStore: SourceStoreLike;
-}) {
+}): {
+  events: SourceEvent[];
+  feedErrors: Array<{ feed: { url: string; label?: string; refreshInterval?: number }; err: unknown }>;
+} {
   // Merge prop-level feeds + store-managed ICS feeds for the polling hook.
   // We use a stable JSON key so that referentially-new but semantically-identical
   // arrays do not trigger unnecessary re-fetches.

--- a/src/hooks/useSourceStore.ts
+++ b/src/hooks/useSourceStore.ts
@@ -95,7 +95,15 @@ export function persistSources(calendarId: string, sources: CalendarSource[]): v
 
 // ── Hook ──────────────────────────────────────────────────────────────────────
 
-export function useSourceStore(calendarId: string) {
+export function useSourceStore(calendarId: string): {
+  sources: CalendarSource[];
+  activeIcsSources: ActiveIcsSource[];
+  activeCsvSources: CsvSource[];
+  addSource: (partial: NewSource) => CalendarSource;
+  removeSource: (id: string) => void;
+  updateSource: (id: string, patch: SourcePatch) => void;
+  toggleSource: (id: string) => void;
+} {
   const [sources, setSources] = useState<CalendarSource[]>(() => loadSources(calendarId));
 
   // Re-load when calendarId changes (multiple embedded calendar instances)

--- a/src/hooks/useSyncedCalendar.ts
+++ b/src/hooks/useSyncedCalendar.ts
@@ -30,6 +30,7 @@ import { SyncManager } from '../api/v1/sync/SyncManager';
 import type { CalendarAdapter } from '../api/v1/adapters/CalendarAdapter';
 import type { CalendarEventV1 } from '../api/v1/types';
 import type { SyncState, SyncManagerOptions } from '../api/v1/sync/SyncManager';
+import type { SyncStatus } from '../api/v1/sync/SyncQueue';
 
 /**
  * @typedef {import('../api/v1/sync/SyncManager.js').SyncManagerOptions} SyncManagerOptions
@@ -72,7 +73,21 @@ export function useSyncedCalendar({
   maxRetries,
   retryBaseDelay,
   live = false,
-}: UseSyncedCalendarOptions) {
+}: UseSyncedCalendarOptions): {
+  events: ReadonlyMap<string, CalendarEventV1>;
+  statusMap: ReadonlyMap<string, SyncStatus>;
+  errorsMap: ReadonlyMap<string, Error>;
+  isSyncing: boolean;
+  pendingCount: number;
+  createEvent: (event: CalendarEventV1) => ReturnType<SyncManager['createEvent']>;
+  updateEvent: (id: string, patch: Partial<CalendarEventV1>) => ReturnType<SyncManager['updateEvent']>;
+  deleteEvent: (id: string) => ReturnType<SyncManager['deleteEvent']>;
+  retryFailed: () => ReturnType<SyncManager['retryFailed']>;
+  clearErrors: () => ReturnType<SyncManager['clearErrors']>;
+  statusFor: (eventId: string) => ReturnType<SyncManager['statusFor']>;
+  errorFor: (eventId: string) => ReturnType<SyncManager['errorFor']>;
+  manager: SyncManager;
+} {
   // ── SyncManager (stable across renders) ────────────────────────────────────
   const managerRef = useRef<SyncManager | null>(null);
 

--- a/src/hooks/useTouchDnd.ts
+++ b/src/hooks/useTouchDnd.ts
@@ -38,7 +38,7 @@ export function useTouchDnd({
   onOver?: (el: Element | null, payload: any) => void
   onDrop?: (el: Element | null, payload: any) => void
   onCancel?: (payload: any) => void
-} = {}) {
+} = {}): (e: any, payload: any) => void {
   const stateRef = useRef<any>(null);
 
   const cleanup = useCallback(() => {

--- a/src/hooks/useTouchSwipe.ts
+++ b/src/hooks/useTouchSwipe.ts
@@ -31,7 +31,7 @@ export function useTouchSwipe({
   minDistance?: number;
   maxOffAxis?: number;
   maxDurationMs?: number;
-}) {
+}): void {
   const gestureRef = useRef<{ x: number; y: number; ts: number } | null>(null);
 
   useEffect(() => {


### PR DESCRIPTION
Adds explicit return-type annotations to the 14 migrated hooks that shipped with inferred returns, closing the last Stage 3 rule gap ("React hook return types must be explicit"). Updates the migration doc to mark Stage 3 complete with final any-ledger entry (+17, within 20-site budget).

Hooks annotated: useDrag, useEventOptions, useFeedEvents, useFetchEvents, useGrouping (useGroupingRows), useKeyboardShortcuts, useOwnerConfig, usePermissions, useSavedViews, useSourceAggregator, useSourceStore, useSyncedCalendar, useTouchDnd, useTouchSwipe.

- `setConfigOpen` typed as `Dispatch<SetStateAction<boolean>>` to preserve functional-update form for callers.
- `useSyncedCalendar` return uses `ReadonlyMap<...>` to match `SyncState`.
- `useGrouping` flatRows typed as `Array<Record<string, any>>` so downstream filters can access `_type` on group-header rows.

Ratchet GREEN (38 paths), advisory tsc GREEN, 1911 tests pass.

https://claude.ai/code/session_012giC73mUMKUYNqxeSrKoqY