### PR TITLE
Migrate strict typing for high-yield UI dialog/setup surfaces

### DIFF
--- a/scripts/typecheck-strict.mjs
+++ b/scripts/typecheck-strict.mjs
@@ -96,6 +96,11 @@ const MIGRATED_PATHS = [
   // Stage 5b PR5
   'src/ui/FilterBar.tsx',
   'src/ui/AdvancedFilterBuilder.tsx',
+  // Stage 5b PR6 (UI dialogs/setup surfaces)
+  'src/ui/ScheduleTemplateDialog.tsx',
+  'src/ui/SetupWizardModal.tsx',
+  'src/ui/SourcePanel.tsx',
+  'src/ui/ImportPreview.tsx',
 ];
 
 // Implicit-any diagnostic codes. See:

--- a/src/ui/ImportPreview.tsx
+++ b/src/ui/ImportPreview.tsx
@@ -1,14 +1,21 @@
 /**
  * ImportPreview — confirm + import parsed iCal events.
  */
-import { useState } from 'react';
+import { useState, type MouseEvent } from 'react';
 import { format } from 'date-fns';
+import type { WorksCalendarEvent } from '../types/events';
 import styles from './ImportPreview.module.css';
 
-export default function ImportPreview({ events, onImport, onClose }: any) {
-  const [selected, setSelected] = useState(() => new Set(events.map((_, i) => i)));
+type ImportPreviewProps = {
+  events: WorksCalendarEvent[];
+  onImport?: (events: WorksCalendarEvent[]) => void;
+  onClose: () => void;
+};
 
-  function toggle(i) {
+export default function ImportPreview({ events, onImport, onClose }: ImportPreviewProps) {
+  const [selected, setSelected] = useState<Set<number>>(() => new Set(events.map((_, i: number) => i)));
+
+  function toggle(i: number) {
     setSelected(prev => {
       const next = new Set(prev);
       next.has(i) ? next.delete(i) : next.add(i);
@@ -18,11 +25,11 @@ export default function ImportPreview({ events, onImport, onClose }: any) {
 
   function toggleAll() {
     if (selected.size === events.length) setSelected(new Set());
-    else setSelected(new Set(events.map((_, i) => i)));
+    else setSelected(new Set(events.map((_, i: number) => i)));
   }
 
   function handleImport() {
-    const toImport = events.filter((_, i) => selected.has(i));
+    const toImport = events.filter((_, i: number) => selected.has(i));
     onImport?.(toImport);
     onClose();
   }
@@ -31,7 +38,7 @@ export default function ImportPreview({ events, onImport, onClose }: any) {
 
   return (
     <div className={styles.overlay} onClick={onClose}>
-      <div className={styles.dialog} onClick={e => e.stopPropagation()}>
+      <div className={styles.dialog} onClick={(e: MouseEvent<HTMLDivElement>) => e.stopPropagation()}>
         <div className={styles.header}>
           <h2 className={styles.title}>Import Events</h2>
           <span className={styles.count}>{events.length} event{events.length !== 1 ? 's' : ''} found</span>
@@ -47,7 +54,7 @@ export default function ImportPreview({ events, onImport, onClose }: any) {
         </div>
 
         <div className={styles.list}>
-          {events.map((ev, i) => {
+          {events.map((ev, i: number) => {
             const start = ev.start instanceof Date ? ev.start : new Date(ev.start);
             return (
               <label key={i} className={[styles.item, selected.has(i) && styles.itemSelected].filter(Boolean).join(' ')}>
@@ -89,6 +96,6 @@ export default function ImportPreview({ events, onImport, onClose }: any) {
   );
 }
 
-function isValid(d) {
+function isValid(d: Date): boolean {
   return d instanceof Date && !isNaN(d.getTime());
 }

--- a/src/ui/ScheduleTemplateDialog.tsx
+++ b/src/ui/ScheduleTemplateDialog.tsx
@@ -1,14 +1,69 @@
 import { useMemo, useState } from 'react';
+import type { FormEvent, MouseEvent } from 'react';
+import type { EventStatus } from '../types/events';
 import styles from './ScheduleTemplateDialog.module.css';
 
-function toDatetimeLocal(date) {
+type TemplateEntry = {
+  title: string;
+  startOffsetMinutes: number;
+  durationMinutes: number;
+};
+
+type ScheduleTemplate = {
+  id: string;
+  name: string;
+  entries: TemplateEntry[];
+};
+
+type GeneratedEvent = {
+  id?: string;
+  title?: string;
+  start?: string | number | Date;
+  end?: string | Date;
+  startOffsetMinutes?: number;
+  durationMinutes?: number;
+  category?: string | null;
+  resource?: string | null;
+  status?: EventStatus;
+  color?: string | null;
+  rrule?: string;
+  exdates?: Array<string | Date>;
+  meta?: Record<string, unknown>;
+};
+
+type PreviewConflict = {
+  index?: number;
+  violations?: Array<{ rule?: string; message?: string }>;
+};
+
+type PreviewResult = {
+  generated: GeneratedEvent[];
+  conflicts: PreviewConflict[];
+  error: string;
+};
+
+type InstantiateRequest = {
+  templateId?: string;
+  anchor: Date;
+  resource?: string;
+  category?: string;
+};
+
+type ScheduleTemplateDialogProps = {
+  templates?: ScheduleTemplate[];
+  onInstantiate?: (request: InstantiateRequest) => void;
+  onPreview?: (request: InstantiateRequest) => { generated?: GeneratedEvent[]; conflicts?: PreviewConflict[]; error?: string };
+  onClose?: () => void;
+};
+
+function toDatetimeLocal(date: string | number | Date): string {
   const d = date instanceof Date ? date : new Date(date);
   if (Number.isNaN(d.getTime())) return '';
-  const pad = (n) => String(n).padStart(2, '0');
+  const pad = (n: number) => String(n).padStart(2, '0');
   return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}`;
 }
 
-function validateTemplate(template) {
+function validateTemplate(template: ScheduleTemplate | null): string {
   if (!template) return 'Please choose a schedule template.';
   if (!Array.isArray(template.entries) || template.entries.length === 0) {
     return 'The selected template has no entries to generate.';
@@ -30,7 +85,7 @@ export default function ScheduleTemplateDialog({
   onInstantiate,
   onPreview,
   onClose,
-}: any) {
+}: ScheduleTemplateDialogProps) {
   const [templateId, setTemplateId] = useState(() => templates[0]?.id ?? '');
   const [anchor, setAnchor] = useState(() => toDatetimeLocal(new Date()));
   const [resource, setResource] = useState('');
@@ -57,7 +112,8 @@ export default function ScheduleTemplateDialog({
       return { generated: [], conflicts: [], error: anchorError || templateError || '' };
     }
     try {
-      return onPreview?.(request) ?? { generated: [], conflicts: [], error: '' };
+      const result = onPreview?.(request);
+      return { generated: result?.generated ?? [], conflicts: result?.conflicts ?? [], error: result?.error ?? '' };
     } catch {
       return { generated: [], conflicts: [], error: 'Unable to build schedule preview.' };
     }
@@ -65,15 +121,15 @@ export default function ScheduleTemplateDialog({
 
   const submitDisabled = !!(templateError || anchorError || preview.error);
   const conflictsByIndex = useMemo(() => {
-    const map = new Map();
-    (preview.conflicts ?? []).forEach((conflict) => {
+    const map = new Map<number, PreviewConflict>();
+    (preview.conflicts ?? []).forEach((conflict: PreviewConflict) => {
       if (typeof conflict?.index !== 'number') return;
       map.set(conflict.index, conflict);
     });
     return map;
   }, [preview.conflicts]);
 
-  function handleSubmit(e) {
+  function handleSubmit(e: FormEvent<HTMLFormElement>) {
     e.preventDefault();
     if (submitDisabled || !selectedTemplate) return;
 
@@ -81,7 +137,7 @@ export default function ScheduleTemplateDialog({
   }
 
   return (
-    <div className={styles.overlay} onClick={(e) => { if (e.target === e.currentTarget) onClose?.(); }}>
+    <div className={styles.overlay} onClick={(e: MouseEvent<HTMLDivElement>) => { if (e.target === e.currentTarget) onClose?.(); }}>
       <div className={styles.dialog} role="dialog" aria-modal="true" aria-label="Add schedule template">
         <div className={styles.header}>
           <h2 className={styles.title}>Add Schedule</h2>
@@ -96,7 +152,7 @@ export default function ScheduleTemplateDialog({
             <label className={styles.label}>
               Template
               <select className={styles.select} value={templateId} onChange={(e) => setTemplateId(e.target.value)}>
-                {templates.map((template) => (
+                {templates.map((template: ScheduleTemplate) => (
                   <option key={template.id} value={template.id}>{template.name}</option>
                 ))}
               </select>
@@ -144,7 +200,7 @@ export default function ScheduleTemplateDialog({
                   )}
                 </div>
                 <ul className={styles.previewList}>
-                  {preview.generated.map((ev, idx) => (
+                  {preview.generated.map((ev: GeneratedEvent, idx: number) => (
                     <li
                       key={`${ev.title}-${idx}`}
                       className={`${styles.previewItem} ${conflictsByIndex.has(idx) ? styles.previewItemConflict : ''}`}
@@ -155,9 +211,9 @@ export default function ScheduleTemplateDialog({
                       </div>
                       {conflictsByIndex.has(idx) && (
                         <ul className={styles.conflictList}>
-                          {conflictsByIndex.get(idx).violations?.map((violation, vIdx) => (
+                          {conflictsByIndex.get(idx)?.violations?.map((violation, vIdx: number) => (
                             <li key={`${violation.rule}-${vIdx}`} className={styles.conflictItem}>
-                              {violation.message}
+                              {violation.message ?? 'Conflict'}
                             </li>
                           ))}
                         </ul>

--- a/src/ui/SetupWizardModal.tsx
+++ b/src/ui/SetupWizardModal.tsx
@@ -17,6 +17,7 @@
  *   onSaveView    (name, filters, opts) => void  — wired to useSavedViews.saveView
  */
 import { useState } from 'react';
+import type { ChangeEvent, MouseEvent } from 'react';
 import { X, ChevronRight, Check, Sparkles, Camera } from 'lucide-react';
 import { THEMES, THEME_META, normalizeTheme } from '../styles/themes';
 import { useFocusTrap } from '../hooks/useFocusTrap';
@@ -24,11 +25,31 @@ import AdvancedFilterBuilder from './AdvancedFilterBuilder';
 import styles from './SetupWizardModal.module.css';
 
 const TOTAL_STEPS = 4;
-const DEFAULT_TEAM_MEMBERS = [
+type TeamMember = {
+  id: number;
+  name: string;
+  color: string;
+  avatar: string | null;
+};
+const DEFAULT_TEAM_MEMBERS: TeamMember[] = [
   { id: 1, name: 'Priya', color: '#8b5cf6', avatar: null },
   { id: 2, name: 'Alex',  color: '#ec4899', avatar: null },
   { id: 3, name: 'Dana',  color: '#14b8a6', avatar: null },
 ];
+
+type CreatedView = {
+  name: string;
+  conditions: unknown[];
+};
+
+type SetupWizardModalProps = {
+  isOpen: boolean;
+  onClose?: () => void;
+  updateConfig?: (patch: Record<string, unknown>) => void;
+  categories?: string[];
+  resources?: string[];
+  onSaveView?: (name: string, filters: Record<string, unknown>, options: Record<string, unknown>) => void;
+};
 
 // ─── Main modal ───────────────────────────────────────────────────────────────
 
@@ -39,19 +60,19 @@ export default function SetupWizardModal({
   categories = [],
   resources  = [],
   onSaveView,
-}: any) {
+}: SetupWizardModalProps) {
   const [step,           setStep]           = useState(1);
   const [calendarName,   setCalendarName]   = useState('My WorksCalendar');
   const [selectedTheme,  setSelectedTheme]  = useState('corporate');
-  const [createdViews,   setCreatedViews]   = useState([]); // { name, conditions }[]
-  const [teamMembers,    setTeamMembers]    = useState(DEFAULT_TEAM_MEMBERS);
+  const [createdViews,   setCreatedViews]   = useState<CreatedView[]>([]); // { name, conditions }[]
+  const [teamMembers,    setTeamMembers]    = useState<TeamMember[]>(DEFAULT_TEAM_MEMBERS);
   const trapRef = useFocusTrap(onClose);
 
   if (!isOpen) return null;
 
-  const handleSaveView = (name, filters, conditions) => {
+  const handleSaveView = (name: string, filters: Record<string, unknown>, conditions: unknown[]) => {
     onSaveView?.(name, filters, { color: null });
-    setCreatedViews(prev => [...prev, { name, conditions }]);
+    setCreatedViews((prev) => [...prev, { name, conditions }]);
   };
 
   const handleFinish = () => {
@@ -68,14 +89,15 @@ export default function SetupWizardModal({
     onClose?.();
   };
 
-  const handleProfileUpload = (memberId, e) => {
+  const handleProfileUpload = (memberId: number, e: ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
     if (!file) return;
 
     const reader = new FileReader();
-    reader.onload = (ev) => {
-      setTeamMembers(prev => prev.map(member =>
-        member.id === memberId ? { ...member, avatar: ev.target.result } : member
+    reader.onload = (ev: ProgressEvent<FileReader>) => {
+      const avatar = typeof ev.target?.result === 'string' ? ev.target.result : null;
+      setTeamMembers((prev) => prev.map((member) =>
+        member.id === memberId ? { ...member, avatar } : member
       ));
     };
     reader.readAsDataURL(file);
@@ -87,7 +109,7 @@ export default function SetupWizardModal({
   return (
     <div
       className={styles.overlay}
-      onClick={e => e.target === e.currentTarget && onClose?.()}
+      onClick={(e: MouseEvent<HTMLDivElement>) => e.target === e.currentTarget && onClose?.()}
     >
       <div
         ref={trapRef}
@@ -182,7 +204,14 @@ export default function SetupWizardModal({
 
 // ─── Step 1: Basic info ───────────────────────────────────────────────────────
 
-function Step1({ calendarName, onCalendarNameChange, selectedTheme, onThemeChange }: any) {
+type Step1Props = {
+  calendarName: string;
+  onCalendarNameChange: (name: string) => void;
+  selectedTheme: string;
+  onThemeChange: (themeId: string) => void;
+};
+
+function Step1({ calendarName, onCalendarNameChange, selectedTheme, onThemeChange }: Step1Props) {
   // The wizard seeds `selectedTheme` with a legacy id ('corporate'); normalize
   // so the matching theme-family card shows as selected on first render.
   const normalizedSelected = normalizeTheme(selectedTheme);
@@ -248,7 +277,13 @@ function Step1({ calendarName, onCalendarNameChange, selectedTheme, onThemeChang
 
 // ─── Step 2: Team members ─────────────────────────────────────────────────────
 
-function Step2Team({ teamMembers, onTeamMemberNameChange, onUpload }: any) {
+type Step2TeamProps = {
+  teamMembers: TeamMember[];
+  onTeamMemberNameChange: (id: number, name: string) => void;
+  onUpload: (id: number, e: ChangeEvent<HTMLInputElement>) => void;
+};
+
+function Step2Team({ teamMembers, onTeamMemberNameChange, onUpload }: Step2TeamProps) {
   return (
     <div className={styles.step}>
       <div className={styles.stepHeader}>
@@ -301,7 +336,14 @@ function Step2Team({ teamMembers, onTeamMemberNameChange, onUpload }: any) {
 
 // ─── Step 3: Smart Views ──────────────────────────────────────────────────────
 
-function Step2({ categories, resources, createdViews, onSaveView }: any) {
+type Step2Props = {
+  categories: string[];
+  resources: string[];
+  createdViews: CreatedView[];
+  onSaveView: (name: string, filters: Record<string, unknown>, conditions: unknown[]) => void;
+};
+
+function Step2({ categories, resources, createdViews, onSaveView }: Step2Props) {
   return (
     <div className={styles.step}>
       <div className={styles.stepHeader}>
@@ -324,7 +366,7 @@ function Step2({ categories, resources, createdViews, onSaveView }: any) {
         <div className={styles.createdList}>
           <span className={styles.createdLabel}>Created this session:</span>
           <div className={styles.createdChips}>
-            {createdViews.map((v, i) => (
+            {createdViews.map((v: CreatedView, i: number) => (
               <span key={i} className={styles.createdChip}>
                 <Check size={11} />{v.name}
               </span>
@@ -338,7 +380,14 @@ function Step2({ categories, resources, createdViews, onSaveView }: any) {
 
 // ─── Step 4: Done ─────────────────────────────────────────────────────────────
 
-function Step3({ calendarName, selectedTheme, teamMembers, createdViews }: any) {
+type Step3Props = {
+  calendarName: string;
+  selectedTheme: string;
+  teamMembers: TeamMember[];
+  createdViews: CreatedView[];
+};
+
+function Step3({ calendarName, selectedTheme, teamMembers, createdViews }: Step3Props) {
   // Summary card lookup — normalize so legacy ids still resolve to metadata.
   const normalizedSelected = selectedTheme ? normalizeTheme(selectedTheme) : undefined;
   const theme = normalizedSelected

--- a/src/ui/SourcePanel.tsx
+++ b/src/ui/SourcePanel.tsx
@@ -16,12 +16,14 @@
  *   onToggle    — (id: string) => void
  */
 import { useState, useRef } from 'react';
+import type { ChangeEvent, KeyboardEvent } from 'react';
 import { format } from 'date-fns';
 import {
   Plus, Trash2, RefreshCw, AlertCircle, CheckCircle,
   Link, FileSpreadsheet,
 } from 'lucide-react';
 import { fetchAndParseICS } from '../core/icalParser';
+import type { WorksCalendarEvent } from '../types/events';
 import styles from './ConfigPanel.module.css';
 
 // ── Shared constants ──────────────────────────────────────────────────────────
@@ -40,7 +42,30 @@ const REFRESH_OPTIONS = [
   { label: 'Manual',     value: null       },
 ];
 
-function ColorDot({ color, size = 12, onClick }: any) {
+type CalendarSource = {
+  id: string;
+  type: string;
+  label?: string;
+  color?: string;
+  enabled?: boolean;
+  url?: string;
+  refreshInterval?: number | null;
+  events?: WorksCalendarEvent[];
+  importedAt?: string;
+};
+
+type FeedErrorEntry = {
+  feed?: { url?: string };
+  err?: unknown;
+};
+
+type SourceHandlers = {
+  onToggle: (id: string) => void;
+  onRemove: (id: string) => void;
+  onUpdate: (id: string, patch: Partial<CalendarSource>) => void;
+};
+
+function ColorDot({ color, size = 12, onClick }: { color: string; size?: number; onClick: () => void }) {
   return (
     <button
       title="Change colour"
@@ -60,7 +85,7 @@ function ColorDot({ color, size = 12, onClick }: any) {
   );
 }
 
-function ToggleSwitch({ checked, onChange, title }: any) {
+function ToggleSwitch({ checked, onChange, title }: { checked: boolean; onChange: () => void; title: string }) {
   return (
     <label
       className={styles.toggle}
@@ -73,7 +98,7 @@ function ToggleSwitch({ checked, onChange, title }: any) {
   );
 }
 
-function RemoveBtn({ onClick, title = 'Remove' }: any) {
+function RemoveBtn({ onClick, title = 'Remove' }: { onClick: () => void; title?: string }) {
   return (
     <button
       className={styles.removeBtn}
@@ -86,7 +111,7 @@ function RemoveBtn({ onClick, title = 'Remove' }: any) {
   );
 }
 
-function rowStyle(enabled) {
+function rowStyle(enabled: boolean) {
   return {
     display: 'flex', alignItems: 'center', gap: 10,
     padding: '9px 10px',
@@ -99,10 +124,10 @@ function rowStyle(enabled) {
 
 // ── ICS feed row ──────────────────────────────────────────────────────────────
 
-function IcsFeedRow({ source, error, onToggle, onRemove, onUpdate }: any) {
+function IcsFeedRow({ source, error, onToggle, onRemove, onUpdate }: { source: CalendarSource; error?: unknown } & SourceHandlers) {
   const [editing, setEditing] = useState(false);
   const [draft,   setDraft]   = useState(source.label);
-  const inputRef = useRef(null);
+  const inputRef = useRef<HTMLInputElement | null>(null);
 
   function commitEdit() {
     const trimmed = draft.trim();
@@ -114,7 +139,7 @@ function IcsFeedRow({ source, error, onToggle, onRemove, onUpdate }: any) {
   const statusIcon = !source.enabled
     ? null
     : error
-      ? <AlertCircle size={14} color="var(--wc-danger)" aria-label={error.message} />
+      ? <AlertCircle size={14} color="var(--wc-danger)" aria-label={error instanceof Error ? error.message : 'Feed error'} />
       : <CheckCircle size={14} color="var(--wc-success, #10b981)" />;
 
   return (
@@ -134,9 +159,9 @@ function IcsFeedRow({ source, error, onToggle, onRemove, onUpdate }: any) {
             autoFocus
             className={styles.input}
             value={draft}
-            onChange={e => setDraft(e.target.value)}
+            onChange={(e: ChangeEvent<HTMLInputElement>) => setDraft(e.target.value)}
             onBlur={commitEdit}
-            onKeyDown={e => {
+            onKeyDown={(e: KeyboardEvent<HTMLInputElement>) => {
               if (e.key === 'Enter') commitEdit();
               if (e.key === 'Escape') { setDraft(source.label); setEditing(false); }
             }}
@@ -179,7 +204,7 @@ function IcsFeedRow({ source, error, onToggle, onRemove, onUpdate }: any) {
 
 // ── CSV dataset row ───────────────────────────────────────────────────────────
 
-function CsvDatasetRow({ source, onToggle, onRemove, onUpdate }: any) {
+function CsvDatasetRow({ source, onToggle, onRemove, onUpdate }: { source: CalendarSource } & SourceHandlers) {
   const [editing, setEditing] = useState(false);
   const [draft,   setDraft]   = useState(source.label);
 
@@ -209,9 +234,9 @@ function CsvDatasetRow({ source, onToggle, onRemove, onUpdate }: any) {
             autoFocus
             className={styles.input}
             value={draft}
-            onChange={e => setDraft(e.target.value)}
+            onChange={(e: ChangeEvent<HTMLInputElement>) => setDraft(e.target.value)}
             onBlur={commitEdit}
-            onKeyDown={e => {
+            onKeyDown={(e: KeyboardEvent<HTMLInputElement>) => {
               if (e.key === 'Enter') commitEdit();
               if (e.key === 'Escape') { setDraft(source.label); setEditing(false); }
             }}
@@ -250,14 +275,14 @@ function CsvDatasetRow({ source, onToggle, onRemove, onUpdate }: any) {
 
 // ── Add ICS feed form ─────────────────────────────────────────────────────────
 
-function AddFeedForm({ onAdd }: any) {
+function AddFeedForm({ onAdd }: { onAdd: (source: Partial<CalendarSource>) => void }) {
   const [open,            setOpen]            = useState(false);
   const [url,             setUrl]             = useState('');
   const [label,           setLabel]           = useState('');
   const [color,           setColor]           = useState(PRESET_COLORS[0]);
   const [refreshInterval, setRefreshInterval] = useState(300_000);
   const [validating,      setValidating]      = useState(false);
-  const [validation,      setValidation]      = useState(null);
+  const [validation,      setValidation]      = useState<{ ok: boolean; count?: number; error?: string; corsLikely?: boolean } | null>(null);
 
   function reset() {
     setUrl(''); setLabel(''); setColor(PRESET_COLORS[0]);
@@ -273,11 +298,11 @@ function AddFeedForm({ onAdd }: any) {
       const events = await fetchAndParseICS(trimmed);
       if (!label) setLabel(_suggestLabel(trimmed));
       setValidation({ ok: true, count: events.length });
-    } catch (err: any) {
+    } catch (err: unknown) {
       const isCors = ['cors', 'fetch', 'network', 'failed'].some(
-        w => err.message?.toLowerCase().includes(w),
+        w => (err instanceof Error ? err.message : String(err)).toLowerCase().includes(w),
       );
-      setValidation({ ok: false, error: err.message, corsLikely: isCors });
+      setValidation({ ok: false, error: err instanceof Error ? err.message : String(err), corsLikely: isCors });
     } finally {
       setValidating(false);
     }
@@ -437,7 +462,7 @@ function AddFeedForm({ onAdd }: any) {
 
 // ── Section heading ───────────────────────────────────────────────────────────
 
-function SectionHeading({ icon: Icon, label, count, errors }: any) {
+function SectionHeading({ icon: Icon, label, count, errors }: { icon: typeof Link; label: string; count?: number; errors: number | null }) {
   return (
     <div style={{
       display: 'flex', alignItems: 'center', gap: 6,
@@ -463,15 +488,28 @@ function SectionHeading({ icon: Icon, label, count, errors }: any) {
 
 // ── Panel ─────────────────────────────────────────────────────────────────────
 
-export default function SourcePanel({ sources, feedErrors, onAdd, onRemove, onToggle, onUpdate }: any) {
-  const icsSources = (sources ?? []).filter(s => s.type === 'ics');
-  const csvSources = (sources ?? []).filter(s => s.type === 'csv');
+type SourcePanelProps = {
+  sources?: Array<Partial<CalendarSource>>;
+  feedErrors?: unknown[];
+  onAdd: (source: Partial<CalendarSource>) => void;
+  onRemove: (id: string) => void;
+  onToggle: (id: string) => void;
+  onUpdate: (id: string, patch: Partial<CalendarSource>) => void;
+};
+
+export default function SourcePanel({ sources, feedErrors, onAdd, onRemove, onToggle, onUpdate }: SourcePanelProps) {
+  const normalizedSources = (sources ?? []) as CalendarSource[];
+  const icsSources = normalizedSources.filter((s: CalendarSource) => s.type === 'ics');
+  const csvSources = normalizedSources.filter((s: CalendarSource) => s.type === 'csv');
 
   const errorByUrl = Object.fromEntries(
-    (feedErrors ?? []).map(({ feed, err }) => [feed.url, err]),
+    (feedErrors ?? []).map((entry) => {
+      const value = entry as FeedErrorEntry;
+      return [value.feed?.url ?? '', value.err];
+    }),
   );
 
-  const icsErrors = icsSources.filter(s => s.enabled && errorByUrl[s.url]).length;
+  const icsErrors = icsSources.filter((s: CalendarSource) => s.enabled && s.url && errorByUrl[s.url]).length;
 
   const hasSources = icsSources.length > 0 || csvSources.length > 0;
 
@@ -482,7 +520,7 @@ export default function SourcePanel({ sources, feedErrors, onAdd, onRemove, onTo
         Toggle any source to show or hide its events instantly.
         {hasSources && (
           <span style={{ marginLeft: 6 }}>
-            {(sources ?? []).filter(s => s.enabled).length} of {(sources ?? []).length} active.
+            {normalizedSources.filter((s: CalendarSource) => s.enabled).length} of {normalizedSources.length} active.
           </span>
         )}
       </p>
@@ -507,7 +545,7 @@ export default function SourcePanel({ sources, feedErrors, onAdd, onRemove, onTo
           </div>
         ) : (
           <div style={{ display: 'flex', flexDirection: 'column', gap: 6, marginBottom: 8 }}>
-            {icsSources.map(src => (
+            {icsSources.map((src: CalendarSource) => (
               <IcsFeedRow
                 key={src.id}
                 source={src}
@@ -533,7 +571,7 @@ export default function SourcePanel({ sources, feedErrors, onAdd, onRemove, onTo
             errors={null}
           />
           <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
-            {csvSources.map(src => (
+            {csvSources.map((src: CalendarSource) => (
               <CsvDatasetRow
                 key={src.id}
                 source={src}
@@ -556,7 +594,7 @@ export default function SourcePanel({ sources, feedErrors, onAdd, onRemove, onTo
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
-function _suggestLabel(url) {
+function _suggestLabel(url: string): string {
   try {
     const u = new URL(url.replace(/^webcal:/, 'https:'));
     return u.hostname.replace(/^(www|calendar)\./, '');
@@ -565,6 +603,6 @@ function _suggestLabel(url) {
   }
 }
 
-function _fmtDate(iso) {
+function _fmtDate(iso: string): string {
   try { return format(new Date(iso), 'MMM d, yyyy'); } catch { return ''; }
 }


### PR DESCRIPTION
### Motivation

- Reduce implicit-`any` hotspots in the largest UI dialog/setup surfaces to advance the staged noImplicitAny migration and avoid a cross-module type cascade. 
- Target the four highest-yield files that drive many diagnostics in `src/ui` so the strict ratchet can be advanced safely.

### Description

- Added explicit local TypeScript types and signatures to `src/ui/ScheduleTemplateDialog.tsx`, `src/ui/SetupWizardModal.tsx`, `src/ui/SourcePanel.tsx`, and `src/ui/ImportPreview.tsx`, converting internal `any` usage to typed shapes while keeping APIs permissive where needed to avoid cascading changes. 
- Made conservative, local model types for templates, generated-preview events, sources, feed errors, team members, and props/handler shapes and adjusted event handler signatures and DOM event typings accordingly. 
- Improved runtime-safe handling for preview/error payloads and feed validation (e.g., safer `Error` checks and fallback strings) without changing UI behavior. 
- Added the four migrated files to the strict migration allowlist in `scripts/typecheck-strict.mjs` so they are enforced by the repo ratchet.

### Testing

- Ran `npm run type-check:strict` and the script reported the strict migration as green with the four files added to `MIGRATED_PATHS` (success). 
- Ran `npx tsc --noEmit -p tsconfig.json` and the TypeScript build completed without errors (success). 
- Ran the focused unit test suite for the dialog via `npx vitest run src/ui/__tests__/ScheduleTemplateDialog.test.tsx` and all tests passed (success).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8b84530f8832cbb6854bbb9442d76)