### PR TITLE
Complete Stage 5 PR6/PR7 ratchet coverage and fix implicit-any in small views

### DIFF
--- a/docs/stage-4a-stage-5-sprint-plan.md
+++ b/docs/stage-4a-stage-5-sprint-plan.md
@@ -53,7 +53,7 @@ without the ratchet update is tracked as **Partially complete**.
 - Define per-PR `any` budget
 - Add checklist to migration doc
 
-**Status:** ✅ Completed (2026-04-21)
+**Status:** 🟡 Partially complete (2026-04-21)
 
 **Decision recorded in `docs/TypeScriptStrictMigration.md`:**
 - **Path A is locked** for this roadmap (continue into Stage 5).
@@ -71,7 +71,7 @@ without the ratchet update is tracked as **Partially complete**.
 - UI data shapes
 - Loose but intentional boundary types
 
-**Status:** ✅ Completed (2026-04-21)
+**Status:** 🟡 Partially complete (2026-04-21)
 
 **Shipped in this PR:**
 - Added shared UI boundary types in `src/types/ui.ts`:
@@ -148,7 +148,7 @@ Goal: Structured data typing
 
 Goal: Handle complex state + flows
 
-**Status:** 🟡 Partially complete (2026-04-21)
+**Status:** ✅ Completed (2026-04-21)
 
 **Shipped in this PR:**
 - Removed implicit `any` from workflow-tab mutators by introducing explicit local draft/patch types in `src/ui/ConfigPanel.tsx` for:
@@ -159,8 +159,8 @@ Goal: Handle complex state + flows
 - Tightened `SmartViewsTab` edit/delete state and `handleUpdate` callback signature with explicit id/filter/conditions types.
 - Added explicit type narrowing for workflow tab select/file-input handlers (approval quorum, request field type, conflict rule type/severity, profile image upload result) to prevent broad `string`/`unknown` writes.
 
-**Outstanding for completion under this plan:**
-- Add the Stage 5 UI files touched by this PR to `MIGRATED_PATHS`.
+**Completion updates in this PR:**
+- Confirmed `src/ui/ConfigPanel.tsx` is present in `MIGRATED_PATHS` in `scripts/typecheck-strict.mjs` (Stage 4a PR2 / Stage 5 PR6 coverage).
 
 ---
 
@@ -171,7 +171,7 @@ Goal: Handle complex state + flows
 
 Goal: Low-risk view typing
 
-**Status:** 🟡 Partially complete (2026-04-21)
+**Status:** ✅ Completed (2026-04-21)
 
 **Shipped in this PR:**
 - Replaced file-level view-prop `any` in `DayView`, `AgendaView`, and `MonthView` with explicit boundary prop types (dates, callbacks, and config slices) to document the small-view public seams.
@@ -179,8 +179,8 @@ Goal: Low-risk view typing
 - Tightened local state typing in `AgendaView` (collapsed group set, drag/drop refs, drop patch shape) and removed implicit numeric arithmetic on `Date` values by sorting via `getTime()`.
 - Added explicit DOM/ref typing in `DayView` (grid ref + focus target) and retained compatibility with existing render/drag/color pipelines via narrow, intentional casts at integration points.
 
-**Outstanding for completion under this plan:**
-- Add the Stage 5 UI files touched by this PR to `MIGRATED_PATHS`.
+**Completion updates in this PR:**
+- Added `src/views/DayView.tsx`, `src/views/AgendaView.tsx`, and `src/views/MonthView.tsx` to `MIGRATED_PATHS` in `scripts/typecheck-strict.mjs`.
 
 ---
 

--- a/scripts/typecheck-strict.mjs
+++ b/scripts/typecheck-strict.mjs
@@ -61,8 +61,12 @@ const MIGRATED_PATHS = [
   'src/hooks/useFocusTrap.ts',
   'src/hooks/useTouchDnd.ts',
   'src/hooks/usePermissions.ts',
-  // Stage 4a PR2
+  // Stage 4a PR2 / Stage 5 PR6
   'src/ui/ConfigPanel.tsx',
+  // Stage 5 PR7
+  'src/views/DayView.tsx',
+  'src/views/AgendaView.tsx',
+  'src/views/MonthView.tsx',
 ];
 
 // Implicit-any diagnostic codes. See:

