### PR TITLE
docs: lock Stage 4 Path A and define Stage 5 PR1 guardrails

### DIFF
--- a/docs/TypeScriptStrictMigration.md
+++ b/docs/TypeScriptStrictMigration.md
@@ -162,6 +162,26 @@ Two legitimate paths:
 
 This decision is explicitly on the plan to prevent the failure mode where scope expansion is assumed rather than chosen.
 
+#### Stage 4 decision record (locked 2026-04-21)
+
+- **Selected path: Path A (continue into Stage 5 UI migration).**
+- Stage 5 execution order is locked to the sprint plan sequence:
+  1. PR 4 — ConfigPanel (Simple Tabs)
+  2. PR 5 — ConfigPanel (Data Tabs)
+  3. PR 6 — ConfigPanel (Workflow Tabs)
+  4. PR 7 — Small Views
+  5. PR 8 — Medium Views
+  6. PR 9 — TimelineView (isolated)
+  7. PR 10 — WorksCalendar (Phase 1)
+  8. PR 11 — WorksCalendar (Phase 2)
+  9. PR 12 — Final Ratchet
+- **Per-PR `any` budget (Stage 5):**
+  - PR 4–8, PR 10: max **+4** each
+  - PR 9: max **+6** (explicit complexity exception)
+  - PR 11: max **+3**
+  - PR 12: **0 net new `any`** (cleanup/ratchet only)
+- Stage 5 cumulative cap is unchanged: **≤ 40 additional `any`**.
+
 ---
 
 ### Stage 5 — UI slice (conditional on Stage 4 → Path A)
@@ -179,6 +199,25 @@ This decision is explicitly on the plan to prevent the failure mode where scope 
 - Running `any` count within budget (target: ≤ 40 additional in stage 5).
 
 **Sizing:** 4–6 weeks.
+
+### Stage 5 PR checklist template (required in every PR description)
+
+- **What was typed**
+  - Files/components touched
+  - New named types/interfaces introduced
+- **What was intentionally left loose**
+  - Exact location(s)
+  - Why tightening is deferred
+- **New `any` introduced**
+  - Count delta (`+N / -N / net`)
+  - Justification per site (or “none”)
+  - Confirm within per-PR budget
+- **Risk level**
+  - Low / Medium / High with one-sentence rationale
+- **Validation**
+  - `npm run type-check:strict` result
+  - Root advisory `tsc --noEmit` result
+  - Tests run for touched scope
 
 ---
 

--- a/docs/stage-4a-stage-5-sprint-plan.md
+++ b/docs/stage-4a-stage-5-sprint-plan.md
@@ -48,6 +48,18 @@ If ANY of these fail → PR is NOT DONE.
 - Define per-PR `any` budget
 - Add checklist to migration doc
 
+**Status:** ✅ Completed (2026-04-21)
+
+**Decision recorded in `docs/TypeScriptStrictMigration.md`:**
+- **Path A is locked** for this roadmap (continue into Stage 5).
+- Stage 5 PR order is fixed as PRs 4 → 12 below.
+- Stage 5 per-PR `any` budget is fixed to keep ratchet pressure:
+  - PR 4–8, 10: max **+4** each
+  - PR 9 (TimelineView isolated): max **+6**
+  - PR 11 (WorksCalendar phase 2): max **+3**
+  - PR 12 (final ratchet): **0 net new `any`** (cleanup only)
+- Stage-level cap remains ≤ 40 additional `any` sites.
+
 ### PR 2 — Shared UI Types
 - Event handler types
 - Shared props


### PR DESCRIPTION
### Motivation
- Finalize the Stage 4 decision to proceed into the UI migration and codify per-PR guardrails so Stage 5 work proceeds with a controlled `any` budget and repeatable PR validation.

### Description
- Marked **PR 1 — Stage 4 Decision** completed in `docs/stage-4a-stage-5-sprint-plan.md` and recorded the outcome with a timestamp. 
- Added a Stage 4 decision record to `docs/TypeScriptStrictMigration.md` that locks Path A, fixes the Stage 5 PR order (PR 4 → PR 12), and defines per-PR `any` budgets plus the cumulative cap. 
- Added a required Stage 5 PR checklist template to `docs/TypeScriptStrictMigration.md` that requires reporting of what was typed, intentional looseness, `any` deltas/justification, risk level, and validation commands. 
- This is a docs-only change (no runtime code modified).

### Testing
- Ran `npm run type-check:strict` and observed `Strict type check GREEN` with the migrated paths listed. 
- Ran `npx tsc --noEmit -p tsconfig.json` and it completed with no blocking diagnostics (exit 0).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7bb182420832ca922f48992556b23)