### PR TITLE
Stage 6 PR A: validate noImplicitAny for ScheduleView & AuditDrawer

### DIFF
--- a/scripts/typecheck-strict.mjs
+++ b/scripts/typecheck-strict.mjs
@@ -93,6 +93,9 @@ const MIGRATED_PATHS = [
   // Stage 5b PR5
   'src/ui/FilterBar.tsx',
   'src/ui/AdvancedFilterBuilder.tsx',
+  // Stage 6 PR A
+  'src/views/ScheduleView.tsx',
+  'src/views/AuditDrawer.tsx',
 ];
 
 // Implicit-any diagnostic codes. See:

--- a/scripts/typecheck-strict.mjs
+++ b/scripts/typecheck-strict.mjs
@@ -77,6 +77,9 @@ const MIGRATED_PATHS = [
   'src/WorksCalendar.tsx',
   // Stage 5 PR12
   'demo/',
+  // Stage 6 PR A
+  'src/views/ScheduleView.tsx',
+  'src/views/AuditDrawer.tsx',
 ];
 
 // Implicit-any diagnostic codes. See:

--- a/src/views/AuditDrawer.tsx
+++ b/src/views/AuditDrawer.tsx
@@ -6,18 +6,18 @@
  * append entries via the onApprovalAction callback (calendar emits, host
  * persists, re-renders with updated history).
  */
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useRef, useState, type MouseEvent } from 'react';
 import { X } from 'lucide-react';
 import styles from './AuditDrawer.module.css';
 import ApprovalActionMenu from '../ui/ApprovalActionMenu';
-import { findNode } from '../core/workflow/workflowSchema';
+import { findNode, type TimeoutBehavior } from '../core/workflow/workflowSchema';
 
 /**
  * Formats an ISO timestamp as a locale-aware date + time string. Returns the
  * raw input unchanged when the value is falsy or unparseable so the caller
  * never renders "Invalid Date".
  */
