### PR TITLE
Stage 5b PR1: clean implicit-any debt in hook test helpers

### DIFF
--- a/scripts/typecheck-strict.mjs
+++ b/scripts/typecheck-strict.mjs
@@ -77,6 +77,9 @@ const MIGRATED_PATHS = [
   'src/WorksCalendar.tsx',
   // Stage 5 PR12
   'demo/',
+  // Stage 5b PR1
+  'src/hooks/__tests__/useSavedViews.test.ts',
+  'src/hooks/__tests__/useSourceStore.test.ts',
 ];
 
 // Implicit-any diagnostic codes. See:

--- a/src/hooks/__tests__/useSavedViews.test.ts
+++ b/src/hooks/__tests__/useSavedViews.test.ts
@@ -12,6 +12,34 @@ import {
 } from '../useSavedViews';
 
 const CAL_ID = 'test-cal';
+type LiveFilters = {
+  categories: Set<string>;
+  resources: Set<string>;
+  sources: Set<string>;
+  search: string;
+  dateRange: { start: Date; end: Date } | null;
+};
+type StoredFilters = {
+  categories: string[];
+  resources: string[];
+  sources: string[];
+  search: string;
+  dateRange: { start: string; end: string } | null;
+};
+const makeEmptyLiveFilters = (): LiveFilters => ({
+  categories: new Set<string>(),
+  resources: new Set<string>(),
+  sources: new Set<string>(),
+  search: '',
+  dateRange: null,
+});
+const makeEmptyStoredFilters = (): StoredFilters => ({
+  categories: [],
+  resources: [],
+  sources: [],
+  search: '',
+  dateRange: null,
+});
 
 beforeEach(() => {
   localStorage.clear();
@@ -21,7 +49,7 @@ beforeEach(() => {
 
 describe('serializeFilters', () => {
   it('converts Sets to arrays', () => {
-    const filters = {
+    const filters: LiveFilters = {
       categories: new Set(['Work', 'PTO']),
       resources:  new Set(['Alice']),
       sources:    new Set(['src-a']),
@@ -67,7 +95,7 @@ describe('serializeFilters', () => {
 
 describe('deserializeFilters', () => {
   it('converts arrays back to Sets', () => {
-    const saved = {
+    const saved: StoredFilters = {
       categories: ['Work', 'PTO'],
       resources:  ['Alice'],
       sources:    ['src-a'],
@@ -87,10 +115,10 @@ describe('deserializeFilters', () => {
   });
 
   it('converts dateRange strings to Date objects', () => {
-    const saved = {
-      categories: [],
-      resources:  [],
-      sources:    [],
+    const saved: StoredFilters = {
+      categories: [] as string[],
+      resources:  [] as string[],
+      sources:    [] as string[],
       search:     '',
       dateRange:  {
         start: '2026-04-01T00:00:00.000Z',
@@ -133,7 +161,7 @@ describe('useSavedViews', () => {
 
   it('saveView adds a view with generated id and serialized filters', () => {
     const { result } = renderHook(() => useSavedViews(CAL_ID));
-    const filters = {
+    const filters: LiveFilters = {
       categories: new Set(['Work']),
       resources:  new Set(),
       sources:    new Set(),
@@ -156,7 +184,7 @@ describe('useSavedViews', () => {
 
   it('saveView returns the created view object', () => {
     const { result } = renderHook(() => useSavedViews(CAL_ID));
-    let created;
+    let created: ReturnType<ReturnType<typeof useSavedViews>['saveView']> | undefined;
     act(() => {
       created = result.current.saveView('Return Test', {
         categories: new Set(),
@@ -167,6 +195,7 @@ describe('useSavedViews', () => {
       });
     });
     expect(created).toBeDefined();
+    if (!created) throw new Error('Expected saveView to return the created view');
     expect(created.name).toBe('Return Test');
   });
 
@@ -208,7 +237,7 @@ describe('useSavedViews', () => {
         id:        'v1',
         name:      'Stored View',
         createdAt: new Date().toISOString(),
-        filters:   { categories: ['PTO'], resources: [], sources: [], search: '', dateRange: null },
+        filters:   { ...makeEmptyStoredFilters(), categories: ['PTO'] },
       },
     ];
     localStorage.setItem(`wc-saved-views-${CAL_ID}`, JSON.stringify({
@@ -226,7 +255,7 @@ describe('useSavedViews', () => {
         id: 'v-old',
         name: 'Old Shape',
         createdAt: new Date().toISOString(),
-        filters: { categories: [], resources: [], sources: [], search: '', dateRange: null },
+        filters: makeEmptyStoredFilters(),
       },
     ];
     localStorage.setItem(`wc-saved-views-${CAL_ID}`, JSON.stringify(existingViews));
@@ -236,12 +265,12 @@ describe('useSavedViews', () => {
   });
 
   it('calendarId switching reloads from correct localStorage key', () => {
-    const viewsA = [{ id: 'va', name: 'View A', createdAt: '', filters: { categories: [], resources: [], sources: [], search: '', dateRange: null } }];
-    const viewsB = [{ id: 'vb', name: 'View B', createdAt: '', filters: { categories: [], resources: [], sources: [], search: '', dateRange: null } }];
+    const viewsA = [{ id: 'va', name: 'View A', createdAt: '', filters: makeEmptyStoredFilters() }];
+    const viewsB = [{ id: 'vb', name: 'View B', createdAt: '', filters: makeEmptyStoredFilters() }];
     localStorage.setItem('wc-saved-views-cal-a', JSON.stringify(viewsA));
     localStorage.setItem('wc-saved-views-cal-b', JSON.stringify(viewsB));
 
-    const { result, rerender } = renderHook(({ id }) => useSavedViews(id), {
+    const { result, rerender } = renderHook(({ id }: { id: string }) => useSavedViews(id), {
       initialProps: { id: 'cal-a' },
     });
     expect(result.current.views[0].name).toBe('View A');
@@ -315,7 +344,7 @@ describe('useSavedViews', () => {
   it('migrates legacy wc-profiles-* data on first load', () => {
     const legacyProfiles = [{
       id: 'p1', name: 'Old Profile', color: '#3b82f6', view: 'week',
-      filters: { categories: ['Work'], resources: [], search: '' },
+      filters: { categories: ['Work'], resources: [] as string[], search: '' },
     }];
     localStorage.setItem('wc-profiles-test-cal', JSON.stringify(legacyProfiles));
     const { result } = renderHook(() => useSavedViews('test-cal'));
@@ -396,13 +425,7 @@ describe('deserializeFilters dateRange validation', () => {
   });
 });
 
-const EMPTY_FILTERS = {
-  categories: new Set(),
-  resources:  new Set(),
-  sources:    new Set(),
-  search:     '',
-  dateRange:  null,
-};
+const EMPTY_FILTERS: LiveFilters = makeEmptyLiveFilters();
 
 describe('useSavedViews — groupBy persistence', () => {
   it('saveView stores groupBy when provided', () => {
@@ -624,7 +647,7 @@ describe('useSavedViews — storage v2 → v4 migration', () => {
           name: 'From v2',
           createdAt: new Date().toISOString(),
           groupBy: 'role',
-          filters: { categories: [], resources: [], sources: [], search: '', dateRange: null },
+          filters: makeEmptyStoredFilters(),
         },
       ],
     };
@@ -643,7 +666,7 @@ describe('useSavedViews — storage v2 → v4 migration', () => {
           id: 'v-legacy',
           name: 'From v2',
           createdAt: new Date().toISOString(),
-          filters: { categories: [], resources: [], sources: [], search: '', dateRange: null },
+          filters: makeEmptyStoredFilters(),
         },
       ],
     };
@@ -661,7 +684,7 @@ describe('useSavedViews — storage v2 → v4 migration', () => {
         id: 'v-legacy',
         name: 'From v2',
         createdAt: new Date().toISOString(),
-        filters: { categories: [], resources: [], sources: [], search: '', dateRange: null },
+        filters: makeEmptyStoredFilters(),
       }],
     }));
     const { result } = renderHook(() => useSavedViews(CAL_ID));

--- a/src/hooks/__tests__/useSourceStore.test.ts
+++ b/src/hooks/__tests__/useSourceStore.test.ts
@@ -10,8 +10,8 @@ import { loadSources, persistSources, useSourceStore } from '../useSourceStore';
 
 const CAL_ID = 'test-calendar';
 
-function sourceKey(id) { return `wc-sources-${id}`; }
-function legacyKey(id) { return `wc-feeds-${id}`; }
+function sourceKey(id: string): string { return `wc-sources-${id}`; }
+function legacyKey(id: string): string { return `wc-feeds-${id}`; }
 
 beforeEach(() => {
   localStorage.clear();
@@ -68,7 +68,7 @@ describe('persistSources', () => {
 
 // ── useSourceStore hook ───────────────────────────────────────────────────────
 
-function renderStore(calendarId = CAL_ID) {
+function renderStore(calendarId: string = CAL_ID) {
   return renderHook(() => useSourceStore(calendarId));
 }
 
@@ -97,8 +97,9 @@ describe('useSourceStore — addSource', () => {
 
   it('returns the created source object', () => {
     const { result } = renderStore();
-    let created;
+    let created: ReturnType<ReturnType<typeof useSourceStore>['addSource']> | undefined;
     act(() => { created = result.current.addSource({ type: 'ics', label: 'X' }); });
+    if (!created) throw new Error('Expected addSource to return created source');
     expect(created.id).toBeDefined();
   });
 
@@ -113,19 +114,22 @@ describe('useSourceStore — addSource', () => {
 describe('useSourceStore — removeSource', () => {
   it('removes a source by id', () => {
     const { result } = renderStore();
-    let src;
+    let src: ReturnType<ReturnType<typeof useSourceStore>['addSource']> | undefined;
     act(() => { src = result.current.addSource({ type: 'ics', url: 'https://a.com/a.ics' }); });
+    if (!src) throw new Error('Expected source to exist');
     act(() => { result.current.removeSource(src.id); });
     expect(result.current.sources).toHaveLength(0);
   });
 
   it('leaves other sources intact', () => {
     const { result } = renderStore();
-    let s1, s2;
+    let s1: ReturnType<ReturnType<typeof useSourceStore>['addSource']> | undefined;
+    let s2: ReturnType<ReturnType<typeof useSourceStore>['addSource']> | undefined;
     act(() => {
       s1 = result.current.addSource({ type: 'ics', url: 'https://a.com/a.ics', label: 'A' });
       s2 = result.current.addSource({ type: 'ics', url: 'https://b.com/b.ics', label: 'B' });
     });
+    if (!s1 || !s2) throw new Error('Expected both sources to be created');
     act(() => { result.current.removeSource(s1.id); });
     expect(result.current.sources).toHaveLength(1);
     expect(result.current.sources[0].id).toBe(s2.id);
@@ -135,16 +139,18 @@ describe('useSourceStore — removeSource', () => {
 describe('useSourceStore — updateSource', () => {
   it('patches a source by id', () => {
     const { result } = renderStore();
-    let src;
+    let src: ReturnType<ReturnType<typeof useSourceStore>['addSource']> | undefined;
     act(() => { src = result.current.addSource({ type: 'ics', label: 'Old', url: 'https://a.com/a.ics' }); });
+    if (!src) throw new Error('Expected source to exist');
     act(() => { result.current.updateSource(src.id, { label: 'New' }); });
     expect(result.current.sources[0].label).toBe('New');
   });
 
   it('does not affect unrelated fields', () => {
     const { result } = renderStore();
-    let src;
+    let src: ReturnType<ReturnType<typeof useSourceStore>['addSource']> | undefined;
     act(() => { src = result.current.addSource({ type: 'ics', url: 'https://a.com/a.ics', color: '#ff0000' }); });
+    if (!src) throw new Error('Expected source to exist');
     act(() => { result.current.updateSource(src.id, { label: 'Updated' }); });
     expect(result.current.sources[0].color).toBe('#ff0000');
   });
@@ -153,8 +159,9 @@ describe('useSourceStore — updateSource', () => {
 describe('useSourceStore — toggleSource', () => {
   it('flips enabled flag', () => {
     const { result } = renderStore();
-    let src;
+    let src: ReturnType<ReturnType<typeof useSourceStore>['addSource']> | undefined;
     act(() => { src = result.current.addSource({ type: 'ics', url: 'https://a.com/a.ics', enabled: true }); });
+    if (!src) throw new Error('Expected source to exist');
     act(() => { result.current.toggleSource(src.id); });
     expect(result.current.sources[0].enabled).toBe(false);
     act(() => { result.current.toggleSource(src.id); });


### PR DESCRIPTION
### Motivation
- The Stage 6 readiness audit showed substantial implicit-any diagnostics in hook tests that must be fixed in narrow slices before re-running Stage 6. 
- This change targets the low-risk, high-density hook test helpers slice to remove non-ratcheted implicit-any debt and keep strict type checks green.

### Description
- Add explicit test-local types `LiveFilters` and `StoredFilters` plus `makeEmptyLiveFilters`/`makeEmptyStoredFilters` factories and use them throughout `src/hooks/__tests__/useSavedViews.test.ts` to eliminate object-literal and property implicit-any errors. 
- Annotate helper function parameters, `renderHook` props, and created-source locals in `src/hooks/__tests__/useSourceStore.test.ts` and add defensive existence checks to remove parameter/variable implicit-any and possibly-undefined access. 
- Register both cleaned test files in the `MIGRATED_PATHS` array in `scripts/typecheck-strict.mjs` so the ratcheted strict checker treats them as migrated for this Stage 5b PR. 
- Changes confined to test fixtures, locals, and the strict-check allowlist; no production runtime code was tightened.

### Testing
- Ran `npm run type-check:strict` which reported `Strict type check GREEN.` and included the two test files in the migrated paths. 
- Ran `npx tsc --noEmit -p tsconfig.json` which completed without errors. 
- Ran `npx vitest run src/hooks/__tests__/useSavedViews.test.ts src/hooks/__tests__/useSourceStore.test.ts` which passed both test files (2 files, 93 tests all passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e840ba0778832cb0406c95ed375b3a)