### PR TITLE
feat(types): add mission requirement types and rewrite demo/types.ts

### DIFF
--- a/demo/types.ts
+++ b/demo/types.ts
@@ -1,138 +1,111 @@
-// Type definitions for EMS data
+/**
+ * JSON-safe record interfaces for the Air EMS demo dataset.
+ *
+ * All fields are plain JSON primitives (string, number, boolean, string[]).
+ * No Date objects, Maps, Sets, or class instances — data must be
+ * serializable and usable in JSON config/data flows.
+ *
+ * Used by demo/emsData.ts (Sprint 4) and demo/App.tsx.
+ */
 
-// Employee ID type
-export type EmployeeId = string;
+import type { EventCategory, EventVisualPriority } from '../src/types/view';
+import type { MissionRequirements, MissionAssignments } from '../src/types/mission';
 
-// Employee record
+// ── Personnel ─────────────────────────────────────────────────────────────────
+
+export type DemoEmployeeRole =
+  | 'dispatcher'
+  | 'pilot'
+  | 'rn'
+  | 'rt'
+  | 'medic'
+  | 'mechanic';
+
+export type DemoShiftType = 'day' | 'night' | 'on-call';
+
+export type DemoDutyStatus = 'on-duty' | 'off-duty' | 'on-call';
+
 export interface DemoEmployee {
-    id: EmployeeId;
-    name: string;
-    position: string;
-    department: string;
+  id: string;
+  name: string;
+  role: DemoEmployeeRole;
+  certifications: string[];
+  shiftType: DemoShiftType;
+  dutyStatus: DemoDutyStatus;
+  basedAt: string;
 }
 
