### PR TITLE
Complete Stage 5 PR7 — Small views typing pass

### DIFF
--- a/docs/stage-4a-stage-5-sprint-plan.md
+++ b/docs/stage-4a-stage-5-sprint-plan.md
@@ -157,6 +157,14 @@ Goal: Handle complex state + flows
 
 Goal: Low-risk view typing
 
+**Status:** ✅ Completed (2026-04-21)
+
+**Shipped in this PR:**
+- Replaced file-level view-prop `any` in `DayView`, `AgendaView`, and `MonthView` with explicit boundary prop types (dates, callbacks, and config slices) to document the small-view public seams.
+- Added a shared `CalendarViewEvent` boundary shape in `src/types/ui.ts` and re-exported it from `src/index.ts` for consistent low-risk view typing.
+- Tightened local state typing in `AgendaView` (collapsed group set, drag/drop refs, drop patch shape) and removed implicit numeric arithmetic on `Date` values by sorting via `getTime()`.
+- Added explicit DOM/ref typing in `DayView` (grid ref + focus target) and retained compatibility with existing render/drag/color pipelines via narrow, intentional casts at integration points.
+
 ---
 
 ### PR 8 — Medium Views

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,7 @@ export type {
   SavedViewUpdateHandler,
   SourceDraft,
   ScheduleTemplateDraft,
+  CalendarViewEvent,
   UpdateConfig,
 } from './types/ui';
 

--- a/src/types/ui.ts
+++ b/src/types/ui.ts
@@ -1,4 +1,5 @@
 import type { ReactNode } from 'react';
+import type { EventStatus } from './events';
 
 export type AnyRecord = Record<string, any>;
 
