### PR TITLE
feat(theme,demo): issue #268 sprint 1 — 6 theme families + Air EMS demo

### DIFF
--- a/demo/App.tsx
+++ b/demo/App.tsx
@@ -7,44 +7,48 @@ import {
   DEFAULT_CATEGORIES,
   createManualLocationProvider,
 } from '../src/index.ts';
-import { THEMES } from '../src/styles/themes';
 import { saveProfiles } from '../src/core/profileStore';
 import { loadConfig, saveConfig, DEFAULT_CONFIG } from '../src/core/configSchema';
 import { loadPools, savePools } from '../src/core/pools/poolStore';
+import {
+  regions,
+  bases,
+  assets as EMS_ASSETS,
+  crew,
+  medicalCrew,
+  mechanics,
+  dispatchShifts,
+  pilotShifts,
+  medicalShifts,
+  mechanicOnCall,
+  maintenanceEvents,
+  requests,
+  mission,
+} from './emsData';
 
-/* ─── Demo profiles ─────────────────────────────────────────────── */
-const DEMO_CALENDAR_ID = 'ihc-oncall-demo';
+/* ─── Demo identity ─────────────────────────────────────────────── */
+// Air EMS demo: new calendar id so the IHC Fleet localStorage doesn't bleed
+// through. Returning users see a clean slate with Air EMS defaults.
+const DEMO_CALENDAR_ID = 'air-ems-demo';
+
+/* ─── Profiles (saved filter sets in the profile bar) ──────────── */
 const DEMO_PROFILES = [
-  { id:'p1', name:'Full Schedule',       color:'#10b981', filters:{ categories:[],              resources:[], search:'' }, view:'schedule' },
-  { id:'p2', name:'On-Call Only',        color:'#ef4444', filters:{ categories:['on-call'],      resources:[], search:'' }, view:'schedule' },
-  { id:'p3', name:'Incidents',           color:'#f59e0b', filters:{ categories:['Incident'],     resources:[], search:'' }, view:'agenda'   },
-  { id:'p4', name:'Sarah\'s Week',       color:'#3b82f6', filters:{ categories:[],              resources:['emp-sarah'], search:'' }, view:'week' },
-  { id:'p5', name:'Month Overview',      color:'#8b5cf6', filters:{ categories:[],              resources:[], search:'' }, view:'month'    },
+  { id: 'p1', name: 'Full Ops',          color: '#0ea5e9', filters: { categories: [],            resources: [], search: '' }, view: 'schedule' },
+  { id: 'p2', name: 'Pilots',            color: '#3b82f6', filters: { categories: ['shift'],     resources: [], search: '' }, view: 'schedule' },
+  { id: 'p3', name: 'Medical Crew',      color: '#10b981', filters: { categories: ['shift'],     resources: [], search: '' }, view: 'schedule' },
+  { id: 'p4', name: 'Mechanics On-Call', color: '#f97316', filters: { categories: ['on-call'],   resources: [], search: '' }, view: 'schedule' },
+  { id: 'p5', name: 'Fleet',             color: '#8b5cf6', filters: { categories: [],            resources: [], search: '' }, view: 'assets'   },
 ];
 const stored = localStorage.getItem(`wc-profiles-${DEMO_CALENDAR_ID}`);
 if (!stored || stored === '[]') saveProfiles(DEMO_CALENDAR_ID, DEMO_PROFILES);
 
-/* ─── Demo config seed ──────────────────────────────────────────── */
-// Bases (airbases / regional hubs). Used by the Base Gantt view, the Assets
-// view's base column, and the approval-flow demo. Employees and assets below
-// reference these by id.
-const DEMO_BASES = [
-  { id: 'base-phx', name: 'Phoenix HQ (KPHX)' },
-  { id: 'base-lax', name: 'Los Angeles (KLAX)' },
-  { id: 'base-den', name: 'Denver (KDEN)' },
-  { id: 'base-ord', name: 'Chicago (KORD)' },
-  { id: 'base-jfk', name: 'New York (KJFK)' },
-  { id: 'base-bos', name: 'Boston (KBOS)' },
-];
+/* ─── Bases ─────────────────────────────────────────────────────── */
+const DEMO_BASES = bases.map(b => ({ id: b.id, name: b.name }));
 
-// Pre-seed config with demo-appropriate defaults. Uses a per-version seed
-// marker so we can re-apply the demo-defaults block once per version bump
-// when we want returning users to pick up new demo features (e.g. the
-// approval workflow), without clobbering arbitrary owner edits every reload.
-//
-// Bump DEMO_SEED_VERSION whenever a new block is added to the seed below
-// so existing demo visitors get the update on their next page load.
-const DEMO_SEED_VERSION = 2;
+/* ─── Config seed ───────────────────────────────────────────────── */
+// Bumped for the Air EMS identity change. Existing visitors on the IHC seed
+// see the new defaults on their next load without a manual storage wipe.
+const DEMO_SEED_VERSION = 3;
 const SEED_VER_KEY      = `wc-demo-seed-v-${DEMO_CALENDAR_ID}`;
 const storedCfg         = localStorage.getItem(`wc-config-${DEMO_CALENDAR_ID}`);
 const storedSeedVer     = Number(localStorage.getItem(SEED_VER_KEY) ?? 0);
@@ -52,207 +56,184 @@ const storedSeedVer     = Number(localStorage.getItem(SEED_VER_KEY) ?? 0);
 if (!storedCfg) {
   saveConfig(DEMO_CALENDAR_ID, {
     ...DEFAULT_CONFIG,
-    title: 'IHC Fleet On-Call',
-    setup: { completed: true, preferredTheme: 'corporate' },
+    title: 'Air EMS Operations',
+    setup: { completed: true, preferredTheme: 'ops-dark' },
     display: { ...DEFAULT_CONFIG.display, defaultView: 'schedule' },
     team: { ...DEFAULT_CONFIG.team, bases: DEMO_BASES },
     approvals: { ...DEFAULT_CONFIG.approvals, enabled: true },
   });
   localStorage.setItem(SEED_VER_KEY, String(DEMO_SEED_VERSION));
 } else if (storedSeedVer < DEMO_SEED_VERSION) {
-  // Returning user predating the current seed version — re-apply the demo
-  // defaults for bases + approvals so the Assets-view approval flow is
-  // visible without requiring a manual localStorage wipe. Preserves
-  // everything else on the config (title, theme, per-user settings).
   const existing = loadConfig(DEMO_CALENDAR_ID);
   saveConfig(DEMO_CALENDAR_ID, {
     ...existing,
-    team:      { ...existing.team,      bases: existing.team?.bases?.length ? existing.team.bases : DEMO_BASES },
+    title:     existing.title ?? 'Air EMS Operations',
+    setup:     { ...existing.setup, preferredTheme: existing.setup?.preferredTheme ?? 'ops-dark' },
+    team:      { ...existing.team, bases: existing.team?.bases?.length ? existing.team.bases : DEMO_BASES },
     approvals: { ...existing.approvals, enabled: true },
   });
   localStorage.setItem(SEED_VER_KEY, String(DEMO_SEED_VERSION));
 }
 
-// Read the stored (or just-seeded) preferred theme so the ThemePicker
-// starts in sync with whatever the config says.
-const _seedConfig = loadConfig(DEMO_CALENDAR_ID);
-const INITIAL_THEME = _seedConfig.setup?.preferredTheme ?? 'corporate';
+const _seedConfig  = loadConfig(DEMO_CALENDAR_ID);
+const INITIAL_THEME = _seedConfig.setup?.preferredTheme ?? 'ops-dark';
 
-/* ─── Employees ─────────────────────────────────────────────────── */
-// Each employee is pre-assigned to a base so the Base Gantt view renders
-// populated rows out of the box. Phoenix and LAX each host two people; Denver
-// and Chicago host one; JFK and Boston are asset-only bases. A few of the
-// people carry "Accountable Manager" assignments so the base header shows the
-// one-stop contact roster (Base / Ops / Maintenance manager + phone).
+/* ─── Employees ────────────────────────────────────────────────── */
+// Pilots + medical crew + mechanics rendered as the people roster. Each
+// gets a role-coded color so the schedule view makes shift type obvious at
+// a glance.
+const PILOT_COLOR    = '#3b82f6';
+const MEDICAL_COLOR  = '#10b981';
+const SPECIAL_COLOR  = '#a855f7'; // ECMO specialist
+const MECHANIC_COLOR = '#f97316';
+
 const INITIAL_EMPLOYEES = [
-  { id: 'emp-sarah',  name: 'Sarah Chen',    role: 'Senior Engineer',   color: '#3b82f6', base: 'base-phx',
-    phone: '602-555-0114',
-    accountableManagers: [{ title: 'Base Manager', phone: '602-555-0114' }] },
-  { id: 'emp-marcus', name: 'Marcus Webb',   role: 'On-Call Engineer',  color: '#ef4444', base: 'base-phx',
-    phone: '602-555-0129',
-    accountableManagers: [{ title: 'Maintenance Manager', phone: '602-555-0129' }] },
-  { id: 'emp-priya',  name: 'Priya Sharma',  role: 'Team Lead',         color: '#10b981', base: 'base-den',
-    phone: '303-555-0177',
-    accountableManagers: [{ title: 'Base Manager' }, { title: 'Ops Manager', phone: '303-555-0177' }] },
-  { id: 'emp-james',  name: 'James Torres',  role: 'DevOps / SRE',      color: '#8b5cf6', base: 'base-lax',
-    phone: '310-555-0141',
-    accountableManagers: [{ title: 'Ops Manager', phone: '310-555-0141' }] },
-  { id: 'emp-alex',   name: 'Alex Kim',      role: 'Software Engineer', color: '#f59e0b', base: 'base-ord',
-    phone: '312-555-0162' },
-  { id: 'emp-dana',   name: 'Dana Okafor',   role: 'Site Reliability',  color: '#06b6d4', base: 'base-lax',
-    phone: '310-555-0198',
-    accountableManagers: [{ title: 'Maintenance Manager', phone: '310-555-0198' }] },
+  ...crew.map(c => ({
+    id:    c.id,
+    name:  c.name,
+    role:  `Pilot (${c.certifications.join(', ')})`,
+    color: PILOT_COLOR,
+    base:  c.baseId,
+  })),
+  ...medicalCrew.map(m => ({
+    id:    m.id,
+    name:  m.name,
+    role:  m.certifications.join(' · '),
+    color: m.certifications.includes('ECMO') ? SPECIAL_COLOR : MEDICAL_COLOR,
+    base:  m.baseId,
+  })),
+  ...mechanics.map(m => ({
+    id:    m.id,
+    name:  m.name,
+    role:  'Mechanic',
+    color: MECHANIC_COLOR,
+    base:  m.baseId,
+  })),
 ];
 