--- a/src/views/AgendaView.tsx
+++ b/src/views/AgendaView.tsx
@@ -1,3 +1,4 @@
+import type { DragEvent, TouchEvent } from 'react';
 import { useMemo, useState, useCallback, useRef } from 'react';
 import {
   startOfMonth, endOfMonth, eachDayOfInterval,
@@ -20,6 +21,12 @@ type GroupTreeNode = {
   depth: number;
   events: CalendarViewEvent[];
   children: GroupTreeNode[];
+};
+
+type LeafEventEntry = {
+  ev: CalendarViewEvent;
+  nativePath: string;
+  nativeLabel: string;
 };
 
 type AgendaViewProps = {
@@ -51,7 +58,7 @@ export default function AgendaView({
   const resourceLabelFor = useMemo(() => {
     const list = Array.isArray(employees) ? employees : [];
     const byId = new Map(list.map((m) => [String(m.id), m.name || m.displayName || m.id]));
-    return (id) => byId.get(String(id)) ?? id;
+    return (id: string | number | null | undefined) => byId.get(String(id)) ?? String(id);
   }, [employees]);
 
   const days = useMemo(() => {
@@ -71,9 +78,9 @@ export default function AgendaView({
   // zero-duration all-day events (start === end) still render on their start day.
   const grouped = useMemo(() => {
     return days
-      .map(day => {
+      .map((day) => {
         const dayMs = day.getTime();
-        const dayEvents = events.filter(e => {
+        const dayEvents = events.filter((e) => {
           const startMs = startOfDay(e.start).getTime();
           const endMs   = Math.max(displayEndDay(e).getTime(), startMs);
           return dayMs >= startMs && dayMs <= endMs;
@@ -85,7 +92,7 @@ export default function AgendaView({
             : [...dayEvents].sort((a, b) => a.start.getTime() - b.start.getTime()),
         };
       })
-      .filter(g => g.events.length > 0);
+      .filter((g) => g.events.length > 0);
   }, [days, events, hasSort]);
 
   // Per-day group trees built from the event-level grouping engine. Pure —
@@ -94,7 +101,7 @@ export default function AgendaView({
     if (!groupBy) return null;
     return grouped.map(({ day, events: dayEvents }) => ({
       day,
-      tree: buildGroupTree(dayEvents as never, groupBy),
+      tree: buildGroupTree(dayEvents as never, groupBy) as GroupTreeNode[],
     }));
   }, [grouped, groupBy]);
 
@@ -136,12 +143,15 @@ export default function AgendaView({
   const bindTouchDnd = useTouchDnd({
     enabled: !!onEventGroupChange,
     dropAttr: 'data-wc-drop',
-    onStart: ({ ev, nativePath }) => { dragRef.current = { ev, nativePath }; },
-    onOver:  (dropEl) => {
+    onStart: ({ ev, nativePath }: { ev: CalendarViewEvent; nativePath: string | null }) => { dragRef.current = { ev, nativePath }; },
+    onOver:  (dropEl: Element | null) => {
       const path = dropEl?.getAttribute('data-wc-drop') ?? null;
       setDropTargetPath(prev => (prev === path ? prev : path));
     },
-    onDrop:  (dropEl, { ev, nativePath, dayTree, dayKey }) => {
+    onDrop:  (
+      dropEl: Element | null,
+      { ev, nativePath, dayTree, dayKey }: { ev: CalendarViewEvent; nativePath: string | null; dayTree: GroupTreeNode[] | null; dayKey: string },
+    ) => {
       dragRef.current = null;
       setDropTargetPath(null);
       if (!dropEl || !onEventGroupChange) return;
@@ -176,7 +186,7 @@ export default function AgendaView({
     // shadow copy would be ambiguous.
     const dndEnabled = !!onEventGroupChange && !crossGroup && !!nativePath;
     const onDragStart = dndEnabled
-      ? (e) => {
+      ? (e: DragEvent<HTMLElement>) => {
           dragRef.current = { ev, nativePath };
           if (e.dataTransfer) {
             e.dataTransfer.effectAllowed = 'move';
@@ -186,7 +196,7 @@ export default function AgendaView({
       : undefined;
     const onDragEnd = dndEnabled ? () => { dragRef.current = null; setDropTargetPath(null); } : undefined;
     const onTouchStart = dndEnabled
-      ? (e) => bindTouchDnd(e, { ev, nativePath, dayTree, dayKey })
+      ? (e: TouchEvent<HTMLElement>) => bindTouchDnd(e, { ev, nativePath, dayTree, dayKey })
       : undefined;
 
     if (ctx?.renderEvent) {
@@ -249,14 +259,14 @@ export default function AgendaView({
   }
 
   // Count every leaf event reachable under a group (respecting nested trees).
-  function countEvents(group) {
+  function countEvents(group: GroupTreeNode): number {
     if (group.children.length === 0) return group.events.length;
     return group.children.reduce((sum, c) => sum + countEvents(c), 0);
   }
 
   // Collect all leaf events in a tree, paired with their native path.
-  function collectLeafEvents(tree, parentPath) {
-    const out = [];
+  function collectLeafEvents(tree: GroupTreeNode[], parentPath: string): LeafEventEntry[] {
+    const out: LeafEventEntry[] = [];
     for (const group of tree) {
       const path = parentPath ? `${parentPath}/${group.key}` : group.key;
       if (group.children.length === 0) {
@@ -268,7 +278,14 @@ export default function AgendaView({
     return out;
   }
 
-  function renderGroupNode(group, parentPath, posInSet, setSize, allLeafEvents, dayTree) {
+  function renderGroupNode(
+    group: GroupTreeNode,
+    parentPath: string,
+    posInSet: number,
+    setSize: number,
+    allLeafEvents: LeafEventEntry[],
+    dayTree: GroupTreeNode[] | null,
+  ) {
     const path = parentPath ? `${parentPath}/${group.key}` : group.key;
     const collapsed = collapsedGroups.has(path);
     const total = countEvents(group);
@@ -279,7 +296,7 @@ export default function AgendaView({
     const dayKey = path.split('/')[0];
     const renderedEvents = (() => {
       if (!isLeaf) return null;
-      if (!showAllGroups) return group.events.map(ev => renderEventItem(ev, { nativePath: path, dayTree, dayKey }));
+      if (!showAllGroups) return group.events.map((ev) => renderEventItem(ev, { nativePath: path, dayTree, dayKey }));
       return allLeafEvents.map(({ ev, nativePath, nativeLabel }) => {
         const isNative = nativePath === path;
         return renderEventItem(ev, {
@@ -297,7 +314,7 @@ export default function AgendaView({
     const isDropTarget = dndEnabled && dropTargetPath === path;
 
     const onDragOver = dndEnabled
-      ? (e) => {
+      ? (e: DragEvent<HTMLDivElement>) => {
           if (!dragRef.current) return;
           e.preventDefault();
           if (e.dataTransfer) e.dataTransfer.dropEffect = 'move';
@@ -308,7 +325,7 @@ export default function AgendaView({
       ? () => { if (dropTargetPath === path) setDropTargetPath(null); }
       : undefined;
     const onDrop = dndEnabled
-      ? (e) => {
+      ? (e: DragEvent<HTMLDivElement>) => {
           e.preventDefault();
           const drag = dragRef.current;
           dragRef.current = null;
@@ -382,7 +399,7 @@ export default function AgendaView({
                 ? tree.map((g, i) =>
                     renderGroupNode(g, dayKey, i + 1, tree.length, allLeafEvents, tree),
                   )
-                : dayEvents.map(ev => renderEventItem(ev))
+                : dayEvents.map((ev) => renderEventItem(ev))
               }
             </div>
           </div>

--- a/src/views/DayView.tsx
+++ b/src/views/DayView.tsx
@@ -1,4 +1,4 @@
-import type { KeyboardEvent as ReactKeyboardEvent } from 'react';
+import type { KeyboardEvent as ReactKeyboardEvent, PointerEvent as ReactPointerEvent } from 'react';
 import { useMemo, useRef, useCallback, useState, useEffect } from 'react';
 import {
   format, isToday, isSameDay, getHours, getMinutes,
@@ -36,12 +36,12 @@ export default function DayView({
   const gridRef = useRef<HTMLDivElement | null>(null);
   const days    = useMemo(() => [currentDate], [currentDate]);
 
-  const hours = [];
+  const hours: number[] = [];
   for (let h = dayStart; h <= dayEnd; h++) hours.push(h);
 
   // Slot hours: exclude last boundary label (each slot spans h to h+1)
   const slotHours = useMemo(() => {
-    const arr = [];
+    const arr: number[] = [];
     for (let h = dayStart; h < dayEnd; h++) arr.push(h);
     return arr;
   }, [dayStart, dayEnd]);
@@ -125,12 +125,12 @@ export default function DayView({
   // ── Drag ────────────────────────────────────────────────────────────────
   const drag = useDrag({ pxPerHour, dayStart, dayEnd });
 
-  const handleGridPointerDown = useCallback((e) => {
+  const handleGridPointerDown = useCallback((e: ReactPointerEvent<HTMLDivElement>) => {
     if (e.button !== 0 || !ctx?.permissions?.canAddEvent) return;
     drag.startCreate(e, gridRef.current, days, GUTTER_W);
   }, [drag.startCreate, days, ctx?.permissions?.canAddEvent]);
 
-  const handleGridPointerMove = useCallback((e) => {
+  const handleGridPointerMove = useCallback((e: ReactPointerEvent<HTMLDivElement>) => {
     drag.onPointerMove(e);
   }, [drag.onPointerMove]);
 
@@ -172,15 +172,15 @@ export default function DayView({
             role="button" tabIndex={0}
             aria-label={ariaLabel}
             onClick={onClick}
-            onKeyDown={e => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); onClick(); } }}
-            onPointerDown={e => { if (e.button !== 0 || !ctx?.permissions?.canDrag) return; e.stopPropagation(); drag.startMove(ev as NormalizedEvent, e, gridRef.current, days, GUTTER_W); }}
+            onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); onClick(); } }}
+            onPointerDown={(e: ReactPointerEvent<HTMLDivElement>) => { if (e.button !== 0 || !ctx?.permissions?.canDrag) return; e.stopPropagation(); drag.startMove(ev as NormalizedEvent, e, gridRef.current, days, GUTTER_W); }}
           >
             <div className={styles.resizeHandleTop}
-              onPointerDown={e => { if (e.button !== 0 || !ctx?.permissions?.canDrag) return; e.stopPropagation(); drag.startResizeTop(ev as NormalizedEvent, e, gridRef.current, days, GUTTER_W); }}
+              onPointerDown={(e: ReactPointerEvent<HTMLDivElement>) => { if (e.button !== 0 || !ctx?.permissions?.canDrag) return; e.stopPropagation(); drag.startResizeTop(ev as NormalizedEvent, e, gridRef.current, days, GUTTER_W); }}
               aria-hidden="true" />
             {custom}
             <div className={styles.resizeHandle}
-              onPointerDown={e => { if (e.button !== 0 || !ctx?.permissions?.canDrag) return; e.stopPropagation(); drag.startResize(ev as NormalizedEvent, e, gridRef.current, days, GUTTER_W); }}
+              onPointerDown={(e: ReactPointerEvent<HTMLDivElement>) => { if (e.button !== 0 || !ctx?.permissions?.canDrag) return; e.stopPropagation(); drag.startResize(ev as NormalizedEvent, e, gridRef.current, days, GUTTER_W); }}
               aria-hidden="true" />
           </div>
         );
@@ -194,17 +194,17 @@ export default function DayView({
         role="button" tabIndex={0}
         aria-label={ariaLabel}
         onClick={onClick}
-        onKeyDown={e => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); onClick(); } }}
-        onPointerDown={e => { if (e.button !== 0 || !ctx?.permissions?.canDrag) return; e.stopPropagation(); drag.startMove(ev as NormalizedEvent, e, gridRef.current, days, GUTTER_W); }}
+        onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); onClick(); } }}
+        onPointerDown={(e: ReactPointerEvent<HTMLDivElement>) => { if (e.button !== 0 || !ctx?.permissions?.canDrag) return; e.stopPropagation(); drag.startMove(ev as NormalizedEvent, e, gridRef.current, days, GUTTER_W); }}
       >
         <div className={styles.resizeHandleTop}
-          onPointerDown={e => { if (e.button !== 0 || !ctx?.permissions?.canDrag) return; e.stopPropagation(); drag.startResizeTop(ev as NormalizedEvent, e, gridRef.current, days, GUTTER_W); }}
+          onPointerDown={(e: ReactPointerEvent<HTMLDivElement>) => { if (e.button !== 0 || !ctx?.permissions?.canDrag) return; e.stopPropagation(); drag.startResizeTop(ev as NormalizedEvent, e, gridRef.current, days, GUTTER_W); }}
           aria-hidden="true" />
         <span className={styles.evTitle}>{ev.title}</span>
         <span className={styles.evTime}>{format(ev.start, 'h:mm a')} – {format(ev.end, 'h:mm a')}</span>
         {ev.resource && numCols === 1 && <span className={styles.evMeta}>{ev.resource}</span>}
         <div className={styles.resizeHandle}
-          onPointerDown={e => { if (e.button !== 0 || !ctx?.permissions?.canDrag) return; e.stopPropagation(); drag.startResize(ev as NormalizedEvent, e, gridRef.current, days, GUTTER_W); }}
+          onPointerDown={(e: ReactPointerEvent<HTMLDivElement>) => { if (e.button !== 0 || !ctx?.permissions?.canDrag) return; e.stopPropagation(); drag.startResize(ev as NormalizedEvent, e, gridRef.current, days, GUTTER_W); }}
           aria-hidden="true" />
       </div>
     );


### PR DESCRIPTION
### Motivation
- Continue the Stage 5 TypeScript strict migration by adding the small-view UI files to the strict ratchet so `noImplicitAny` can be enforced for PR 6/PR 7 scope.
- Surface and fix the implicit-`any` diagnostics that appear once the new view files are added to the `MIGRATED_PATHS` allowlist so the repo-level strict check remains green.

### Description
- Grew the strict migration allowlist in `scripts/typecheck-strict.mjs` to include `src/ui/ConfigPanel.tsx` (annotated as PR6 coverage) and the small-view files `src/views/DayView.tsx`, `src/views/AgendaView.tsx`, and `src/views/MonthView.tsx` (PR7).
- Updated `docs/stage-4a-stage-5-sprint-plan.md` to record the PR6/PR7 completion updates and to reflect the ratchet changes and completion notes.
- Applied focused typing fixes to `src/views/AgendaView.tsx`: imported `DragEvent`/`TouchEvent`, added `LeafEventEntry` and explicit function/parameter/return types (resource resolver, group/tree traversal helpers, DnD/touch handlers, render helpers, and group-node traversal callbacks) to eliminate implicit `any` sites.
- Applied focused typing fixes to `src/views/DayView.tsx`: added pointer event types, typed local numeric arrays and handler signatures, and narrowed inline event handler parameter types used by drag/resizing plumbing.

### Testing
- Ran the strict ratchet: `npm run type-check:strict` and it passed (strict type check GREEN).
- Verified repository advisory type-check: `npm run type-check` succeeded (root `tsc --noEmit` passed).
- Executed the affected unit tests with `npx vitest run` for the touched view and ConfigPanel tests and all selected tests passed (5 files, 67 tests) .

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7ff445728832c8ce0c9ebd126c9fd)