-function formatAt(iso) {
+function formatAt(iso: string | undefined): string {
   if (!iso) return '';
   try {
     const d = new Date(iso);
@@ -28,7 +28,7 @@ function formatAt(iso) {
   }
 }
 
-const ACTION_LABELS = {
+const ACTION_LABELS: Record<string, string> = {
   submit:    'Submitted',
   approve:   'Approved',
   deny:      'Denied',
@@ -41,7 +41,18 @@ const ACTION_LABELS = {
  * Returns null when inapplicable (no instance, not awaiting, no SLA, or
  * the active node isn't in the workflow anymore).
  */
-function computeSlaPill(workflow, workflowInstance, nowMs) {
+type SlaPill = {
+  remainingMs: number;
+  slaMinutes: number;
+  onTimeout: TimeoutBehavior;
+  expired: boolean;
+};
+
+function computeSlaPill(
+  workflow: any,
+  workflowInstance: any,
+  nowMs: number,
+): SlaPill | null {
   if (!workflow || !workflowInstance) return null;
   if (workflowInstance.status !== 'awaiting') return null;
   const nodeId = workflowInstance.currentNodeId;
@@ -68,7 +79,7 @@ function computeSlaPill(workflow, workflowInstance, nowMs) {
   };
 }
 
-function formatRemaining(ms) {
+function formatRemaining(ms: number): string {
   const abs = Math.abs(ms);
   const totalMinutes = Math.max(0, Math.round(abs / 60_000));
   if (totalMinutes < 60) return `${totalMinutes}m`;
@@ -77,14 +88,43 @@ function formatRemaining(ms) {
   return m === 0 ? `${h}h` : `${h}h ${m}m`;
 }
 
-export default function AuditDrawer({ event, onClose, approvalsConfig, onAction, workflow }: any) {
-  const closeRef = useRef(null);
+type AuditStageHistoryEntry = {
+  at: string;
+  action: string;
+  tier?: number;
+  actor?: string;
+  reason?: string;
+};
+
+type AuditStageData = {
+  stage?: string;
+  history?: AuditStageHistoryEntry[];
+};
+
+type AuditDrawerEvent = {
+  title: string;
+  meta?: {
+    approvalStage?: AuditStageData;
+    workflowInstance?: any;
+  };
+};
+
+type AuditDrawerProps = {
+  event?: AuditDrawerEvent;
+  onClose?: () => void;
+  approvalsConfig?: any;
+  onAction?: (action: string) => void;
+  workflow?: any;
+};
+
+export default function AuditDrawer({ event, onClose, approvalsConfig, onAction, workflow }: AuditDrawerProps) {
+  const closeRef = useRef<HTMLButtonElement | null>(null);
   const [nowMs, setNowMs] = useState(() => Date.now());
 
   useEffect(() => {
     if (!event) return;
     closeRef.current?.focus();
-    const onKey = (e) => { if (e.key === 'Escape') onClose?.(); };
+    const onKey = (e: KeyboardEvent) => { if (e.key === 'Escape') onClose?.(); };
     window.addEventListener('keydown', onKey);
     return () => window.removeEventListener('keydown', onKey);
   }, [event, onClose]);
@@ -108,7 +148,7 @@ export default function AuditDrawer({ event, onClose, approvalsConfig, onAction,
   return (
     <div
       className={styles.overlay}
-      onClick={(e) => { if (e.target === e.currentTarget) onClose?.(); }}
+      onClick={(e: MouseEvent<HTMLDivElement>) => { if (e.target === e.currentTarget) onClose?.(); }}
       data-testid="audit-drawer-overlay"
     >
       <aside

--- a/src/views/ScheduleView.tsx
+++ b/src/views/ScheduleView.tsx
@@ -9,16 +9,24 @@ import {
 } from 'date-fns';
 import type { Day } from 'date-fns';
 import { useCalendarContext, resolveColor } from '../core/CalendarContext';
+import type { NormalizedEvent } from '../types/events';
 import styles from './ScheduleView.module.css';
 
 const WEEKS = 6;
 
-export default function ScheduleView({ currentDate, events, onEventClick, weekStartDay = 0 }: { currentDate: Date; events: any; onEventClick?: any; weekStartDay?: Day } & Record<string, any>) {
+type ScheduleViewProps = {
+  currentDate: Date;
+  events: NormalizedEvent[];
+  onEventClick?: (event: NormalizedEvent) => void;
+  weekStartDay?: Day;
+} & Record<string, unknown>;
+
+export default function ScheduleView({ currentDate, events, onEventClick, weekStartDay = 0 }: ScheduleViewProps) {
   const ctx = useCalendarContext();
 
   const resources = useMemo<string[]>(() => {
     const set = new Set<string>();
-    events.forEach(e => { if (e.resource) set.add(e.resource); });
+    events.forEach((e) => { if (e.resource) set.add(e.resource); });
     return [...set].sort();
   }, [events]);
 
@@ -33,7 +41,7 @@ export default function ScheduleView({ currentDate, events, onEventClick, weekSt
       <div className={styles.fallback}>
         <p className={styles.hint}>Schedule view groups events by resource. Add a <code>resource</code> field to your events.</p>
         <div className={styles.simpleList}>
-          {events.slice(0, 40).map(ev => {
+          {events.slice(0, 40).map((ev) => {
             const color = resolveColor(ev, ctx?.colorRules);
             return (
               <button key={ev.id} className={styles.simpleEvent} onClick={() => onEventClick?.(ev)}
@@ -73,11 +81,11 @@ export default function ScheduleView({ currentDate, events, onEventClick, weekSt
                 <span className={styles.weekDay}>{format(day, 'EEE')}</span>
                 <span className={styles.dayNum}>{format(day, 'MMM d')}</span>
               </div>
-              {resources.map(res => {
-                const cellEvents = events.filter(e => e.resource === res && isSameDay(e.start, day));
+              {resources.map((res) => {
+                const cellEvents = events.filter((e) => e.resource === res && isSameDay(e.start, day));
                 return (
                   <div key={res} className={styles.cell}>
-                    {cellEvents.map(ev => {
+                    {cellEvents.map((ev) => {
                       const color = resolveColor(ev, ctx?.colorRules);
                       const statusClass = ev.status === 'cancelled' ? styles.cancelled
                         : ev.status === 'tentative' ? styles.tentative : '';

--- a/src/views/ScheduleView.tsx
+++ b/src/views/ScheduleView.tsx
@@ -61,14 +61,14 @@ export default function ScheduleView({ currentDate, events, onEventClick, weekSt
       {/* Header */}
       <div className={styles.header} style={{ gridTemplateColumns: `120px repeat(${resources.length}, minmax(100px, 1fr))` }}>
         <div className={styles.cornerCell} />
-        {resources.map(r => (
+        {resources.map((r: string) => (
           <div key={r} className={styles.resourceHead}>{r}</div>
         ))}
       </div>
 
       {/* Body */}
       <div className={styles.body}>
-        {days.map(day => {
+        {days.map((day: Date) => {
           const key = format(day, 'yyyy-MM-dd');
           const isWeekStart = day.getDay() === weekStartDay;
 
@@ -81,7 +81,7 @@ export default function ScheduleView({ currentDate, events, onEventClick, weekSt
                 <span className={styles.weekDay}>{format(day, 'EEE')}</span>
                 <span className={styles.dayNum}>{format(day, 'MMM d')}</span>
               </div>
-              {resources.map((res) => {
+              {resources.map((res: string) => {
                 const cellEvents = events.filter((e) => e.resource === res && isSameDay(e.start, day));
                 return (
                   <div key={res} className={styles.cell}>


### PR DESCRIPTION
### Motivation
- Enable the Stage 6 noImplicitAny ratchet by validating previously-unmigrated hidden view files and remove remaining implicit-`any` sites so strict checks can pass. 

### Description
- Added `src/views/ScheduleView.tsx` and `src/views/AuditDrawer.tsx` to the strict migration allowlist in `scripts/typecheck-strict.mjs` so they are covered by the repo-wide `noImplicitAny` validation. 
- Introduced explicit prop types for `ScheduleView` (`ScheduleViewProps`) and typed `events` as `NormalizedEvent[]`, plus typed callback signatures and iterator callbacks to remove implicit `any`s. 
- Added typed helpers and compact domain types to `AuditDrawer` (typed `formatAt`, `formatRemaining`, `SlaPill`, audit history shapes, `AuditDrawerProps`) and typed event handlers/refs to eliminate implicit `any` occurrences while preserving runtime behavior. 
- Kept a minimal `any` surface where strict domain enums or broader test fixtures required flexible typing to avoid cascading changes to unrelated tests. 

### Testing
- Ran `npm run -s type-check:strict` and it completed successfully ("Strict type check GREEN.").
- Ran `npm run -s type-check` and it completed successfully with no new errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e83bf78148832c8728fc0a5d34c63a)