### PR TITLE
Stage 5b PR2: clean implicit-any debt in root integration tests

### DIFF
--- a/scripts/typecheck-strict.mjs
+++ b/scripts/typecheck-strict.mjs
@@ -80,6 +80,12 @@ const MIGRATED_PATHS = [
   // Stage 5b PR1
   'src/hooks/__tests__/useSavedViews.test.ts',
   'src/hooks/__tests__/useSourceStore.test.ts',
+  // Stage 5b PR2
+  'src/__tests__/WorksCalendar.scheduleModel.integration.test.tsx',
+  'src/__tests__/WorksCalendar.employees.sync.test.tsx',
+  'src/__tests__/WorksCalendar.sort.integration.test.tsx',
+  'src/__tests__/groupingFilteringSorting.integration.test.ts',
+  'src/__tests__/phaseB.integration.test.tsx',
 ];
 
 // Implicit-any diagnostic codes. See:

--- a/src/__tests__/WorksCalendar.employees.sync.test.tsx
+++ b/src/__tests__/WorksCalendar.employees.sync.test.tsx
@@ -13,6 +13,8 @@ import '@testing-library/jest-dom';
 
 import { WorksCalendar } from '../WorksCalendar.tsx';
 
+type TeamMemberLike = { name?: string };
+
 beforeEach(() => {
   if (!Element.prototype.scrollIntoView) {
     Element.prototype.scrollIntoView = vi.fn();
@@ -82,7 +84,7 @@ describe('WorksCalendar employees ↔ TeamTab bidirectional sync (issue #101)', 
 
     await waitFor(() => expect(onEmployeeAdd).toHaveBeenCalled());
     const lastConfig = onConfigSave.mock.calls.at(-1)[0];
-    const echoCount = (lastConfig.team?.members ?? []).filter(m => m.name === 'Echo').length;
+    const echoCount = (lastConfig.team?.members ?? []).filter((m: TeamMemberLike) => m.name === 'Echo').length;
     expect(echoCount).toBe(1);
   });
 });

--- a/src/__tests__/WorksCalendar.scheduleModel.integration.test.tsx
+++ b/src/__tests__/WorksCalendar.scheduleModel.integration.test.tsx
@@ -4,11 +4,27 @@ import React, { createRef } from 'react';
 
 import { WorksCalendar } from '../WorksCalendar.tsx';
 
