### PR TITLE
feat(types): add EventVisualPriority, EventCategory, and ViewState types

### DIFF
--- a/src/types/view.ts
+++ b/src/types/view.ts
@@ -1,0 +1,62 @@
+/**
+ * UI-facing state types for the View / Focus / Saved control system and the
+ * importance-based event visual model.
+ *
+ * These types are consumed by:
+ *   - Sprint 3: Sidebar & Control UX (ViewState, FocusFilterId, ViewId)
+ *   - Sprint 6: Event Visual System (EventVisualPriority, EventCategory)
+ *   - demo/types.ts (EventCategory, EventVisualPriority)
+ */
+
+// ── Event visual model ────────────────────────────────────────────────────────
+
+/**
+ * Drives .wcEvent.muted vs .wcEvent.high CSS classes across all views.
+ *
+ * muted  — normal recurring ops (shifts, on-call): should recede visually
+ * high   — exceptions that affect planning (PTO, mission assignment, unavailable)
+ */
+export type EventVisualPriority = 'muted' | 'high';
+
+/** Exhaustive set of operational event categories for the Air EMS demo. */
+export type EventCategory =
+  | 'dispatch-shift'
+  | 'pilot-shift'
+  | 'medical-shift'
+  | 'mechanic-shift'
+  | 'on-call'
+  | 'pto'
+  | 'mission-assignment'
+  | 'maintenance'
+  | 'training'
+  | 'aircraft-request'
+  | 'asset-request'
+  | 'base-event';
+
+export interface CalendarEventMeta {
+  visualPriority: EventVisualPriority;
+  category: EventCategory;
+}
+
+// ── View / filter state ───────────────────────────────────────────────────────
+
+/** Predefined operational views — each maps to a fixed grouping structure. */
+export type ViewId =
+  | 'by-base'
+  | 'dispatch'
+  | 'maintenance'
+  | 'crew'
+  | 'aircraft'
+  | 'mission-timeline';
+
+/** Everyday quick-filter chips (Region / Aircraft Type / Asset Requests). */
+export type FocusFilterId =
+  | 'region'
+  | 'aircraft-type'
+  | 'asset-requests';
+
+export interface ViewState {
+  activeView: ViewId;
+  focusFilters: FocusFilterId[];
+  savedViewId: string | null;
+}


### PR DESCRIPTION
Creates src/types/view.ts with all UI-facing state types needed by the View/Focus/Saved control system (Sprint 3) and importance-based event coloring (Sprint 6):

- EventVisualPriority: 'muted' | 'high'
- EventCategory: exhaustive 12-member union for Air EMS event types
- CalendarEventMeta: combines priority + category
- ViewId: 6 predefined operational views
- FocusFilterId: 3 everyday quick-filter chips
- ViewState: active view + focus filters + saved view id

Closes #311
https://claude.ai/code/session_01BjSanhei7rk75wuoDE4a5X

## Summary
Describe exactly what this PR changes.

## Scope
- Stage: 
- Planned PR number in sprint: 
- Target files/directories: 
- Why this slice is isolated: 

## Lessons Learned Check (REQUIRED)
Confirm these were actively used while building this PR:

- [ ] PR is intentionally small and isolated
- [ ] Boundary typing was prioritized over internal perfection
- [ ] No silent spread of `any`
- [ ] Advisory root `tsc` was used to catch integration issues
- [ ] I did not assume “looks typed” means “safe”
- [ ] I stopped and isolated typing cascades instead of expanding scope

## Definition of Done (ALL REQUIRED)
This PR is not done unless every box is checked.

- [ ] `npm run type-check:strict` passes
- [ ] Root advisory `tsc --noEmit` passes
- [ ] Tests pass for touched scope at minimum
- [ ] No uncontrolled increase in `any`
- [ ] All new types are intentional and named
- [ ] Public interfaces and exported functions are explicitly typed
- [ ] PR scope matches the sprint plan with no scope creep
- [ ] Any new `any` has an adjacent justification comment
- [ ] No file-wide `: any`
- [ ] No implicit `any` in exported functions

## What Was Typed
List exactly what was typed in this PR.

- 
- 
- 

## What Was Intentionally Left Loose
List anything intentionally not tightened yet.

- 
- 
- 

## `any` Ledger (REQUIRED)
- New `any` added: 
- Existing `any` removed: 
- Net change: 

For every new `any`, explain why it is required and why a safer type was not used yet.

1. 
2. 
3. 

## Boundary Notes
Document any public seams, caller-protection choices, or compatibility decisions.

- 
- 
- 

## Risk Level
- [ ] Low
- [ ] Medium
- [ ] High

Why:

## Validation Evidence
Paste the exact commands run and a short result summary.

```bash
npm run type-check:strict
npx tsc --noEmit -p tsconfig.json
```

Test commands run:

```bash
# paste commands here
```

## Stop Conditions Check
If any item below happened, explain how scope was reduced before merge.

- [ ] `any` started spreading across files
- [ ] Root `tsc` broke repeatedly
- [ ] Types required cross-module rewrites
- [ ] Scope was reduced to keep the PR reviewable

Notes:

## Reviewer Focus
What should reviewers look at first?

- 
- 
- 
