### PR TITLE
Stage 5b PR3: strict typing cleanup for small UI forms/dialogs

### DIFF
--- a/scripts/typecheck-strict.mjs
+++ b/scripts/typecheck-strict.mjs
@@ -86,6 +86,10 @@ const MIGRATED_PATHS = [
   'src/__tests__/WorksCalendar.sort.integration.test.tsx',
   'src/__tests__/groupingFilteringSorting.integration.test.ts',
   'src/__tests__/phaseB.integration.test.tsx',
+  // Stage 5b PR3
+  'src/ui/ScheduleEditorForm.tsx',
+  'src/ui/CalendarExternalForm.tsx',
+  'src/ui/RequestForm.tsx',
 ];
 
 // Implicit-any diagnostic codes. See:

--- a/src/ui/CalendarExternalForm.tsx
+++ b/src/ui/CalendarExternalForm.tsx
@@ -1,9 +1,36 @@
-import { useMemo, useState } from 'react';
+import { useMemo, useState, type FormEvent } from 'react';
 import styles from './CalendarExternalForm.module.css';
 
 const SUPPORTED_FIELD_TYPES = new Set(['text', 'textarea', 'datetime-local', 'date', 'checkbox', 'select']);
 
-const DEFAULT_FIELDS = [
+type ExternalFormFieldType = 'text' | 'textarea' | 'datetime-local' | 'date' | 'checkbox' | 'select';
+
+type ExternalFormOption = {
+  value: string;
+  label: string;
+};
+
+type ExternalFormField = {
+  name: string;
+  label?: string;
+  type?: ExternalFormFieldType;
+  required?: boolean;
+  placeholder?: string;
+  options?: ExternalFormOption[];
+};
+
+type ExternalFormValues = Record<string, string | boolean | null | undefined>;
+
+type ExternalFormSubmitContext = {
+  values: ExternalFormValues;
+  fields: ExternalFormField[];
+};
+
+type ExternalFormAdapter = {
+  submitEvent: (payload: unknown, context: ExternalFormSubmitContext) => Promise<unknown> | unknown;
+};
+
+const DEFAULT_FIELDS: ExternalFormField[] = [
   { name: 'title', label: 'Title', type: 'text', required: true },
   { name: 'start', label: 'Start', type: 'datetime-local', required: true },
   { name: 'end', label: 'End', type: 'datetime-local', required: true },
@@ -13,7 +40,7 @@ const DEFAULT_FIELDS = [
   { name: 'description', label: 'Description', type: 'textarea', required: false },
 ];
 
-function normalizeFields(fields) {
+function normalizeFields(fields: ExternalFormField[]): ExternalFormField[] {
   if (!Array.isArray(fields) || fields.length === 0) {
     throw new Error('CalendarExternalForm requires at least one field.');
   }
@@ -29,7 +56,7 @@ function normalizeFields(fields) {
     }
     names.add(field.name);
 
-    const type = field.type || 'text';
+    const type = field.type ?? 'text';
     if (!SUPPORTED_FIELD_TYPES.has(type)) {
       throw new Error(`Unsupported field type: ${type}`);
     }
@@ -44,14 +71,14 @@ function normalizeFields(fields) {
   });
 }
 
-function ensureAdapter(adapter) {
-  if (!adapter || typeof adapter.submitEvent !== 'function') {
+function ensureAdapter(adapter: unknown): ExternalFormAdapter {
+  if (!adapter || typeof (adapter as { submitEvent?: unknown }).submitEvent !== 'function') {
     throw new Error('CalendarExternalForm adapter must define submitEvent(payload, context).');
   }
-  return adapter;
+  return adapter as ExternalFormAdapter;
 }
 
-function defaultValidate(values, fields) {
+function defaultValidate(values: ExternalFormValues, fields: ExternalFormField[]): Record<string, string> {
   const errors: Record<string, string> = {};
   fields.forEach((field) => {
     if (!field.required) return;
@@ -62,7 +89,8 @@ function defaultValidate(values, fields) {
     }
   });
 
-  if (values.start && values.end && new Date(values.start) > new Date(values.end)) {
+  if (typeof values.start === 'string' && typeof values.end === 'string' && values.start && values.end
+      && new Date(values.start) > new Date(values.end)) {
     errors.end = 'End must be after start.';
   }
 
@@ -84,14 +112,23 @@ export default function CalendarExternalForm({
   submitLabel = 'Submit event',
   onSuccess,
   onError,
-}: any) {
+}: {
+  adapter: unknown;
+  fields?: ExternalFormField[];
+  initialValues?: ExternalFormValues;
+  validate?: (values: ExternalFormValues, fields: ExternalFormField[]) => Record<string, string>;
+  transform?: (values: ExternalFormValues) => unknown;
+  submitLabel?: string;
+  onSuccess?: (result: unknown, values: ExternalFormValues) => void;
+  onError?: (error: unknown, values: ExternalFormValues) => void;
+}) {
   // Validate eagerly in the component body (before hooks) so errors throw
   // synchronously from render() and are catchable by tests / error boundaries.
   const safeAdapter = ensureAdapter(adapter);
   const normalizedFields = normalizeFields(fields);
 
   const mergedInitialValues = useMemo(() => {
-    const fromFields = normalizeFields(fields).reduce((acc, field) => {
+    const fromFields = normalizeFields(fields).reduce<ExternalFormValues>((acc, field) => {
       acc[field.name] = field.type === 'checkbox' ? false : '';
       return acc;
     }, {});
@@ -99,17 +136,20 @@ export default function CalendarExternalForm({
   }, [fields, initialValues]);
 
   const [values, setValues] = useState(mergedInitialValues);
-  const [errors, setErrors] = useState({});
+  const [errors, setErrors] = useState<Record<string, string>>({});
   const [submitError, setSubmitError] = useState('');
   const [isSubmitting, setIsSubmitting] = useState(false);
 
-  function setValue(name, value) {
+  const toInputValue = (value: string | boolean | null | undefined): string =>
+    typeof value === 'string' ? value : '';
+
+  function setValue(name: string, value: string | boolean) {
     setValues((prev) => ({ ...prev, [name]: value }));
     setErrors((prev) => ({ ...prev, [name]: undefined }));
     setSubmitError('');
   }
 
-  async function handleSubmit(event) {
+  async function handleSubmit(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
     const validationErrors = validate(values, normalizedFields);
     setErrors(validationErrors);
@@ -145,7 +185,7 @@ export default function CalendarExternalForm({
                 <textarea
                   id={inputId}
                   className={styles.textarea}
-                  value={value}
+                  value={toInputValue(value)}
                   placeholder={field.placeholder}
                   onChange={(e) => setValue(field.name, e.target.value)}
                   rows={3}
@@ -155,7 +195,7 @@ export default function CalendarExternalForm({
                 <select
                   id={inputId}
                   className={styles.select}
-                  value={value}
+                  value={toInputValue(value)}
                   onChange={(e) => setValue(field.name, e.target.value)}
                 >
                   <option value="">Select…</option>
@@ -177,7 +217,7 @@ export default function CalendarExternalForm({
                   id={inputId}
                   className={styles.input}
                   type={field.type || 'text'}
-                  value={value}
+                  value={toInputValue(value)}
                   placeholder={field.placeholder}
                   onChange={(e) => setValue(field.name, e.target.value)}
                 />

--- a/src/ui/RequestForm.tsx
+++ b/src/ui/RequestForm.tsx
@@ -18,13 +18,39 @@
  *   select     dropdown, options parsed from comma-separated string
  *   checkbox   boolean toggle
  */
-import { useMemo, useState } from 'react';
+import { useMemo, useState, type FormEvent } from 'react';
 import { useFocusTrap } from '../hooks/useFocusTrap';
 import styles from './RequestForm.module.css';
 
 const INPUT_TYPES = new Set(['text', 'textarea', 'number', 'date', 'datetime', 'select', 'checkbox']);
 
-function normalizeField(field, idx) {
+type RequestFormFieldType = 'text' | 'textarea' | 'number' | 'date' | 'datetime' | 'select' | 'checkbox';
+
+type RequestFormFieldDraft = {
+  key?: string;
+  label?: string;
+  type?: RequestFormFieldType;
+  required?: boolean;
+  placeholder?: string;
+  options?: string;
+};
+
+type RequestFormField = {
+  key: string;
+  label: string;
+  type: RequestFormFieldType;
+  required: boolean;
+  placeholder: string;
+  options: string;
+};
+
+type RequestSchema = {
+  fields?: RequestFormFieldDraft[];
+} | null | undefined;
+
+type RequestFormValues = Record<string, string | boolean>;
+
+function normalizeField(field: RequestFormFieldDraft, idx: number): RequestFormField {
   const key = typeof field?.key === 'string' && field.key.trim()
     ? field.key.trim()
     : `field-${idx + 1}`;
@@ -39,7 +65,7 @@ function normalizeField(field, idx) {
   };
 }
 
-function defaultForField(field) {
+function defaultForField(field: RequestFormField): string | boolean {
   switch (field.type) {
     case 'checkbox': return false;
     case 'number':   return '';
@@ -47,7 +73,7 @@ function defaultForField(field) {
   }
 }
 
-function parseOptions(raw) {
+function parseOptions(raw: string): string[] {
   return String(raw ?? '')
     .split(',')
     .map(s => s.trim())
@@ -68,7 +94,13 @@ export default function RequestForm({
   onSubmit,
   onCancel,
   title = 'New request',
-}: any) {
+}: {
+  schema: RequestSchema;
+  initialValues?: RequestFormValues;
+  onSubmit: (payload: { values: any }) => void;
+  onCancel: () => void;
+  title?: string;
+}) {
   const trapRef = useFocusTrap(onCancel);
 
   const fields = useMemo(() => {
@@ -76,19 +108,21 @@ export default function RequestForm({
     return raw.map(normalizeField);
   }, [schema]);
 
-  const [values, setValues] = useState(() => {
-    const seed = {};
+  const [values, setValues] = useState<RequestFormValues>(() => {
+    const seed: RequestFormValues = {};
     for (const f of fields) {
       seed[f.key] = initialValues[f.key] ?? defaultForField(f);
     }
     return seed;
   });
-  const [errors, setErrors] = useState({});
+  const [errors, setErrors] = useState<Record<string, string>>({});
+  const toInputValue = (value: string | boolean | undefined): string =>
+    typeof value === 'string' ? value : '';
 
-  const setValue = (key, next) => setValues(prev => ({ ...prev, [key]: next }));
+  const setValue = (key: string, next: string | boolean) => setValues(prev => ({ ...prev, [key]: next }));
 
   const validate = () => {
-    const next = {};
+    const next: Record<string, string> = {};
     for (const f of fields) {
       if (!f.required) continue;
       const v = values[f.key];
@@ -102,7 +136,7 @@ export default function RequestForm({
     return Object.keys(next).length === 0;
   };
 
-  const handleSubmit = (e) => {
+  const handleSubmit = (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     if (!validate()) return;
     onSubmit?.({ values });
@@ -144,7 +178,7 @@ export default function RequestForm({
                   <span>{field.label}{field.required ? ' *' : ''}</span>
                   <textarea
                     className={styles.textarea}
-                    value={values[field.key] ?? ''}
+                    value={toInputValue(values[field.key])}
                     onChange={e => setValue(field.key, e.target.value)}
                     placeholder={field.placeholder}
                     aria-label={field.label}
@@ -163,7 +197,7 @@ export default function RequestForm({
                   <span>{field.label}{field.required ? ' *' : ''}</span>
                   <select
                     className={styles.select}
-                    value={values[field.key] ?? ''}
+                    value={toInputValue(values[field.key])}
                     onChange={e => setValue(field.key, e.target.value)}
                     aria-label={field.label}
                     aria-invalid={ariaInvalid}
@@ -204,7 +238,7 @@ export default function RequestForm({
                 <input
                   type={htmlType}
                   className={styles.input}
-                  value={values[field.key] ?? ''}
+                  value={toInputValue(values[field.key])}
                   onChange={e => setValue(field.key, e.target.value)}
                   placeholder={field.placeholder}
                   aria-label={field.label}

--- a/src/ui/ScheduleEditorForm.tsx
+++ b/src/ui/ScheduleEditorForm.tsx
@@ -1,13 +1,23 @@
-import { useState } from 'react';
+import { useState, type FormEvent } from 'react';
 import { format, parseISO, isValid, addDays, addHours } from 'date-fns';
 import { X } from 'lucide-react';
 import { useFocusTrap } from '../hooks/useFocusTrap';
 import { createId } from '../core/createId';
 import styles from './ScheduleEditorForm.module.css';
+import type { WorksCalendarEvent } from '../types/events';
 
 // ─── Shift templates ──────────────────────────────────────────────────────────
 
-const SHIFT_TEMPLATES = [
+type ShiftTemplate = {
+  id: string;
+  label: string;
+  description: string;
+  rrule: string;
+  durationHours: number;
+  note?: string;
+};
+
+const SHIFT_TEMPLATES: ShiftTemplate[] = [
   {
     id:    'mon-thu',
     label: 'Mon–Thu (4×10)',
@@ -39,7 +49,9 @@ const SHIFT_TEMPLATES = [
   },
 ];
 
-const RRULE_PRESETS = [
+type RrulePresetId = 'daily' | 'weekdays' | 'weekly' | 'biweekly' | 'custom';
+
+const RRULE_PRESETS: Array<{ id: RrulePresetId; label: string; rrule: string | null }> = [
   { id: 'daily',    label: 'Daily',              rrule: 'FREQ=DAILY' },
   { id: 'weekdays', label: 'Weekdays (Mon–Fri)',  rrule: 'FREQ=WEEKLY;BYDAY=MO,TU,WE,TH,FR' },
   { id: 'weekly',   label: 'Weekly',              rrule: null }, // computed from start day
@@ -49,9 +61,9 @@ const RRULE_PRESETS = [
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
-const WEEKDAY_CODES = ['SU', 'MO', 'TU', 'WE', 'TH', 'FR', 'SA'];
+const WEEKDAY_CODES = ['SU', 'MO', 'TU', 'WE', 'TH', 'FR', 'SA'] as const;
 
-function toInput(date, allDay) {
+function toInput(date: Date | string | null | undefined, allDay: boolean): string {
   if (!date) return '';
   try {
     const d = date instanceof Date ? date : parseISO(date);
@@ -61,13 +73,13 @@ function toInput(date, allDay) {
   }
 }
 
-function fromInput(str, allDay) {
+function fromInput(str: string, allDay: boolean): Date | null {
   if (!str) return null;
   const d = new Date(str + (allDay && str.length === 10 ? 'T00:00:00' : ''));
   return isValid(d) ? d : null;
 }
 
-function buildRrule(preset, startStr) {
+function buildRrule(preset: RrulePresetId, startStr: string): string | null {
   const start = fromInput(startStr, false);
   if (preset === 'daily')    return 'FREQ=DAILY';
   if (preset === 'weekdays') return 'FREQ=WEEKLY;BYDAY=MO,TU,WE,TH,FR';
@@ -98,11 +110,18 @@ export default function ScheduleEditorForm({
   onCallCategory = 'on-call',
   onSave,
   onClose,
-}: any) {
+}: {
+  emp: { id: string; name: string; role?: string };
+  initialStart?: Date | null;
+  initialEnd?: Date | null;
+  onCallCategory?: string;
+  onSave: (eventOrEvents: WorksCalendarEvent | WorksCalendarEvent[]) => void;
+  onClose: () => void;
+}) {
   const trapRef = useFocusTrap(onClose);
 
   // Mode: 'onetime' | 'recurring' | 'template'
-  const [mode, setMode] = useState('onetime');
+  const [mode, setMode] = useState<'onetime' | 'recurring' | 'template'>('onetime');
 
   const defaultStart = initialStart ?? new Date();
   const defaultEnd   = initialEnd ?? addHours(defaultStart, 8);
@@ -110,14 +129,14 @@ export default function ScheduleEditorForm({
   const [start,       setStart]       = useState(toInput(defaultStart, false));
   const [end,         setEnd]         = useState(toInput(defaultEnd,   false));
   const [title,       setTitle]       = useState('On-Call Shift');
-  const [rrulePreset, setRrulePreset] = useState('weekdays');
+  const [rrulePreset, setRrulePreset] = useState<RrulePresetId>('weekdays');
   const [customRrule, setCustomRrule] = useState('');
   const [templateId,  setTemplateId]  = useState(SHIFT_TEMPLATES[0].id);
   const [errors,      setErrors]      = useState<Record<string, string>>({});
 
   const selectedTemplate = SHIFT_TEMPLATES.find(t => t.id === templateId) ?? SHIFT_TEMPLATES[0];
 
-  function validateDateRange(startStr, endStr) {
+  function validateDateRange(startStr: string, endStr: string): { isValid: boolean; message: string } {
     const s = fromInput(startStr, false);
     const e = fromInput(endStr, false);
     if (!s || !e) return { isValid: false, message: 'Enter valid start and end date/times' };
@@ -151,7 +170,7 @@ export default function ScheduleEditorForm({
     return Object.keys(errs).length === 0;
   }
 
-  function buildEvent(startDate, endDate, rrule) {
+  function buildEvent(startDate: Date, endDate: Date, rrule: string | null): WorksCalendarEvent {
     return {
       id:       createId('shift'),
       title:    title.trim(),
@@ -164,13 +183,14 @@ export default function ScheduleEditorForm({
     };
   }
 
-  function handleSubmit(e) {
+  function handleSubmit(e: FormEvent<HTMLFormElement>) {
     e.preventDefault();
     if (!validate()) return;
 
     if (mode === 'onetime') {
       const s  = fromInput(start, false);
       const en = fromInput(end,   false);
+      if (!s || !en) return;
       onSave(buildEvent(s, en, null));
       return;
     }
@@ -181,6 +201,7 @@ export default function ScheduleEditorForm({
       const rrule = rrulePreset === 'custom'
         ? customRrule.trim().toUpperCase()
         : buildRrule(rrulePreset, start);
+      if (!s || !en) return;
       onSave(buildEvent(s, en, rrule));
       return;
     }
@@ -227,7 +248,7 @@ export default function ScheduleEditorForm({
         <form className={styles.form} onSubmit={handleSubmit} noValidate>
           {/* Mode tabs */}
           <div className={styles.modeTabs} role="group" aria-label="Shift type">
-            {(['onetime', 'recurring', 'template']).map(m => (
+            {(['onetime', 'recurring', 'template'] as const).map(m => (
               <button
                 key={m}
                 type="button"
@@ -296,7 +317,7 @@ export default function ScheduleEditorForm({
                 id="sef-rrule"
                 className={styles.select}
                 value={rrulePreset}
-                onChange={e => { setRrulePreset(e.target.value); setErrors(v => ({ ...v, rrule: undefined })); }}
+                onChange={e => { setRrulePreset(e.target.value as RrulePresetId); setErrors(v => ({ ...v, rrule: undefined })); }}
               >
                 {RRULE_PRESETS.map(p => (
                   <option key={p.id} value={p.id}>{p.label}</option>


### PR DESCRIPTION
### Motivation

- Reduce non-ratcheted implicit-any debt in a narrow UI slice (small forms/dialogs) per the Stage 5b cleanup plan.  
- Keep the strict ratchet (`type-check:strict`) green while preparing these files to be added to `MIGRATED_PATHS` for Stage 5b re-entry criteria.  

### Description

- Add explicit TypeScript types and annotations to `src/ui/ScheduleEditorForm.tsx`, `src/ui/CalendarExternalForm.tsx`, and `src/ui/RequestForm.tsx` (props, helper signatures, handler event types, local shape aliases).  
- Add safe input coercion helpers (`toInputValue`) and narrow unions so JSX `value` props accept the typed form-state values without runtime changes.  
- Add the three cleaned files to the strict-ratchet allowlist (`MIGRATED_PATHS`) in `scripts/typecheck-strict.mjs` under a new `Stage 5b PR3` section.  
- Preserve intended boundary looseness on external callback payloads where needed to avoid wide cascade changes.  

### Testing

- Ran the strict ratchet: `npm run type-check:strict` — passed.  
- Verified root check: `npx tsc --noEmit -p tsconfig.json` — passed.  
- Ran relevant unit tests: `npx vitest run src/ui/__tests__/CalendarExternalForm.test.tsx src/ui/__tests__/RequestForm.test.tsx src/__tests__/WorksCalendar.scheduleWorkflow.test.tsx` — all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e852bb49d0832ca03b03c1cb360541)