### PR TITLE
Stage 4a PR2: introduce shared UI boundary types for ConfigPanel

### DIFF
--- a/docs/stage-4a-stage-5-sprint-plan.md
+++ b/docs/stage-4a-stage-5-sprint-plan.md
@@ -66,6 +66,17 @@ If ANY of these fail → PR is NOT DONE.
 - UI data shapes
 - Loose but intentional boundary types
 
+**Status:** ✅ Completed (2026-04-21)
+
+**Shipped in this PR:**
+- Added shared UI boundary types in `src/types/ui.ts`:
+  - `ConfigPanelProps` + `ConfigPanelTabId`
+  - Saved-view seam types (`SavedViewDraft`, `SaveViewOptions`, handlers)
+  - Source/template draft shapes
+  - Shared event/update handler aliases (`UpdateConfig`, `InputChangeHandler`, `ToggleHandler`)
+- Switched `ConfigPanel` from file-level props `: any` to `ConfigPanelProps`.
+- Re-exported shared UI types from `src/index.ts` for downstream consumers.
+
 ### PR 3 — ConfigPanel Seam
 - Create `ConfigPanelProps`
 - Type top-level state

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,17 @@
 export * from './api/v1/index';
 
 export type { WorksCalendarEvent, NormalizedEvent, EventStatus } from './types/events';
+export type {
+  ConfigPanelProps,
+  ConfigPanelTabId,
+  SaveViewHandler,
+  SaveViewOptions,
+  SavedViewDraft,
+  SavedViewUpdateHandler,
+  SourceDraft,
+  ScheduleTemplateDraft,
+  UpdateConfig,
+} from './types/ui';
 
 export { WorksCalendar }                  from './WorksCalendar.tsx';
 export { default as TimelineView }        from './views/TimelineView';

--- a/src/types/ui.ts
+++ b/src/types/ui.ts
@@ -23,7 +23,7 @@ export type SavedViewDraft = {
   hiddenFromStrip?: boolean;
 };
 
