### PR TITLE
Fix seeded value rendering and date-order validation regressions

### DIFF
--- a/src/ui/CalendarExternalForm.tsx
+++ b/src/ui/CalendarExternalForm.tsx
@@ -19,7 +19,7 @@ type ExternalFormField = {
   options?: ExternalFormOption[];
 };
 
-type ExternalFormValues = Record<string, string | boolean | null | undefined>;
+type ExternalFormValues = Record<string, string | number | boolean | Date | null | undefined>;
 
 type ExternalFormSubmitContext = {
   values: ExternalFormValues;
@@ -89,8 +89,19 @@ function defaultValidate(values: ExternalFormValues, fields: ExternalFormField[]
     }
   });
 
-  if (typeof values.start === 'string' && typeof values.end === 'string' && values.start && values.end
-      && new Date(values.start) > new Date(values.end)) {
+  const toDate = (value: ExternalFormValues[string]): Date | null => {
+    if (value instanceof Date) return Number.isNaN(value.getTime()) ? null : value;
+    if (typeof value === 'string' || typeof value === 'number') {
+      if (value === '') return null;
+      const parsed = new Date(value);
+      return Number.isNaN(parsed.getTime()) ? null : parsed;
+    }
+    return null;
+  };
+
+  const start = toDate(values.start);
+  const end = toDate(values.end);
+  if (start && end && start > end) {
     errors.end = 'End must be after start.';
   }
 
@@ -140,8 +151,10 @@ export default function CalendarExternalForm({
   const [submitError, setSubmitError] = useState('');
   const [isSubmitting, setIsSubmitting] = useState(false);
 
-  const toInputValue = (value: string | boolean | null | undefined): string =>
-    typeof value === 'string' ? value : '';
+  const toInputValue = (value: string | number | boolean | Date | null | undefined): string => {
+    if (typeof value === 'boolean' || value == null) return '';
+    return String(value);
+  };
 
   function setValue(name: string, value: string | boolean) {
     setValues((prev) => ({ ...prev, [name]: value }));

--- a/src/ui/RequestForm.tsx
+++ b/src/ui/RequestForm.tsx
@@ -48,7 +48,7 @@ type RequestSchema = {
   fields?: RequestFormFieldDraft[];
 } | null | undefined;
 
-type RequestFormValues = Record<string, string | boolean>;
+type RequestFormValues = Record<string, string | number | boolean | Date>;
 
 function normalizeField(field: RequestFormFieldDraft, idx: number): RequestFormField {
   const key = typeof field?.key === 'string' && field.key.trim()
@@ -116,8 +116,10 @@ export default function RequestForm({
     return seed;
   });
   const [errors, setErrors] = useState<Record<string, string>>({});
-  const toInputValue = (value: string | boolean | undefined): string =>
-    typeof value === 'string' ? value : '';
+  const toInputValue = (value: string | number | boolean | Date | undefined): string => {
+    if (typeof value === 'boolean' || value == null) return '';
+    return String(value);
+  };
 
   const setValue = (key: string, next: string | boolean) => setValues(prev => ({ ...prev, [key]: next }));
 

--- a/src/ui/__tests__/CalendarExternalForm.test.tsx
+++ b/src/ui/__tests__/CalendarExternalForm.test.tsx
@@ -34,6 +34,25 @@ describe('CalendarExternalForm', () => {
     expect(submitEvent).not.toHaveBeenCalled();
   });
 
+  it('validates date ordering when prefilled with Date instances', async () => {
+    const submitEvent = vi.fn();
+    render(
+      <CalendarExternalForm
+        adapter={{ submitEvent }}
+        initialValues={{
+          title: 'Seeded event',
+          start: new Date('2026-04-13T10:00:00.000Z'),
+          end: new Date('2026-04-13T09:00:00.000Z'),
+        }}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Submit event' }));
+
+    expect(await screen.findByText('End must be after start.')).toBeInTheDocument();
+    expect(submitEvent).not.toHaveBeenCalled();
+  });
+
   it('surfaces adapter/network failures', async () => {
     const submitEvent = vi.fn(async () => {
       throw new Error('network failed');

--- a/src/ui/__tests__/RequestForm.test.tsx
+++ b/src/ui/__tests__/RequestForm.test.tsx
@@ -92,6 +92,16 @@ describe('RequestForm — rendering', () => {
     expect(screen.getByLabelText('Title')).toHaveValue('Hello');
     expect(screen.getByLabelText('Notes')).toHaveValue('World');
   });
+
+  it('preserves non-string seeded values for text-like inputs', () => {
+    renderForm({
+      schema: {
+        fields: [{ key: 'count', label: 'Count', type: 'number' }],
+      },
+      initialValues: { count: 42 },
+    });
+    expect(screen.getByLabelText('Count')).toHaveValue(42);
+  });
 });
 
 describe('RequestForm — validation + submit', () => {


### PR DESCRIPTION
### Motivation
- Prefilled numeric and Date values were being dropped from inputs so seeded numbers rendered blank and seeded `Date` objects bypassed the start/end ordering check.
- The change restores predictable behavior for consumers that supply non-string `initialValues` (numbers, timestamps, or `Date` instances) so the UI reflects seeds and validation remains enforced.

### Description
- Widened value types to include `number` and `Date` in `RequestForm` (`RequestFormValues`) and `CalendarExternalForm` (`ExternalFormValues`).
- Updated `toInputValue` in both forms to coerce non-boolean, non-null values to `String(value)` instead of blanking them for controlled inputs. 
- Restored robust date-order validation in `CalendarExternalForm` by adding a `toDate` helper that safely normalizes `string`, `number`, and `Date` inputs before comparing `start` and `end`.
- Added regression tests: a `RequestForm` spec asserting seeded numeric values remain visible, and a `CalendarExternalForm` spec asserting an invalid `Date`-prefilled range is rejected with `End must be after start.`.

### Testing
- Ran the targeted unit tests with `pnpm -s vitest src/ui/__tests__/RequestForm.test.tsx src/ui/__tests__/CalendarExternalForm.test.tsx` and all tests passed (`21 passed`).
- Ran type checking with `pnpm -s type-check` and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e855d3b6e0832ca67af8e126dd5dbe)