### PR TITLE
feat(types): add ThemeFamilyMeta and ThemeDefinition interfaces

### DIFF
--- a/src/styles/themes.ts
+++ b/src/styles/themes.ts
@@ -24,6 +24,18 @@ export type ThemeMode = 'light' | 'dark';
 
 export type ThemeId = `${ThemeFamily}-${ThemeMode}`;
 
+export interface ThemeFamilyMeta {
+  id: ThemeFamily;
+  label: string;
+  description: string;
+}
+
+export interface ThemeDefinition {
+  id: ThemeId;
+  family: ThemeFamily;
+  mode: ThemeMode;
+}
+
 // ── Families ─────────────────────────────────────────────────────────────────
 
 export const THEME_FAMILIES = [
@@ -94,16 +106,13 @@ export type ThemePreview = {
   border: string;
 };
 
-export type ThemeMeta = {
-  id: ThemeId;
-  family: ThemeFamily;
-  mode: ThemeMode;
+export interface ThemeMeta extends ThemeDefinition {
   label: string;
   description: string;
   dark: boolean;
   preview: ThemePreview;
   cssTheme: string;
-};
+}
 
 export const THEME_META: Record<ThemeId, ThemeMeta> = {
   'canvas-light': {


### PR DESCRIPTION
Adds the two missing type interfaces to src/styles/themes.ts as required
by Sprint 1 / PR #310. ThemeMeta now extends ThemeDefinition to eliminate
the duplicated id/family/mode fields and make the type hierarchy explicit.

Closes #310
https://claude.ai/code/session_01BjSanhei7rk75wuoDE4a5X