-export type SaveViewOptions = Omit<SavedViewDraft, 'id' | 'name' | 'filters'>;
+export type SaveViewOptions = Omit<SavedViewDraft, 'id' | 'name' | 'filters' | 'hiddenFromStrip'>;
 
 export type SaveViewHandler = (
   name: string,

--- a/src/types/ui.ts
+++ b/src/types/ui.ts
@@ -1,0 +1,103 @@
+import type { ReactNode } from 'react';
+
+export type AnyRecord = Record<string, any>;
+
+export type UpdateConfig = (updater: (current: AnyRecord) => AnyRecord) => void;
+
+export type SavedViewFilters = Record<string, unknown>;
+
+export type SavedViewDraft = {
+  id: string;
+  name: string;
+  filters: SavedViewFilters;
+  color?: string | null;
+  view?: string | null;
+  conditions?: unknown[] | null;
+  groupBy?: unknown;
+  sort?: unknown;
+  sortBy?: unknown;
+  zoomLevel?: unknown;
+  collapsedGroups?: unknown;
+  showAllGroups?: unknown;
+  selectedBaseIds?: unknown;
+  hiddenFromStrip?: boolean;
+};
+
+export type SaveViewOptions = Omit<SavedViewDraft, 'id' | 'name' | 'filters'>;
+
+export type SaveViewHandler = (
+  name: string,
+  filters: SavedViewFilters,
+  options?: SaveViewOptions,
+) => void;
+
+export type SavedViewUpdateHandler = (
+  id: string,
+  patch: Record<string, any>,
+) => void;
+
+export type SourceDraft = {
+  id?: string;
+  label?: string;
+  enabled?: boolean;
+  type?: string;
+  url?: string;
+  [k: string]: any;
+};
+
+export type ScheduleTemplateDraft = {
+  id?: string;
+  name?: string;
+  [k: string]: any;
+};
+
+export type ConfigPanelTabId =
+  | 'setup'
+  | 'hoverCard'
+  | 'eventFields'
+  | 'categories'
+  | 'assets'
+  | 'display'
+  | 'theme'
+  | 'feeds'
+  | 'templates'
+  | 'smartViews'
+  | 'team'
+  | 'approvals'
+  | 'approvalFlows'
+  | 'conflicts'
+  | 'requestForm'
+  | 'access';
+
+export interface ConfigPanelProps {
+  config: AnyRecord;
+  categories: string[];
+  resources: string[];
+  schema: AnyRecord;
+  items: AnyRecord[];
+  onUpdate: UpdateConfig;
+  onClose: () => void;
+  onSaveView?: SaveViewHandler;
+  savedViews?: SavedViewDraft[];
+  onUpdateView?: SavedViewUpdateHandler;
+  onDeleteView?: (id: string) => void;
+  sources?: SourceDraft[];
+  feedErrors?: unknown[];
+  onAddSource?: (...args: any[]) => void;
+  onRemoveSource?: (...args: any[]) => void;
+  onToggleSource?: (...args: any[]) => void;
+  onUpdateSource?: (...args: any[]) => void;
+  scheduleTemplates?: ScheduleTemplateDraft[];
+  onCreateScheduleTemplate?: (...args: any[]) => void;
+  onDeleteScheduleTemplate?: (...args: any[]) => void;
+  scheduleTemplateError?: string | null;
+  onEmployeeAdd?: (...args: any[]) => void;
+  onEmployeeDelete?: (...args: any[]) => void;
+  initialTab?: string;
+  initialSmartViewEditId?: string | null;
+  calendarId?: string;
+}
+
+export type InputChangeHandler = (value: string) => void;
+export type ToggleHandler = (next: boolean) => void;
+export type RenderOptional = ReactNode | null;

--- a/src/ui/ConfigPanel.tsx
+++ b/src/ui/ConfigPanel.tsx
@@ -10,6 +10,7 @@ import {
   APPROVAL_STAGE_IDS,
   APPROVAL_ACTIONS,
 } from '../core/configSchema';
+import type { ConfigPanelProps, ConfigPanelTabId } from '../types/ui';
 import { CONFLICT_RULE_TYPES } from '../core/conflictEngine.ts';
 import { DEFAULT_CATEGORIES } from '../types/assets.ts';
 import { useFocusTrap } from '../hooks/useFocusTrap';
@@ -65,7 +66,7 @@ const SECTIONS = [
   { id: 'access',     label: 'Access',     tabs: ['access'] },
 ];
 
-function sectionContaining(tabId) {
+function sectionContaining(tabId: ConfigPanelTabId | string) {
   return SECTIONS.find(s => s.tabs.includes(tabId))?.id ?? SECTIONS[0].id;
 }
 
@@ -89,8 +90,8 @@ export default function ConfigPanel({
   // Per-calendar scope for workflow persistence. Defaults to 'default'
   // so hosts that don't multiplex calendars still get stable storage.
   calendarId = 'default',
-}: any) {
-  const [tab, setTab] = useState(() =>
+}: ConfigPanelProps) {
+  const [tab, setTab] = useState<string>(() =>
     initialTab && TABS.some(t => t.id === initialTab) ? initialTab : 'setup',
   );
   // Open the section containing the active tab; allow others to be expanded


### PR DESCRIPTION
### Motivation
- Prepare the UI slice for Stage 5 by introducing a small, intentional set of shared boundary types to stabilize component seams and handler shapes. 
- Replace a file-wide `: any` props surface on `ConfigPanel` with an explicit top-level props interface so future per-tab typing can proceed safely.

### Description
- Added a new module `src/types/ui.ts` with shared UI boundary types including `ConfigPanelProps`, `ConfigPanelTabId`, saved-view shapes (`SavedViewDraft`, `SaveViewOptions`), source/template draft shapes, and handler aliases (`UpdateConfig`, `SaveViewHandler`, `SavedViewUpdateHandler`).
- Switched `ConfigPanel` from a file-level `: any` props annotation to `ConfigPanelProps`, and typed `sectionContaining` accordingly while keeping the internal tab state as `string` for compatibility with current callsites.
- Re-exported the new UI types from the package entry in `src/index.ts` so downstream consumers can reference the shared seam types.
- Updated `docs/stage-4a-stage-5-sprint-plan.md` to mark PR 2 completed and record the shipped scope and intent of the shared UI types.

### Testing
- Ran `npm run type-check:strict` and the strict migration filter reported `Strict type check GREEN` for the migrated paths. 
- Ran `npx tsc --noEmit -p tsconfig.json` and the root advisory `tsc` check passed with no type errors.
- Executed the focused unit tests `src/ui/__tests__/ConfigPanel.initialTab.test.tsx` and `src/ui/__tests__/ConfigPanel.focusTrap.test.tsx` via `npm test` and both test files passed (10 tests total).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7bc9ab2f0832caef6040e2504f92c)