### PR TITLE
Complete Stage 5b PR4: Type cleanup for ThemeCustomizer and CSVImportDialog

### DIFF
--- a/docs/stage-5b-readiness-cleanup-plan.md
+++ b/docs/stage-5b-readiness-cleanup-plan.md
@@ -250,13 +250,14 @@ Status reconciled against merged PRs and current `MIGRATED_PATHS` on `main` as o
 | 1 | Hook test helpers | **Complete** (PR #295 merged) | **Yes** | No |
 | 2 | Root/integration tests | **Complete** (PR #296 merged) | **Yes** | No |
 | 3 | Small UI forms/dialogs | **Complete** (PR #297 merged) | **Yes** | **Checkpoint recorded below** |
-| 4 | Medium UI utilities | Planned | No | No |
+| 4 | Medium UI utilities | **Complete** (this PR) | **Yes** | No |
 | 5 | Shared UI filtering | **Complete** (PR #299 merged) | **Yes** | **Full audit rerun still needed** |
 | 6 | Remaining non-ratcheted views | Planned | No | Maybe |
 
 ### Current status notes
 
 - PRs **1, 2, 3, and 5** have landed on `main`.
+- PR **4** is completed in this branch (`ThemeCustomizer` + `CSVImportDialog`) and adds both files to `MIGRATED_PATHS`.
 - The corresponding files are present in `scripts/typecheck-strict.mjs` under `MIGRATED_PATHS`.
 - No merged Stage 5b PR was found yet for the planned **PR 4** (`ThemeCustomizer` / `CSVImportDialog`) slice.
 - No merged Stage 5b PR was found yet for the planned **PR 6** remaining-views slice.

--- a/scripts/typecheck-strict.mjs
+++ b/scripts/typecheck-strict.mjs
@@ -90,6 +90,9 @@ const MIGRATED_PATHS = [
   'src/ui/ScheduleEditorForm.tsx',
   'src/ui/CalendarExternalForm.tsx',
   'src/ui/RequestForm.tsx',
+  // Stage 5b PR4
+  'src/ui/ThemeCustomizer.tsx',
+  'src/ui/CSVImportDialog.tsx',
   // Stage 5b PR5
   'src/ui/FilterBar.tsx',
   'src/ui/AdvancedFilterBuilder.tsx',

--- a/src/ui/CSVImportDialog.tsx
+++ b/src/ui/CSVImportDialog.tsx
@@ -26,14 +26,56 @@ import {
 import styles from './ImportZone.module.css';
 import pStyles from './ImportPreview.module.css';
 
+type CsvRow = Record<string, string>;
+type CsvFileData = { filename: string; headers: string[]; rows: CsvRow[] };
+type Mapping = Record<string, string>;
+type CsvEvent = {
+  id: string;
+  title: string;
+  start: Date | string;
+  end?: Date | string;
+  category?: string;
+  resource?: string;
+  status?: string;
+  color?: string;
+  allDay?: boolean;
+};
+type CsvError = { row: CsvRow; index: number; message: string };
+type MappedData = { events: CsvEvent[]; errors: CsvError[]; mapping: Mapping; dateFormat: string };
+type CsvPreset = { id: string; name: string; mapping: Mapping; dateFormat?: string };
+type Step = 'drop' | 'map' | 'preview';
+
+type DropStepProps = {
+  onFile: (fileData: CsvFileData) => void;
+  onClose: () => void;
+};
+
+type MapStepProps = CsvFileData & {
+  onBack: () => void;
+  onNext: (mappedData: MappedData) => void;
+};
+
+type PreviewStepProps = {
+  events: CsvEvent[];
+  errors: CsvError[];
+  onBack: () => void;
+  onImport: (events: CsvEvent[]) => void;
+  onClose: () => void;
+};
+
+type CSVImportDialogProps = {
+  onImport: (events: CsvEvent[], metadata?: { label?: string }) => void;
+  onClose: () => void;
+};
+
 // ── Step 1: Drop zone ─────────────────────────────────────────────────────────
 
-function DropStep({ onFile, onClose }: any) {
+function DropStep({ onFile, onClose }: DropStepProps) {
   const [dragging, setDragging] = useState(false);
-  const [error,    setError]    = useState(null);
-  const inputRef = useRef(null);
+  const [error, setError] = useState<string | null>(null);
+  const inputRef = useRef<HTMLInputElement | null>(null);
 
-  function processFile(file) {
+  function processFile(file: File | null | undefined): void {
     if (!file) return;
     if (!file.name?.toLowerCase().endsWith('.csv') && file.type !== 'text/csv') {
       setError('Please choose a .csv file.');
@@ -41,14 +83,16 @@ function DropStep({ onFile, onClose }: any) {
     }
     setError(null);
     const reader = new FileReader();
-    reader.onload = e => {
+    reader.onload = (e: ProgressEvent<FileReader>) => {
       try {
-        const { headers, rows } = parseCSV(e.target.result as string);
+        const text = typeof e.target?.result === 'string' ? e.target.result : '';
+        const { headers, rows } = parseCSV(text);
         if (!headers.length) { setError('No columns detected in this file.'); return; }
         if (!rows.length)    { setError('No data rows found (file has headers but no data).'); return; }
         onFile({ filename: file.name, headers, rows });
-      } catch (err: any) {
-        setError(`Could not read file: ${err.message}`);
+      } catch (err: unknown) {
+        const message = err instanceof Error ? err.message : String(err);
+        setError(`Could not read file: ${message}`);
       }
     };
     reader.onerror = () => setError('Could not read file.');
@@ -92,18 +136,18 @@ function DropStep({ onFile, onClose }: any) {
 
 const SKIP = '';
 
-function MapStep({ filename, headers, rows, onBack, onNext }: any) {
-  const [mapping,     setMapping]     = useState(() => suggestMapping(headers));
-  const [dateFormat,  setDateFormat]  = useState('auto');
-  const [presets,     setPresets]     = useState(() => loadPresets());
-  const [presetName,  setPresetName]  = useState('');
+function MapStep({ filename, headers, rows, onBack, onNext }: MapStepProps) {
+  const [mapping, setMapping] = useState<Mapping>(() => suggestMapping(headers));
+  const [dateFormat, setDateFormat] = useState('auto');
+  const [presets, setPresets] = useState<CsvPreset[]>(() => loadPresets() as CsvPreset[]);
+  const [presetName, setPresetName] = useState('');
   const [savingPreset, setSavingPreset] = useState(false);
 
-  function setField(field, header) {
-    setMapping(m => ({ ...m, [field]: header }));
+  function setField(field: string, header: string): void {
+    setMapping((m) => ({ ...m, [field]: header }));
   }
 
-  function applyPreset(preset) {
+  function applyPreset(preset: CsvPreset): void {
     setMapping(preset.mapping);
     setDateFormat(preset.dateFormat ?? 'auto');
   }
@@ -118,14 +162,14 @@ function MapStep({ filename, headers, rows, onBack, onNext }: any) {
       dateFormat,
     };
     savePreset(preset);
-    setPresets(loadPresets());
+    setPresets(loadPresets() as CsvPreset[]);
     setPresetName('');
     setSavingPreset(false);
   }
 
-  function handleDeletePreset(id) {
+  function handleDeletePreset(id: string): void {
     deletePreset(id);
-    setPresets(loadPresets());
+    setPresets(loadPresets() as CsvPreset[]);
   }
 
   function handleNext() {
@@ -246,7 +290,7 @@ function MapStep({ filename, headers, rows, onBack, onNext }: any) {
                     }}
                   >
                     <option value={SKIP}>── skip ──</option>
-                    {headers.map(h => <option key={h} value={h}>{h}</option>)}
+                    {headers.map((h: string) => <option key={h} value={h}>{h}</option>)}
                   </select>
                 </div>
               ))}
@@ -278,7 +322,7 @@ function MapStep({ filename, headers, rows, onBack, onNext }: any) {
               <table style={{ fontSize: 11, borderCollapse: 'collapse', width: '100%' }}>
                 <thead>
                   <tr style={{ background: 'var(--wc-surface)' }}>
-                    {headers.map(h => (
+                    {headers.map((h: string) => (
                       <th key={h} style={{
                         padding: '6px 10px', textAlign: 'left', fontWeight: 600,
                         color: Object.values(mapping).includes(h) ? 'var(--wc-accent)' : 'var(--wc-text-muted)',
@@ -288,9 +332,9 @@ function MapStep({ filename, headers, rows, onBack, onNext }: any) {
                   </tr>
                 </thead>
                 <tbody>
-                  {previewRows.map((row, i) => (
+                  {previewRows.map((row: CsvRow, i: number) => (
                     <tr key={i} style={{ borderBottom: '1px solid var(--wc-border)' }}>
-                      {headers.map(h => (
+                      {headers.map((h: string) => (
                         <td key={h} style={{
                           padding: '5px 10px', color: 'var(--wc-text)',
                           maxWidth: 160, whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis',
@@ -358,11 +402,11 @@ function MapStep({ filename, headers, rows, onBack, onNext }: any) {
 
 // ── Step 3: Preview & import ──────────────────────────────────────────────────
 
-function PreviewStep({ events, errors, onBack, onImport, onClose }: any) {
-  const [selected, setSelected] = useState(() => new Set(events.map((_, i) => i)));
+function PreviewStep({ events, errors, onBack, onImport, onClose }: PreviewStepProps) {
+  const [selected, setSelected] = useState<Set<number>>(() => new Set(events.map((_, i: number) => i)));
 
-  function toggle(i) {
-    setSelected(prev => {
+  function toggle(i: number): void {
+    setSelected((prev) => {
       const next = new Set(prev);
       next.has(i) ? next.delete(i) : next.add(i);
       return next;
@@ -371,11 +415,11 @@ function PreviewStep({ events, errors, onBack, onImport, onClose }: any) {
 
   function toggleAll() {
     if (selected.size === events.length) setSelected(new Set());
-    else setSelected(new Set(events.map((_, i) => i)));
+    else setSelected(new Set(events.map((_, i: number) => i)));
   }
 
   function handleImport() {
-    const toImport = events.filter((_, i) => selected.has(i));
+    const toImport = events.filter((_, i: number) => selected.has(i));
     onImport(toImport);
     onClose();
   }
@@ -408,7 +452,7 @@ function PreviewStep({ events, errors, onBack, onImport, onClose }: any) {
             <div style={{ display: 'flex', alignItems: 'center', gap: 6, fontSize: 12, fontWeight: 600, color: '#991b1b' }}>
               <AlertCircle size={13} /> {errors.length} row{errors.length > 1 ? 's' : ''} could not be parsed
             </div>
-            {errors.slice(0, 3).map((e, i) => (
+            {errors.slice(0, 3).map((e: CsvError, i: number) => (
               <div key={i} style={{ fontSize: 11, color: '#7f1d1d' }}>
                 Row {e.index}: {e.message}
               </div>
@@ -426,7 +470,7 @@ function PreviewStep({ events, errors, onBack, onImport, onClose }: any) {
         </div>
 
         <div className={pStyles.list}>
-          {events.map((ev, i) => {
+          {events.map((ev: CsvEvent, i: number) => {
             const start = ev.start instanceof Date ? ev.start : new Date(ev.start);
             return (
               <label key={i} className={[pStyles.item, selected.has(i) && pStyles.itemSelected].filter(Boolean).join(' ')}>
@@ -462,15 +506,15 @@ function PreviewStep({ events, errors, onBack, onImport, onClose }: any) {
 
 // ── Main dialog ───────────────────────────────────────────────────────────────
 
-export default function CSVImportDialog({ onImport, onClose }: any) {
-  const [step, setStep] = useState('drop'); // 'drop' | 'map' | 'preview'
-  const [fileData, setFileData]     = useState(null); // { filename, headers, rows }
-  const [mappedData, setMappedData] = useState(null); // { events, errors }
+export default function CSVImportDialog({ onImport, onClose }: CSVImportDialogProps) {
+  const [step, setStep] = useState<Step>('drop');
+  const [fileData, setFileData] = useState<CsvFileData | null>(null);
+  const [mappedData, setMappedData] = useState<MappedData | null>(null);
 
   if (step === 'drop') {
     return (
       <DropStep
-        onFile={data => { setFileData(data); setStep('map'); }}
+        onFile={(data: CsvFileData) => { setFileData(data); setStep('map'); }}
         onClose={onClose}
       />
     );
@@ -478,31 +522,35 @@ export default function CSVImportDialog({ onImport, onClose }: any) {
 
   if (step === 'map') {
     return (
-      <MapStep
-        {...fileData}
-        onBack={() => setStep('drop')}
-        onNext={data => { setMappedData(data); setStep('preview'); }}
-      />
+      fileData && (
+        <MapStep
+          {...fileData}
+          onBack={() => setStep('drop')}
+          onNext={(data: MappedData) => { setMappedData(data); setStep('preview'); }}
+        />
+      )
     );
   }
 
   return (
-    <PreviewStep
-      {...mappedData}
-      onBack={() => setStep('map')}
-      onImport={(events) => onImport(events, { label: fileData?.filename })}
-      onClose={onClose}
-    />
+    mappedData && (
+      <PreviewStep
+        {...mappedData}
+        onBack={() => setStep('map')}
+        onImport={(events: CsvEvent[]) => onImport(events, { label: fileData?.filename })}
+        onClose={onClose}
+      />
+    )
   );
 }
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
-function _fmtDate(d) {
+function _fmtDate(d: Date): string {
   try { return format(d, 'MMM d, yyyy'); } catch { return '—'; }
 }
 
-function btnStyle(bg) {
+function btnStyle(bg: string): React.CSSProperties {
   return {
     display: 'inline-flex', alignItems: 'center', gap: 5,
     padding: '7px 14px', fontSize: 12, fontWeight: 600,

--- a/src/ui/ThemeCustomizer.tsx
+++ b/src/ui/ThemeCustomizer.tsx
@@ -2,7 +2,30 @@ import { normalizeCustomTheme, customThemeToCssVars } from '../core/themeSchema'
 import styles from './ThemeCustomizer.module.css';
 import { useMemo, useState } from 'react';
 
-const COLOR_CONTROLS = [
+type ThemeGroupKey = 'colors' | 'typography' | 'spacing' | 'borders' | 'shadows';
+type ColorKey = 'accent' | 'accentDim' | 'bg' | 'surface' | 'surface2' | 'border' | 'borderDark' | 'text' | 'textMuted';
+type TypographyKey = 'fontFamily' | 'headingFontFamily' | 'monoFontFamily' | 'baseSize';
+type SpacingKey = 'density';
+type BordersKey = 'radius' | 'radiusSm' | 'borderWidth';
+type ShadowsKey = 'elevation';
+type ThemePath = [ThemeGroupKey, ColorKey | TypographyKey | SpacingKey | BordersKey | ShadowsKey];
+
+type ThemeConfig = {
+  customTheme?: Record<string, unknown>;
+};
+
+type ThemeCustomizerProps = {
+  theme: Record<string, unknown> | null | undefined;
+  onChange: (updater: (config: ThemeConfig) => ThemeConfig) => void;
+};
+
+type PresetTheme = {
+  id: string;
+  label: string;
+  customTheme: Record<string, unknown>;
+};
+
+const COLOR_CONTROLS: Array<[ColorKey, string]> = [
   ['accent', 'Accent'],
   ['accentDim', 'Accent Soft'],
   ['bg', 'Background'],
@@ -14,7 +37,7 @@ const COLOR_CONTROLS = [
   ['textMuted', 'Muted Text'],
 ];
 
-const TOKEN_SLIDERS = [
+const TOKEN_SLIDERS: Array<[ThemeGroupKey, TypographyKey | SpacingKey | BordersKey | ShadowsKey, string, number, number, number, string]> = [
   ['typography', 'baseSize', 'Base Font Size', 12, 20, 1, 'px'],
   ['spacing', 'density', 'Density', 0.8, 1.2, 0.05, 'x'],
   ['borders', 'radius', 'Radius', 0, 24, 1, 'px'],
@@ -23,7 +46,7 @@ const TOKEN_SLIDERS = [
   ['shadows', 'elevation', 'Shadow', 0, 32, 1, ''],
 ];
 
-const PRESET_THEMES = [
+const PRESET_THEMES: PresetTheme[] = [
   {
     id: 'default',
     label: 'Default',
@@ -79,7 +102,13 @@ const FONT_STACK_OPTIONS = [
   { label: 'JetBrains Mono', value: "'JetBrains Mono', 'Roboto Mono', 'Courier New', monospace" },
 ];
 
-const FONT_ROLE_CONTROLS = [
+type FontRoleKey = Exclude<TypographyKey, 'baseSize'>;
+
+const FONT_ROLE_CONTROLS: Array<{
+  key: FontRoleKey;
+  label: string;
+  customPlaceholder: string;
+}> = [
   {
     key: 'fontFamily',
     label: 'Body Font',
@@ -97,13 +126,13 @@ const FONT_ROLE_CONTROLS = [
   },
 ];
 
-function valueLabel(value, suffix) {
+function valueLabel(value: string | number, suffix: string): string {
   if (suffix === 'x') return `${Number(value).toFixed(2)}x`;
   if (!suffix) return String(value);
   return `${value}${suffix}`;
 }
 
-function hexToRgb(hex) {
+function hexToRgb(hex: string): { r: number; g: number; b: number } | null {
   const normalized = String(hex || '').trim().replace('#', '');
   if (!/^[0-9a-f]{6}$/i.test(normalized)) return null;
   const int = Number.parseInt(normalized, 16);
@@ -114,7 +143,7 @@ function hexToRgb(hex) {
   };
 }
 
-function relativeLuminance(hex) {
+function relativeLuminance(hex: string): number | null {
   const rgb = hexToRgb(hex);
   if (!rgb) return null;
   const map = [rgb.r, rgb.g, rgb.b].map((channel) => {
@@ -124,7 +153,7 @@ function relativeLuminance(hex) {
   return 0.2126 * map[0] + 0.7152 * map[1] + 0.0722 * map[2];
 }
 
-function contrastRatio(hexA, hexB) {
+function contrastRatio(hexA: string, hexB: string): number | null {
   const lumA = relativeLuminance(hexA);
   const lumB = relativeLuminance(hexB);
   if (lumA === null || lumB === null) return null;
@@ -133,7 +162,7 @@ function contrastRatio(hexA, hexB) {
   return (lighter + 0.05) / (darker + 0.05);
 }
 
-function wcagRating(ratio) {
+function wcagRating(ratio: number | null): { label: string; tone: 'good' | 'warn' | 'bad' } {
   if (ratio === null) return { label: 'Invalid color', tone: 'bad' };
   if (ratio >= 7) return { label: 'AAA', tone: 'good' };
   if (ratio >= 4.5) return { label: 'AA', tone: 'good' };
@@ -141,7 +170,7 @@ function wcagRating(ratio) {
   return { label: 'Fail', tone: 'bad' };
 }
 
-export default function ThemeCustomizer({ theme, onChange }: any) {
+export default function ThemeCustomizer({ theme, onChange }: ThemeCustomizerProps) {
   const [draftImport, setDraftImport] = useState('');
   const [importError, setImportError] = useState('');
   const [importMode, setImportMode] = useState('merge');
@@ -175,9 +204,9 @@ export default function ThemeCustomizer({ theme, onChange }: any) {
     };
   })), [merged]);
 
-  function update(path, value) {
-    onChange((config) => {
-      const current = normalizeCustomTheme(config.customTheme);
+  function update(path: ThemePath, value: string | number) {
+    onChange((config: ThemeConfig) => {
+      const current = normalizeCustomTheme(config.customTheme) as Record<string, Record<string, unknown>>;
       const [group, key] = path;
       return {
         ...config,
@@ -192,8 +221,8 @@ export default function ThemeCustomizer({ theme, onChange }: any) {
     });
   }
 
-  function applyPreset(preset) {
-    onChange((config) => ({ ...config, customTheme: preset.customTheme }));
+  function applyPreset(preset: PresetTheme) {
+    onChange((config: ThemeConfig) => ({ ...config, customTheme: preset.customTheme }));
   }
 
   function applyImport() {
@@ -206,8 +235,8 @@ export default function ThemeCustomizer({ theme, onChange }: any) {
       }
       setImportError('');
       setImportSuccess(importMode === 'merge' ? 'Imported and merged into current theme.' : 'Imported and replaced current theme.');
-      onChange((config) => {
-        const current = normalizeCustomTheme(config.customTheme);
+      onChange((config: ThemeConfig) => {
+        const current = normalizeCustomTheme(config.customTheme) as Record<string, Record<string, unknown>>;
         const nextCustomTheme = importMode === 'replace'
           ? parsed
           : {
@@ -324,7 +353,7 @@ export default function ThemeCustomizer({ theme, onChange }: any) {
       </div>
 
       <div className={styles.actions}>
-        <button className={styles.btn} onClick={() => onChange((c) => ({ ...c, customTheme: {} }))}>Reset to default</button>
+        <button className={styles.btn} onClick={() => onChange((c: ThemeConfig) => ({ ...c, customTheme: {} }))}>Reset to default</button>
       </div>
 
       <div className={styles.ioSection}>


### PR DESCRIPTION
### Motivation
- Reduce non-ratcheted `implicit-any` debt inside `src/ui` as part of the Stage 5b cleanup slice (PR 4). 
- Bring `ThemeCustomizer` and `CSVImportDialog` into the migrated allowlist so they no longer block the strict repo-level check.

### Description
- Added explicit local types and component prop types in `src/ui/ThemeCustomizer.tsx` (theme group/key aliases, `ThemeCustomizerProps`, typed helpers such as `valueLabel`, `hexToRgb`, `contrastRatio`, and typed update/apply functions). 
- Added explicit types in `src/ui/CSVImportDialog.tsx` for CSV rows/file payloads, mapping, parsed events/errors, presets, step props, and all handlers, plus null-guarded render branches for `fileData`/`mappedData`. 
- Added both `src/ui/ThemeCustomizer.tsx` and `src/ui/CSVImportDialog.tsx` to the `MIGRATED_PATHS` allowlist in `scripts/typecheck-strict.mjs`. 
- Updated the Stage 5b tracking table in `docs/stage-5b-readiness-cleanup-plan.md` to mark PR 4 complete and note the `MIGRATED_PATHS` additions.

### Testing
- Ran `npm run type-check:strict` (the `scripts/typecheck-strict.mjs` ratchet) and it passed (strict type check GREEN). 
- Ran `npx tsc --noEmit -p tsconfig.json` and it passed with no errors. 
- Ran `npx vitest run src/ui/__tests__/ThemeCustomizer.test.tsx` and the test file passed (`11 tests`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8b3336fbc832c839c2eef0e4607df)