### PR TITLE
Stage 5b PR5: type shared filtering UI (FilterBar + AdvancedFilterBuilder)

### DIFF
--- a/scripts/typecheck-strict.mjs
+++ b/scripts/typecheck-strict.mjs
@@ -90,6 +90,9 @@ const MIGRATED_PATHS = [
   'src/ui/ScheduleEditorForm.tsx',
   'src/ui/CalendarExternalForm.tsx',
   'src/ui/RequestForm.tsx',
+  // Stage 5b PR5
+  'src/ui/FilterBar.tsx',
+  'src/ui/AdvancedFilterBuilder.tsx',
 ];
 
 // Implicit-any diagnostic codes. See:

--- a/src/ui/AdvancedFilterBuilder.tsx
+++ b/src/ui/AdvancedFilterBuilder.tsx
@@ -31,12 +31,48 @@ import { Plus, X, Check } from 'lucide-react';
 import { createId } from '../core/createId';
 import { DEFAULT_FILTER_SCHEMA, defaultOperatorsForType } from '../filters/filterSchema';
 import { conditionsToFilters } from '../filters/conditionEngine';
+import type { FilterField, FilterOperator, FilterOption } from '../filters/filterSchema';
 import styles from './AdvancedFilterBuilder.module.css';
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
-function makeCondition(logic = 'AND', firstFieldKey = 'categories') {
+type ConditionLogic = 'AND' | 'OR';
+
+type BuilderCondition = {
+  id: string;
+  field: string;
+  operator: string;
+  value: string;
+  logic: ConditionLogic;
+};
+
+type AdvancedFilterBuilderProps = {
+  schema?: FilterField[];
+  items?: unknown[];
+  onSave?: (name: string, filters: Record<string, unknown>, conditions: BuilderCondition[]) => void;
+  categories?: unknown[];
+  resources?: unknown[];
+  initialName?: string;
+  initialConditions?: unknown[] | null;
+  editingId?: string | null;
+  onUpdate?: (id: string, name: string, filters: Record<string, unknown>, conditions: BuilderCondition[]) => void;
+  onCancelEdit?: () => void;
+};
+
+function makeCondition(logic: ConditionLogic = 'AND', firstFieldKey = 'categories'): BuilderCondition {
   return { id: createId('cond'), field: firstFieldKey, operator: 'is', value: '', logic };
+}
+
+function toBuilderCondition(input: unknown, fallbackFieldKey: string): BuilderCondition {
+  const candidate = (input ?? {}) as Partial<BuilderCondition>;
+  const logic: ConditionLogic = candidate.logic === 'OR' ? 'OR' : 'AND';
+  return {
+    id: createId('cond'),
+    field: typeof candidate.field === 'string' ? candidate.field : fallbackFieldKey,
+    operator: typeof candidate.operator === 'string' ? candidate.operator : 'is',
+    value: typeof candidate.value === 'string' ? candidate.value : '',
+    logic,
+  };
 }
 
 // ─── Component ────────────────────────────────────────────────────────────────
@@ -52,16 +88,19 @@ export default function AdvancedFilterBuilder({
   editingId = null,
   onUpdate,
   onCancelEdit,
-}: any) {
+}: AdvancedFilterBuilderProps) {
+  void categories;
+  void resources;
+
   // Exclude date-range fields from the condition builder field list
   const fieldOptions = useMemo(
-    () => schema.filter(f => f.type !== 'date-range'),
+    () => schema.filter((f) => f.type !== 'date-range'),
     [schema]
   );
 
   // Operator map keyed by field.key — falls back to defaultOperatorsForType
-  const operatorMap = useMemo(() => {
-    const map = {};
+  const operatorMap = useMemo<Record<string, FilterOperator[]>>(() => {
+    const map: Record<string, FilterOperator[]> = {};
     for (const f of fieldOptions) {
       map[f.key] = f.operators ?? defaultOperatorsForType(f.type);
     }
@@ -70,17 +109,17 @@ export default function AdvancedFilterBuilder({
 
   const firstFieldKey = fieldOptions[0]?.key ?? 'categories';
 
-  const [conditions, setConditions] = useState(() =>
+  const [conditions, setConditions] = useState<BuilderCondition[]>(() =>
     initialConditions && initialConditions.length > 0
-      ? initialConditions.map(c => ({ ...c, id: createId('cond') }))
+      ? initialConditions.map((c) => toBuilderCondition(c, firstFieldKey))
       : [makeCondition('AND', firstFieldKey)]
   );
   const [viewName,   setViewName]   = useState(initialName);
   const [nameError,  setNameError]  = useState('');
   const [saved,      setSaved]      = useState(false);
-  const savedTimerRef = useRef(null);
-  const rootRef       = useRef(null);
-  const nameInputRef  = useRef(null);
+  const savedTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const rootRef       = useRef<HTMLDivElement | null>(null);
+  const nameInputRef  = useRef<HTMLInputElement | null>(null);
 
   // Clear the "Saved!" feedback timeout on unmount to avoid state updates on
   // an unmounted component (can happen in edit mode when the parent unmounts
@@ -101,11 +140,11 @@ export default function AdvancedFilterBuilder({
 
   // ── Condition mutations ─────────────────────────────────────────────────
 
-  const addCondition = (logic) => {
+  const addCondition = (logic: ConditionLogic) => {
     setConditions(prev => [...prev, makeCondition(logic, firstFieldKey)]);
   };
 
-  const updateCondition = (id, updates) => {
+  const updateCondition = (id: string, updates: Partial<BuilderCondition>) => {
     setConditions(prev => prev.map(c => {
       if (c.id !== id) return c;
       const next = { ...c, ...updates };
@@ -118,7 +157,7 @@ export default function AdvancedFilterBuilder({
     }));
   };
 
-  const removeCondition = (id) => {
+  const removeCondition = (id: string) => {
     setConditions(prev => prev.length > 1 ? prev.filter(c => c.id !== id) : prev);
   };
 
@@ -155,8 +194,8 @@ export default function AdvancedFilterBuilder({
       {/* ── Condition rows ── */}
       <div className={styles.conditions}>
         {conditions.map((cond, index) => {
-          const fieldDef = schema.find(f => f.key === cond.field);
-          const options  = fieldDef?.options
+          const fieldDef = schema.find((f) => f.key === cond.field);
+          const options: FilterOption[] | null = fieldDef?.options
                         ?? (fieldDef?.getOptions ? fieldDef.getOptions(items) : null);
           return (
             <div key={cond.id} className={styles.conditionWrap}>
@@ -164,7 +203,7 @@ export default function AdvancedFilterBuilder({
               {/* Logic connector (AND / OR) between rows */}
               {index > 0 && (
                 <div className={styles.logicRow}>
-                  {(['AND', 'OR']).map(lbl => (
+                  {(['AND', 'OR'] as const).map((lbl) => (
                     <button
                       key={lbl}
                       className={[styles.logicBtn, cond.logic === lbl && styles.logicActive].filter(Boolean).join(' ')}

--- a/src/ui/FilterBar.tsx
+++ b/src/ui/FilterBar.tsx
@@ -5,22 +5,48 @@ import { useEffect, useMemo, useRef, useState } from 'react';
 import { Search, X, ChevronDown } from 'lucide-react';
 import { DEFAULT_FILTER_SCHEMA } from '../filters/filterSchema';
 import { buildActiveFilterPills, clearFilterValue, hasActiveFilters as computeHasActiveFilters } from '../filters/filterState';
+import type { FilterField, FilterOption } from '../filters/filterSchema';
 import styles from './FilterBar.module.css';
 
-function formatDateInput(date) {
+type GroupKey = 'categories' | 'resources' | 'sources' | 'more';
+
+type SourceLike = {
+  id: string | number;
+  color?: string;
+  type?: string;
+};
+
+type DateRangeValue = { start?: Date | string | null; end?: Date | string | null } | null;
+
+type FilterBarProps = {
+  schema?: FilterField[];
+  filters?: Record<string, unknown>;
+  items?: unknown[];
+  onChange?: (fieldKey: string, value: unknown) => void;
+  onClear?: (fieldKey: string) => void;
+  onClearAll?: () => void;
+  sources?: SourceLike[];
+  groupLabels?: Partial<Record<GroupKey, string>>;
+  pillHoverTitle?: boolean;
+  onPillHoverTitleToggle?: (() => void) | undefined;
+};
+
+function formatDateInput(date: unknown): string {
   if (!date) return '';
+  if (!(date instanceof Date) && typeof date !== 'string' && typeof date !== 'number') return '';
   const d = date instanceof Date ? date : new Date(date);
+  if (Number.isNaN(d.getTime())) return '';
   return d.toISOString().slice(0, 10);
 }
 
-function getGroupKey(fieldKey) {
+function getGroupKey(fieldKey: string): GroupKey {
   if (fieldKey === 'categories') return 'categories';
   if (fieldKey === 'resources') return 'resources';
   if (fieldKey === 'sources') return 'sources';
   return 'more';
 }
 
-const DEFAULT_GROUP_LABELS = {
+const DEFAULT_GROUP_LABELS: Record<GroupKey, string> = {
   categories: 'Categories',
   resources: 'People',
   sources: 'Sources',
@@ -38,21 +64,28 @@ export default function FilterBar({
   groupLabels = {},
   pillHoverTitle = false,
   onPillHoverTitleToggle = undefined,
-}: any) {
-  const [openGroup, setOpenGroup] = useState(null);
-  const dropdownRefs = useRef({});
+}: FilterBarProps) {
+  const [openGroup, setOpenGroup] = useState<GroupKey | null>(null);
+  const dropdownRefs = useRef<Record<GroupKey, HTMLDivElement | null>>({
+    categories: null,
+    resources: null,
+    sources: null,
+    more: null,
+  });
 
-  function handleToggle(fieldKey, value) {
+  function handleToggle(fieldKey: string, value: string | number | boolean) {
     const current = filters[fieldKey];
-    const next = current instanceof Set ? new Set(current) : new Set();
+    const next = current instanceof Set
+      ? new Set<string | number | boolean>(current as Set<string | number | boolean>)
+      : new Set<string | number | boolean>();
     next.has(value) ? next.delete(value) : next.add(value);
     onChange?.(fieldKey, next);
   }
 
   useEffect(() => {
-    function onDocClick(e) {
+    function onDocClick(e: MouseEvent) {
       const currentRef = openGroup ? dropdownRefs.current[openGroup] : null;
-      if (currentRef && !currentRef.contains(e.target)) {
+      if (currentRef && e.target instanceof Node && !currentRef.contains(e.target)) {
         setOpenGroup(null);
       }
     }
@@ -75,8 +108,8 @@ export default function FilterBar({
     });
   }, [schema, items, filters]);
 
-  const groupedFields = useMemo(() => {
-    const groups = {
+  const groupedFields = useMemo<Record<GroupKey, FilterField[]>>(() => {
+    const groups: Record<GroupKey, FilterField[]> = {
       categories: [],
       resources: [],
       sources: [],
@@ -98,7 +131,7 @@ export default function FilterBar({
   const hasActiveFilters = computeHasActiveFilters(filters, schema);
   const activePills = buildActiveFilterPills(filters, schema);
 
-  function selectedCountForGroup(groupKey) {
+  function selectedCountForGroup(groupKey: GroupKey): number {
     return groupedFields[groupKey].reduce((count, field) => {
       const value = filters[field.key];
       if (value instanceof Set) return count + value.size;
@@ -107,14 +140,15 @@ export default function FilterBar({
     }, 0);
   }
 
-  function renderOption(field, opt) {
+  function renderOption(field: FilterField, opt: FilterOption) {
     const activeValues = filters[field.key] ?? new Set();
+    const activeArray = Array.isArray(activeValues) ? activeValues : [];
     const active = activeValues instanceof Set
       ? activeValues.has(opt.value)
-      : (activeValues ?? []).includes(opt.value);
+      : activeArray.includes(opt.value);
 
     const isSourceField = field.key === 'sources';
-    const src = isSourceField ? sources.find(s => s.id === opt.value) : null;
+    const src = isSourceField ? sources.find((s) => s.id === opt.value) : null;
 
     return (
       <button
@@ -146,20 +180,21 @@ export default function FilterBar({
       {Object.entries(groupedFields).map(([groupKey, fields]) => {
         if (!fields.length) return null;
 
-        const count = selectedCountForGroup(groupKey);
+        const typedGroupKey = groupKey as GroupKey;
+        const count = selectedCountForGroup(typedGroupKey);
 
         return (
           <div
             key={groupKey}
             className={styles.dropdownWrap}
-            ref={el => { dropdownRefs.current[groupKey] = el; }}
+            ref={(el) => { dropdownRefs.current[typedGroupKey] = el; }}
           >
             <button
               type="button"
               className={[styles.dropdownBtn, openGroup === groupKey && styles.dropdownBtnOpen].filter(Boolean).join(' ')}
-              onClick={() => setOpenGroup(openGroup === groupKey ? null : groupKey)}
+              onClick={() => setOpenGroup(openGroup === groupKey ? null : typedGroupKey)}
             >
-              <span>{mergedGroupLabels[groupKey] ?? DEFAULT_GROUP_LABELS[groupKey] ?? groupKey}</span>
+              <span>{mergedGroupLabels[typedGroupKey] ?? DEFAULT_GROUP_LABELS[typedGroupKey] ?? typedGroupKey}</span>
               {count > 0 && <span className={styles.countBadge}>{count}</span>}
               <span className={styles.chevronIcon}><ChevronDown size={14} /></span>
             </button>
@@ -188,7 +223,8 @@ export default function FilterBar({
       {schema
         .filter(field => field.type === 'text' && !field.hidden)
         .map(field => {
-          const value = filters[field.key] ?? '';
+          const rawValue = filters[field.key];
+          const value = rawValue == null ? '' : String(rawValue);
           return (
             <div key={field.key} className={styles.searchWrap}>
               <Search size={14} className={styles.searchIcon} />
@@ -215,17 +251,17 @@ export default function FilterBar({
 
       {schema.filter(f => f.type === 'select' && !f.hidden).map(field => {
         const options = field.getOptions ? field.getOptions(items) : (field.options ?? []);
-        const value = filters[field.key] ?? '';
+        const value = filters[field.key];
         return (
           <select
             key={field.key}
             className={styles.selectInput}
-            value={value}
+            value={value == null ? '' : String(value)}
             onChange={e => onChange?.(field.key, e.target.value || null)}
           >
             <option value="">{field.placeholder ?? `All ${field.label ?? field.key}`}</option>
             {options.map(opt => (
-              <option key={String(opt.value)} value={opt.value as string | number | readonly string[]}>
+              <option key={String(opt.value)} value={String(opt.value)}>
                 {opt.label}
               </option>
             ))}
@@ -252,7 +288,7 @@ export default function FilterBar({
       })}
 
       {schema.filter(f => f.type === 'date-range' && !f.hidden).map(field => {
-        const range = filters[field.key];
+        const range = (filters[field.key] ?? null) as DateRangeValue;
         const startVal = range?.start ? formatDateInput(range.start) : '';
         const endVal   = range?.end   ? formatDateInput(range.end)   : '';
 


### PR DESCRIPTION
### Motivation
- Reduce non-ratcheted implicit-any debt in the shared UI filtering slice so the repo can progress toward a root `noImplicitAny` flip. 
- Bring the two highest-risk shared filter UI files under the strict ratchet so future typing work is enforced incrementally.

### Description
- Added explicit TypeScript typings to `src/ui/FilterBar.tsx` including `FilterBarProps`, `GroupKey`, `SourceLike`, `DateRangeValue`, and strengthened callback/handler signatures while preserving runtime behavior. 
- Added explicit TypeScript typings to `src/ui/AdvancedFilterBuilder.tsx` including `BuilderCondition`, `AdvancedFilterBuilderProps`, a typed `operatorMap`, and a `toBuilderCondition` normalizer to safely handle unknown `initialConditions` payloads from existing callers. 
- Updated `scripts/typecheck-strict.mjs` to add `src/ui/FilterBar.tsx` and `src/ui/AdvancedFilterBuilder.tsx` to `MIGRATED_PATHS` so implicit-any diagnostics in these files are tracked by the strict ratchet. 
- Made conservative runtime-safe value normalizations (text/select/date handling, Set/array checks, Node checks for document clicks) to avoid cascading type tightening outside the migration slice.

### Testing
- Ran the strict ratchet with `npm run type-check:strict` and it passed ("Strict type check GREEN").
- Ran the full TypeScript check with `npx tsc --noEmit -p tsconfig.json` and it passed with no errors. 
- Ran the full test suite with `npm test` (Vitest) and all tests passed: 129 files, 1911 tests passed (1 todo).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e858f60f80832ca0690c2713d98986)