### PR TITLE
Stage 5 PR8: add medium views to strict migration and tighten WeekView/AssetsView typings

### DIFF
--- a/scripts/typecheck-strict.mjs
+++ b/scripts/typecheck-strict.mjs
@@ -63,6 +63,10 @@ const MIGRATED_PATHS = [
   'src/hooks/usePermissions.ts',
   // Stage 4a PR2
   'src/ui/ConfigPanel.tsx',
+  // Stage 5 PR8
+  'src/views/WeekView.tsx',
+  'src/views/AssetsView.tsx',
+  'src/views/BaseGanttView.tsx',
 ];
 
 // Implicit-any diagnostic codes. See:

--- a/src/views/AssetsView.tsx
+++ b/src/views/AssetsView.tsx
@@ -58,10 +58,10 @@ const APPROVAL_STAGES = new Set([
  * earliest slot that's free at the event's start day. Returns the clipped
  * events plus the max lane count so the row can size its height.
  */
-function assignLanes(events, monthStart, monthEnd) {
+function assignLanes(events: any[], monthStart: Date, monthEnd: Date) {
   const clipped = events
-    .filter(e => startOfDay(e.start) <= monthEnd && startOfDay(e.end) >= monthStart)
-    .map(e => ({
+     .filter((e: any) => startOfDay(e.start) <= monthEnd && startOfDay(e.end) >= monthStart)
+    .map((e: any) => ({
       ...e,
       _dayStart: differenceInCalendarDays(
         max([startOfDay(e.start), monthStart]),
@@ -72,7 +72,7 @@ function assignLanes(events, monthStart, monthEnd) {
         monthStart,
       ),
     }))
-    .sort((a, b) => a._dayStart - b._dayStart || a._dayEnd - b._dayEnd);
+    .sort((a: any, b: any) => a._dayStart - b._dayStart || a._dayEnd - b._dayEnd);
 
   const laneEnd = [];
   for (const ev of clipped) {
@@ -99,7 +99,7 @@ function assignLanes(events, monthStart, monthEnd) {
  * (falling back to DEFAULT_CATEGORIES when the prop is empty). Used by
  * resolveAssetColor to look up the pill hue for a given event.
  */
-function buildCategoryColorMap(categoriesConfig) {
+function buildCategoryColorMap(categoriesConfig: any) {
   const map = new Map();
   const defs = categoriesConfig?.categories?.length
     ? categoriesConfig.categories
@@ -115,7 +115,7 @@ function buildCategoryColorMap(categoriesConfig) {
  * context colorRules > categoriesConfig > event.color > undefined (falls
  * through to CSS default).
  */
-function resolveAssetColor(ev, categoryColorMap, colorRules) {
+function resolveAssetColor(ev: any, categoryColorMap: Map<string, string>, colorRules: any) {
   const ruleColor = resolveColor(ev, colorRules);
   if (ruleColor) return ruleColor;
   if (ev.category && categoryColorMap.has(ev.category)) {
@@ -129,7 +129,7 @@ function resolveAssetColor(ev, categoryColorMap, colorRules) {
  * value, otherwise null. Unknown strings are treated as null so the pill
  * renders without a stage-specific CSS class.
  */
-function getApprovalStage(ev) {
+function getApprovalStage(ev: any) {
   const stage = ev?.meta?.approvalStage?.stage;
   return APPROVAL_STAGES.has(stage) ? stage : null;
 }
@@ -138,7 +138,7 @@ function getApprovalStage(ev) {
  * Maps an ApprovalStageId to the CSS module class that styles the pill for
  * that stage. Returns '' for null/unknown stages.
  */
-function approvalClass(stage) {
+function approvalClass(stage: string | null) {
   switch (stage) {
     case 'requested':      return styles.stageRequested;
     case 'approved':       return styles.stageApproved;
@@ -155,7 +155,7 @@ function approvalClass(stage) {
  * Approved and denied skip the prefix — approved is the "happy path" and
  * denied is already communicated via strikethrough + fade.
  */
-function approvalPrefix(stage) {
+function approvalPrefix(stage: string | null) {
   if (stage === 'requested')      return 'REQUESTED';
   if (stage === 'finalized')      return 'FINALIZED';
   if (stage === 'pending_higher') return 'PENDING';
@@ -197,7 +197,7 @@ export default function AssetsView({
   const [approvalMenu, setApprovalMenu] = useState(null);
   const approvalMenuOpenerRef = useRef(null);
 
-  const openApprovalMenu = useCallback((ev, stage, trigger) => {
+  const openApprovalMenu = useCallback((ev: any, stage: string | null, trigger: any) => {
     const rect = trigger?.getBoundingClientRect?.();
     approvalMenuOpenerRef.current = trigger ?? null;
     setApprovalMenu({
@@ -216,18 +216,18 @@ export default function AssetsView({
     approvalMenuOpenerRef.current = null;
   }, []);
 
-  const handleApprovalActionInternal = useCallback((action) => {
+  const handleApprovalActionInternal = useCallback((action: any) => {
     if (!approvalMenu) return;
     onApprovalAction?.(approvalMenu.event, action);
   }, [approvalMenu, onApprovalAction]);
 
-  const announce = useCallback((msg) => {
+  const announce = useCallback((msg: string) => {
     // Appending a zero-width space forces a diff so screen readers re-read
     // even when the same message fires twice in a row.
     setAnnouncement(prev => (prev === msg ? msg + '\u200b' : msg));
   }, []);
 
-  const openAudit = useCallback((ev, opener) => {
+  const openAudit = useCallback((ev: any, opener: any) => {
     drawerOpenerRef.current = opener ?? null;
     setAuditEvent(ev);
     announce(`Audit history opened for ${ev.title}`);
@@ -337,7 +337,7 @@ export default function AssetsView({
   // (e.g. team-wide meetings that belong on Schedule, not Assets).
   const events = useMemo(() => {
     if (!strictAssetFiltering || !assetRegistry) return eventsProp;
-    return eventsProp.filter(e => {
+    return eventsProp.filter((e: any) => {
       const r = e.resource;
       return r != null && r !== '' && assetById.has(r);
     });
@@ -361,12 +361,12 @@ export default function AssetsView({
     return map;
   }, [events]);
 
-  const applySort = useCallback((ids) => {
+  const applySort = useCallback((ids: string[]) => {
     if (sortMode === 'registry' || !assetRegistry) return ids;
     const byId = assetById;
-    const labelOf = (id) => byId.get(id)?.label ?? id;
-    const groupOf = (id) => byId.get(id)?.group ?? '';
-    const lastOf  = (id) => lastEventByResource.get(id) ?? -Infinity;
+    const labelOf = (id: string) => byId.get(id)?.label ?? id;
+    const groupOf = (id: string) => byId.get(id)?.group ?? '';
+    const lastOf  = (id: string) => lastEventByResource.get(id) ?? -Infinity;
     const copy = [...ids];
     copy.sort((a, b) => {
       // Always keep "(Unassigned)" at the end.
@@ -384,12 +384,12 @@ export default function AssetsView({
     if (assetRegistry) {
       const ordered = assetRegistry.map(a => a.id);
       const orderedSet = new Set(ordered);
-      const hasOrphan = events.some(e => !orderedSet.has(e.resource ?? '(Unassigned)'));
+      const hasOrphan = events.some((e: any) => !orderedSet.has(e.resource ?? '(Unassigned)'));
       const base = hasOrphan ? [...ordered, '(Unassigned)'] : ordered;
       return applySort(base);
     }
     const set = new Set<string>();
-    events.forEach(e => set.add(e.resource ?? '(Unassigned)'));
+    events.forEach((e: any) => set.add(e.resource ?? '(Unassigned)'));
     return [...set].sort((a, b) => {
       if (a === '(Unassigned)') return 1;
       if (b === '(Unassigned)') return -1;
@@ -427,23 +427,23 @@ export default function AssetsView({
    * Row height is computed from the laned events so rows stay tight when
    * most events are filtered into a different group bucket.
    */
-  const buildAssetRow = useCallback((resource, subsetEvents) => {
+  const buildAssetRow = useCallback((resource: string, subsetEvents: any[]) => {
     // "(Unassigned)" bucket catches any event whose resource isn't in the
     // registry (or is missing entirely). Registry rows keep exact-id match.
     const matchesRow = assetRegistry
-      ? (e) => {
+      ? ((e: any) => {
           const r = e.resource ?? '(Unassigned)';
           if (resource === '(Unassigned)') return !assetById.has(r);
           return r === resource;
-        }
-      : (e) => (e.resource ?? '(Unassigned)') === resource;
+        })
+      : ((e: any) => (e.resource ?? '(Unassigned)') === resource);
     const resEvents = subsetEvents.filter(matchesRow);
     const { events: laned, laneCount } = assignLanes(resEvents, monthStart, monthEnd);
     const rowH = Math.max(
       laneCount * (LANE_H + LANE_GAP) + ROW_PAD * 2,
       ROW_PAD * 2 + LANE_H + 16,
     );
-    const firstWithMeta = resEvents.find(e => e.meta?.assetSublabel || e.meta?.sublabel);
+    const firstWithMeta = resEvents.find((e: any) => e.meta?.assetSublabel || e.meta?.sublabel);
     const registryEntry = assetById.get(resource) ?? null;
     const sublabel = firstWithMeta?.meta?.assetSublabel
       ?? firstWithMeta?.meta?.sublabel
@@ -464,7 +464,7 @@ export default function AssetsView({
     };
   }, [monthStart.toISOString(), monthEnd.toISOString(), assetRegistry, assetById, resolveResourceLabel]);
 
-  const sortResourceKeys = useCallback((keys) => {
+  const sortResourceKeys = useCallback((keys: Iterable<string>) => {
     return [...keys].sort((a, b) => {
       if (a === '(Unassigned)') return 1;
       if (b === '(Unassigned)') return -1;
@@ -491,7 +491,7 @@ export default function AssetsView({
     : (Array.isArray(collapsedGroupsProp) ? new Set(collapsedGroupsProp) : null);
   const collapsedGroups = collapsedControlled ?? collapsedLocal;
 
-  const toggleGroup = useCallback((path) => {
+  const toggleGroup = useCallback((path: string) => {
     if (collapsedControlled && onCollapsedGroupsChange) {
       const next = new Set(collapsedControlled);
       if (next.has(path)) next.delete(path);
@@ -509,9 +509,9 @@ export default function AssetsView({
   }, [collapsedControlled, onCollapsedGroupsChange]);
 
   // Count every leaf event reachable under a group (respecting nested trees).
-  const countEvents = useCallback((node) => {
+  const countEvents = useCallback((node: any): number => {
     if (!node.children || node.children.length === 0) return node.events.length;
-    return node.children.reduce((sum, c) => sum + countEvents(c), 0);
+    return node.children.reduce((sum: number, c: any) => sum + countEvents(c), 0);
   }, []);
 
   // Pool rows (#212): each pool renders as a synthetic row at the top of
@@ -532,13 +532,13 @@ export default function AssetsView({
         // Scope to member-held events; use the raw events list (not the
         // strictly-filtered one) so a pool row stays populated even when
         // strictAssetFiltering hides some members.
-        const scoped = eventsProp.filter(e => e.resource != null && memberSet.has(e.resource));
+        const scoped = eventsProp.filter((e: any) => e.resource != null && memberSet.has(e.resource));
         const { events: laned, laneCount } = assignLanes(scoped, monthStart, monthEnd);
         const rowH = Math.max(
           laneCount * (LANE_H + LANE_GAP) + ROW_PAD * 2,
           ROW_PAD * 2 + LANE_H + 16,
         );
-        const memberLabels = p.memberIds.map(id => assetById.get(id)?.label ?? id);
+        const memberLabels = p.memberIds.map((id: string) => assetById.get(id)?.label ?? id);
         return {
           _type:       'poolRow',
           key:         `__pool__${p.id}`,
@@ -559,11 +559,11 @@ export default function AssetsView({
   const flatRows = useMemo(() => {
     const prefix = poolRows;
     if (!groupTree) {
-      return [...prefix, ...resourceList.map(r => buildAssetRow(r, events))];
+          return [...prefix, ...resourceList.map((r: string) => buildAssetRow(r, events))];
     }
     const out: any[] = [...prefix];
-    const walk = (nodes, parentPath) => {
-      nodes.forEach((node, i) => {
+    const walk = (nodes: any[], parentPath: string) => {
+      nodes.forEach((node: any, i: number) => {
         const path = parentPath ? `${parentPath}/${node.key}` : node.key;
         const collapsed = collapsedGroups.has(path);
         out.push({
@@ -583,7 +583,7 @@ export default function AssetsView({
           walk(node.children, path);
         } else {
           // Leaf: build one asset row per distinct resource in this bucket.
-          const leafResources = new Set();
+          const leafResources = new Set<string>();
           for (const ev of node.events) {
             leafResources.add(ev.resource ?? '(Unassigned)');
           }
@@ -677,7 +677,7 @@ export default function AssetsView({
     }
   }, [focusedCell, rowOffsets, flatRows]);
 
-  const handleCellKeyDown = useCallback((e, ri, di, cellRowEvents, resourceId, isPoolRow) => {
+  const handleCellKeyDown = useCallback((e: any, ri: number, di: number, cellRowEvents: any[], resourceId: string, isPoolRow: boolean) => {
     const maxRi = flatRows.length - 1;
     const maxDi = totalDays - 1;
     let nextRi = ri, nextDi = di;
@@ -692,7 +692,7 @@ export default function AssetsView({
       case 'Enter':
       case ' ': {
         e.preventDefault();
-        const hit = cellRowEvents.find(ev => ev._dayStart <= di && ev._dayEnd >= di);
+        const hit = cellRowEvents.find((ev: any) => ev._dayStart <= di && ev._dayEnd >= di);
         // On pool rows, rowEvents is the aggregate of member bookings — an
         // occupied cell just means *some* member is busy, not that the pool
         // itself is taken. Always route pool cells to onPoolDateSelect so
@@ -728,7 +728,7 @@ export default function AssetsView({
    *   ArrowRight — if the group is collapsed, expand it; otherwise move to
    *     the first child row so the tree pattern flows naturally.
    */
-  const handleHeaderArrowKey = useCallback((rowIdx, key) => {
+  const handleHeaderArrowKey = useCallback((rowIdx: number, key: string) => {
     const row = flatRows[rowIdx];
     if (!row || row._type !== 'groupHeader') return;
     const maxRi = flatRows.length - 1;
@@ -1025,7 +1025,7 @@ export default function AssetsView({
                     const di = visColStart + relDi;
                     const isFocused  = focusedCell.rowIdx === rowIdx && focusedCell.dayIdx === di;
                     const resourceId = resource;
-                    const cellHasEvent = rowEvents.some(ev => ev._dayStart <= di && ev._dayEnd >= di);
+                    const cellHasEvent = rowEvents.some((ev: any) => ev._dayStart <= di && ev._dayEnd >= di);
                     return (
                       <div
                         key={`kbcell-${di}`}
@@ -1067,13 +1067,13 @@ export default function AssetsView({
                   })}
 
                   {/* Event pills */}
-                  {rowEvents.map(ev => {
+                  {rowEvents.map((ev: any) => {
                     const evColor = resolveAssetColor(ev, categoryColorMap, ctx?.colorRules);
                     const left    = ev._dayStart * dayColW + 2;
                     const width   = Math.max(dayColW - 4, (ev._dayEnd - ev._dayStart + 1) * dayColW - 4);
                     const top     = ROW_PAD + ev._lane * (LANE_H + LANE_GAP);
                     const stage       = getApprovalStage(ev);
-                    const onClick = (e) => {
+                    const onClick = (e: any) => {
                       if (AUDIT_STAGES.has(stage)) openAudit(ev, e.currentTarget);
                       else onEventClick?.(ev);
                     };
@@ -1149,7 +1149,7 @@ export default function AssetsView({
                               left: left + width - 18,
                               top:  top + (LANE_H - 16) / 2,
                             }}
-                            onClick={(e) => {
+                            onClick={(e: any) => {
                               e.stopPropagation();
                               openApprovalMenu(ev, stage, e.currentTarget);
                             }}
@@ -1176,7 +1176,7 @@ export default function AssetsView({
         approvalsConfig={approvalsConfig}
         onAction={
           auditEvent && typeof onApprovalAction === 'function'
-            ? (action) => onApprovalAction(auditEvent, action)
+            ? (action: any) => onApprovalAction(auditEvent, action)
             : undefined
         }
       />

--- a/src/views/AssetsView.tsx
+++ b/src/views/AssetsView.tsx
@@ -18,6 +18,7 @@
  *     (5 states per Phase 0 contract).
  */
 import { useMemo, useRef, useState, useCallback, useEffect } from 'react';
+import type { KeyboardEvent as ReactKeyboardEvent, MouseEvent as ReactMouseEvent } from 'react';
 import {
   startOfMonth, endOfMonth, eachDayOfInterval,
   format, isToday, isWeekend,
@@ -29,6 +30,7 @@ import { buildGroupTree } from '../hooks/useGrouping.ts';
 import GroupHeader from '../ui/GroupHeader.tsx';
 import { useResourceLocations } from '../hooks/useResourceLocations.ts';
 import { DEFAULT_CATEGORIES } from '../types/assets.ts';
+import type { CalendarViewEvent } from '../types/ui';
 import AuditDrawer from './AuditDrawer';
 import ApprovalActionMenu, { allowedActionsFor } from '../ui/ApprovalActionMenu';
 
@@ -50,6 +52,15 @@ const APPROVAL_STAGES = new Set([
   'requested', 'approved', 'finalized', 'pending_higher', 'denied',
 ]);
 
+type AssetEvent = CalendarViewEvent & {
+  _dayStart: number;
+  _dayEnd: number;
+  _lane: number;
+  color?: string;
+  meta?: Record<string, any>;
+};
+type CategoryConfigLike = { categories?: Array<{ id?: string; color?: string }> } | null | undefined;
+
 // ─── Helpers ─────────────────────────────────────────────────────────────────
 
 /**
@@ -58,10 +69,10 @@ const APPROVAL_STAGES = new Set([
  * earliest slot that's free at the event's start day. Returns the clipped
  * events plus the max lane count so the row can size its height.
  */
-function assignLanes(events: any[], monthStart: Date, monthEnd: Date) {
+function assignLanes(events: CalendarViewEvent[], monthStart: Date, monthEnd: Date): { events: AssetEvent[]; laneCount: number } {
   const clipped = events
-     .filter((e: any) => startOfDay(e.start) <= monthEnd && startOfDay(e.end) >= monthStart)
-    .map((e: any) => ({
+    .filter((e) => startOfDay(e.start) <= monthEnd && startOfDay(e.end) >= monthStart)
+    .map((e) => ({
       ...e,
       _dayStart: differenceInCalendarDays(
         max([startOfDay(e.start), monthStart]),
@@ -71,8 +82,8 @@ function assignLanes(events: any[], monthStart: Date, monthEnd: Date) {
         min([startOfDay(e.end), monthEnd]),
         monthStart,
       ),
-    }))
-    .sort((a: any, b: any) => a._dayStart - b._dayStart || a._dayEnd - b._dayEnd);
+    } as AssetEvent))
+    .sort((a, b) => a._dayStart - b._dayStart || a._dayEnd - b._dayEnd);
 
   const laneEnd = [];
   for (const ev of clipped) {
@@ -99,8 +110,8 @@ function assignLanes(events: any[], monthStart: Date, monthEnd: Date) {
  * (falling back to DEFAULT_CATEGORIES when the prop is empty). Used by
  * resolveAssetColor to look up the pill hue for a given event.
  */
-function buildCategoryColorMap(categoriesConfig: any) {
-  const map = new Map();
+function buildCategoryColorMap(categoriesConfig: CategoryConfigLike): Map<string, string> {
+  const map = new Map<string, string>();
   const defs = categoriesConfig?.categories?.length
     ? categoriesConfig.categories
     : DEFAULT_CATEGORIES;
@@ -115,8 +126,8 @@ function buildCategoryColorMap(categoriesConfig: any) {
  * context colorRules > categoriesConfig > event.color > undefined (falls
  * through to CSS default).
  */
-function resolveAssetColor(ev: any, categoryColorMap: Map<string, string>, colorRules: any) {
-  const ruleColor = resolveColor(ev, colorRules);
+function resolveAssetColor(ev: CalendarViewEvent & { color?: string }, categoryColorMap: Map<string, string>, colorRules: unknown) {
+  const ruleColor = resolveColor(ev as any, colorRules as any);
   if (ruleColor) return ruleColor;
   if (ev.category && categoryColorMap.has(ev.category)) {
     return categoryColorMap.get(ev.category);
@@ -129,8 +140,9 @@ function resolveAssetColor(ev: any, categoryColorMap: Map<string, string>, color
  * value, otherwise null. Unknown strings are treated as null so the pill
  * renders without a stage-specific CSS class.
  */
-function getApprovalStage(ev: any) {
-  const stage = ev?.meta?.approvalStage?.stage;
+function getApprovalStage(ev: CalendarViewEvent | null | undefined): string | null {
+  const meta = ev?.meta as Record<string, any> | undefined;
+  const stage = meta?.approvalStage?.stage;
   return APPROVAL_STAGES.has(stage) ? stage : null;
 }
 
@@ -384,12 +396,12 @@ export default function AssetsView({
     if (assetRegistry) {
       const ordered = assetRegistry.map(a => a.id);
       const orderedSet = new Set(ordered);
-      const hasOrphan = events.some((e: any) => !orderedSet.has(e.resource ?? '(Unassigned)'));
+      const hasOrphan = events.some((e: CalendarViewEvent) => !orderedSet.has(e.resource ?? '(Unassigned)'));
       const base = hasOrphan ? [...ordered, '(Unassigned)'] : ordered;
       return applySort(base);
     }
     const set = new Set<string>();
-    events.forEach((e: any) => set.add(e.resource ?? '(Unassigned)'));
+    events.forEach((e: CalendarViewEvent) => set.add(e.resource ?? '(Unassigned)'));
     return [...set].sort((a, b) => {
       if (a === '(Unassigned)') return 1;
       if (b === '(Unassigned)') return -1;
@@ -427,23 +439,26 @@ export default function AssetsView({
    * Row height is computed from the laned events so rows stay tight when
    * most events are filtered into a different group bucket.
    */
-  const buildAssetRow = useCallback((resource: string, subsetEvents: any[]) => {
+  const buildAssetRow = useCallback((resource: string, subsetEvents: CalendarViewEvent[]) => {
     // "(Unassigned)" bucket catches any event whose resource isn't in the
     // registry (or is missing entirely). Registry rows keep exact-id match.
     const matchesRow = assetRegistry
-      ? ((e: any) => {
+      ? ((e: CalendarViewEvent) => {
           const r = e.resource ?? '(Unassigned)';
           if (resource === '(Unassigned)') return !assetById.has(r);
           return r === resource;
         })
-      : ((e: any) => (e.resource ?? '(Unassigned)') === resource);
+      : ((e: CalendarViewEvent) => (e.resource ?? '(Unassigned)') === resource);
     const resEvents = subsetEvents.filter(matchesRow);
     const { events: laned, laneCount } = assignLanes(resEvents, monthStart, monthEnd);
     const rowH = Math.max(
       laneCount * (LANE_H + LANE_GAP) + ROW_PAD * 2,
       ROW_PAD * 2 + LANE_H + 16,
     );
-    const firstWithMeta = resEvents.find((e: any) => e.meta?.assetSublabel || e.meta?.sublabel);
+    const firstWithMeta = resEvents.find((e: CalendarViewEvent) => {
+      const meta = e.meta as Record<string, unknown> | undefined;
+      return meta?.assetSublabel || meta?.sublabel;
+    });
     const registryEntry = assetById.get(resource) ?? null;
     const sublabel = firstWithMeta?.meta?.assetSublabel
       ?? firstWithMeta?.meta?.sublabel
@@ -509,7 +524,7 @@ export default function AssetsView({
   }, [collapsedControlled, onCollapsedGroupsChange]);
 
   // Count every leaf event reachable under a group (respecting nested trees).
-  const countEvents = useCallback((node: any): number => {
+  const countEvents = useCallback((node: { children?: Array<any>; events: CalendarViewEvent[] }): number => {
     if (!node.children || node.children.length === 0) return node.events.length;
     return node.children.reduce((sum: number, c: any) => sum + countEvents(c), 0);
   }, []);
@@ -532,7 +547,7 @@ export default function AssetsView({
         // Scope to member-held events; use the raw events list (not the
         // strictly-filtered one) so a pool row stays populated even when
         // strictAssetFiltering hides some members.
-        const scoped = eventsProp.filter((e: any) => e.resource != null && memberSet.has(e.resource));
+        const scoped = eventsProp.filter((e: CalendarViewEvent) => e.resource != null && memberSet.has(e.resource));
         const { events: laned, laneCount } = assignLanes(scoped, monthStart, monthEnd);
         const rowH = Math.max(
           laneCount * (LANE_H + LANE_GAP) + ROW_PAD * 2,
@@ -677,7 +692,7 @@ export default function AssetsView({
     }
   }, [focusedCell, rowOffsets, flatRows]);
 
-  const handleCellKeyDown = useCallback((e: any, ri: number, di: number, cellRowEvents: any[], resourceId: string, isPoolRow: boolean) => {
+  const handleCellKeyDown = useCallback((e: ReactKeyboardEvent<HTMLElement>, ri: number, di: number, cellRowEvents: AssetEvent[], resourceId: string, isPoolRow: boolean) => {
     const maxRi = flatRows.length - 1;
     const maxDi = totalDays - 1;
     let nextRi = ri, nextDi = di;
@@ -692,7 +707,7 @@ export default function AssetsView({
       case 'Enter':
       case ' ': {
         e.preventDefault();
-        const hit = cellRowEvents.find((ev: any) => ev._dayStart <= di && ev._dayEnd >= di);
+        const hit = cellRowEvents.find((ev) => ev._dayStart <= di && ev._dayEnd >= di);
         // On pool rows, rowEvents is the aggregate of member bookings — an
         // occupied cell just means *some* member is busy, not that the pool
         // itself is taken. Always route pool cells to onPoolDateSelect so
@@ -1025,7 +1040,7 @@ export default function AssetsView({
                     const di = visColStart + relDi;
                     const isFocused  = focusedCell.rowIdx === rowIdx && focusedCell.dayIdx === di;
                     const resourceId = resource;
-                    const cellHasEvent = rowEvents.some((ev: any) => ev._dayStart <= di && ev._dayEnd >= di);
+                    const cellHasEvent = rowEvents.some((ev: AssetEvent) => ev._dayStart <= di && ev._dayEnd >= di);
                     return (
                       <div
                         key={`kbcell-${di}`}
@@ -1067,13 +1082,13 @@ export default function AssetsView({
                   })}
 
                   {/* Event pills */}
-                  {rowEvents.map((ev: any) => {
+                  {rowEvents.map((ev: AssetEvent) => {
                     const evColor = resolveAssetColor(ev, categoryColorMap, ctx?.colorRules);
                     const left    = ev._dayStart * dayColW + 2;
                     const width   = Math.max(dayColW - 4, (ev._dayEnd - ev._dayStart + 1) * dayColW - 4);
                     const top     = ROW_PAD + ev._lane * (LANE_H + LANE_GAP);
                     const stage       = getApprovalStage(ev);
-                    const onClick = (e: any) => {
+                    const onClick = (e: ReactMouseEvent<HTMLButtonElement>) => {
                       if (AUDIT_STAGES.has(stage)) openAudit(ev, e.currentTarget);
                       else onEventClick?.(ev);
                     };
@@ -1149,7 +1164,7 @@ export default function AssetsView({
                               left: left + width - 18,
                               top:  top + (LANE_H - 16) / 2,
                             }}
-                            onClick={(e: any) => {
+                            onClick={(e: ReactMouseEvent<HTMLButtonElement>) => {
                               e.stopPropagation();
                               openApprovalMenu(ev, stage, e.currentTarget);
                             }}

--- a/src/views/WeekView.tsx
+++ b/src/views/WeekView.tsx
@@ -1,4 +1,5 @@
 import { useMemo, useRef, useState, useCallback, useEffect } from 'react';
+import type { KeyboardEvent as ReactKeyboardEvent, MouseEvent as ReactMouseEvent, PointerEvent as ReactPointerEvent } from 'react';
 import {
   startOfWeek, endOfWeek, eachDayOfInterval,
   format, isSameDay, isToday,
@@ -11,6 +12,7 @@ import { hoursInTimezone } from '../core/engine/time/timezone';
 import { layoutOverlaps, layoutSpans } from '../core/layout';
 import { useDrag } from '../hooks/useDrag';
 import { useFocusTrap } from '../hooks/useFocusTrap';
+import type { CalendarViewEvent } from '../types/ui';
 import styles from './WeekView.module.css';
 
 const SPAN_H    = 34;
@@ -18,16 +20,38 @@ const SPAN_GAP  = 3;
 const MAX_SPANS = 4;
 const GUTTER_W  = 56;
 
-function isMultiDay(ev) {
+type WeekDisplayConfig = { dayStart?: number; dayEnd?: number };
+type WeekConfig = { display?: WeekDisplayConfig };
+type WeekViewProps = {
+  currentDate: Date;
+  events: CalendarViewEvent[];
+  onEventClick?: (event: CalendarViewEvent) => void;
+  onEventMove?: (event: CalendarViewEvent, newStart: Date, newEnd: Date) => void;
+  onEventResize?: (event: CalendarViewEvent, newStart: Date, newEnd: Date) => void;
+  onDateSelect?: (start: Date, end: Date) => void;
+  config?: WeekConfig;
+  weekStartDay?: Day;
+};
+type AllDayGhost = { ev: CalendarViewEvent; startCol: number; endCol: number };
+type AllDayDragState = {
+  ev: CalendarViewEvent;
+  spanStartCol: number;
+  spanEndCol: number;
+  spanWidth: number;
+  clickOffset: number;
+  colWidth: number;
+};
+
+function isMultiDay(ev: CalendarViewEvent): boolean {
   return ev.allDay || !isSameDay(ev.start, ev.end);
 }
 
-function clamp(v, lo, hi) { return Math.max(lo, Math.min(hi, v)); }
+function clamp(v: number, lo: number, hi: number): number { return Math.max(lo, Math.min(hi, v)); }
 
 export default function WeekView({
   currentDate, events, onEventClick, onEventMove, onEventResize, onDateSelect,
   config, weekStartDay = 0,
-}: { currentDate: Date; events: any; onEventClick?: any; onEventMove?: any; onEventResize?: any; onDateSelect?: any; config?: any; weekStartDay?: Day } & Record<string, any>) {
+}: WeekViewProps): JSX.Element {
   const ctx = useCalendarContext();
   const dayStart   = config?.display?.dayStart ?? 6;
   const dayEnd     = config?.display?.dayEnd   ?? 22;
@@ -35,8 +59,8 @@ export default function WeekView({
   const pxPerHour  = 64;
   const bizHours   = ctx?.businessHours ?? null;
 
-  const gridRef    = useRef(null);
-  const allDayRef  = useRef(null);
+  const gridRef    = useRef<HTMLDivElement | null>(null);
+  const allDayRef  = useRef<HTMLDivElement | null>(null);
   // Tracks whether the most recent pointer-up was a real drag (not a click).
   // Used to guard onClick handlers so a just-finished drag doesn't fire onEventClick.
   const wasDragRef = useRef(false);
@@ -49,7 +73,7 @@ export default function WeekView({
     if (!lastKeyNavSlot.current || !gridRef.current) return;
     lastKeyNavSlot.current = false;
     const { dayIdx, hourIdx } = focusedSlot;
-    const el = gridRef.current.querySelector(`[data-slot="${dayIdx}-${hourIdx}"]`);
+    const el = gridRef.current.querySelector(`[data-slot="${dayIdx}-${hourIdx}"]`) as HTMLElement | null;
     el?.focus({ preventScroll: false });
   }, [focusedSlot]);
 
@@ -64,13 +88,13 @@ export default function WeekView({
 
   // Slot hours = hours that have a full 1-hour slot below them
   const slotHours = useMemo(() => {
-    const arr = [];
+    const arr: number[] = [];
     for (let h = dayStart; h < dayEnd; h++) arr.push(h);
     return arr;
   }, [dayStart, dayEnd]);
 
   // ── Slot keyboard navigation ───────────────────────────────────────────────
-  const handleSlotKeyDown = useCallback((e, di, hi, slotStart, slotEnd) => {
+  const handleSlotKeyDown = useCallback((e: ReactKeyboardEvent, di: number, hi: number, slotStart: Date, slotEnd: Date) => {
     const maxDi = days.length - 1;
     const maxHi = slotHours.length - 1;
     let nextDi = di, nextHi = hi;
@@ -101,9 +125,9 @@ export default function WeekView({
   const overflowTrapRef = useFocusTrap(() => setAllDayOverflowOpen(false), allDayOverflowOpen);
 
   const { allDayEvents, timedEvents } = useMemo(() => {
-    const allDay = [];
-    const timed  = [];
-    events.forEach(ev => (isMultiDay(ev) ? allDay : timed).push(ev));
+    const allDay: CalendarViewEvent[] = [];
+    const timed: CalendarViewEvent[] = [];
+    events.forEach((ev) => (isMultiDay(ev) ? allDay : timed).push(ev));
     return { allDayEvents: allDay, timedEvents: timed };
   }, [events]);
 
@@ -117,7 +141,7 @@ export default function WeekView({
   const overflowCount = allDayLanes > MAX_SPANS ? allDayLanes - MAX_SPANS : 0;
 
   const timedByDay = useMemo(() => {
-    const map = new Map();
+    const map = new Map<string, CalendarViewEvent[]>();
     days.forEach(day => {
       const key    = format(day, 'yyyy-MM-dd');
       const dayEvs = timedEvents.filter(e => isSameDay(e.start, day));
@@ -126,10 +150,10 @@ export default function WeekView({
     return map;
   }, [days, timedEvents]);
 
-  const hours = [];
+  const hours: number[] = [];
   for (let h = dayStart; h <= dayEnd; h++) hours.push(h);
 
-  function isBizHour(h, day) {
+  function isBizHour(h: number, day: Date): boolean {
     if (!bizHours) return true;
     const bizDays = bizHours.days ?? [1, 2, 3, 4, 5];
     return bizDays.includes(day.getDay()) && h >= bizHours.start && h < bizHours.end;
@@ -137,7 +161,7 @@ export default function WeekView({
 
   const displayTz = ctx?.displayTimezone ?? null;
 
-  function eventPosition(start, end) {
+  function eventPosition(start: Date, end: Date): { top: number; height: number } | null {
     const startH = displayTz ? hoursInTimezone(start, displayTz) : getHours(start) + getMinutes(start) / 60;
     const endH   = displayTz ? hoursInTimezone(end,   displayTz) : getHours(end)   + getMinutes(end)   / 60;
     const startMin = (startH - dayStart) * 60;
@@ -160,13 +184,13 @@ export default function WeekView({
   // ── Timed-grid drag ───────────────────────────────────────────────────────
   const drag = useDrag({ pxPerHour, dayStart, dayEnd });
 
-  const handleGridPointerDown = useCallback((e) => {
+  const handleGridPointerDown = useCallback((e: ReactPointerEvent<HTMLDivElement>) => {
     if (e.button !== 0) return;
     if (!ctx?.permissions?.canAddEvent) return;
     drag.startCreate(e, gridRef.current, days, GUTTER_W);
   }, [drag.startCreate, days, ctx?.permissions?.canAddEvent]);
 
-  const handleGridPointerMove = useCallback((e) => {
+  const handleGridPointerMove = useCallback((e: ReactPointerEvent<HTMLDivElement>) => {
     drag.onPointerMove(e);
   }, [drag.onPointerMove]);
 
@@ -187,10 +211,10 @@ export default function WeekView({
 
   // Single click on an empty time slot → create a 1-hour event at that time.
   // Drags are excluded via wasDragRef (set true in handleGridPointerUp for real drags).
-  const handleGridClick = useCallback((e) => {
+  const handleGridClick = useCallback((e: ReactMouseEvent<HTMLDivElement>) => {
     if (wasDragRef.current) return;
     if (!ctx?.permissions?.canAddEvent) return;
-    if (e.target.closest('[data-event]')) return; // click was on an event, not empty space
+    if ((e.target as HTMLElement | null)?.closest?.('[data-event]')) return; // click was on an event, not empty space
     const rect = gridRef.current.getBoundingClientRect();
     const colWidth = (rect.width - GUTTER_W) / days.length;
     const relX = e.clientX - rect.left - GUTTER_W;
@@ -204,11 +228,11 @@ export default function WeekView({
   }, [ctx?.permissions?.canAddEvent, days, dayStart, dayEnd, pxPerHour, onDateSelect]);
 
   // ── All-day bar drag ──────────────────────────────────────────────────────
-  const allDayDragRef  = useRef(null);
-  const allDayGhostRef = useRef(null);
-  const [allDayGhost, setAllDayGhost] = useState(null);
+  const allDayDragRef  = useRef<AllDayDragState | null>(null);
+  const allDayGhostRef = useRef<AllDayGhost | null>(null);
+  const [allDayGhost, setAllDayGhost] = useState<AllDayGhost | null>(null);
 
-  function updateAllDayGhost(next) {
+  function updateAllDayGhost(next: AllDayGhost | null): void {
     allDayGhostRef.current = next;
     setAllDayGhost(prev => {
       if (!next && !prev) return prev;
@@ -219,7 +243,7 @@ export default function WeekView({
     });
   }
 
-  function startAllDayBarDrag(ev, e, spanStartCol, spanEndCol) {
+  function startAllDayBarDrag(ev: CalendarViewEvent, e: ReactPointerEvent<HTMLButtonElement>, spanStartCol: number, spanEndCol: number): void {
     e.preventDefault();
     e.stopPropagation();
     const grid     = allDayRef.current;
@@ -237,7 +261,7 @@ export default function WeekView({
     updateAllDayGhost({ ev, startCol: spanStartCol, endCol: spanEndCol });
   }
 
-  function handleAllDayPointerMove(e) {
+  function handleAllDayPointerMove(e: ReactPointerEvent<HTMLDivElement>): void {
     const d = allDayDragRef.current;
     if (!d) return;
     const rect       = allDayRef.current.getBoundingClientRect();
@@ -265,17 +289,17 @@ export default function WeekView({
   // ── Renderers ─────────────────────────────────────────────────────────────
 
 
-  function formatPillDate(date) {
+  function formatPillDate(date: Date): string {
     return format(date, 'M/d h:mma');
   }
 
-  function pillResource(ev) {
+  function pillResource(ev: CalendarViewEvent): string {
     return ev.resource || 'Unassigned';
   }
 
-  function renderTimedEvent(ev) {
+  function renderTimedEvent(ev: CalendarViewEvent): JSX.Element | null {
     const isDimmed = drag.draggedId === ev.id;
-    const color    = resolveColor(ev, ctx?.colorRules);
+    const color    = resolveColor(ev as any, ctx?.colorRules);
     const onClick  = () => !wasDragRef.current && onEventClick?.(ev);
     const pos = eventPosition(ev.start, ev.end);
     if (!pos) return null;
@@ -287,13 +311,13 @@ export default function WeekView({
     const statusClass = ev.status === 'cancelled' ? styles.cancelled
       : ev.status === 'tentative' ? styles.tentative : '';
     const ariaLabel = `${ev.title}, ${format(ev.start, 'h:mm a')} to ${format(ev.end, 'h:mm a')}${ev.category ? `, ${ev.category}` : ''}${ev.status && ev.status !== 'confirmed' ? `, ${ev.status}` : ''}`;
-    const display   = ev.meta?._display ?? {};
+    const display = (ev.meta as Record<string, any> | undefined)?._display ?? {};
     const isUltraCompact = height < 42;
     const isCompact = height < 72;
     const timeRangeLabel = `${format(ev.start, 'h:mm a')} - ${format(ev.end, 'h:mm a')}`;
 
     const inner = ctx?.renderEvent
-      ? ctx.renderEvent(ev, { view: 'week', isCompact: false, onClick, color })
+      ? ctx.renderEvent(ev as any, { view: 'week', isCompact: false, onClick, color })
       : null;
 
     return (
@@ -314,10 +338,10 @@ export default function WeekView({
         aria-label={ariaLabel}
         onClick={onClick}
         onKeyDown={e => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); onClick(); } }}
-        onPointerDown={e => { if (e.button !== 0 || !ctx?.permissions?.canDrag) return; e.stopPropagation(); drag.startMove(ev, e, gridRef.current, days, GUTTER_W); }}
+        onPointerDown={e => { if (e.button !== 0 || !ctx?.permissions?.canDrag) return; e.stopPropagation(); drag.startMove(ev as any, e, gridRef.current, days, GUTTER_W); }}
       >
         <div className={styles.resizeHandleTop}
-          onPointerDown={e => { if (e.button !== 0 || !ctx?.permissions?.canDrag) return; e.stopPropagation(); drag.startResizeTop(ev, e, gridRef.current, days, GUTTER_W); }}
+          onPointerDown={e => { if (e.button !== 0 || !ctx?.permissions?.canDrag) return; e.stopPropagation(); drag.startResizeTop(ev as any, e, gridRef.current, days, GUTTER_W); }}
           aria-hidden="true" />
         {inner ?? (
           <>
@@ -337,13 +361,13 @@ export default function WeekView({
           </>
         )}
         <div className={styles.resizeHandle}
-          onPointerDown={e => { if (e.button !== 0 || !ctx?.permissions?.canDrag) return; e.stopPropagation(); drag.startResize(ev, e, gridRef.current, days, GUTTER_W); }}
+          onPointerDown={e => { if (e.button !== 0 || !ctx?.permissions?.canDrag) return; e.stopPropagation(); drag.startResize(ev as any, e, gridRef.current, days, GUTTER_W); }}
           aria-hidden="true" />
       </div>
     );
   }
 
-  function renderGhost(day) {
+  function renderGhost(day: Date): JSX.Element | null {
     const g = drag.ghost;
     if (!g || !isSameDay(g.start, day)) return null;
     const pos = eventPosition(g.start, g.end);
@@ -359,7 +383,7 @@ export default function WeekView({
       left  = '2px';
       width = 'calc(100% - 4px)';
     }
-    const color = g.ev ? resolveColor(g.ev, ctx?.colorRules) : undefined;
+    const color = g.ev ? resolveColor(g.ev as any, ctx?.colorRules) : undefined;
     return (
       <div key="ghost" className={[styles.ghost, !g.ev && styles.ghostCreate].filter(Boolean).join(' ')}
         aria-hidden="true"
@@ -409,7 +433,7 @@ export default function WeekView({
             {allDaySpans
               .filter(s => s.lane < MAX_SPANS)
               .map(({ ev, startCol, endCol, lane, continuesBefore, continuesAfter }) => {
-                const color = resolveColor(ev, ctx?.colorRules);
+                const color = resolveColor(ev as any, ctx?.colorRules);
                 const pctLeft  = (startCol / 7) * 100;
                 const pctWidth = ((endCol - startCol + 1) / 7) * 100;
                 const statusClass = ev.status === 'cancelled' ? styles.cancelled
@@ -453,7 +477,7 @@ export default function WeekView({
             {/* All-day drag ghost */}
             {allDayGhost && (() => {
               const g = allDayGhost;
-              const color = resolveColor(g.ev, ctx?.colorRules);
+              const color = resolveColor(g.ev as any, ctx?.colorRules);
               return (
                 <div key="allday-ghost" className={styles.allDayGhost} aria-hidden="true"
                   style={{
@@ -501,7 +525,7 @@ export default function WeekView({
                     {allDaySpans
                       .filter(s => s.lane >= MAX_SPANS)
                       .map(({ ev }) => {
-                        const color = resolveColor(ev, ctx?.colorRules);
+                        const color = resolveColor(ev as any, ctx?.colorRules);
                         return (
                           <button
                             key={ev.id}


### PR DESCRIPTION
### Motivation
- Progress the Stage 5 TypeScript strict migration by bringing the medium views into the migrated-paths ratchet and removing implicit `any` at view boundaries. 
- Reduce type-surface risk in interactive view seams while preserving existing runtime behavior and avoiding wide cross-module type cascades.

### Description
- Added `src/views/WeekView.tsx`, `src/views/AssetsView.tsx`, and `src/views/BaseGanttView.tsx` to `MIGRATED_PATHS` in `scripts/typecheck-strict.mjs` to include PR8 in the strict ratchet. 
- `WeekView`: introduced `CalendarViewEvent` import and explicit `WeekViewProps`, typed local helpers and all-day drag state, and added types for keyboard/mouse/pointer handlers and DOM refs with narrow casts where needed. 
- `AssetsView`: added typed signatures for helpers and callbacks (`assignLanes`, `buildCategoryColorMap`, `resolveAssetColor`, row/building and grouping helpers, keyboard handlers, event-pill callbacks) and applied targeted `any` annotations at dynamic integration boundaries to avoid cascading type churn. 
- Minor fixes (Map/Set generics, element/handler types, small casts) to satisfy the strict-check without altering behavior.

### Testing
- `npm run -s type-check:strict` — passed (output: "Strict type check GREEN.").
- `npx tsc --noEmit` — completed with no errors.
- `npx vitest run src/views/__tests__/WeekDayView.offHoursClipping.test.tsx src/views/__tests__/AssetsView.test.tsx src/views/__tests__/BaseGanttView.test.tsx` — all tests passed (3 files, 66 tests).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e80141e208832cb9d2aa910f9ea997)