-/* ─── Events ────────────────────────────────────────────────────── */
-const today = new Date();
-today.setHours(0, 0, 0, 0);
+/* ─── Assets ───────────────────────────────────────────────────── */
+// Fleet rows rendered by the Assets view. `group` is the region so the
+// assets view can pivot by region; `meta.base` ties into the base column.
+const REGION_BY_BASE = Object.fromEntries(bases.map(b => [b.id, regions.find(r => r.id === b.regionId)?.name ?? '']));
 
-// Shift an ISO date by `days` days
-function shift(date, days) {
-  const d = new Date(date);
-  d.setDate(d.getDate() + days);
-  return d;
-}
+const AIRCRAFT_RESOURCES = EMS_ASSETS.map(a => ({
+  id:    a.id,
+  label: a.name,
+  group: REGION_BY_BASE[a.baseId] || 'Fleet',
+  meta: {
+    sublabel: a.capability.join(' · '),
+    model:    a.type === 'helicopter' ? 'Helicopter' : 'Fixed-wing',
+    base:     a.baseId,
+    status:   a.status,
+    location: { text: bases.find(b => b.id === a.baseId)?.name ?? '—', status: 'live', asOf: new Date().toISOString() },
+  },
+}));
 
-// Start of the current month
-const monthStart = new Date(today.getFullYear(), today.getMonth(), 1);
+/* ─── Events ───────────────────────────────────────────────────── */
+// Convert the Air EMS dataset into WorksCalendar's event shape
+// ({ id, title, start, end, category, resource, color }).
 
-// Build on-call rotation: each engineer covers 7 days in round-robin order
-function buildOnCallRotation(employees, monthStart) {
-  const shifts = [];
-  let id = 100;
-  // 6 rotation slots across the month (some may overlap month boundary)
-  for (let slot = 0; slot < 5; slot++) {
-    const emp = employees[slot % employees.length];
-    const start = shift(monthStart, slot * 7);
-    const end   = shift(start, 7);     // exclusive end
-    shifts.push({
-      id: String(id++),
-      title: 'On Call',
-      start: start.toISOString(),
-      end:   end.toISOString(),
-      category: 'on-call',
-      resource: emp.id,
-      color: emp.color,
-    });
-  }
-  return shifts;
-}
+const DISPATCH_COLOR    = '#0ea5e9';
+const SHIFT_PILOT_COLOR = PILOT_COLOR;
+const SHIFT_MED_COLOR   = MEDICAL_COLOR;
+const ONCALL_COLOR      = MECHANIC_COLOR;
+const MAINT_COLOR       = '#ef4444';
+const REQUEST_COLOR     = '#64748b';
+const MISSION_COLOR     = '#a855f7';
 
-// Regular events
-function d(offsetDays, hour = 9) {
-  const dt = new Date(today);
-  dt.setDate(dt.getDate() + offsetDays);
-  dt.setHours(hour, 0, 0, 0);
-  return dt.toISOString();
-}
-function dEnd(offsetDays, hour = 9, durH = 1) {
-  const dt = new Date(today);
-  dt.setDate(dt.getDate() + offsetDays);
-  dt.setHours(hour + durH, 0, 0, 0);
-  return dt.toISOString();
-}
+const DISPATCH_EVENTS = dispatchShifts.map(s => ({
+  id: s.id, title: s.title, start: s.start, end: s.end,
+  category: 'dispatch', resource: null, color: DISPATCH_COLOR,
+}));
 
-const REGULAR_EVENTS = [
-  // Team standup — daily (not recurring in this demo, just a few instances)
-  { id:'m1',  title:'Daily Standup',        start:d(0,9),   end:dEnd(0,9,0.25),  category:'Meeting',  resource:null,         color:'#64748b' },
-  { id:'m2',  title:'Daily Standup',        start:d(1,9),   end:dEnd(1,9,0.25),  category:'Meeting',  resource:null,         color:'#64748b' },
-  { id:'m3',  title:'Daily Standup',        start:d(2,9),   end:dEnd(2,9,0.25),  category:'Meeting',  resource:null,         color:'#64748b' },
-  { id:'m4',  title:'Daily Standup',        start:d(3,9),   end:dEnd(3,9,0.25),  category:'Meeting',  resource:null,         color:'#64748b' },
-  { id:'m5',  title:'Daily Standup',        start:d(4,9),   end:dEnd(4,9,0.25),  category:'Meeting',  resource:null,         color:'#64748b' },
+const PILOT_SHIFT_EVENTS = pilotShifts.map(s => ({
+  id: s.id, title: s.title, start: s.start, end: s.end,
+  category: 'shift', resource: s.crewId, color: SHIFT_PILOT_COLOR,
+}));
 
-  // 1-on-1s
-  { id:'o1',  title:'1-on-1 w/ Sarah',      start:d(1,10),  end:dEnd(1,10),      category:'Meeting',  resource:'emp-sarah',  color:'#3b82f6' },
-  { id:'o2',  title:'1-on-1 w/ Marcus',     start:d(2,10),  end:dEnd(2,10),      category:'Meeting',  resource:'emp-marcus', color:'#ef4444' },
-  { id:'o3',  title:'1-on-1 w/ Alex',       start:d(3,11),  end:dEnd(3,11),      category:'Meeting',  resource:'emp-alex',   color:'#f59e0b' },
-  { id:'o4',  title:'1-on-1 w/ Dana',       start:d(5,14),  end:dEnd(5,14),      category:'Meeting',  resource:'emp-dana',   color:'#06b6d4' },
+const MEDICAL_SHIFT_EVENTS = medicalShifts.map(s => ({
+  id: s.id, title: s.title, start: s.start, end: s.end,
+  category: 'shift', resource: s.crewId, color: SHIFT_MED_COLOR,
+}));
 
-  // Incidents
-  { id:'i1',  title:'P1 Incident — API timeout',  start:d(-1,2),  end:dEnd(-1,2,3),  category:'Incident', resource:'emp-marcus', color:'#ef4444', status:'confirmed' },
-  { id:'i2',  title:'P2 Incident — DB slow query', start:d(2,14), end:dEnd(2,14,2),  category:'Incident', resource:'emp-james',  color:'#f97316' },
+const ONCALL_EVENTS = mechanicOnCall.map(s => ({
+  id: s.id, title: s.title, start: s.start, end: s.end,
+  category: 'on-call', resource: s.crewId, color: ONCALL_COLOR, allDay: true,
+}));
 
-  // Code reviews / deploys
-  { id:'d1',  title:'Prod Deploy — v2.4.1',  start:d(4,15),  end:dEnd(4,15,1),   category:'Deploy',   resource:'emp-james',  color:'#8b5cf6' },
-  { id:'d2',  title:'Staging Deploy',        start:d(1,16),  end:dEnd(1,16,1),   category:'Deploy',   resource:'emp-james',  color:'#8b5cf6' },
+const MAINT_EVENTS = maintenanceEvents.map(m => ({
+  id: m.id, title: m.title, start: m.start, end: m.end,
+  category: 'maintenance', resource: m.assetId, color: MAINT_COLOR,
+  meta: { approvalStage: { stage: 'approved', updatedAt: m.start } },
+}));
 
-  // Sprint events
-  { id:'s1',  title:'Sprint Planning',       start:d(7,9),   end:dEnd(7,9,3),    category:'Meeting',  resource:null,         color:'#64748b' },
-  { id:'s2',  title:'Sprint Retrospective',  start:d(-3,14), end:dEnd(-3,14,2),  category:'Meeting',  resource:null,         color:'#64748b' },
-  { id:'s3',  title:'Sprint Demo',           start:d(-1,15), end:dEnd(-1,15,1),  category:'Meeting',  resource:null,         color:'#64748b' },
+const REQUEST_EVENTS = requests.map(r => ({
+  id: r.id, title: r.title, start: r.start, end: r.end,
+  category: 'request', resource: r.assetId, color: REQUEST_COLOR,
+  meta: { approvalStage: { stage: r.status === 'pending' ? 'requested' : 'approved', updatedAt: r.start } },
+}));
 
-  // PTO
-  { id:'v1',  title:'PTO — Priya',           start:d(8),     end:dEnd(11),       category:'PTO',      resource:'emp-priya',  color:'#10b981', allDay:true },
-
-  // Training
-  { id:'t1',  title:'AWS Security Training', start:d(5,10),  end:dEnd(5,10,4),   category:'Training', resource:'emp-alex',   color:'#f59e0b' },
-  { id:'t2',  title:'K8s Workshop',          start:d(6,9),   end:dEnd(6,9,3),    category:'Training', resource:'emp-dana',   color:'#06b6d4' },
-];
+// Flight legs — rendered on the Jet 1 row so the mission is visible on the
+// assets view.  Pilot and medical crew assignments are exposed as additional
+// events on the respective people rows for the same leg windows.
+const MISSION_LEG_EVENTS = mission.legs.flatMap(leg => {
+  const flightTitle = `${mission.name} — ${leg.from} → ${leg.to}`;
+  const pilotAssignment   = mission.assignments.pilots.find(a => a.legId === leg.id);
+  const medicalAssignment = mission.assignments.medical.find(a => a.legId === leg.id);
+  return [
+    {
+      id: `mission-${leg.id}-jet`,
+      title: flightTitle, start: leg.start, end: leg.end,
+      category: 'mission', resource: 'a3', color: MISSION_COLOR,
+      meta: { sublabel: `Leg ${leg.id}` },
+    },
+    pilotAssignment && {
+      id: `mission-${leg.id}-pilot`,
+      title: `Flight: ${leg.from} → ${leg.to}`,
+      start: leg.start, end: leg.end,
+      category: 'mission', resource: pilotAssignment.crewId, color: MISSION_COLOR,
+    },
+    medicalAssignment && {
+      id: `mission-${leg.id}-medical`,
+      title: `Flight: ${leg.from} → ${leg.to}`,
+      start: leg.start, end: leg.end,
+      category: 'mission', resource: medicalAssignment.crewId, color: MISSION_COLOR,
+    },
+  ].filter(Boolean);
+});
 
 const INITIAL_EVENTS = [
-  ...buildOnCallRotation(INITIAL_EMPLOYEES, monthStart),
-  ...REGULAR_EVENTS,
-];
-
-/* ─── Assets (aircraft, trucks, equipment…) ───────────────────────
- *
- * Assets are first-class rows in the Assets view (distinct from people,
- * who live on the Schedule view). The demo ships a small fleet of
- * aircraft; the library accepts any resource kind the user defines.
- */
-const AIRCRAFT_RESOURCES = [
-  { id: 'N121AB', label: 'N121AB', group: 'West',    meta: { sublabel: 'Citation CJ3',    model: 'Citation CJ3',     base: 'base-phx', location: { text: 'KPHX', status: 'live',  asOf: new Date().toISOString() } } },
-  { id: 'N505CD', label: 'N505CD', group: 'West',    meta: { sublabel: 'Phenom 300',      model: 'Phenom 300',       base: 'base-lax', location: { text: 'KLAX', status: 'stale', asOf: new Date().toISOString() } } },
-  { id: 'N88QR',  label: 'N88QR',  group: 'Central', meta: { sublabel: 'King Air 350',    model: 'King Air 350',     base: 'base-den', location: { text: 'KDEN', status: 'live',  asOf: new Date().toISOString() } } },
-  { id: 'N733XY', label: 'N733XY', group: 'Central', meta: { sublabel: 'Challenger 350',  model: 'Challenger 350',   base: 'base-ord', location: { text: 'KORD', status: 'live',  asOf: new Date().toISOString() } } },
-  { id: 'N901JT', label: 'N901JT', group: 'East',    meta: { sublabel: 'Gulfstream G280', model: 'Gulfstream G280',  base: 'base-jfk', location: { text: 'KJFK', status: 'live',  asOf: new Date().toISOString() } } },
-  { id: 'N245LM', label: 'N245LM', group: 'East',    meta: { sublabel: 'Pilatus PC-24',   model: 'Pilatus PC-24',    base: 'base-bos', location: { text: 'KBOS', status: 'live',  asOf: new Date().toISOString() } } },
-];
-const FLEET_EVENTS = [
-  { id: 'f1',  title: 'Recurrent training',   start: d(0, 9),   end: dEnd(0, 9, 6),  category: 'training',    resource: 'N121AB', meta: { sublabel: 'Citation CJ3',  region: 'West' } },
-  { id: 'f2',  title: 'VIP lift to KTEB',     start: d(2, 6),   end: dEnd(2, 6, 8),  category: 'pr',          resource: 'N121AB', meta: { sublabel: 'Citation CJ3',  region: 'West' } },
-  { id: 'f3',  title: 'A-check',              start: d(5),      end: dEnd(8),        category: 'maintenance', resource: 'N505CD', meta: { sublabel: 'Phenom 300',    region: 'West',  approvalStage: { stage: 'approved', updatedAt: d(-1) } }, allDay: true },
-  { id: 'f4',  title: 'Charter: Aspen',       start: d(3, 10),  end: dEnd(4, 16),    category: 'pr',          resource: 'N88QR',  meta: { sublabel: 'King Air 350',  region: 'Central' } },
-  { id: 'f5',  title: 'Brake inspection',     start: d(1),      end: dEnd(1),        category: 'maintenance', resource: 'N88QR',  meta: { sublabel: 'King Air 350',  region: 'Central', approvalStage: { stage: 'finalized', updatedAt: d(-2) } }, allDay: true },
-  { id: 'f6',  title: 'Type rating',          start: d(6, 9),   end: dEnd(6, 9, 6),  category: 'training',    resource: 'N733XY', meta: { sublabel: 'Challenger 350', region: 'Central' } },
-  { id: 'f7',  title: 'Avionics upgrade',     start: d(9),      end: dEnd(12),       category: 'maintenance', resource: 'N733XY', meta: { sublabel: 'Challenger 350', region: 'Central', approvalStage: { stage: 'pending_higher', updatedAt: d(-1) } }, allDay: true },
-  { id: 'f8',  title: 'Charter: Cabo',        start: d(4, 8),   end: dEnd(6, 18),    category: 'pr',          resource: 'N901JT', meta: { sublabel: 'Gulfstream G280', region: 'East' } },
-  { id: 'f9',  title: 'Coverage block',       start: d(7, 7),   end: dEnd(7, 7, 10), category: 'coverage',    resource: 'N901JT', meta: { sublabel: 'Gulfstream G280', region: 'East' } },
-  { id: 'f10', title: 'Dispatch ferry',       start: d(2, 14),  end: dEnd(2, 14, 4), category: 'pr',          resource: 'N245LM', meta: { sublabel: 'Pilatus PC-24', region: 'East',  approvalStage: { stage: 'requested', updatedAt: d(-1) } } },
-  { id: 'f11', title: 'Paint refresh',        start: d(10),     end: dEnd(15),       category: 'maintenance', resource: 'N245LM', meta: { sublabel: 'Pilatus PC-24', region: 'East',  approvalStage: { stage: 'denied', updatedAt: d(-1), history: [{ action: 'deny', at: d(-1), actor: 'chief-pilot', tier: 2, reason: 'Conflicts with higher-priority dispatch.' }] } }, allDay: true },
-  { id: 'f12', title: 'SIM session',          start: d(11, 9),  end: dEnd(11, 9, 4), category: 'training',    resource: 'N505CD', meta: { sublabel: 'Phenom 300',    region: 'West' } },
+  ...DISPATCH_EVENTS,
+  ...PILOT_SHIFT_EVENTS,
+  ...MEDICAL_SHIFT_EVENTS,
+  ...ONCALL_EVENTS,
+  ...MAINT_EVENTS,
+  ...REQUEST_EVENTS,
+  ...MISSION_LEG_EVENTS,
 ];
 
 /* ─── Resource pools (#212) ─────────────────────────────────────── */
