### PR TITLE
Complete Stage 5 PR12: add demo to strict allowlist and reconcile docs

### DIFF
--- a/docs/TypeScriptStrictMigration.md
+++ b/docs/TypeScriptStrictMigration.md
@@ -200,10 +200,14 @@ This decision is explicitly on the plan to prevent the failure mode where scope 
 
 **Sizing:** 4–6 weeks.
 
-**Status note (2026-04-21):**
-- Stage 5 code-typing work has started, but Stage 5 is not complete under this
-  roadmap until Stage 5 UI/view paths are added to `MIGRATED_PATHS` and pass
-  the strict ratchet.
+**Status note (updated 2026-04-22):**
+- Stage 5 is complete for the planned slice in this roadmap.
+- `scripts/typecheck-strict.mjs` now ratchets all Stage 5 targets from the
+  plan sequence: `src/ui/ConfigPanel.tsx`, the Stage 5 view set
+  (`DayView`/`AgendaView`/`MonthView`/`WeekView`/`AssetsView`/`BaseGanttView`/`TimelineView`),
+  `src/WorksCalendar.tsx`, and `demo/**` (via the `demo/` allowlist entry).
+- `npm run type-check:strict` passes with those paths included, and advisory
+  root `tsc --noEmit -p tsconfig.json` remains green.
 
 ### Stage 5 PR checklist template (required in every PR description)
 

--- a/docs/stage-4a-stage-5-sprint-plan.md
+++ b/docs/stage-4a-stage-5-sprint-plan.md
@@ -285,6 +285,15 @@ Goal: Stabilize root without over-tightening
 - Update migration doc
 - Confirm full strict pass
 
+**Status:** ✅ Completed (2026-04-22)
+
+**Shipped in this PR:**
+- Added `demo/` to `MIGRATED_PATHS` in `scripts/typecheck-strict.mjs` to complete the Stage 5 scope ratchet for the planned UI + root + demo migration set.
+- Reconciled Stage 5 status documentation in `docs/TypeScriptStrictMigration.md` to mark Stage 5 complete under the ratchet rules.
+- Confirmed strict and advisory validation:
+  - `npm run type-check:strict`
+  - `npx tsc --noEmit -p tsconfig.json`
+
 ---
 
 ## 🔍 Per-PR Checklist

--- a/scripts/typecheck-strict.mjs
+++ b/scripts/typecheck-strict.mjs
@@ -75,6 +75,8 @@ const MIGRATED_PATHS = [
   'src/views/TimelineView.tsx',
   // Stage 5 PR10
   'src/WorksCalendar.tsx',
+  // Stage 5 PR12
+  'demo/',
 ];
 
 // Implicit-any diagnostic codes. See:


### PR DESCRIPTION
### Motivation
- Finalize the Stage 5 migration ratchet by ensuring the planned UI + demo slice is enforced by the strict typecheck allowlist.  
- Reconcile sprint plan and migration roadmap to reflect the completed ratchet and validation status.  
- Close the PR 12 checklist (no net new `any`) and record the shipped validation steps.

### Description
- Added `demo/` to the `MIGRATED_PATHS` allowlist in `scripts/typecheck-strict.mjs` so the demo tree is now part of the Stage 5 ratchet.  
- Marked PR 12 as completed and documented the shipped checks in `docs/stage-4a-stage-5-sprint-plan.md`.  
- Updated the Stage 5 status note in `docs/TypeScriptStrictMigration.md` to reflect that the Stage 5 targets are now ratcheted and validated.

### Testing
- Ran `npm run type-check:strict` which reported `Strict type check GREEN.` and listed the migrated paths; the command succeeded.  
- Ran `npx tsc --noEmit -p tsconfig.json` (advisory root tsc) which completed successfully.  
- Ran `npm test` and the test suite completed successfully (`1911 passed, 1 todo`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e825569428832c9635440d7ca6957d)