### PR TITLE
docs: record Stage 5b post-PR3 audit rerun metrics

### DIFF
--- a/docs/stage-5b-readiness-cleanup-plan.md
+++ b/docs/stage-5b-readiness-cleanup-plan.md
@@ -204,6 +204,22 @@ Record:
 - updated unique files count
 - whether remaining debt is still dominated by `src/ui`
 
+#### Checkpoint run recorded — 2026-04-22
+
+Command run:
+
+```bash
+npx tsc --noEmit -p tsconfig.strict.json --pretty false
+```
+
+Results:
+- **253** implicit-any diagnostics (down from 413)
+- **55** unique files with implicit-any diagnostics (down from 67)
+- Remaining debt is **still dominated by `src/ui`** (167 / 253 diagnostics, ~66%)
+
+Notes:
+- The run also reports a non-implicit-any type mismatch in `src/WorksCalendar.tsx` (`TS2345`), which is outside this implicit-any checkpoint metric.
+
 ### Required checkpoint after PR 5
 After PRs 4–5 land, rerun the full Stage 6 readiness audit in:
 - `docs/stage-6-readiness-audit.md`


### PR DESCRIPTION
### Motivation
- Record the required post-PR3 Stage 5b checkpoint metrics so the cleanup plan reflects the current TypeScript implicit-any state after PRs 1–3.

### Description
- Add a `Checkpoint run recorded — 2026-04-22` section to `docs/stage-5b-readiness-cleanup-plan.md` that includes the `npx tsc --noEmit -p tsconfig.strict.json --pretty false` command and the extracted results: **253** implicit-any diagnostics (down from 413), **55** unique files (down from 67), and that remaining debt is still dominated by `src/ui` (167 / 253, ~66%), plus a note about a separate `TS2345` in `src/WorksCalendar.tsx`.

### Testing
- Ran `npx tsc --noEmit -p tsconfig.strict.json --pretty false` to generate the compiler output used for metrics extraction, and the command exited with errors as expected (output used for metrics). 
- Executed a Python parsing script against the tsc log to compute implicit-any totals, unique file count, and `src/ui` share, and recorded those computed metrics in the document.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8b0823840832ca12e2b284cf9b2ed)