-// Demo pools group aircraft by region. Bookings that target a pool id
-// (via event.resourcePoolId) resolve to a concrete tail number at
-// submit time; the round-robin cursor persists in localStorage so a
-// refresh doesn't reset the rotation.
+// Group aircraft by region so bookings can target a pool instead of a tail
+// number; the round-robin cursor persists in localStorage.
 const DEMO_POOLS_DEFAULT = [
-  { id: 'fleet-west',    name: 'West Fleet',    memberIds: ['N121AB', 'N505CD'],          strategy: 'round-robin'    },
-  { id: 'fleet-central', name: 'Central Fleet', memberIds: ['N88QR',  'N733XY'],          strategy: 'round-robin'    },
-  { id: 'fleet-east',    name: 'East Fleet',    memberIds: ['N901JT', 'N245LM'],          strategy: 'first-available' },
+  { id: 'pool-mountain',  name: 'Mountain Fleet',  memberIds: ['a1', 'a3'], strategy: 'round-robin'     },
+  { id: 'pool-southwest', name: 'Southwest Fleet', memberIds: [],           strategy: 'first-available' },
 ];
-// Seed once — on subsequent loads we read the persisted pools so a
-// cursor advance from the previous session survives the reload.
 const _storedPools = loadPools(DEMO_CALENDAR_ID);
 if (_storedPools.length === 0) savePools(DEMO_CALENDAR_ID, DEMO_POOLS_DEFAULT);
 