@@ -101,3 +102,17 @@ export interface ConfigPanelProps {
 export type InputChangeHandler = (value: string) => void;
 export type ToggleHandler = (next: boolean) => void;
 export type RenderOptional = ReactNode | null;
+
+export interface CalendarViewEvent {
+  id: string;
+  title: string;
+  start: Date;
+  end: Date;
+  allDay?: boolean;
+  category?: string | null;
+  resource?: string | null;
+  status?: EventStatus;
+  meta?: Record<string, unknown>;
+  _col?: number;
+  _numCols?: number;
+}

--- a/src/views/AgendaView.tsx
+++ b/src/views/AgendaView.tsx
@@ -7,8 +7,31 @@ import { useCalendarContext, resolveColor } from '../core/CalendarContext';
 import { displayEndDay } from '../core/layout';
 import { buildGroupTree } from '../hooks/useGrouping.ts';
 import { useTouchDnd } from '../hooks/useTouchDnd';
+import type { GroupByInput } from '../hooks/useNormalizedConfig.ts';
+import type { NormalizedEvent } from '../types/events';
+import type { CalendarViewEvent } from '../types/ui';
 import GroupHeader from '../ui/GroupHeader.tsx';
 import styles from './AgendaView.module.css';
+
+type GroupTreeNode = {
+  key: string;
+  label: string;
+  field: string;
+  depth: number;
+  events: CalendarViewEvent[];
+  children: GroupTreeNode[];
+};
+
+type AgendaViewProps = {
+  currentDate: Date;
+  events: CalendarViewEvent[];
+  onEventClick?: (event: CalendarViewEvent) => void;
+  onEventGroupChange?: (event: CalendarViewEvent, patch: Record<string, string | null>) => void;
+  groupBy?: GroupByInput;
+  sort?: unknown;
+  showAllGroups?: boolean;
+  employees?: Array<{ id?: string; name?: string; displayName?: string }>;
+};
 
 export default function AgendaView({
   currentDate,
@@ -19,7 +42,7 @@ export default function AgendaView({
   sort,
   showAllGroups = false,
   employees,
-}: any) {
+}: AgendaViewProps) {
   const ctx = useCalendarContext();
 
   // Resolve resource IDs (e.g. "emp-sarah") to display names (e.g. "Sarah Chen").
@@ -59,7 +82,7 @@ export default function AgendaView({
           day,
           events: hasSort
             ? dayEvents
-            : [...dayEvents].sort((a, b) => a.start - b.start),
+            : [...dayEvents].sort((a, b) => a.start.getTime() - b.start.getTime()),
         };
       })
       .filter(g => g.events.length > 0);
@@ -71,12 +94,12 @@ export default function AgendaView({
     if (!groupBy) return null;
     return grouped.map(({ day, events: dayEvents }) => ({
       day,
-      tree: buildGroupTree(dayEvents, groupBy),
+      tree: buildGroupTree(dayEvents as never, groupBy),
     }));
   }, [grouped, groupBy]);
 
-  const [collapsedGroups, setCollapsedGroups] = useState(() => new Set());
-  const toggleGroup = useCallback((path) => {
+  const [collapsedGroups, setCollapsedGroups] = useState<Set<string>>(() => new Set());
+  const toggleGroup = useCallback((path: string) => {
     setCollapsedGroups(prev => {
       const next = new Set(prev);
       if (next.has(path)) next.delete(path);
@@ -87,17 +110,17 @@ export default function AgendaView({
 
   // Active drag state: tracks the event being dragged and its native leaf path
   // so onDrop handlers can decide whether to emit a change.
-  const dragRef = useRef(null);
-  const [dropTargetPath, setDropTargetPath] = useState(null);
+  const dragRef = useRef<{ ev: CalendarViewEvent; nativePath: string | null } | null>(null);
+  const [dropTargetPath, setDropTargetPath] = useState<string | null>(null);
 
   // Walk a tree along a slashed path (relative to parentPath/day) and collect
   // the { field: value } patch implied by landing in that leaf. "(Ungrouped)"
   // keys map to null to clear the field.
-  const resolveDropPatch = useCallback((tree, targetPath, dayKey) => {
+  const resolveDropPatch = useCallback((tree: GroupTreeNode[] | null, targetPath: string | null, dayKey: string) => {
     if (!tree || !targetPath) return null;
     const parts = targetPath.split('/');
     if (parts[0] === dayKey) parts.shift();
-    const patch = {};
+    const patch: Record<string, string | null> = {};
     let level = tree;
     for (const keyPart of parts) {
       const match = level.find(g => g.key === keyPart);
@@ -130,9 +153,9 @@ export default function AgendaView({
     onCancel: () => { dragRef.current = null; setDropTargetPath(null); },
   });
 
-  function renderEventItem(ev, opts: { crossGroup?: boolean; sourceLabel?: string | null; nativePath?: string | null; dayTree?: any; dayKey?: string | null } = {}) {
+  function renderEventItem(ev: CalendarViewEvent, opts: { crossGroup?: boolean; sourceLabel?: string | null; nativePath?: string | null; dayTree?: GroupTreeNode[] | null; dayKey?: string | null } = {}) {
     const { crossGroup = false, sourceLabel = null, nativePath = null, dayTree = null, dayKey = null } = opts;
-    const color = resolveColor(ev, ctx?.colorRules);
+    const color = resolveColor(ev as NormalizedEvent, ctx?.colorRules);
     const evStartDay = startOfDay(ev.start);
     const rawEndDay  = displayEndDay(ev);
     const evEndDay   = rawEndDay < evStartDay ? evStartDay : rawEndDay;
@@ -167,7 +190,7 @@ export default function AgendaView({
       : undefined;
 
     if (ctx?.renderEvent) {
-      const custom = ctx.renderEvent(ev, { view: 'agenda', isCompact: true, onClick, color });
+      const custom = ctx.renderEvent(ev as NormalizedEvent, { view: 'agenda', isCompact: true, onClick, color });
       if (custom != null) {
         return (
           <div

--- a/src/views/DayView.tsx
+++ b/src/views/DayView.tsx
@@ -7,20 +7,32 @@ import { useCalendarContext, resolveColor } from '../core/CalendarContext';
 import { hoursInTimezone } from '../core/engine/time/timezone';
 import { layoutOverlaps } from '../core/layout';
 import { useDrag } from '../hooks/useDrag';
+import type { NormalizedEvent } from '../types/events';
+import type { CalendarViewEvent } from '../types/ui';
 import styles from './DayView.module.css';
 
 const GUTTER_W = 56;
 
+type DayViewProps = {
+  currentDate: Date;
+  events: CalendarViewEvent[];
+  onEventClick?: (event: CalendarViewEvent) => void;
+  onEventMove?: (event: CalendarViewEvent, newStart: Date, newEnd: Date) => void;
+  onEventResize?: (event: CalendarViewEvent, newStart: Date, newEnd: Date) => void;
+  onDateSelect?: (start: Date, end: Date) => void;
+  config?: { display?: { dayStart?: number; dayEnd?: number } };
+};
+
 export default function DayView({
   currentDate, events, onEventClick, onEventMove, onEventResize, onDateSelect, config,
-}: any) {
+}: DayViewProps) {
   const ctx = useCalendarContext();
   const dayStart  = config?.display?.dayStart ?? 6;
   const dayEnd    = config?.display?.dayEnd   ?? 22;
   const pxPerHour = 64;
   const bizHours  = ctx?.businessHours ?? null;
 
-  const gridRef = useRef(null);
+  const gridRef = useRef<HTMLDivElement | null>(null);
   const days    = useMemo(() => [currentDate], [currentDate]);
 
   const hours = [];
@@ -40,7 +52,7 @@ export default function DayView({
   useEffect(() => {
     if (!lastKeyNavSlot.current || !gridRef.current) return;
     lastKeyNavSlot.current = false;
-    const el = gridRef.current.querySelector(`[data-slot="${focusedHour}"]`);
+    const el = gridRef.current.querySelector<HTMLElement>(`[data-slot="${focusedHour}"]`);
     el?.focus({ preventScroll: false });
   }, [focusedHour]);
 
@@ -83,7 +95,7 @@ export default function DayView({
   const nowTop  = (nowHour - dayStart) * pxPerHour;
   const showNow = isToday(currentDate) && nowHour >= dayStart && nowHour < dayEnd;
 
-  function eventPosition(start, end) {
+  function eventPosition(start: Date, end: Date) {
     const startH = displayTz ? hoursInTimezone(start, displayTz) : getHours(start) + getMinutes(start) / 60;
     const endH   = displayTz ? hoursInTimezone(end,   displayTz) : getHours(end)   + getMinutes(end)   / 60;
     const startMin = (startH - dayStart) * 60;
@@ -98,7 +110,7 @@ export default function DayView({
     };
   }
 
-  function isBizHour(h) {
+  function isBizHour(h: number) {
     if (!bizHours) return true;
     const bizDays = bizHours.days ?? [1, 2, 3, 4, 5];
     return bizDays.includes(currentDate.getDay()) && h >= bizHours.start && h < bizHours.end;
@@ -129,9 +141,9 @@ export default function DayView({
   }, [drag.onPointerUp, onEventMove, onEventResize, onDateSelect]);
 
   // ── Renderers ─────────────────────────────────────────────────────────
-  function renderEvent(ev) {
+  function renderEvent(ev: CalendarViewEvent) {
     const isDimmed = drag.draggedId === ev.id;
-    const color    = resolveColor(ev, ctx?.colorRules);
+    const color    = resolveColor(ev as NormalizedEvent, ctx?.colorRules);
     const onClick  = () => !isDimmed && onEventClick?.(ev);
     const pos = eventPosition(ev.start, ev.end);
     if (!pos) return null;
@@ -145,7 +157,7 @@ export default function DayView({
     const ariaLabel = `${ev.title}, ${format(ev.start, 'h:mm a')} to ${format(ev.end, 'h:mm a')}${ev.category ? `, ${ev.category}` : ''}${ev.status && ev.status !== 'confirmed' ? `, ${ev.status}` : ''}`;
 
     if (ctx?.renderEvent) {
-      const custom = ctx.renderEvent(ev, { view: 'day', isCompact: false, onClick, color });
+      const custom = ctx.renderEvent(ev as NormalizedEvent, { view: 'day', isCompact: false, onClick, color });
       if (custom != null) {
         return (
           <div key={ev.id} data-event="1"
@@ -155,14 +167,14 @@ export default function DayView({
             aria-label={ariaLabel}
             onClick={onClick}
             onKeyDown={e => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); onClick(); } }}
-            onPointerDown={e => { if (e.button !== 0 || !ctx?.permissions?.canDrag) return; e.stopPropagation(); drag.startMove(ev, e, gridRef.current, days, GUTTER_W); }}
+            onPointerDown={e => { if (e.button !== 0 || !ctx?.permissions?.canDrag) return; e.stopPropagation(); drag.startMove(ev as NormalizedEvent, e, gridRef.current, days, GUTTER_W); }}
           >
             <div className={styles.resizeHandleTop}
-              onPointerDown={e => { if (e.button !== 0 || !ctx?.permissions?.canDrag) return; e.stopPropagation(); drag.startResizeTop(ev, e, gridRef.current, days, GUTTER_W); }}
+              onPointerDown={e => { if (e.button !== 0 || !ctx?.permissions?.canDrag) return; e.stopPropagation(); drag.startResizeTop(ev as NormalizedEvent, e, gridRef.current, days, GUTTER_W); }}
               aria-hidden="true" />
             {custom}
             <div className={styles.resizeHandle}
-              onPointerDown={e => { if (e.button !== 0 || !ctx?.permissions?.canDrag) return; e.stopPropagation(); drag.startResize(ev, e, gridRef.current, days, GUTTER_W); }}
+              onPointerDown={e => { if (e.button !== 0 || !ctx?.permissions?.canDrag) return; e.stopPropagation(); drag.startResize(ev as NormalizedEvent, e, gridRef.current, days, GUTTER_W); }}
               aria-hidden="true" />
           </div>
         );
@@ -177,16 +189,16 @@ export default function DayView({
         aria-label={ariaLabel}
         onClick={onClick}
         onKeyDown={e => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); onClick(); } }}
-        onPointerDown={e => { if (e.button !== 0 || !ctx?.permissions?.canDrag) return; e.stopPropagation(); drag.startMove(ev, e, gridRef.current, days, GUTTER_W); }}
+        onPointerDown={e => { if (e.button !== 0 || !ctx?.permissions?.canDrag) return; e.stopPropagation(); drag.startMove(ev as NormalizedEvent, e, gridRef.current, days, GUTTER_W); }}
       >
         <div className={styles.resizeHandleTop}
-          onPointerDown={e => { if (e.button !== 0 || !ctx?.permissions?.canDrag) return; e.stopPropagation(); drag.startResizeTop(ev, e, gridRef.current, days, GUTTER_W); }}
+          onPointerDown={e => { if (e.button !== 0 || !ctx?.permissions?.canDrag) return; e.stopPropagation(); drag.startResizeTop(ev as NormalizedEvent, e, gridRef.current, days, GUTTER_W); }}
           aria-hidden="true" />
         <span className={styles.evTitle}>{ev.title}</span>
         <span className={styles.evTime}>{format(ev.start, 'h:mm a')} – {format(ev.end, 'h:mm a')}</span>
         {ev.resource && numCols === 1 && <span className={styles.evMeta}>{ev.resource}</span>}
         <div className={styles.resizeHandle}
-          onPointerDown={e => { if (e.button !== 0 || !ctx?.permissions?.canDrag) return; e.stopPropagation(); drag.startResize(ev, e, gridRef.current, days, GUTTER_W); }}
+          onPointerDown={e => { if (e.button !== 0 || !ctx?.permissions?.canDrag) return; e.stopPropagation(); drag.startResize(ev as NormalizedEvent, e, gridRef.current, days, GUTTER_W); }}
           aria-hidden="true" />
       </div>
     );
@@ -238,7 +250,7 @@ export default function DayView({
           </div>
           <div className={styles.allDayEvents} role="gridcell" aria-label="All-day events">
             {allDayEvs.map(ev => {
-              const color = resolveColor(ev, ctx?.colorRules);
+              const color = resolveColor(ev as NormalizedEvent, ctx?.colorRules);
               const ariaLabel = `${ev.title}${ev.category ? `, ${ev.category}` : ''}${ev.status && ev.status !== 'confirmed' ? `, ${ev.status}` : ''}`;
               return (
                 <button key={ev.id} className={styles.allDayPill} style={{ '--ev-color': color }}

--- a/src/views/MonthView.tsx
+++ b/src/views/MonthView.tsx
@@ -7,6 +7,7 @@ import {
 import type { Day } from 'date-fns';
 import { useCalendarContext, resolveColor } from '../core/CalendarContext';
 import { displayEndDay, layoutSpans } from '../core/layout';
+import type { CalendarViewEvent } from '../types/ui';
 import styles from './MonthView.module.css';
 
 const SPAN_H   = 22;
@@ -19,10 +20,26 @@ function isMultiDay(ev) {
   return !isSameDay(startOfDay(ev.start), displayEndDay(ev));
 }
 
+type MonthViewProps = {
+  currentDate: Date;
+  events: CalendarViewEvent[];
+  onEventClick?: (event: CalendarViewEvent) => void;
+  onEventMove?: (event: CalendarViewEvent, newStart: Date, newEnd: Date) => void;
+  onDateSelect?: (start: Date, end: Date) => void;
+  config?: {
+    display?: {
+      showWeekNumbers?: boolean;
+      enlargeMonthRowOnHover?: boolean;
+    };
+  };
+  weekStartDay?: Day;
+  pillHoverTitle?: boolean;
+} & Record<string, unknown>;
+
 export default function MonthView({
   currentDate, events, onEventClick, onEventMove, onDateSelect,
   config, weekStartDay = 0, pillHoverTitle = false,
-}: { currentDate: Date; events: any; onEventClick?: any; onEventMove?: any; onDateSelect?: any; config?: any; weekStartDay?: Day; pillHoverTitle?: boolean } & Record<string, any>) {
+}: MonthViewProps) {
   const [popoverState, setPopoverState] = useState(null);
   const [hoveredWeekIdx, setHoveredWeekIdx] = useState(null);
   const [viewportWidth, setViewportWidth] = useState(


### PR DESCRIPTION
### Motivation
- Move Stage 5 PR7 (small views) forward by replacing broad `any` view props with explicit boundary types to reduce implicit-any exposure and document public seams. 
- Provide a lightweight shared event shape for view-level APIs so multiple small views can adopt a consistent, low-risk boundary type.

### Description
- Replaced `any` view props with explicit prop types for `DayView`, `AgendaView`, and `MonthView`, including `DayViewProps`, `AgendaViewProps`, and `MonthViewProps`. 
- Added `CalendarViewEvent` to `src/types/ui.ts` and re-exported it from `src/index.ts` to standardize the view boundary event shape. 
- Tightened local typing in `AgendaView` (typed `collapsedGroups` as `Set<string>`, `dragRef` shape, `dropTargetPath` and `resolveDropPatch` return/patch types, and switched date sorting to `getTime()`), and added `GroupTreeNode`/`GroupByInput` annotations. 
- Added DOM/ref typing and focused-element narrowing in `DayView`, and introduced intentional narrow casts when integrating with existing `NormalizedEvent`-based pipelines (color, renderEvent, and drag helpers) to preserve runtime behavior. 
- Updated `docs/stage-4a-stage-5-sprint-plan.md` to mark PR 7 as completed and record the shipped scope. 

### Testing
- Ran `npm run type-check` and it completed with no TypeScript errors. 
- Ran `npm run type-check:strict` (the staged strict checker) and it reported `Strict type check GREEN.`. 
- Ran unit tests via `npx vitest run` for a focused set of view/a11y tests and the test run completed successfully (4 test files, 92 tests passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7db99a424832ca969acdd4df5981f)