-function getKinds(events) {
+type EventMetaLike = Record<string, unknown> & {
+  kind?: string;
+  sourceShiftId?: string;
+  coveredBy?: string | null;
+  status?: string;
+  shiftStatus?: string;
+  openShiftId?: string;
+  coveredEmployeeId?: string;
+};
+
+type ScheduleEventLike = {
+  id?: string;
+  kind?: string;
+  meta?: EventMetaLike;
+};
+
+function getKinds(events: ScheduleEventLike[]) {
   return events.map((ev) => String(ev?.meta?.kind ?? ev?.kind ?? '').toLowerCase());
 }
 
-function getByKind(events, kind) {
+function getByKind(events: ScheduleEventLike[], kind: string) {
   return events.filter((ev) => String(ev?.meta?.kind ?? ev?.kind ?? '').toLowerCase() === kind);
 }
 
@@ -37,7 +53,7 @@ describe('WorksCalendar schedule model integration', () => {
     fireEvent.click(await screen.findByRole('button', { name: 'Save PTO Request' }));
   }
 
-  async function assignCoverageTo(nameRegex) {
+  async function assignCoverageTo(nameRegex: RegExp) {
     fireEvent.click(await screen.findByRole('button', { name: 'Shift not covered — click to assign coverage' }));
     fireEvent.click(await screen.findByRole('button', { name: nameRegex }));
   }
@@ -80,7 +96,7 @@ describe('WorksCalendar schedule model integration', () => {
       expect(saved.resource).toBe('emp-1');
 
       const visible = apiRef.current.getVisibleEvents();
-      const ptoEvents = visible.filter((ev) => String(ev?.meta?.kind ?? '') === 'pto');
+      const ptoEvents = visible.filter((ev: ScheduleEventLike) => String(ev?.meta?.kind ?? '') === 'pto');
       expect(ptoEvents.length).toBeGreaterThan(0);
     });
   }, 30000);
@@ -97,7 +113,7 @@ describe('WorksCalendar schedule model integration', () => {
     await waitFor(() => {
       const visible = apiRef.current.getVisibleEvents();
       const openShifts = getByKind(visible, 'open-shift').filter(
-        (ev) => String(ev.meta?.sourceShiftId ?? '') === 'shift-1',
+        (ev: ScheduleEventLike) => String(ev.meta?.sourceShiftId ?? '') === 'shift-1',
       );
       expect(openShifts).toHaveLength(1);
     });
@@ -114,7 +130,7 @@ describe('WorksCalendar schedule model integration', () => {
 
     await waitFor(() => {
       const visible = apiRef.current.getVisibleEvents();
-      const shift = visible.find((ev) => String(ev.id) === 'shift-1');
+      const shift = visible.find((ev: ScheduleEventLike) => String(ev.id) === 'shift-1');
       expect(String(shift.meta?.coveredBy ?? '')).toBe('emp-2');
 
       const openShift = getByKind(visible, 'open-shift')[0];
@@ -147,7 +163,7 @@ describe('WorksCalendar schedule model integration', () => {
       expect(kinds).not.toContain('covering');
       expect(kinds).not.toContain('covering-shift');
 
-      const shift = visible.find((ev) => String(ev.id) === 'shift-1');
+      const shift = visible.find((ev: ScheduleEventLike) => String(ev.id) === 'shift-1');
       expect(shift.meta?.shiftStatus).toBeUndefined();
       expect(shift.meta?.coveredBy).toBeUndefined();
       expect(shift.meta?.openShiftId).toBeUndefined();
@@ -206,13 +222,13 @@ describe('WorksCalendar schedule model integration', () => {
 
     await waitFor(() => {
       const visible = apiRef.current.getVisibleEvents();
-      const coveringEvents = visible.filter((ev) => {
+      const coveringEvents = visible.filter((ev: ScheduleEventLike) => {
         const kind = String(ev?.meta?.kind ?? '').toLowerCase();
         return kind === 'covering' || kind === 'covering-shift';
       });
       expect(coveringEvents).toHaveLength(1);
 
-      const shift = visible.find((ev) => String(ev.id) === 'shift-1');
+      const shift = visible.find((ev: ScheduleEventLike) => String(ev.id) === 'shift-1');
       expect(String(shift.meta?.coveredBy ?? '')).toBe('emp-3');
     });
   }, 30000);
@@ -230,7 +246,7 @@ describe('WorksCalendar schedule model integration', () => {
 
     await waitFor(() => {
       const visible = apiRef.current.getVisibleEvents();
-      const shift = visible.find((ev) => String(ev.id) === 'shift-1');
+      const shift = visible.find((ev: ScheduleEventLike) => String(ev.id) === 'shift-1');
       expect(shift.meta?.coveredBy).toBeNull();
 
       const openShift = getByKind(visible, 'open-shift')[0];

--- a/src/__tests__/WorksCalendar.sort.integration.test.tsx
+++ b/src/__tests__/WorksCalendar.sort.integration.test.tsx
@@ -11,7 +11,7 @@ import { createRef } from 'react';
 import { WorksCalendar } from '../WorksCalendar.tsx';
 
 const base = new Date('2026-04-10T00:00:00.000Z');
-function d(days) { return new Date(base.getTime() + days * 86400000); }
+function d(days: number) { return new Date(base.getTime() + days * 86400000); }
 
 const events = [
   { id: 'a', title: 'Charlie', start: d(2), end: d(3), meta: { priority: 1 } },
@@ -30,7 +30,7 @@ describe('WorksCalendar sort prop', () => {
         sort={{ field: 'title', direction: 'asc' }}
       />,
     );
-    const titles = apiRef.current.getVisibleEvents().map(e => e.title);
+    const titles = apiRef.current.getVisibleEvents().map((e: { title: string }) => e.title);
     expect(titles).toEqual(['Alpha', 'Alpha', 'Bravo', 'Charlie']);
   });
 
@@ -46,7 +46,7 @@ describe('WorksCalendar sort prop', () => {
         ]}
       />,
     );
-    const ids = apiRef.current.getVisibleEvents().map(e => e.id);
+    const ids = apiRef.current.getVisibleEvents().map((e: { id: string }) => e.id);
     // Alphas are tied by title → the later start date wins ('d' before 'b').
     expect(ids).toEqual(['d', 'b', 'c', 'a']);
   });
@@ -54,7 +54,7 @@ describe('WorksCalendar sort prop', () => {
   it('defaults to start-date order when sort is omitted (baseline preserved)', () => {
     const apiRef = createRef<any>();
     render(<WorksCalendar ref={apiRef} events={events} />);
-    const ids = apiRef.current.getVisibleEvents().map(e => e.id);
+    const ids = apiRef.current.getVisibleEvents().map((e: { id: string }) => e.id);
     // Pipeline default: events surface in chronological start order.
     expect(ids).toEqual(['b', 'c', 'a', 'd']);
   });

--- a/src/__tests__/groupingFilteringSorting.integration.test.ts
+++ b/src/__tests__/groupingFilteringSorting.integration.test.ts
@@ -23,7 +23,7 @@ import { DEFAULT_FILTER_SCHEMA } from '../filters/filterSchema.ts';
 import { sortEvents } from '../core/sortEngine.ts';
 import { buildGroupTree } from '../hooks/useGrouping.ts';
 
-const baseDay = (day) => new Date(2026, 3, day);
+const baseDay = (day: number) => new Date(2026, 3, day);
 
 const events = [
   { id: 'e1', title: 'Charlie Flight', start: baseDay(2), end: baseDay(2),  category: 'training',    resource: 'N100', meta: { region: 'West', priority: 1 } },

--- a/src/__tests__/phaseB.integration.test.tsx
+++ b/src/__tests__/phaseB.integration.test.tsx
@@ -27,6 +27,30 @@ import ApprovalActionMenu, { allowedActionsFor } from '../ui/ApprovalActionMenu'
 import { evaluateConflicts } from '../core/conflictEngine.ts';
 import { DEFAULT_CONFIG } from '../core/configSchema';
 
+type RequestValues = {
+  title: string;
+  start: string;
+  end: string;
+  resource: string;
+  category?: string;
+};
+
+type EventLike = {
+  id: string;
+  title: string;
+  start: Date;
+  end: Date;
+  resource: string;
+  category?: string;
+  meta?: {
+    approvalStage?: {
+      stage: string;
+      updatedAt: string;
+      history: unknown[];
+    };
+  };
+};
+
 // ─── Test fixtures ────────────────────────────────────────────────────────────
 
 /** Cross-cutting config the three systems all read. */
@@ -78,13 +102,13 @@ const seededEvent = {
  * Small orchestrator that wires the three systems the way a host app would.
  * Not production code — exists only for the test pipeline.
  */
-function Pipeline({ config, initialEvents = [seededEvent], onCommit }: any) {
-  const [events, setEvents]     = useState(initialEvents);
-  const [proposed, setProposed] = useState(null);
-  const [conflict, setConflict] = useState(null);
-  const [committed, setCommitted] = useState(null);
+function Pipeline({ config, initialEvents = [seededEvent], onCommit }: { config: Record<string, any>; initialEvents?: EventLike[]; onCommit?: (evt: EventLike) => void }) {
+  const [events, setEvents]     = useState<EventLike[]>(initialEvents);
+  const [proposed, setProposed] = useState<EventLike | null>(null);
+  const [conflict, setConflict] = useState<{ allowed?: boolean; severity?: string } | null>(null);
+  const [committed, setCommitted] = useState<EventLike | null>(null);
 
-  const handleSubmit = ({ values }) => {
+  const handleSubmit = ({ values }: { values: RequestValues }) => {
     const evt = {
       id: `new-${events.length + 1}`,
       title: values.title,
@@ -107,12 +131,12 @@ function Pipeline({ config, initialEvents = [seededEvent], onCommit }: any) {
     }
   };
 
-  const persist = (evt) => {
+  const persist = (evt: EventLike) => {
     const withStage = {
       ...evt,
-      meta: { approvalStage: { stage: 'requested', updatedAt: '', history: [] } },
+      meta: { approvalStage: { stage: 'requested', updatedAt: '', history: [] as unknown[] } },
     };
-    setEvents(prev => [...prev, withStage]);
+    setEvents((prev: EventLike[]) => [...prev, withStage]);
     setCommitted(withStage);
     onCommit?.(withStage);
   };
@@ -145,7 +169,7 @@ function Pipeline({ config, initialEvents = [seededEvent], onCommit }: any) {
   );
 }
 
-function fillRequestForm({ title, start, end, resource, category }: any) {
+function fillRequestForm({ title, start, end, resource, category }: RequestValues) {
   fireEvent.change(screen.getByLabelText('Title'),    { target: { value: title } });
   fireEvent.change(screen.getByLabelText('Starts'),   { target: { value: start } });
   fireEvent.change(screen.getByLabelText('Ends'),     { target: { value: end } });
@@ -277,7 +301,7 @@ describe('Phase B pipeline — committed event exposes approval actions', () => 
         ...fullConfig.approvals,
         rules: {
           ...fullConfig.approvals.rules,
-          requested: { allow: [], prefix: 'Req' },
+          requested: { allow: [] as string[], prefix: 'Req' },
         },
       },
     };


### PR DESCRIPTION
### Motivation
- Reduce non-ratcheted implicit-any diagnostics reported by the Stage 6 audit by cleaning the root-level integration/test-harness files. 
- Make the root integration test slice reviewable and enforceable under the strict ratchet so subsequent stages can proceed safely. 

### Description
- Added narrow helper/event shape types and parameter annotations in `src/__tests__/WorksCalendar.scheduleModel.integration.test.tsx` to remove implicit-any parameters and filter callbacks. 
- Added lightweight types for test fixtures and local callback usage in `src/__tests__/WorksCalendar.employees.sync.test.tsx`, `src/__tests__/WorksCalendar.sort.integration.test.tsx`, and `src/__tests__/groupingFilteringSorting.integration.test.ts` (typed `d`/`baseDay` helpers and visible-event mappers). 
- Introduced explicit request/event harness types, typed component state and updater signatures, and annotated empty-array literals in `src/__tests__/phaseB.integration.test.tsx` to resolve object-literal/array `any` inference. 
- Added the cleaned test files to the strict enforcement allowlist in `scripts/typecheck-strict.mjs` so the ratchet will track these paths going forward. 

### Testing
- Ran `npm run type-check:strict` and it reported `Strict type check GREEN.` for the updated `MIGRATED_PATHS`. 
- Ran `npx tsc --noEmit -p tsconfig.json` and the compilation passed. 
- Ran the targeted integration test suite with `npx vitest run` for the modified files and all test files passed (`Test Files 5 passed`, `Tests 41 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e84ee23514832cb767ae84a5c6cf4b)