-// Unified category palette — engineering ops + fleet ops. The calendar
-// uses a single category set across views; each event references whichever
-// category suits it (on-call / Incident / Deploy for people, training /
-// maintenance / pr / coverage for aircraft).
+/* ─── Categories ────────────────────────────────────────────────── */
 const UNIFIED_CATEGORIES = [
-  // Engineering
-  { id: 'on-call',  label: 'On Call',    color: '#ef4444' },
-  { id: 'Incident', label: 'Incident',   color: '#f97316' },
-  { id: 'Deploy',   label: 'Deploy',     color: '#8b5cf6' },
-  { id: 'Meeting',  label: 'Meeting',    color: '#64748b' },
-  { id: 'PTO',      label: 'PTO',        color: '#10b981' },
-  // Fleet (from DEFAULT_CATEGORIES, spread here so both sets share the palette)
+  // Operations
+  { id: 'dispatch',    label: 'Dispatch',    color: DISPATCH_COLOR },
+  { id: 'shift',       label: 'Shift',       color: PILOT_COLOR    },
+  { id: 'on-call',     label: 'On Call',     color: ONCALL_COLOR   },
+  { id: 'mission',     label: 'Mission',     color: MISSION_COLOR  },
+  // Fleet
+  { id: 'maintenance', label: 'Maintenance', color: MAINT_COLOR    },
+  { id: 'request',     label: 'Request',     color: REQUEST_COLOR  },
+  { id: 'training',    label: 'Training',    color: '#f59e0b'      },
   ...DEFAULT_CATEGORIES,
-  // Demo-only: asset movement requests route through the approvals workflow.
-  { id: 'aircraft-movement', label: 'Aircraft Movement', color: '#06b6d4' },
 ];
 
 const UNIFIED_CATEGORIES_CONFIG = {
@@ -262,18 +243,6 @@ const UNIFIED_CATEGORIES_CONFIG = {
 };
 
 /* ─── Approval state machine (demo) ─────────────────────────────── */
-//
-// Resolves the next stage purely from action-verb semantics, so any
-// (stage, action) pair the owner-configured ApprovalActionMenu can present
-// produces a sensible transition — no dead clicks if the owner customizes
-// `config.approvals.rules[stage].allow[]`.
-//
-//   approve  ─▶ pending_higher → finalized    (second-tier approval)
-//              everything else → approved     (first approval lands here)
-//   deny     ─▶ denied
-//   finalize ─▶ finalized
-//   revoke   ─▶ finalized → approved          (roll back one step)
-//              everything else → requested
 function nextStageFor(currentStage, actionId) {
   const stage = currentStage ?? 'requested';
   switch (actionId) {
@@ -293,9 +262,7 @@ function applyApprovalTransition(event, actionId, payload) {
 
   const now = new Date().toISOString();
   const historyEntry = {
-    action: actionId,
-    at:     now,
-    actor:  payload?.actor ?? 'demo-user',
+    action: actionId, at: now, actor: payload?.actor ?? 'demo-user',
     ...(payload?.tier   !== undefined ? { tier:   payload.tier   } : {}),
     ...(payload?.reason !== undefined ? { reason: payload.reason } : {}),
   };
@@ -310,82 +277,6 @@ function applyApprovalTransition(event, actionId, payload) {
       },
     },
   };
-}
-
-/* ─── Theme picker ──────────────────────────────────────────────── */
-function ThemePicker({ current, onChange }) {
-  const [open, setOpen] = useState(false);
-  const active = THEMES.find(t => t.id === current) ?? THEMES[0];
-
-  return (
-    <div style={{ position: 'relative' }}>
-      <button
-        onClick={() => setOpen(o => !o)}
-        style={{
-          display: 'flex', alignItems: 'center', gap: 8,
-          padding: '6px 10px',
-          background: active.preview.bg,
-          border: `2px solid ${active.preview.accent}`,
-          borderRadius: 8, cursor: 'pointer', fontSize: 12,
-          color: active.preview.text, fontWeight: 600,
-          boxShadow: '0 1px 4px rgba(0,0,0,.12)',
-        }}
-        title="Change theme"
-      >
-        <span style={{ display:'flex', gap:3 }}>
-          {[active.preview.accent, active.preview.bg, active.preview.surface].map((c, i) => (
-            <span key={i} style={{ width:12, height:12, borderRadius:'50%', background:c, border:'1px solid rgba(0,0,0,.15)', display:'inline-block' }} />
-          ))}
-        </span>
-        {active.label}
-        <span style={{ opacity:0.6 }}>{open ? '▲' : '▼'}</span>
-      </button>
-
-      {open && (
-        <div style={{
-          position: 'absolute', right: 0, top: 'calc(100% + 6px)',
-          background: '#fff', border: '1px solid #e2e8f0',
-          borderRadius: 12, boxShadow: '0 8px 32px rgba(0,0,0,.15)',
-          padding: 10, display: 'flex', flexDirection: 'column', gap: 4,
-          zIndex: 1000, minWidth: 220,
-        }}>
-          <div style={{ fontSize: 10, fontWeight: 700, textTransform: 'uppercase', letterSpacing: '0.08em', color: '#94a3b8', padding: '2px 6px 6px' }}>
-            Choose a theme
-          </div>
-          {THEMES.map(t => (
-            <button
-              key={t.id}
-              onClick={() => { onChange(t.id); setOpen(false); }}
-              style={{
-                display: 'flex', alignItems: 'center', gap: 10,
-                padding: '8px 10px', border: 'none', borderRadius: 8,
-                background: t.id === current ? t.preview.accent + '18' : 'transparent',
-                cursor: 'pointer', textAlign: 'left',
-                outline: t.id === current ? `2px solid ${t.preview.accent}` : 'none',
-                outlineOffset: -2,
-              }}
-            >
-              <div style={{
-                width: 36, height: 28, borderRadius: 5, flexShrink: 0,
-                background: t.preview.bg, border: `1px solid ${t.preview.border}`,
-                overflow: 'hidden', position: 'relative',
-              }}>
-                <div style={{ height: 8, background: t.preview.surface, borderBottom: `1px solid ${t.preview.border}` }} />
-                <div style={{ position:'absolute', bottom:4, left:4, right:4, height:6, borderRadius:2, background: t.preview.accent, opacity:0.85 }} />
-              </div>
-              <div>
-                <div style={{ fontSize: 13, fontWeight: 600, color: '#0f172a', display:'flex', alignItems:'center', gap:5 }}>
-                  {t.label}
-                  {t.dark && <span style={{ fontSize:9, background:'#334155', color:'#94a3b8', padding:'1px 5px', borderRadius:3, fontWeight:600 }}>DARK</span>}
-                </div>
-                <div style={{ fontSize: 11, color: '#94a3b8', marginTop: 1 }}>{t.description.slice(0, 48)}{t.description.length > 48 ? '…' : ''}</div>
-              </div>
-            </button>
-          ))}
-        </div>
-      )}
-    </div>
-  );
 }
 
 /* ─── PWA update toast ──────────────────────────────────────────── */
@@ -424,24 +315,17 @@ function UpdateToast({ onUpdate, onDismiss }) {
 
 /* ─── Demo App ──────────────────────────────────────────────────── */
 function App() {
-  // A single events array holds both people-events (resource = emp-*) and
-  // asset-events (resource = aircraft registration). Schedule view picks up
-  // the people subset via the employees prop; Assets view picks up the
-  // aircraft subset via the assets prop + strictAssetFiltering.
-  const [events,       setEvents]       = useState([...INITIAL_EVENTS, ...FLEET_EVENTS]);
+  const [events,       setEvents]       = useState(INITIAL_EVENTS);
   const [notes,        setNotes]        = useState({});
   const [theme,        setTheme]        = useState(INITIAL_THEME);
   const [employees,    setEmployees]    = useState(INITIAL_EMPLOYEES);
   const [eventLog,     setEventLog]     = useState([]);
   const [needsRefresh, setNeedsRefresh] = useState(false);
-  // Resource pools (#212). Hydrated from localStorage so the round-robin
-  // cursor persists across reloads. WorksCalendar calls onPoolsChange
-  // after each cursor advance; we push that back to storage and state so
-  // the next mutation (or reload) sees the updated cursor.
   const [pools, setPools] = useState(() => {
     const persisted = loadPools(DEMO_CALENDAR_ID);
     return persisted.length > 0 ? persisted : DEMO_POOLS_DEFAULT;
   });
+
   const handlePoolsChange = useCallback((next) => {
     setPools(next);
     savePools(DEMO_CALENDAR_ID, next);
@@ -454,15 +338,8 @@ function App() {
 
   const [updateSW] = useState(() =>
     registerSW({
-      onNeedRefresh() { setNeedsRefresh(true); },
+      onNeedRefresh()  { setNeedsRefresh(true); },
       onOfflineReady() { console.info('[PWA] App ready to work offline.'); },
-      // Probe for a new bundle on registration and whenever the tab regains
-      // focus. Without this, a visitor with a stale SW would only pick up
-      // new bundles on the next fresh navigation. Combined with the
-      // onNeedRefresh auto-apply below this means a user who already had
-      // the pre-sidebar build cached will get bumped to the latest UI
-      // (e.g. the unified Filter/Group/Views sidebar) within seconds of
-      // re-opening the demo tab.
       onRegisteredSW(_swUrl, r) {
         if (!r) return;
         void r.update();
@@ -473,9 +350,6 @@ function App() {
     })
   );
 
-  // Keep the public demo on the latest bundle automatically so feature
-  // updates (like the unified Filter/Group/Views sidebar) are visible
-  // without requiring users to notice and click the update toast.
   useEffect(() => {
     if (!needsRefresh) return;
     void updateSW(true);
@@ -484,18 +358,11 @@ function App() {
 
   const log = (msg) => setEventLog(prev => [`[${new Date().toLocaleTimeString()}] ${msg}`, ...prev].slice(0, 8));
 
-  // When the owner saves config (e.g. changes preferred theme in Settings > Setup),
-  // sync the demo's ThemePicker so both stay in agreement.
   const handleConfigSave = useCallback((cfg) => {
     log('Config saved');
     const newTheme = cfg.setup?.preferredTheme;
     if (newTheme) setTheme(newTheme);
   }, []);
-
-  const isDark       = THEMES.find(t => t.id === theme)?.dark ?? false;
-  const headerBg     = isDark ? '#0f172a' : '#fff';
-  const headerBorder = isDark ? '#1e293b' : '#e2e8f0';
-  const pageBg       = isDark ? '#060d1a' : '#f1f5f9';
 
   const handleEventSave = useCallback((ev) => {
     setEvents(prev => {
@@ -547,9 +414,7 @@ function App() {
   }, []);
 
   return (
-    <div style={{ height: '100vh', display: 'flex', flexDirection: 'column', background: pageBg }}>
-
-      {/* ── Calendar ── */}
+    <div style={{ height: '100vh', display: 'flex', flexDirection: 'column', background: '#060d1a' }}>
       <div style={{ flex: 1, padding: 0, minHeight: 0 }}>
         <div style={{ height: '100%', width: '100%' }}>
           <WorksCalendar
@@ -559,7 +424,7 @@ function App() {
             pools={pools}
             onPoolsChange={handlePoolsChange}
             strictAssetFiltering={true}
-            assetRequestCategories={['maintenance', 'pr', 'training', 'aircraft-movement']}
+            assetRequestCategories={['maintenance', 'request', 'training', 'mission']}
             onEmployeeAdd={handleEmployeeAdd}
             onEmployeeDelete={handleEmployeeDelete}
             calendarId={DEMO_CALENDAR_ID}
@@ -583,7 +448,6 @@ function App() {
           />
         </div>
       </div>
-
 
       {/* Demo hint: owner password floats below the gear icon */}
       <div style={{

--- a/demo/emsData.ts
+++ b/demo/emsData.ts
@@ -1,0 +1,255 @@
+/**
+ * demo/emsData.ts — Air EMS (emergency medical services) demo dataset.
+ *
+ * Replaces the old engineering on-call + jet-charter fixtures used prior to
+ * issue #268. Models a small operations console: regions + bases, pilots +
+ * medical crew + mechanics, aircraft with capabilities, shifts (day/night),
+ * mechanic on-call rotation, maintenance events, training requests, and an
+ * international critical-care transfer mission with leg-by-leg crew + medical
+ * assignments and country clearance compliance.
+ *
+ * All datetimes are local-time ISO-8601 strings (no timezone suffix) anchored
+ * around 2026-04-21 so the schedule view always has populated rows relative
+ * to "today" in the demo.
+ */
+
+// ── Geography ─────────────────────────────────────────────────────────────────
+
+export const regions = [
+  { id: 'r1', name: 'Mountain' },
+  { id: 'r2', name: 'Southwest' },
+];
+
+export const bases = [
+  { id: 'b1', name: 'Salt Lake', regionId: 'r1' },
+  { id: 'b2', name: 'Logan',     regionId: 'r1' },
+  { id: 'b3', name: 'Phoenix',   regionId: 'r2' },
+];
+
+// ── Fleet ─────────────────────────────────────────────────────────────────────
+
+export const assets = [
+  {
+    id: 'a1',
+    name: 'Heli 1',
+    type: 'helicopter',
+    baseId: 'b1',
+    capability: ['IFR', 'Night', 'Vent'],
+    status: 'available',
+  },
+  {
+    id: 'a2',
+    name: 'Heli 2',
+    type: 'helicopter',
+    baseId: 'b2',
+    capability: ['VFR'],
+    status: 'maintenance',
+  },
+  {
+    id: 'a3',
+    name: 'Jet 1',
+    type: 'fixed-wing',
+    baseId: 'b1',
+    capability: ['IFR', 'International', 'Critical Care'],
+    status: 'assigned',
+  },
+];
+
+// ── People ────────────────────────────────────────────────────────────────────
+
+export const crew = [
+  {
+    id: 'c1',
+    name: 'Pilot A',
+    baseId: 'b1',
+    certifications: ['IFR', 'Night'],
+    dutyStatus: 'on-duty',
+  },
+  {
+    id: 'c2',
+    name: 'Pilot B',
+    baseId: 'b1',
+    certifications: ['IFR', 'International'],
+    dutyStatus: 'on-duty',
+  },
+  {
+    id: 'c3',
+    name: 'Pilot C',
+    baseId: 'b2',
+    certifications: ['IFR'],
+    dutyStatus: 'off-duty',
+  },
+];
+
+export const medicalCrew = [
+  {
+    id: 'mc1',
+    name: 'Nurse Kelly',
+    baseId: 'b1',
+    certifications: ['RN', 'Critical Care', 'Flight'],
+    dutyStatus: 'on-duty',
+  },
+  {
+    id: 'mc2',
+    name: 'Respiratory Alex',
+    baseId: 'b1',
+    certifications: ['RT', 'Vent'],
+    dutyStatus: 'on-duty',
+  },
+  {
+    id: 'mc3',
+    name: 'Medic Jordan',
+    baseId: 'b2',
+    certifications: ['Medic', 'Neonatal'],
+    dutyStatus: 'off-duty',
+  },
+  {
+    id: 'mc4',
+    name: 'ECMO Specialist Sam',
+    baseId: 'b1',
+    certifications: ['RN', 'ECMO', 'International'],
+    dutyStatus: 'on-call',
+  },
+];
+
+export const mechanics = [
+  { id: 'mech1', name: 'Tech Mike',  baseId: 'b1', status: 'on-call'  },
+  { id: 'mech2', name: 'Tech Sarah', baseId: 'b2', status: 'off-duty' },
+];
+
+// ── Shifts (day / night, all roles) ───────────────────────────────────────────
+
+export const dispatchShifts = [
+  {
+    id: 'd1',
+    title: 'Dispatch Day Shift',
+    baseId: 'b1',
+    start: '2026-04-21T07:00',
+    end:   '2026-04-21T19:00',
+    type:  'dispatch',
+  },
+  {
+    id: 'd2',
+    title: 'Dispatch Night Shift',
+    baseId: 'b1',
+    start: '2026-04-21T19:00',
+    end:   '2026-04-22T07:00',
+    type:  'dispatch',
+  },
+];
+
+export const pilotShifts = [
+  {
+    id: 'ps1',
+    title: 'Pilot Day Shift',
+    crewId: 'c1',
+    start: '2026-04-21T07:00',
+    end:   '2026-04-21T19:00',
+    type:  'shift',
+  },
+  {
+    id: 'ps2',
+    title: 'Pilot Night Shift',
+    crewId: 'c2',
+    start: '2026-04-21T19:00',
+    end:   '2026-04-22T07:00',
+    type:  'shift',
+  },
+];
+
+export const medicalShifts = [
+  {
+    id: 'ms1',
+    title: 'Medical Day Shift',
+    crewId: 'mc1',
+    start: '2026-04-21T07:00',
+    end:   '2026-04-21T19:00',
+    type:  'shift',
+  },
+  {
+    id: 'ms2',
+    title: 'Medical Night Shift',
+    crewId: 'mc2',
+    start: '2026-04-21T19:00',
+    end:   '2026-04-22T07:00',
+    type:  'shift',
+  },
+];
+
+// Mechanic on-call rotates weekly so the schedule shows coverage continuity
+// even when the schedule view is zoomed out to the month.
+export const mechanicOnCall = [
+  {
+    id: 'oc1',
+    title: 'On Call - Week A',
+    crewId: 'mech1',
+    start: '2026-04-20T00:00',
+    end:   '2026-04-27T00:00',
+    type:  'on-call',
+  },
+  {
+    id: 'oc2',
+    title: 'On Call - Week B',
+    crewId: 'mech2',
+    start: '2026-04-27T00:00',
+    end:   '2026-05-04T00:00',
+    type:  'on-call',
+  },
+];
+
+// ── Maintenance + approvals ──────────────────────────────────────────────────
+
+export const maintenanceEvents = [
+  {
+    id: 'm1',
+    title: '100hr Inspection - Heli 1',
+    assetId: 'a1',
+    start: '2026-04-22T08:00',
+    end:   '2026-04-22T14:00',
+    type:  'maintenance',
+  },
+];
+
+export const requests = [
+  {
+    id: 'req1',
+    title: 'Training Flight Request',
+    assetId: 'a1',
+    status: 'pending',
+    start: '2026-04-23T09:00',
+    end:   '2026-04-23T12:00',
+    type:  'request',
+  },
+];
+
+// ── International mission — the product's headline demo ──────────────────────
+
+export const mission = {
+  id: 'mission1',
+  name: 'Brazil → Germany Critical Care Transfer',
+  requiredCrew: {
+    pilots:  ['IFR', 'International'],
+    medical: ['Critical Care', 'Vent'],
+  },
+  legs: [
+    { id: 'leg1', from: 'SLC',    to: 'JFK',     start: '2026-04-24T06:00', end: '2026-04-24T12:00' },
+    { id: 'leg2', from: 'JFK',    to: 'London',  start: '2026-04-24T14:00', end: '2026-04-25T02:00' },
+    { id: 'leg3', from: 'London', to: 'Germany', start: '2026-04-25T04:00', end: '2026-04-25T08:00' },
+  ],
+  assignments: {
+    pilots: [
+      { crewId: 'c1',  legId: 'leg1' },
+      { crewId: 'c2',  legId: 'leg2' },
+    ],
+    medical: [
+      { crewId: 'mc1', legId: 'leg1' },
+      { crewId: 'mc2', legId: 'leg2' },
+    ],
+  },
+  compliance: [
+    { id: 'comp1', label: 'Brazil Exit Clearance',       status: 'approved' },
+    { id: 'comp2', label: 'UK Entry Clearance',          status: 'approved' },
+    { id: 'comp3', label: 'Germany Entry Clearance',     status: 'pending'  },
+    { id: 'comp4', label: 'Medical Capability Verified', status: 'approved' },
+  ],
+};

--- a/demo/index.html
+++ b/demo/index.html
@@ -3,11 +3,11 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>WorksCalendar — IHC Fleet Demo</title>
+  <title>WorksCalendar — Air EMS Operations Demo</title>
 
   <!-- PWA / theme metadata -->
-  <meta name="theme-color" content="#4f46e5" />
-  <meta name="description" content="WorksCalendar IHC Fleet Demo — embeddable React calendar with filters and scheduling" />
+  <meta name="theme-color" content="#00d4ff" />
+  <meta name="description" content="WorksCalendar Air EMS Operations Demo — flight coordination, medical staffing, and maintenance coverage in one view" />
   <meta name="mobile-web-app-capable" content="yes" />
   <meta name="apple-mobile-web-app-capable" content="yes" />
   <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
@@ -26,8 +26,10 @@
     body {
       margin: 0;
       font-family: 'Inter', system-ui, sans-serif;
-      background: #f1f5f9;
-      color: #0f172a;
+      /* Match the default ops-dark theme so the initial paint doesn't
+         flash light before React mounts. */
+      background: #060d1a;
+      color: #c8e8f0;
     }
     /* Let the calendar sit flush with the viewport edges in the demo. */
     #root > div > [data-testid="works-calendar"] {

--- a/src/WorksCalendar.tsx
+++ b/src/WorksCalendar.tsx
@@ -36,6 +36,7 @@ import { validateOperation } from './core/engine/validation/validateOperation.ts
 import RecurringScopeDialog   from './ui/RecurringScopeDialog';
 import SetupLanding, { type SetupLandingResult, type SetupRecipeId } from './ui/SetupLanding';
 import { applyFilters, getCategories, getResources } from './filters/filterEngine';
+import { resolveCssTheme } from './styles/themes';
 import { DEFAULT_FILTER_SCHEMA, buildDefaultFilterSchema, makeResourceResolver, viewScopedSchema, type FilterField } from './filters/filterSchema';
 import { SCHEDULE_WORKFLOW_CATEGORIES } from './core/scheduleModel';
 import { useTabScopedEvents } from './hooks/useTabScopedEvents';
@@ -439,7 +440,12 @@ export const WorksCalendar = forwardRef<CalendarApi, WorksCalendarProps>(functio
   const ownerCfg = useOwnerConfig({ calendarId, ownerPassword, onConfigSave, devMode });
   const weekStartDay = weekStartDayProp ?? ownerCfg.config?.display?.weekStartDay ?? 0;
   const customThemeVars = useMemo(() => customThemeToCssVars(ownerCfg.config?.customTheme), [ownerCfg.config?.customTheme]);
-  const effectiveTheme = theme || ownerCfg.config?.setup?.preferredTheme || 'light';
+  // The raw theme value (from props, owner config, or default). The new theme
+  // system uses `family-mode` IDs (see src/styles/themes.ts); the CSS runtime
+  // still matches the historical single-word selectors, so we resolve the
+  // user-facing ID to a CSS selector via resolveCssTheme().
+  const rawTheme = theme || ownerCfg.config?.setup?.preferredTheme || 'canvas-light';
+  const effectiveTheme = resolveCssTheme(rawTheme);
   const calendarTitle = ownerCfg.config?.title || 'My WorksCalendar';
   // Merge parent's employees prop with owner-config team.members so edits
   // made from the Settings → Employees tab (e.g. renaming a member) are
@@ -1931,7 +1937,7 @@ export const WorksCalendar = forwardRef<CalendarApi, WorksCalendarProps>(functio
             onSkip={handleSetupSkip}
             onFinish={handleSetupFinish}
             initialName={ownerCfg.config?.title}
-            initialTheme={ownerCfg.config?.setup?.preferredTheme ?? effectiveTheme}
+            initialTheme={ownerCfg.config?.setup?.preferredTheme ?? rawTheme}
           />
         </div>
       </CalendarErrorBoundary>

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,7 +22,18 @@ export {
   statusField, priorityField, ownerField, tagsField, metaSelectField,
 } from './filters/filterSchema';
 export { createInitialFilters, buildActiveFilterPills, isEmptyFilterValue } from './filters/filterState';
-export { THEMES, THEMES_BY_ID, THEME_IDS } from './styles/themes';
+export {
+  THEMES,
+  THEMES_BY_ID,
+  THEME_IDS,
+  THEME_FAMILIES,
+  THEME_META,
+  DEFAULT_THEME,
+  buildThemeId,
+  normalizeTheme,
+  resolveCssTheme,
+} from './styles/themes';
+export type { ThemeId, ThemeFamily, ThemeMode, ThemeMeta, ThemePreview } from './styles/themes';
 export {
   default as CalendarExternalForm,
   SUPPORTED_EXTERNAL_FORM_FIELD_TYPES,

--- a/src/styles/themes.ts
+++ b/src/styles/themes.ts
@@ -1,76 +1,226 @@
 /**
  * WorksCalendar — Theme Metadata
  *
- * Import this to get all available themes with display info and preview colors.
+ * Theme families × modes: 6 families × { light, dark } = 12 themes.
  *
- * Usage:
- *   import { THEMES } from 'works-calendar/themes';
- *   // or for a specific theme CSS:
- *   import 'works-calendar/styles/aviation';
- *   <WorksCalendar theme="aviation" />
+ *   import { DEFAULT_THEME, normalizeTheme } from 'works-calendar/themes';
+ *   <WorksCalendar theme="ops-dark" />
+ *
+ * Legacy theme names ("aviation", "corporate", "light", …) are still accepted
+ * via normalizeTheme(), which maps them onto the new ThemeId space.
  */
 
-export const THEMES = [
-  {
-    id: 'light',
-    label: 'Default',
-    description: 'Clean modern light theme. Blue accent on white.',
+// ── Types ────────────────────────────────────────────────────────────────────
+
+export type ThemeFamily =
+  | 'canvas'
+  | 'corporate'
+  | 'industrial'
+  | 'grid'
+  | 'ops'
+  | 'neon';
+
+export type ThemeMode = 'light' | 'dark';
+
+export type ThemeId = `${ThemeFamily}-${ThemeMode}`;
+
+// ── Families ─────────────────────────────────────────────────────────────────
+
+export const THEME_FAMILIES = [
+  { id: 'canvas',     label: 'Canvas',     description: 'Clean and structured' },
+  { id: 'corporate',  label: 'Corporate',  description: 'Business-ready' },
+  { id: 'industrial', label: 'Industrial', description: 'Rugged and practical' },
+  { id: 'grid',       label: 'Grid',       description: 'Dense and data-focused' },
+  { id: 'ops',        label: 'Ops',        description: 'Operations console' },
+  { id: 'neon',       label: 'Neon',       description: 'Bold and high-contrast' },
+] as const;
+
+// Generate all theme IDs (12 total)
+export const THEMES: ThemeId[] = THEME_FAMILIES.flatMap((f) => [
+  `${f.id}-light` as ThemeId,
+  `${f.id}-dark`  as ThemeId,
+]);
+
+// Default — ops-dark is the operations-console look used by the Air EMS demo
+export const DEFAULT_THEME: ThemeId = 'ops-dark';
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+export function buildThemeId(family: ThemeFamily, mode: ThemeMode): ThemeId {
+  return `${family}-${mode}`;
+}
+
+/**
+ * Resolve arbitrary input to a canonical ThemeId.
+ *
+ * Accepts: new-style "family-mode" IDs, legacy single-word theme names
+ * ("aviation", "corporate", "light", "dark", "minimal"), or undefined.
+ * Anything we don't recognize falls back to DEFAULT_THEME.
+ */
+export function normalizeTheme(input?: string): ThemeId {
+  if (!input) return DEFAULT_THEME;
+
+  const legacyMap: Record<string, ThemeId> = {
+    light:     'canvas-light',
+    dark:      'canvas-dark',
+    aviation:  'ops-dark',
+    minimal:   'grid-light',
+    corporate: 'corporate-light',
+    soft:      'neon-light',
+    forest:    'industrial-light',
+    ocean:     'corporate-dark',
+  };
+  if (legacyMap[input]) return legacyMap[input];
+
+  if ((THEMES as string[]).includes(input)) return input as ThemeId;
+  return DEFAULT_THEME;
+}
+
+// ── Display metadata ─────────────────────────────────────────────────────────
+//
+// The Setup Wizard, Setup Landing, and Config Panel all render a theme picker
+// with a small preview swatch. Each theme needs a label, description, dark
+// flag, 5-color preview palette, and a `cssTheme` hint that maps onto the CSS
+// theme file currently shipped in src/styles/ (aviation.css, corporate.css,
+// forest.css, minimal.css, ocean.css, soft.css). Until this sprint's follow-up
+// ships dedicated CSS for every family, multiple ThemeIds fall back to the
+// closest existing CSS theme.
+
+export type ThemePreview = {
+  bg: string;
+  surface: string;
+  accent: string;
+  text: string;
+  border: string;
+};
+
+export type ThemeMeta = {
+  id: ThemeId;
+  family: ThemeFamily;
+  mode: ThemeMode;
+  label: string;
+  description: string;
+  dark: boolean;
+  preview: ThemePreview;
+  cssTheme: string;
+};
+
+export const THEME_META: Record<ThemeId, ThemeMeta> = {
+  'canvas-light': {
+    id: 'canvas-light', family: 'canvas', mode: 'light',
+    label: 'Canvas Light',
+    description: 'Clean white canvas, blue accent. The default starting point.',
     dark: false,
     preview: { bg: '#ffffff', surface: '#f8fafc', accent: '#3b82f6', text: '#0f172a', border: '#e2e8f0' },
+    cssTheme: 'minimal',
   },
-  {
-    id: 'dark',
-    label: 'Dark',
-    description: 'Slate dark mode. Easy on the eyes.',
+  'canvas-dark': {
+    id: 'canvas-dark', family: 'canvas', mode: 'dark',
+    label: 'Canvas Dark',
+    description: 'Slate dark mode. Easy on the eyes, familiar to everyone.',
     dark: true,
     preview: { bg: '#0f172a', surface: '#1e293b', accent: '#3b82f6', text: '#f1f5f9', border: '#334155' },
+    cssTheme: 'ocean',
   },
-  {
-    id: 'aviation',
-    label: 'Aviation',
-    description: 'Instrument-panel aesthetic. Dark navy with cyan readouts. Monospace font. Sharp corners.',
-    dark: true,
-    preview: { bg: '#080c16', surface: '#0d1525', accent: '#00d4ff', text: '#c8e8f0', border: '#1a3a4a' },
-  },
-  {
-    id: 'soft',
-    label: 'Soft',
-    description: 'Warm cream background, violet accent, very rounded corners. Approachable and friendly.',
-    dark: false,
-    preview: { bg: '#fffbf7', surface: '#fdf6ee', accent: '#7c3aed', text: '#2d1f0e', border: '#e8d5c0' },
-  },
-  {
-    id: 'minimal',
-    label: 'Minimal',
-    description: 'Pure white, near-invisible borders, indigo accent. Typography-first.',
-    dark: false,
-    preview: { bg: '#ffffff', surface: '#ffffff', accent: '#6366f1', text: '#111827', border: '#f0f0f0' },
-  },
-  {
-    id: 'corporate',
-    label: 'Corporate',
-    description: 'Professional navy blue. Appropriate for enterprise dashboards.',
+  'corporate-light': {
+    id: 'corporate-light', family: 'corporate', mode: 'light',
+    label: 'Corporate Light',
+    description: 'Professional navy blue. Enterprise dashboards.',
     dark: false,
     preview: { bg: '#ffffff', surface: '#f0f4f8', accent: '#1d4ed8', text: '#0f2040', border: '#c9d4e0' },
+    cssTheme: 'corporate',
   },
-  {
-    id: 'forest',
-    label: 'Forest',
-    description: 'Earthy greens and warm browns. Natural, calm feel.',
-    dark: false,
-    preview: { bg: '#fafdf7', surface: '#f2f8ee', accent: '#15803d', text: '#1a2e12', border: '#c6ddb8' },
-  },
-  {
-    id: 'ocean',
-    label: 'Ocean',
-    description: 'Deep ocean blue with sky-blue accents. Dark ambient feel.',
+  'corporate-dark': {
+    id: 'corporate-dark', family: 'corporate', mode: 'dark',
+    label: 'Corporate Dark',
+    description: 'Deep corporate blue with sky accents. Ambient dark.',
     dark: true,
     preview: { bg: '#0a1628', surface: '#0f1f38', accent: '#0ea5e9', text: '#e0f2fe', border: '#1e3a5a' },
+    cssTheme: 'ocean',
   },
-];
+  'industrial-light': {
+    id: 'industrial-light', family: 'industrial', mode: 'light',
+    label: 'Industrial Light',
+    description: 'Warm cream, burnt orange accent. Field-friendly.',
+    dark: false,
+    preview: { bg: '#fffbf7', surface: '#fdf6ee', accent: '#c2410c', text: '#2d1f0e', border: '#e8d5c0' },
+    cssTheme: 'soft',
+  },
+  'industrial-dark': {
+    id: 'industrial-dark', family: 'industrial', mode: 'dark',
+    label: 'Industrial Dark',
+    description: 'Warm dark with orange accent. Shop-floor readable.',
+    dark: true,
+    preview: { bg: '#1a1410', surface: '#2a221c', accent: '#f97316', text: '#f5efe7', border: '#3d312a' },
+    cssTheme: 'aviation',
+  },
+  'grid-light': {
+    id: 'grid-light', family: 'grid', mode: 'light',
+    label: 'Grid Light',
+    description: 'Pure white, typography-first, indigo accent.',
+    dark: false,
+    preview: { bg: '#ffffff', surface: '#ffffff', accent: '#6366f1', text: '#111827', border: '#f0f0f0' },
+    cssTheme: 'minimal',
+  },
+  'grid-dark': {
+    id: 'grid-dark', family: 'grid', mode: 'dark',
+    label: 'Grid Dark',
+    description: 'High-density dark grid. Data-dense views.',
+    dark: true,
+    preview: { bg: '#0a0a0a', surface: '#141414', accent: '#818cf8', text: '#fafafa', border: '#1f1f1f' },
+    cssTheme: 'aviation',
+  },
+  'ops-light': {
+    id: 'ops-light', family: 'ops', mode: 'light',
+    label: 'Ops Light',
+    description: 'Daytime ops console. Cyan accent on clean slate.',
+    dark: false,
+    preview: { bg: '#f8fafc', surface: '#eef2f7', accent: '#0ea5e9', text: '#0f172a', border: '#cbd5e1' },
+    cssTheme: 'corporate',
+  },
+  'ops-dark': {
+    id: 'ops-dark', family: 'ops', mode: 'dark',
+    label: 'Ops Dark',
+    description: 'Instrument-panel aesthetic. Cyan readouts on navy. Monospace.',
+    dark: true,
+    preview: { bg: '#080c16', surface: '#0d1525', accent: '#00d4ff', text: '#c8e8f0', border: '#1a3a4a' },
+    cssTheme: 'aviation',
+  },
+  'neon-light': {
+    id: 'neon-light', family: 'neon', mode: 'light',
+    label: 'Neon Light',
+    description: 'Cream background, vivid violet accent. Bold but approachable.',
+    dark: false,
+    preview: { bg: '#fffbf7', surface: '#fdf6ee', accent: '#7c3aed', text: '#2d1f0e', border: '#e8d5c0' },
+    cssTheme: 'soft',
+  },
+  'neon-dark': {
+    id: 'neon-dark', family: 'neon', mode: 'dark',
+    label: 'Neon Dark',
+    description: 'Deep violet dark with magenta accents. Maximum contrast.',
+    dark: true,
+    preview: { bg: '#0f0a1e', surface: '#1a1033', accent: '#a855f7', text: '#f5ebff', border: '#2d1e4a' },
+    cssTheme: 'aviation',
+  },
+};
 
-/** Convenience map: id → theme object */
-export const THEMES_BY_ID = Object.fromEntries(THEMES.map(t => [t.id, t]));
+/**
+ * Resolve a theme prop down to the CSS theme selector the component runtime
+ * understands (what goes into `data-wc-theme`). Legacy names pass through
+ * as-is so they keep matching the historical CSS files.
+ */
+export function resolveCssTheme(input?: string): string {
+  if (!input) return THEME_META[DEFAULT_THEME].cssTheme;
+  const legacyCss = new Set(['light', 'dark', 'aviation', 'corporate', 'soft', 'minimal', 'forest', 'ocean']);
+  if (legacyCss.has(input)) return input;
+  const id = normalizeTheme(input);
+  return THEME_META[id].cssTheme;
+}
 
-/** IDs of all available themes */
-export const THEME_IDS = THEMES.map(t => t.id);
+// ── Back-compat aliases for the public API ───────────────────────────────────
+
+/** @deprecated Use THEMES (ThemeId[]) + THEME_META[id] instead. */
+export const THEME_IDS: ThemeId[] = THEMES;
+
+/** @deprecated Use THEME_META instead. */
+export const THEMES_BY_ID: Record<ThemeId, ThemeMeta> = THEME_META;

--- a/src/ui/ConfigPanel.tsx
+++ b/src/ui/ConfigPanel.tsx
@@ -14,7 +14,7 @@ import { CONFLICT_RULE_TYPES } from '../core/conflictEngine.ts';
 import { DEFAULT_CATEGORIES } from '../types/assets.ts';
 import { useFocusTrap } from '../hooks/useFocusTrap';
 import { serializeFilters } from '../hooks/useSavedViews';
-import { THEMES, THEME_META } from '../styles/themes';
+import { THEMES, THEME_META, normalizeTheme } from '../styles/themes';
 import SourcePanel from './SourcePanel';
 import ThemeCustomizer from './ThemeCustomizer';
 import AdvancedFilterBuilder from './AdvancedFilterBuilder';
@@ -250,7 +250,10 @@ export default function ConfigPanel({
 }
 
 function SetupTab({ config, onUpdate }: any) {
-  const selectedTheme = config.setup?.preferredTheme ?? 'corporate';
+  // Stored `preferredTheme` may be a legacy id (e.g. 'corporate', 'ocean')
+  // for upgraded calendars. Normalize for the aria-pressed/selected match
+  // so the active card still highlights after the theme-system rewrite.
+  const selectedTheme = normalizeTheme(config.setup?.preferredTheme ?? 'corporate');
   const calendarName = config.title ?? 'My WorksCalendar';
 
   const setCalendarName = (name) => onUpdate(c => ({

--- a/src/ui/ConfigPanel.tsx
+++ b/src/ui/ConfigPanel.tsx
@@ -14,7 +14,7 @@ import { CONFLICT_RULE_TYPES } from '../core/conflictEngine.ts';
 import { DEFAULT_CATEGORIES } from '../types/assets.ts';
 import { useFocusTrap } from '../hooks/useFocusTrap';
 import { serializeFilters } from '../hooks/useSavedViews';
-import { THEMES } from '../styles/themes';
+import { THEMES, THEME_META } from '../styles/themes';
 import SourcePanel from './SourcePanel';
 import ThemeCustomizer from './ThemeCustomizer';
 import AdvancedFilterBuilder from './AdvancedFilterBuilder';
@@ -277,27 +277,30 @@ function SetupTab({ config, onUpdate }: any) {
         />
       </label>
       <div className={styles.themeGrid}>
-        {THEMES.map((theme) => (
-          <button
-            key={theme.id}
-            className={[styles.themeCard, selectedTheme === theme.id && styles.themeCardSelected].filter(Boolean).join(' ')}
-            onClick={() => setPreferredTheme(theme.id)}
-            title={theme.description}
-            aria-pressed={selectedTheme === theme.id}
-          >
-            <div className={styles.themeCardPreview} style={{ background: theme.preview.bg, borderColor: theme.preview.border }}>
-              <div className={styles.themeCardAccent} style={{ background: theme.preview.accent }} />
-              <div className={styles.themeCardLines}>
-                <span style={{ background: theme.preview.text }} />
-                <span style={{ background: theme.preview.text, width: '65%' }} />
+        {THEMES.map((id) => {
+          const theme = THEME_META[id];
+          return (
+            <button
+              key={theme.id}
+              className={[styles.themeCard, selectedTheme === theme.id && styles.themeCardSelected].filter(Boolean).join(' ')}
+              onClick={() => setPreferredTheme(theme.id)}
+              title={theme.description}
+              aria-pressed={selectedTheme === theme.id}
+            >
+              <div className={styles.themeCardPreview} style={{ background: theme.preview.bg, borderColor: theme.preview.border }}>
+                <div className={styles.themeCardAccent} style={{ background: theme.preview.accent }} />
+                <div className={styles.themeCardLines}>
+                  <span style={{ background: theme.preview.text }} />
+                  <span style={{ background: theme.preview.text, width: '65%' }} />
+                </div>
               </div>
-            </div>
-            <div className={styles.themeCardTop}>
-              <span>{theme.label}</span>
-              {selectedTheme === theme.id && <Check size={12} />}
-            </div>
-          </button>
-        ))}
+              <div className={styles.themeCardTop}>
+                <span>{theme.label}</span>
+                {selectedTheme === theme.id && <Check size={12} />}
+              </div>
+            </button>
+          );
+        })}
       </div>
     </div>
   );

--- a/src/ui/SetupLanding.tsx
+++ b/src/ui/SetupLanding.tsx
@@ -11,7 +11,7 @@
  */
 import { useMemo, useState } from 'react';
 import { ChevronRight, ChevronLeft, Check, Sparkles, Rocket, Users, Palette, LayoutGrid, Wand2, MapPin } from 'lucide-react';
-import { THEMES, THEME_META } from '../styles/themes';
+import { THEMES, THEME_META, normalizeTheme, resolveCssTheme } from '../styles/themes';
 import styles from './SetupLanding.module.css';
 import {
   IllustrationTheme,
@@ -181,7 +181,7 @@ export default function SetupLanding({
   /* ── Welcome ─────────────────────────────────────────────────────────── */
   if (step === 0) {
     return (
-      <div className={styles.landing} data-wc-theme={theme} role="region" aria-label="Calendar setup">
+      <div className={styles.landing} data-wc-theme={resolveCssTheme(theme)} role="region" aria-label="Calendar setup">
         <div className={styles.hero}>
           <div className={styles.heroIcon}><Rocket size={40} aria-hidden="true" /></div>
           <h1 className={styles.heroTitle}>Let’s set up your calendar</h1>
@@ -215,7 +215,7 @@ export default function SetupLanding({
 
   /* ── Steps ───────────────────────────────────────────────────────────── */
   return (
-    <div className={styles.landing} data-wc-theme={theme} role="region" aria-label="Calendar setup">
+    <div className={styles.landing} data-wc-theme={resolveCssTheme(theme)} role="region" aria-label="Calendar setup">
       <div className={styles.shell}>
         <header className={styles.topBar}>
           <span className={styles.brand}><Sparkles size={14} aria-hidden="true" /> Calendar setup</span>
@@ -317,6 +317,10 @@ function StepName({ name, onChange }: { name: string; onChange: (v: string) => v
 }
 
 function StepTheme({ current, onChange }: { current: string; onChange: (id: string) => void }) {
+  // The stored value may be a legacy id ('corporate', 'ocean', …) for
+  // upgraded calendars — normalize before matching so the currently-active
+  // card still renders as selected.
+  const normalizedCurrent = normalizeTheme(current);
   return (
     <section className={styles.step}>
       <h2 className={styles.stepTitle}>How should it look?</h2>
@@ -328,7 +332,7 @@ function StepTheme({ current, onChange }: { current: string; onChange: (id: stri
       <div className={styles.themeGrid}>
         {THEMES.map(id => {
           const t = THEME_META[id];
-          const selected = current === t.id;
+          const selected = normalizedCurrent === t.id;
           return (
             <button
               key={t.id}

--- a/src/ui/SetupLanding.tsx
+++ b/src/ui/SetupLanding.tsx
@@ -11,7 +11,7 @@
  */
 import { useMemo, useState } from 'react';
 import { ChevronRight, ChevronLeft, Check, Sparkles, Rocket, Users, Palette, LayoutGrid, Wand2, MapPin } from 'lucide-react';
-import { THEMES } from '../styles/themes';
+import { THEMES, THEME_META } from '../styles/themes';
 import styles from './SetupLanding.module.css';
 import {
   IllustrationTheme,
@@ -326,7 +326,8 @@ function StepTheme({ current, onChange }: { current: string; onChange: (id: stri
       </p>
 
       <div className={styles.themeGrid}>
-        {THEMES.map(t => {
+        {THEMES.map(id => {
+          const t = THEME_META[id];
           const selected = current === t.id;
           return (
             <button

--- a/src/ui/SetupWizardModal.tsx
+++ b/src/ui/SetupWizardModal.tsx
@@ -18,7 +18,7 @@
  */
 import { useState } from 'react';
 import { X, ChevronRight, Check, Sparkles, Camera } from 'lucide-react';
-import { THEMES } from '../styles/themes';
+import { THEMES, THEME_META } from '../styles/themes';
 import { useFocusTrap } from '../hooks/useFocusTrap';
 import AdvancedFilterBuilder from './AdvancedFilterBuilder';
 import styles from './SetupWizardModal.module.css';
@@ -207,31 +207,34 @@ function Step1({ calendarName, onCalendarNameChange, selectedTheme, onThemeChang
         <fieldset className={styles.fieldset}>
           <legend className={styles.fieldLabel}>Theme</legend>
           <div className={styles.themeGrid}>
-          {THEMES.map(theme => (
-            <button
-              key={theme.id}
-              className={[styles.themeCard, selectedTheme === theme.id && styles.themeCardSelected].filter(Boolean).join(' ')}
-              onClick={() => onThemeChange(theme.id)}
-              title={theme.description}
-              aria-pressed={selectedTheme === theme.id}
-            >
-              {/* Mini preview swatch */}
-              <div
-                className={styles.themeSwatch}
-                style={{ background: theme.preview.bg, borderColor: theme.preview.border }}
+          {THEMES.map(id => {
+            const theme = THEME_META[id];
+            return (
+              <button
+                key={theme.id}
+                className={[styles.themeCard, selectedTheme === theme.id && styles.themeCardSelected].filter(Boolean).join(' ')}
+                onClick={() => onThemeChange(theme.id)}
+                title={theme.description}
+                aria-pressed={selectedTheme === theme.id}
               >
-                <div className={styles.swatchAccent} style={{ background: theme.preview.accent }} />
-                <div className={styles.swatchLines}>
-                  <span style={{ background: theme.preview.text }} />
-                  <span style={{ background: theme.preview.text, width: '60%' }} />
+                {/* Mini preview swatch */}
+                <div
+                  className={styles.themeSwatch}
+                  style={{ background: theme.preview.bg, borderColor: theme.preview.border }}
+                >
+                  <div className={styles.swatchAccent} style={{ background: theme.preview.accent }} />
+                  <div className={styles.swatchLines}>
+                    <span style={{ background: theme.preview.text }} />
+                    <span style={{ background: theme.preview.text, width: '60%' }} />
+                  </div>
                 </div>
-              </div>
-              <span className={styles.themeLabel}>{theme.label}</span>
-              {selectedTheme === theme.id && (
-                <span className={styles.themeCheck}><Check size={10} /></span>
-              )}
-            </button>
-          ))}
+                <span className={styles.themeLabel}>{theme.label}</span>
+                {selectedTheme === theme.id && (
+                  <span className={styles.themeCheck}><Check size={10} /></span>
+                )}
+              </button>
+            );
+          })}
           </div>
         </fieldset>
       </div>
@@ -332,7 +335,9 @@ function Step2({ categories, resources, createdViews, onSaveView }: any) {
 // ─── Step 4: Done ─────────────────────────────────────────────────────────────
 
 function Step3({ calendarName, selectedTheme, teamMembers, createdViews }: any) {
-  const theme = THEMES.find(t => t.id === selectedTheme);
+  const theme = selectedTheme && (THEMES as string[]).includes(selectedTheme)
+    ? THEME_META[selectedTheme as keyof typeof THEME_META]
+    : undefined;
 
   return (
     <div className={[styles.step, styles.stepDone].join(' ')}>

--- a/src/ui/SetupWizardModal.tsx
+++ b/src/ui/SetupWizardModal.tsx
@@ -18,7 +18,7 @@
  */
 import { useState } from 'react';
 import { X, ChevronRight, Check, Sparkles, Camera } from 'lucide-react';
-import { THEMES, THEME_META } from '../styles/themes';
+import { THEMES, THEME_META, normalizeTheme } from '../styles/themes';
 import { useFocusTrap } from '../hooks/useFocusTrap';
 import AdvancedFilterBuilder from './AdvancedFilterBuilder';
 import styles from './SetupWizardModal.module.css';
@@ -183,6 +183,9 @@ export default function SetupWizardModal({
 // ─── Step 1: Basic info ───────────────────────────────────────────────────────
 
 function Step1({ calendarName, onCalendarNameChange, selectedTheme, onThemeChange }: any) {
+  // The wizard seeds `selectedTheme` with a legacy id ('corporate'); normalize
+  // so the matching theme-family card shows as selected on first render.
+  const normalizedSelected = normalizeTheme(selectedTheme);
   return (
     <div className={styles.step}>
       <div className={styles.stepHeader}>
@@ -209,13 +212,14 @@ function Step1({ calendarName, onCalendarNameChange, selectedTheme, onThemeChang
           <div className={styles.themeGrid}>
           {THEMES.map(id => {
             const theme = THEME_META[id];
+            const selected = normalizedSelected === theme.id;
             return (
               <button
                 key={theme.id}
-                className={[styles.themeCard, selectedTheme === theme.id && styles.themeCardSelected].filter(Boolean).join(' ')}
+                className={[styles.themeCard, selected && styles.themeCardSelected].filter(Boolean).join(' ')}
                 onClick={() => onThemeChange(theme.id)}
                 title={theme.description}
-                aria-pressed={selectedTheme === theme.id}
+                aria-pressed={selected}
               >
                 {/* Mini preview swatch */}
                 <div
@@ -229,7 +233,7 @@ function Step1({ calendarName, onCalendarNameChange, selectedTheme, onThemeChang
                   </div>
                 </div>
                 <span className={styles.themeLabel}>{theme.label}</span>
-                {selectedTheme === theme.id && (
+                {selected && (
                   <span className={styles.themeCheck}><Check size={10} /></span>
                 )}
               </button>
@@ -335,8 +339,10 @@ function Step2({ categories, resources, createdViews, onSaveView }: any) {
 // ─── Step 4: Done ─────────────────────────────────────────────────────────────
 
 function Step3({ calendarName, selectedTheme, teamMembers, createdViews }: any) {
-  const theme = selectedTheme && (THEMES as string[]).includes(selectedTheme)
-    ? THEME_META[selectedTheme as keyof typeof THEME_META]
+  // Summary card lookup — normalize so legacy ids still resolve to metadata.
+  const normalizedSelected = selectedTheme ? normalizeTheme(selectedTheme) : undefined;
+  const theme = normalizedSelected
+    ? THEME_META[normalizedSelected]
     : undefined;
 
   return (

--- a/tests-e2e/calendar.assets-grouping.spec.ts
+++ b/tests-e2e/calendar.assets-grouping.spec.ts
@@ -8,7 +8,7 @@
  */
 import { test, expect } from '@playwright/test';
 
-const DEMO_CALENDAR_ID = 'ihc-oncall-demo';
+const DEMO_CALENDAR_ID = 'air-ems-demo';
 const SAVED_VIEWS_KEY = `wc-saved-views-${DEMO_CALENDAR_ID}`;
 
 test.describe('WorksCalendar Assets view', () => {

--- a/tests-e2e/calendar.happy-paths.spec.ts
+++ b/tests-e2e/calendar.happy-paths.spec.ts
@@ -48,9 +48,11 @@ test.describe('WorksCalendar happy paths', () => {
   });
 
   test('can drag an event in month view without crashing', async ({ page }) => {
-    // Schedule-workflow events (on-call, shift, PTO, …) are scoped to the
-    // Schedule tab now, so drag a non-schedule event from Month view instead.
-    const event = page.getByRole('button', { name: /Daily Standup.*Meeting/i }).first();
+    // Schedule-workflow events (shift, on-call, PTO, …) are scoped to the
+    // Schedule tab now, so drag a non-schedule event from Month view. The
+    // Air EMS demo renders dispatch shifts (category 'dispatch', resource
+    // null) on Month.
+    const event = page.getByRole('button', { name: /Dispatch Day Shift/i }).first();
     await expect(event).toBeVisible();
 
     const sourceBox = await event.boundingBox();
@@ -71,7 +73,7 @@ test.describe('WorksCalendar happy paths', () => {
     await page.mouse.up();
 
     await expect(page.getByTestId('works-calendar')).toBeVisible();
-    await expect(page.getByRole('button', { name: /Daily Standup.*Meeting/i }).first()).toBeVisible();
+    await expect(page.getByRole('button', { name: /Dispatch Day Shift/i }).first()).toBeVisible();
   });
 
   test('can create a recurring event from the add-event modal', async ({ page }) => {
@@ -105,8 +107,10 @@ test.describe('WorksCalendar happy paths', () => {
     // Dialog auto-opens on successful auth (SHA-256 check is async, give it time).
     await expect(page.getByRole('dialog', { name: /Calendar settings/i })).toBeVisible({ timeout: 10000 });
 
-    // The Setup tab should be active by default, click the Ocean theme
-    await page.getByRole('button', { name: /Ocean/i }).click();
+    // The Setup tab should be active by default, click the Corporate Dark
+    // theme (after issue #268 the theme list is family × mode; corporate-dark
+    // resolves to the historical 'ocean' CSS selector via resolveCssTheme).
+    await page.getByRole('button', { name: /Corporate Dark/i }).click();
 
     // Close the settings panel
     await page.getByLabel('Close settings').click();

--- a/tests-e2e/workflow-builder.spec.ts
+++ b/tests-e2e/workflow-builder.spec.ts
@@ -16,7 +16,7 @@ import { expect, test } from '@playwright/test';
  */
 
 // Must match the calendarId threaded through <WorksCalendar> in demo/App.tsx.
-const STORAGE_KEY = 'wc-saved-workflows-ihc-oncall-demo';
+const STORAGE_KEY = 'wc-saved-workflows-air-ems-demo';
 
 async function authenticateAsOwner(page: import('@playwright/test').Page): Promise<void> {
   await page.getByLabel('Owner settings').click();


### PR DESCRIPTION
## Theme system

Replaces the ad-hoc 8-theme object array with a structured model:

- ThemeFamily × ThemeMode → ThemeId template literal type
  (canvas | corporate | industrial | grid | ops | neon) × (light | dark)
- 12 themes total, default 'ops-dark' for the Air EMS console look
- THEME_FAMILIES list + THEME_META preview/label/cssTheme map
- normalizeTheme() accepts legacy single-word names (aviation, corporate,
  light, dark, minimal, soft, forest, ocean) for backward compatibility
- resolveCssTheme() picks the closest existing CSS selector so runtime
  theming works against today's aviation/corporate/forest/minimal/ocean/
  soft CSS files until per-family CSS ships in the follow-up

ConfigPanel, SetupWizardModal, and SetupLanding now iterate THEMES
(ThemeId[]) and look up THEME_META[id] for label/description/preview.

WorksCalendar resolves its theme prop via resolveCssTheme() before
emitting data-wc-theme, so theme="ops-dark" maps onto the aviation CSS
selector for now.

## Air EMS demo dataset

New demo/emsData.ts models an operations console:

- regions (Mountain, Southwest), bases (Salt Lake, Logan, Phoenix)
- assets — Heli 1, Heli 2 (maintenance), Jet 1 (International/CritCare)
- crew — 3 pilots with IFR/Night/International certs
- medicalCrew — Nurse, RT, Medic, ECMO specialist
- mechanics on weekly on-call rotation
- dispatch/pilot/medical shifts (day/night), maintenance, requests
- Brazil→Germany international mission with leg-by-leg pilot + medical
  crew assignments and country clearance compliance

demo/App.tsx is ported onto this dataset:
- calendarId renamed to 'air-ems-demo', seed version bumped to 3
- title "Air EMS Operations", preferredTheme 'ops-dark'
- profiles rewritten (Full Ops, Pilots, Medical Crew, Mechanics, Fleet)
- dead ThemePicker component removed (theme selection lives in Settings)
- initial page background matches ops-dark to avoid light flash

## Verification

- npm run type-check:strict → GREEN (38 migrated paths unchanged)
- npx tsc -p tsconfig.json → exit 0
- npx vitest run → 1911 passed / 0 failed / 1 todo
- npm run build → library builds
- npm run build:demo → demo builds, PWA generated

https://claude.ai/code/session_012giC73mUMKUYNqxeSrKoqY