-// Asset resource record
-export interface DemoAssetResource {
-    id: string;
-    name: string;
-    type: string;
-    status: string;
+// ── Aircraft ──────────────────────────────────────────────────────────────────
+
+export type DemoAircraftType = 'helicopter' | 'fixed-wing';
+
+export type DemoAircraftStatus = 'available' | 'maintenance' | 'assigned';
+
+export interface DemoAircraft {
+  id: string;
+  tail: string;
+  name: string;
+  type: DemoAircraftType;
+  hoursRemaining: number;
+  basedAt: string;
+  capabilities: string[];
+  status: DemoAircraftStatus;
 }
 
-// Approval stages
-export enum ApprovalStage {
-    Pending,
-    Approved,
-    Rejected,
+// ── Geography ─────────────────────────────────────────────────────────────────
+
+export interface DemoRegion {
+  id: string;
+  name: string;
 }
 
-// Approval action payload
-export interface ApprovalActionPayload {
-    employeeId: EmployeeId;
-    approvalStage: ApprovalStage;
+export interface DemoBase {
+  id: string;
+  name: string;
+  regionId: string;
 }
 
-// Event record
+// ── Events ────────────────────────────────────────────────────────────────────
+
 export interface DemoEvent {
-    id: string;
-    title: string;
-    start: Date;
-    end: Date;
+  id: string;
+  title: string;
+  /** ISO 8601 string — no Date objects. */
+  start: string;
+  /** ISO 8601 string — no Date objects. */
+  end: string;
+  category: EventCategory;
+  visualPriority: EventVisualPriority;
+  /** Employee id, aircraft id, or base id this event belongs to. */
+  assignedTo?: string;
+  basedAt?: string;
 }
 
-// Note record
-export interface DemoNote {
-    id: string;
-    content: string;
+// ── Mission request ───────────────────────────────────────────────────────────
+
+export interface DemoMissionLeg {
+  id: string;
+  from: string;
+  to: string;
+  start: string;
+  end: string;
 }
 
-// Notes map
-export interface DemoNotesMap {
-    [key: string]: DemoNote;
+export type DemoComplianceStatus = 'approved' | 'pending' | 'rejected';
+
+export interface DemoComplianceItem {
+  id: string;
+  label: string;
+  status: DemoComplianceStatus;
 }
 
-// Category record
-export interface DemoCategory {
-    id: string;
-    name: string;
-}
-
-// Pool record
-export interface DemoPool {
-    id: string;
-    name: string;
-}
-
-// Profile record
-export interface DemoProfile {
-    employeeId: EmployeeId;
-    skills: string[];
-    certifications: string[];
-}
-
-// EMS data record types
-export interface RegionRecord {
-    id: string;
-    name: string;
-}
-
-export interface BaseRecord {
-    id: string;
-    createdAt: Date;
-}
-
-export interface AssetRecord extends BaseRecord {
-    assetId: string;
-    resource: DemoAssetResource;
-}
-
-export interface PilotRecord extends BaseRecord {
-    pilotId: string;
-    hoursFlown: number;
-}
-
-export interface MedicalRecord extends BaseRecord {
-    recordId: string;
-    medicalHistory: string;
-}
-
-export interface MechanicRecord extends BaseRecord {
-    mechanicId: string;
-    maintenanceRecord: string;
-}
-
-export interface ShiftRecord extends BaseRecord {
-    shiftId: string;
-    schedule: Date[];
-}
-
-export interface MaintenanceRecord extends BaseRecord {
-    maintenanceId: string;
-    status: string;
-}
-
-export interface RequestRecord extends BaseRecord {
-    requestId: string;
-    details: string;
-}
-
-export interface MissionLeg {
-    id: string;
-    departure: string;
-    arrival: string;
-}
-
-export interface CrewAssignment {
-    crewId: string;
-    memberIds: EmployeeId[];
-}
-
-export interface ComplianceItem {
-    itemId: string;
-    status: string;
-}
-
-export interface MissionRecord extends BaseRecord {
-    missionId: string;
-    legs: MissionLeg[];
+export interface DemoMissionRequest {
+  id: string;
+  title: string;
+  start: string;
+  end: string;
+  requirements: MissionRequirements;
+  assignments: MissionAssignments;
+  legs: DemoMissionLeg[];
+  compliance: DemoComplianceItem[];
 }

--- a/src/types/mission.ts
+++ b/src/types/mission.ts
@@ -1,0 +1,60 @@
+/**
+ * Mission requirement and assignment types.
+ *
+ * Used by:
+ *   - Sprint 5: Mission request workflow (hover card, slot assignment, validation)
+ *   - demo/types.ts: DemoMissionRequest
+ */
+
+// ── Requirement slot types ────────────────────────────────────────────────────
+
+export interface PilotRequirement {
+  count: number;
+  certifications: string[];
+}
+
+export interface MedicalSlot {
+  role: string;
+  certifications: string[];
+}
+
+export interface AircraftRequirement {
+  minHoursRemaining: number;
+  requiredCapabilities?: string[];
+}
+
+export interface MissionRequirements {
+  aircraft: AircraftRequirement;
+  crew: {
+    pilots: PilotRequirement;
+    medical: MedicalSlot[];
+  };
+  durationDays: number;
+}
+
+// ── Assignment types ──────────────────────────────────────────────────────────
+
+export type AssignedResourceType = 'pilot' | 'medical' | 'aircraft';
+
+export interface AssignedResource {
+  resourceId: string;
+  resourceType: AssignedResourceType;
+}
+
+export interface MissionAssignments {
+  pilots: AssignedResource[];
+  medical: AssignedResource[];
+  aircraft: AssignedResource | null;
+}
+
+// ── Validation types ──────────────────────────────────────────────────────────
+
+/** Per-slot validation result rendered as ✅ met / ⚠ partial / ❌ unmet. */
+export type RequirementStatus = 'met' | 'partial' | 'unmet';
+
+export interface RequirementValidation {
+  pilots: RequirementStatus;
+  /** One entry per MedicalSlot in MissionRequirements.crew.medical. */
+  medical: RequirementStatus[];
+  aircraft: RequirementStatus;
+}


### PR DESCRIPTION
Creates src/types/mission.ts with all requirement slot and assignment types needed by the Sprint 5 request workflow:
- PilotRequirement, MedicalSlot, AircraftRequirement, MissionRequirements
- AssignedResource, MissionAssignments
- RequirementStatus, RequirementValidation

Rewrites demo/types.ts (was unused placeholder code with non-JSON-safe Date fields and enums) with clean JSON-safe interfaces for Sprint 4:
- DemoEmployee, DemoAircraft, DemoRegion, DemoBase
- DemoEvent (ISO string dates, EventCategory, EventVisualPriority)
- DemoMissionRequest, DemoMissionLeg, DemoComplianceItem

Closes #312
https://claude.ai/code/session_01BjSanhei7rk75wuoDE4a5X

## Summary
Describe exactly what this PR changes.

## Scope
- Stage: 
- Planned PR number in sprint: 
- Target files/directories: 
- Why this slice is isolated: 

## Lessons Learned Check (REQUIRED)
Confirm these were actively used while building this PR:

- [ ] PR is intentionally small and isolated
- [ ] Boundary typing was prioritized over internal perfection
- [ ] No silent spread of `any`
- [ ] Advisory root `tsc` was used to catch integration issues
- [ ] I did not assume “looks typed” means “safe”
- [ ] I stopped and isolated typing cascades instead of expanding scope

## Definition of Done (ALL REQUIRED)
This PR is not done unless every box is checked.

- [ ] `npm run type-check:strict` passes
- [ ] Root advisory `tsc --noEmit` passes
- [ ] Tests pass for touched scope at minimum
- [ ] No uncontrolled increase in `any`
- [ ] All new types are intentional and named
- [ ] Public interfaces and exported functions are explicitly typed
- [ ] PR scope matches the sprint plan with no scope creep
- [ ] Any new `any` has an adjacent justification comment
- [ ] No file-wide `: any`
- [ ] No implicit `any` in exported functions

## What Was Typed
List exactly what was typed in this PR.

- 
- 
- 

## What Was Intentionally Left Loose
List anything intentionally not tightened yet.

- 
- 
- 

## `any` Ledger (REQUIRED)
- New `any` added: 
- Existing `any` removed: 
- Net change: 

For every new `any`, explain why it is required and why a safer type was not used yet.

1. 
2. 
3. 

## Boundary Notes
Document any public seams, caller-protection choices, or compatibility decisions.

- 
- 
- 

## Risk Level
- [ ] Low
- [ ] Medium
- [ ] High

Why:

## Validation Evidence
Paste the exact commands run and a short result summary.

```bash
npm run type-check:strict
npx tsc --noEmit -p tsconfig.json
```

Test commands run:

```bash
# paste commands here
```

## Stop Conditions Check
If any item below happened, explain how scope was reduced before merge.

- [ ] `any` started spreading across files
- [ ] Root `tsc` broke repeatedly
- [ ] Types required cross-module rewrites
- [ ] Scope was reduced to keep the PR reviewable

Notes:

## Reviewer Focus
What should reviewers look at first?

- 
- 
- 
