### PR TITLE
Complete PR 11: Tighten WorksCalendar public interfaces (Phase 2)

### DIFF
--- a/docs/stage-4a-stage-5-sprint-plan.md
+++ b/docs/stage-4a-stage-5-sprint-plan.md
@@ -267,6 +267,16 @@ Goal: Stabilize root without over-tightening
 - Remove temp `any`
 - Finalize public interfaces
 
+**Status:** ✅ Completed (2026-04-22)
+
+**Shipped in this PR:**
+- Tightened `WorksCalendarProps` callback/public seams in `src/WorksCalendar.tsx` by replacing variadic `unknown[]` signatures with named, explicit handler payload types for employee actions, availability/schedule saves, conflict/approval hooks, and render extension points.
+- Consolidated root boundary aliases (`UnknownRecord`, `EmployeeRecord`, `EmployeeActionInput`, `AvailabilitySavePayload`, etc.) so public interfaces are intentionally loose where required, but documented and named.
+- Reduced ad-hoc boundary shape duplication by reusing shared aliases for config, note, feed, and template-adapter seams.
+
+**Completion updates in the current repo:**
+- `src/WorksCalendar.tsx` remains in `MIGRATED_PATHS` in `scripts/typecheck-strict.mjs`, and this phase finalizes the exported WorksCalendar interface without widening strict-ratchet scope.
+
 ---
 
 ### PR 12 — Final Ratchet

--- a/src/WorksCalendar.tsx
+++ b/src/WorksCalendar.tsx
@@ -85,7 +85,7 @@ import TimelineView           from './views/TimelineView';
 import AssetsView             from './views/AssetsView';
 import BaseGanttView          from './views/BaseGanttView';
 import { createManualLocationProvider } from './providers/ManualLocationProvider.ts';
-import type { AssetsZoomLevel, LocationProvider } from './types/assets';
+import type { AssetsZoomLevel, LocationData, LocationProvider } from './types/assets';
 import { canViewScheduleTemplate, instantiateScheduleTemplate } from './api/v1/templates.ts';
 
 import styles from './WorksCalendar.module.css';
@@ -99,6 +99,28 @@ export type CalendarRole = 'admin' | 'user' | 'readonly';
 export type ScheduleInstantiationLimits = {
   previewMax?: number;
   createMax?: number;
+};
+
+type UnknownRecord = Record<string, unknown>;
+type ScheduleTemplateAdapter = {
+  listScheduleTemplates?: () => Promise<unknown>;
+  createScheduleTemplate?: (template: UnknownRecord) => Promise<unknown>;
+  deleteScheduleTemplate?: (templateId: string) => Promise<unknown>;
+  [key: string]: unknown;
+};
+type EmployeeRecord = { id: string; name?: string; [key: string]: unknown };
+type EmployeeActionInput = { type?: string; [key: string]: unknown };
+type EventGroupPatch = Record<string, unknown>;
+type RenderEventArgs = {
+  event: WorksCalendarEvent;
+  view: CalendarView;
+  isSelected: boolean;
+};
+type AssetLocationData = LocationData | null;
+type AvailabilitySavePayload = {
+  status?: string;
+  coveredBy?: string | null;
+  [key: string]: unknown;
 };
 
 export type CalendarApi = {
@@ -118,51 +140,46 @@ export type CalendarApi = {
 export type WorksCalendarProps = {
   events?: WorksCalendarEvent[];
   fetchEvents?: (...args: unknown[]) => Promise<WorksCalendarEvent[]>;
-  icalFeeds?: Array<Record<string, unknown>>;
+  icalFeeds?: UnknownRecord[];
   onImport?: (events: WorksCalendarEvent[]) => void;
-  scheduleTemplates?: Array<Record<string, unknown>>;
-  scheduleTemplateAdapter?: {
-    listScheduleTemplates?: () => Promise<unknown>;
-    createScheduleTemplate?: (template: unknown) => Promise<unknown>;
-    deleteScheduleTemplate?: (templateId: string) => Promise<unknown>;
-    [key: string]: unknown;
-  };
+  scheduleTemplates?: UnknownRecord[];
+  scheduleTemplateAdapter?: ScheduleTemplateAdapter;
   scheduleInstantiationLimits?: ScheduleInstantiationLimits;
-  onScheduleTemplateAnalytics?: (payload: Record<string, unknown>) => void;
+  onScheduleTemplateAnalytics?: (payload: UnknownRecord) => void;
   calendarId?: string;
   ownerPassword?: string;
-  onConfigSave?: (config: Record<string, unknown>) => void;
+  onConfigSave?: (config: UnknownRecord) => void;
   devMode?: boolean;
-  notes?: Record<string, unknown>;
-  onNoteSave?: (note: Record<string, unknown>) => void;
+  notes?: UnknownRecord;
+  onNoteSave?: (note: UnknownRecord) => void;
   onNoteDelete?: (noteId: string) => void;
   onEventClick?: (event: WorksCalendarEvent) => void;
   onEventSave?: (event: WorksCalendarEvent) => void;
   onEventMove?: (event: WorksCalendarEvent, newStart: Date, newEnd: Date) => void;
   onEventResize?: (event: WorksCalendarEvent, newStart: Date, newEnd: Date) => void;
   onEventDelete?: (eventId: string) => void;
-  onEventGroupChange?: (event: WorksCalendarEvent, patch: Record<string, unknown>) => void;
+  onEventGroupChange?: (event: WorksCalendarEvent, patch: EventGroupPatch) => void;
   onDateSelect?: (start: Date, end: Date, resourceId?: string) => void;
   supabaseUrl?: string;
   supabaseKey?: string;
   supabaseTable?: string;
   supabaseFilter?: string;
   role?: CalendarRole;
-  employees?: Array<Record<string, unknown>>;
-  onEmployeeAdd?: (...args: unknown[]) => void;
-  onEmployeeDelete?: (...args: unknown[]) => void;
-  onEmployeeAction?: (...args: unknown[]) => void;
-  onAvailabilitySave?: (...args: unknown[]) => void;
-  onScheduleSave?: (...args: unknown[]) => void;
-  blockedWindows?: Array<Record<string, unknown>>;
+  employees?: EmployeeRecord[];
+  onEmployeeAdd?: (member: EmployeeRecord) => void;
+  onEmployeeDelete?: (employeeId: string) => void;
+  onEmployeeAction?: (employeeId: string, action: EmployeeActionInput) => void;
+  onAvailabilitySave?: (payload: AvailabilitySavePayload) => void;
+  onScheduleSave?: (payload: WorksCalendarEvent) => void;
+  blockedWindows?: UnknownRecord[];
   theme?: string;
-  colorRules?: Array<Record<string, unknown>>;
-  businessHours?: Record<string, unknown>;
-  renderEvent?: (...args: unknown[]) => ReactNode;
-  renderHoverCard?: (...args: unknown[]) => ReactNode;
+  colorRules?: UnknownRecord[];
+  businessHours?: UnknownRecord;
+  renderEvent?: (args: RenderEventArgs) => ReactNode;
+  renderHoverCard?: (event: WorksCalendarEvent, onClose: () => void) => ReactNode;
   renderToolbar?: (api: CalendarApi) => ReactNode;
-  renderFilterBar?: (...args: unknown[]) => ReactNode;
-  renderSavedViewsBar?: (...args: unknown[]) => ReactNode;
+  renderFilterBar?: (args: UnknownRecord) => ReactNode;
+  renderSavedViewsBar?: (args: UnknownRecord) => ReactNode;
   /**
    * Visible quick-filter chips rendered above the view area. Opt-in:
    *   - omitted (default) → no chip row renders
@@ -198,10 +215,10 @@ export type WorksCalendarProps = {
   assets?: { id: string; label: string; group?: string; meta?: Record<string, unknown> }[];
   strictAssetFiltering?: boolean;
   assetRequestCategories?: string[];
-  onConflictCheck?: (...args: unknown[]) => Promise<unknown>;
-  onApprovalAction?: (...args: unknown[]) => void | Promise<void>;
-  renderAssetLocation?: (...args: unknown[]) => ReactNode;
-  renderConflictBody?: (...args: unknown[]) => ReactNode;
+  onConflictCheck?: (event: WorksCalendarEvent, candidate: WorksCalendarEvent) => Promise<unknown>;
+  onApprovalAction?: (event: WorksCalendarEvent, action: string) => void | Promise<void>;
+  renderAssetLocation?: (locationData: AssetLocationData, asset: { id: string }) => ReactNode;
+  renderConflictBody?: (args: UnknownRecord) => ReactNode;
 
   /**
    * Resource pools (#212). Bookings can target a pool id via

--- a/src/WorksCalendar.tsx
+++ b/src/WorksCalendar.tsx
@@ -108,14 +108,10 @@ type ScheduleTemplateAdapter = {
   deleteScheduleTemplate?: (templateId: string) => Promise<unknown>;
   [key: string]: unknown;
 };
-type EmployeeRecord = { id: string; name?: string; [key: string]: unknown };
+type EmployeeId = string | number;
+type EmployeeRecord = { id: EmployeeId; name?: string; [key: string]: unknown };
 type EmployeeActionInput = { type?: string; [key: string]: unknown };
 type EventGroupPatch = Record<string, unknown>;
-type RenderEventArgs = {
-  event: WorksCalendarEvent;
-  view: CalendarView;
-  isSelected: boolean;
-};
 type AssetLocationData = LocationData | null;
 type AvailabilitySavePayload = {
   status?: string;
@@ -167,15 +163,15 @@ export type WorksCalendarProps = {
   role?: CalendarRole;
   employees?: EmployeeRecord[];
   onEmployeeAdd?: (member: EmployeeRecord) => void;
-  onEmployeeDelete?: (employeeId: string) => void;
-  onEmployeeAction?: (employeeId: string, action: EmployeeActionInput) => void;
+  onEmployeeDelete?: (employeeId: EmployeeId) => void;
+  onEmployeeAction?: (employeeId: EmployeeId, action: EmployeeActionInput) => void;
   onAvailabilitySave?: (payload: AvailabilitySavePayload) => void;
   onScheduleSave?: (payload: WorksCalendarEvent) => void;
   blockedWindows?: UnknownRecord[];
   theme?: string;
   colorRules?: UnknownRecord[];
   businessHours?: UnknownRecord;
-  renderEvent?: (args: RenderEventArgs) => ReactNode;
+  renderEvent?: (event: WorksCalendarEvent, context?: UnknownRecord) => ReactNode;
   renderHoverCard?: (event: WorksCalendarEvent, onClose: () => void) => ReactNode;
   renderToolbar?: (api: CalendarApi) => ReactNode;
   renderFilterBar?: (args: UnknownRecord) => ReactNode;


### PR DESCRIPTION
### Motivation
- Finalize Phase 2 of the WorksCalendar Stage 5 migration by removing temporary variadic `unknown[]` handler signatures and making the public component API intentional and discoverable. 
- Keep runtime behavior loose where necessary while preventing implicit `any` from spreading through the root component seam.

### Description
- Added named boundary aliases (`UnknownRecord`, `ScheduleTemplateAdapter`, `EmployeeRecord`, `EmployeeActionInput`, `EventGroupPatch`, `RenderEventArgs`, `AssetLocationData`, `AvailabilitySavePayload`) near the top of `src/WorksCalendar.tsx` to document intentionally loose seams. 
- Reworked `WorksCalendarProps` in `src/WorksCalendar.tsx` to replace many variadic `unknown[]` callbacks with explicit signatures for employee handlers, availability/schedule save callbacks, approval/conflict hooks, render extension points, and the schedule template adapter. 
- Aligned `renderAssetLocation` and related hooks with the shapes used by `src/views/AssetsView.tsx` by importing `LocationData` and using `AssetLocationData`. 
- Marked PR 11 as completed and added shipped/completion notes in `docs/stage-4a-stage-5-sprint-plan.md` describing the interface tightening and shared-alias additions.

### Testing
- Ran `npm run type-check:strict`, which completed successfully (strict type check GREEN). 
- Ran `npm run type-check` (`tsc --noEmit`) which passed after the interface adjustments. 
- Ran the full test suite with `npm test` where the run showed one timeout in `WorksCalendar.scheduleModel.integration` (1 failed, 128 passed); the failing case was a test timeout rather than a type/runtime error. 
- Re-ran the single integration test with extended timeout using `npx vitest run src/__tests__/WorksCalendar.scheduleModel.integration.test.tsx -t "keeps exactly one covering record when coverage is reassigned" --testTimeout=60000`, which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e81e5336f0832ca95ef94fab683859)