### PR TITLE
Sprint 3: finish non-view UI strict typing pass and ProfileBar redesign test

### DIFF
--- a/scripts/typecheck-strict.mjs
+++ b/scripts/typecheck-strict.mjs
@@ -101,6 +101,27 @@ const MIGRATED_PATHS = [
   'src/ui/SetupWizardModal.tsx',
   'src/ui/SourcePanel.tsx',
   'src/ui/ImportPreview.tsx',
+  // Stage 5b PR7 (remaining non-view UI block + ProfileBar redesign test)
+  'src/ui/ApprovalActionMenu.tsx',
+  'src/ui/AssetRequestForm.tsx',
+  'src/ui/AvailabilityForm.tsx',
+  'src/ui/ConflictModal.tsx',
+  'src/ui/EmployeeActionCard.tsx',
+  'src/ui/EventForm.tsx',
+  'src/ui/EventFormSections/CategorySection.tsx',
+  'src/ui/EventFormSections/CustomFieldsSection.tsx',
+  'src/ui/EventFormSections/RecurrenceSection.tsx',
+  'src/ui/HoverCard.tsx',
+  'src/ui/ICSFeedPanel.tsx',
+  'src/ui/ImportZone.tsx',
+  'src/ui/InlineEventEditor.tsx',
+  'src/ui/OwnerLock.tsx',
+  'src/ui/OwnerLoginModal.tsx',
+  'src/ui/ScreenReaderAnnouncer.tsx',
+  'src/ui/ValidationAlert.tsx',
+  'src/ui/ViewsDropdown.tsx',
+  'src/ui/WorkflowSimulator.tsx',
+  'src/ui/__tests__/ProfileBar.redesign.test.tsx',
 ];
 
 // Implicit-any diagnostic codes. See:

--- a/src/ui/ApprovalActionMenu.tsx
+++ b/src/ui/ApprovalActionMenu.tsx
@@ -25,7 +25,7 @@ const DEFAULT_LABELS = {
  * approvals block. Returns [] when the feature is disabled, the stage is
  * unknown, or the stage has no rules.
  */
-export function allowedActionsFor(stage, approvalsConfig) {
+export function allowedActionsFor(stage: string, approvalsConfig: any): string[] {
   if (!approvalsConfig || approvalsConfig.enabled !== true) return [];
   const stageRule = approvalsConfig.rules?.[stage];
   const allow = Array.isArray(stageRule?.allow) ? stageRule.allow : [];
@@ -47,14 +47,14 @@ export default function ApprovalActionMenu({
   anchorRect,
   variant = 'popover',
 }: any) {
-  const ref = useRef(null);
+  const ref = useRef<HTMLDivElement | null>(null);
   const actions = allowedActionsFor(stage, approvalsConfig);
 
   useEffect(() => {
     if (variant !== 'popover' || actions.length === 0) return;
-    const onKey = e => { if (e.key === 'Escape') onClose?.(); };
-    const onDown = e => {
-      if (ref.current && !ref.current.contains(e.target)) onClose?.();
+    const onKey = (e: KeyboardEvent): void => { if (e.key === 'Escape') onClose?.(); };
+    const onDown = (e: MouseEvent): void => {
+      if (ref.current && !ref.current.contains(e.target as Node)) onClose?.();
     };
     window.addEventListener('keydown', onKey);
     window.addEventListener('mousedown', onDown);
@@ -88,7 +88,7 @@ export default function ApprovalActionMenu({
       data-variant={variant}
       style={style}
     >
-      {actions.map(action => (
+      {actions.map((action: string) => (
         <button
           key={action}
           type="button"
@@ -101,7 +101,7 @@ export default function ApprovalActionMenu({
             onClose?.();
           }}
         >
-          {labels[action] ?? DEFAULT_LABELS[action] ?? action}
+          {labels[action] ?? DEFAULT_LABELS[action as keyof typeof DEFAULT_LABELS] ?? action}
         </button>
       ))}
     </div>

--- a/src/ui/AssetRequestForm.tsx
+++ b/src/ui/AssetRequestForm.tsx
@@ -10,16 +10,17 @@
  * ships with `meta.approvalStage = { stage: 'requested', updatedAt }`.
  */
 import { useMemo, useState } from 'react';
+import type { FormEvent, ChangeEvent, MouseEvent } from 'react';
 import { X } from 'lucide-react';
 import { useFocusTrap } from '../hooks/useFocusTrap';
 import styles from './EventForm.module.css';
 
-function toLocalInput(date) {
-  const pad = (n) => String(n).padStart(2, '0');
+function toLocalInput(date: Date): string {
+  const pad = (n: number): string => String(n).padStart(2, '0');
   return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}T${pad(date.getHours())}:${pad(date.getMinutes())}`;
 }
 
-function fromLocalInput(value) {
+function fromLocalInput(value: string): Date {
   // Interpret as local time (same convention as EventForm's fromDatetimeLocal).
   const [datePart, timePart] = value.split('T');
   const [y, m, d] = datePart.split('-').map(Number);
@@ -49,7 +50,7 @@ export default function AssetRequestForm({
   const [errors,   setErrors]   = useState<Record<string, string>>({});
 
   const assetOptions = useMemo(
-    () => assets.map(a => ({ value: a.id, label: a.label || a.id })),
+    () => assets.map((a: any) => ({ value: a.id, label: a.label || a.id })),
     [assets],
   );
 
@@ -67,7 +68,7 @@ export default function AssetRequestForm({
     return Object.keys(e).length === 0;
   }
 
-  function handleSubmit(e) {
+  function handleSubmit(e: FormEvent<HTMLFormElement>) {
     e.preventDefault();
     if (!validate()) return;
     const now = new Date().toISOString();
@@ -86,7 +87,7 @@ export default function AssetRequestForm({
   }
 
   return (
-    <div className={styles.overlay} onClick={e => e.target === e.currentTarget && onClose()}>
+    <div className={styles.overlay} onClick={(e: MouseEvent<HTMLDivElement>) => e.target === e.currentTarget && onClose()}>
       <div
         className={styles.modal}
         ref={trapRef}
@@ -105,7 +106,7 @@ export default function AssetRequestForm({
               id="ar-title"
               className={[styles.input, errors.title && styles.inputError].filter(Boolean).join(' ')}
               value={title}
-              onChange={e => setTitle(e.target.value)}
+              onChange={(e: ChangeEvent<HTMLInputElement>) => setTitle(e.target.value)}
               placeholder="e.g. A-check, VIP charter, CRM training"
               autoFocus
             />
@@ -119,9 +120,9 @@ export default function AssetRequestForm({
                 id="ar-asset"
                 className={styles.select}
                 value={assetId}
-                onChange={e => setAssetId(e.target.value)}
+                onChange={(e: ChangeEvent<HTMLSelectElement>) => setAssetId(e.target.value)}
               >
-                {assetOptions.map(o => <option key={o.value} value={o.value}>{o.label}</option>)}
+                {assetOptions.map((o: { value: string; label: string }) => <option key={o.value} value={o.value}>{o.label}</option>)}
               </select>
               {errors.assetId && <span className={styles.error}>{errors.assetId}</span>}
             </div>
@@ -131,9 +132,9 @@ export default function AssetRequestForm({
                 id="ar-category"
                 className={styles.select}
                 value={category}
-                onChange={e => setCategory(e.target.value)}
+                onChange={(e: ChangeEvent<HTMLSelectElement>) => setCategory(e.target.value)}
               >
-                {categories.map(c => (
+                {categories.map((c: any) => (
                   <option key={c.id} value={c.id}>{c.label || c.id}</option>
                 ))}
               </select>
@@ -149,7 +150,7 @@ export default function AssetRequestForm({
                 type="datetime-local"
                 className={[styles.input, errors.start && styles.inputError].filter(Boolean).join(' ')}
                 value={startStr}
-                onChange={e => setStartStr(e.target.value)}
+                onChange={(e: ChangeEvent<HTMLInputElement>) => setStartStr(e.target.value)}
               />
               {errors.start && <span className={styles.error}>{errors.start}</span>}
             </div>
@@ -160,7 +161,7 @@ export default function AssetRequestForm({
                 type="datetime-local"
                 className={[styles.input, errors.end && styles.inputError].filter(Boolean).join(' ')}
                 value={endStr}
-                onChange={e => setEndStr(e.target.value)}
+                onChange={(e: ChangeEvent<HTMLInputElement>) => setEndStr(e.target.value)}
               />
               {errors.end && <span className={styles.error}>{errors.end}</span>}
             </div>
@@ -172,7 +173,7 @@ export default function AssetRequestForm({
               id="ar-notes"
               className={styles.textarea}
               value={notes}
-              onChange={e => setNotes(e.target.value)}
+              onChange={(e: ChangeEvent<HTMLTextAreaElement>) => setNotes(e.target.value)}
               placeholder="Optional — context for the approver"
               rows={3}
             />

--- a/src/ui/AvailabilityForm.tsx
+++ b/src/ui/AvailabilityForm.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, type ChangeEvent, type FormEvent, type MouseEvent } from 'react';
 import { format, parseISO, isValid } from 'date-fns';
 import { X } from 'lucide-react';
 import { useFocusTrap } from '../hooks/useFocusTrap';
@@ -31,7 +31,7 @@ const KIND_META = {
   },
 };
 
-const INTENT_META = {
+const INTENT_META: Record<string, { heading: string; submitLabel: string; allDayLocked: boolean; allDayHelp: string | null }> = {
   pto: {
     heading: 'Request PTO',
     submitLabel: 'Save PTO Request',
@@ -54,7 +54,7 @@ const INTENT_META = {
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
-function toDateInput(date, allDay) {
+function toDateInput(date: Date | string | null | undefined, allDay: boolean): string {
   if (!date) return '';
   try {
     const d = date instanceof Date ? date : parseISO(date);
@@ -64,7 +64,7 @@ function toDateInput(date, allDay) {
   }
 }
 
-function fromInput(str, allDay) {
+function fromInput(str: string, allDay: boolean): Date | null {
   if (!str) return null;
   const d = new Date(str + (allDay && str.length === 10 ? 'T00:00:00' : ''));
   return isValid(d) ? d : null;
@@ -86,8 +86,8 @@ function fromInput(str, allDay) {
 export default function AvailabilityForm({ emp, kind: initialKind, initialStart, initialEvent = null, onSave, onClose }: any) {
   const trapRef = useFocusTrap(onClose);
 
-  const kind = initialKind ?? 'pto';
-  const meta = KIND_META[kind] ?? KIND_META.pto;
+  const kind = (initialKind ?? 'pto') as string;
+  const meta = KIND_META[kind as keyof typeof KIND_META] ?? KIND_META.pto;
   const isEdit = Boolean(initialEvent?.id);
   const intentMeta = INTENT_META[kind] ?? INTENT_META.pto;
   const isAllDayLocked = Boolean(intentMeta.allDayLocked);
@@ -122,7 +122,7 @@ export default function AvailabilityForm({ emp, kind: initialKind, initialStart,
     return Object.keys(errs).length === 0;
   }
 
-  function handleSubmit(e) {
+  function handleSubmit(e: FormEvent<HTMLFormElement>) {
     e.preventDefault();
     if (!validate()) return;
 
@@ -147,7 +147,7 @@ export default function AvailabilityForm({ emp, kind: initialKind, initialStart,
   const kindLabel = meta.label;
 
   return (
-    <div className={styles.overlay} onClick={e => e.target === e.currentTarget && onClose()}>
+    <div className={styles.overlay} onClick={(e: MouseEvent<HTMLDivElement>) => e.target === e.currentTarget && onClose()}>
       <div
         ref={trapRef}
         className={styles.modal}
@@ -176,7 +176,7 @@ export default function AvailabilityForm({ emp, kind: initialKind, initialStart,
               id="af-title"
               className={[styles.input, errors.title && styles.inputError].filter(Boolean).join(' ')}
               value={title}
-              onChange={e => { setTitle(e.target.value); setErrors(v => ({ ...v, title: undefined })); }}
+              onChange={(e: ChangeEvent<HTMLInputElement>) => { setTitle(e.target.value); setErrors((v: Record<string, string>) => ({ ...v, title: undefined })); }}
               placeholder="e.g. Vacation, Doctor appointment…"
               autoFocus
             />
@@ -189,7 +189,7 @@ export default function AvailabilityForm({ emp, kind: initialKind, initialStart,
               type="checkbox"
               checked={allDay}
               disabled={isAllDayLocked}
-              onChange={e => {
+              onChange={(e: ChangeEvent<HTMLInputElement>) => {
                 const next = e.target.checked;
                 setAllDay(next);
                 // Re-normalise existing start/end values to the new input format
@@ -216,7 +216,7 @@ export default function AvailabilityForm({ emp, kind: initialKind, initialStart,
                 type={allDay ? 'date' : 'datetime-local'}
                 className={[styles.input, errors.start && styles.inputError].filter(Boolean).join(' ')}
                 value={start}
-                onChange={e => { setStart(e.target.value); setErrors(v => ({ ...v, start: undefined, end: undefined })); }}
+                onChange={(e: ChangeEvent<HTMLInputElement>) => { setStart(e.target.value); setErrors((v: Record<string, string>) => ({ ...v, start: undefined, end: undefined })); }}
               />
               {errors.start && <span className={styles.error}>{errors.start}</span>}
             </div>
@@ -229,7 +229,7 @@ export default function AvailabilityForm({ emp, kind: initialKind, initialStart,
                 type={allDay ? 'date' : 'datetime-local'}
                 className={[styles.input, errors.end && styles.inputError].filter(Boolean).join(' ')}
                 value={end}
-                onChange={e => { setEnd(e.target.value); setErrors(v => ({ ...v, end: undefined })); }}
+                onChange={(e: ChangeEvent<HTMLInputElement>) => { setEnd(e.target.value); setErrors((v: Record<string, string>) => ({ ...v, end: undefined })); }}
               />
               {errors.end && <span className={styles.error}>{errors.end}</span>}
             </div>
@@ -243,7 +243,7 @@ export default function AvailabilityForm({ emp, kind: initialKind, initialStart,
               className={styles.textarea}
               rows={3}
               value={notes}
-              onChange={e => setNotes(e.target.value)}
+              onChange={(e: ChangeEvent<HTMLTextAreaElement>) => setNotes(e.target.value)}
               placeholder="Optional notes…"
             />
           </div>

--- a/src/ui/ConflictModal.tsx
+++ b/src/ui/ConflictModal.tsx
@@ -12,6 +12,7 @@
  * engine and two callbacks. It does not mutate state itself.
  */
 import { AlertTriangle, X } from 'lucide-react';
+import type { MouseEvent } from 'react';
 import { useFocusTrap } from '../hooks/useFocusTrap';
 import styles from './ConflictModal.module.css';
 
@@ -32,7 +33,7 @@ export default function ConflictModal({
   return (
     <div
       className={styles.overlay}
-      onClick={(e) => e.target === e.currentTarget && onCancel()}
+      onClick={(e: MouseEvent<HTMLDivElement>) => e.target === e.currentTarget && onCancel()}
     >
       <div
         ref={trapRef}
@@ -58,7 +59,7 @@ export default function ConflictModal({
         </div>
 
         <ul className={styles.list} aria-label="Conflict violations">
-          {result.violations.map((v, i) => (
+          {result.violations.map((v: any, i: number) => (
             <li
               key={`${v.rule}:${v.conflictingEventId ?? i}`}
               className={styles.item}

--- a/src/ui/EmployeeActionCard.tsx
+++ b/src/ui/EmployeeActionCard.tsx
@@ -12,16 +12,16 @@ import styles from './EmployeeActionCard.module.css';
  *   onClose    () => void
  */
 export default function EmployeeActionCard({ emp, anchorRect, onAction, onClose }: any) {
-  const cardRef = useRef(null);
+  const cardRef = useRef<HTMLDivElement | null>(null);
   // Start invisible so we can measure before revealing
   const [pos, setPos] = useState({ top: anchorRect.bottom + 4, left: anchorRect.left, visible: false });
 
   // Close on outside click or Escape
   useEffect(() => {
-    function handleMouseDown(e) {
-      if (cardRef.current && !cardRef.current.contains(e.target)) onClose();
+    function handleMouseDown(e: MouseEvent) {
+      if (cardRef.current && !cardRef.current.contains(e.target as Node)) onClose();
     }
-    function handleKeyDown(e) {
+    function handleKeyDown(e: KeyboardEvent) {
       if (e.key === 'Escape') onClose();
     }
     document.addEventListener('mousedown', handleMouseDown);
@@ -62,7 +62,7 @@ export default function EmployeeActionCard({ emp, anchorRect, onAction, onClose 
     }
   }, [pos.visible]);
 
-  function handleAction(action) {
+  function handleAction(action: string) {
     onAction(action);
     onClose();
   }

--- a/src/ui/EventForm.tsx
+++ b/src/ui/EventForm.tsx
@@ -4,6 +4,7 @@
  * and the extracted section components.
  */
 import { useState } from 'react';
+import type { FormEvent } from 'react';
 import { X } from 'lucide-react';
 import { useFocusTrap } from '../hooks/useFocusTrap';
 import { useEventDraftState, fromDatetimeLocal } from '../hooks/useEventDraftState';
@@ -20,7 +21,7 @@ export default function EventForm({ event, config, categories, onSave, onDelete,
   const draft   = useEventDraftState(event, categories, config);
   const [confirmDeleteOpen, setConfirmDeleteOpen] = useState(false);
 
-  function handleSubmit(e) {
+  function handleSubmit(e: FormEvent<HTMLFormElement>) {
     e.preventDefault();
     if (!draft.validate()) return;
     const normalizedResource = draft.values.resource == null ? '' : String(draft.values.resource);
@@ -98,7 +99,7 @@ export default function EventForm({ event, config, categories, onSave, onDelete,
               onPresetChange={d.setRecurrencePreset} onCustomRruleChange={d.setCustomRrule} />
             <div className={styles.row2}>
               <CategorySection value={d.values.category} allCats={d.allCats}
-                onAddCategory={onAddCategory} onChange={cat => d.set('category', cat)} />
+                onAddCategory={onAddCategory} onChange={(cat: string) => d.set('category', cat)} />
               <div className={styles.field}>
                 <label className={styles.label} htmlFor="ef-resource">Resource</label>
                 <input id="ef-resource" className={styles.input} value={d.values.resource}

--- a/src/ui/EventFormSections/CategorySection.tsx
+++ b/src/ui/EventFormSections/CategorySection.tsx
@@ -1,4 +1,5 @@
 import { useState, useRef, useEffect } from 'react';
+import type { ChangeEvent, KeyboardEvent } from 'react';
 import { Plus } from 'lucide-react';
 import styles from '../EventForm.module.css';
 
@@ -14,7 +15,7 @@ import styles from '../EventForm.module.css';
 export function CategorySection({ value, allCats, onAddCategory, onChange }: any) {
   const [addCatOpen, setAddCatOpen] = useState(false);
   const [newCatName, setNewCatName] = useState('');
-  const newCatRef = useRef(null);
+  const newCatRef = useRef<HTMLInputElement | null>(null);
 
   useEffect(() => {
     if (addCatOpen) newCatRef.current?.focus();
@@ -36,7 +37,7 @@ export function CategorySection({ value, allCats, onAddCategory, onChange }: any
           <button
             type="button"
             className={styles.addCatBtn}
-            onClick={() => setAddCatOpen(v => !v)}
+            onClick={() => setAddCatOpen((v: boolean) => !v)}
             title="Add category"
             aria-label="Add category"
           >
@@ -52,8 +53,8 @@ export function CategorySection({ value, allCats, onAddCategory, onChange }: any
             className={styles.addCatInput}
             placeholder="New category name"
             value={newCatName}
-            onChange={e => setNewCatName(e.target.value)}
-            onKeyDown={e => {
+            onChange={(e: ChangeEvent<HTMLInputElement>) => setNewCatName(e.target.value)}
+            onKeyDown={(e: KeyboardEvent<HTMLInputElement>) => {
               if (e.key === 'Enter') { e.preventDefault(); submitNewCat(); }
               if (e.key === 'Escape') setAddCatOpen(false);
             }}
@@ -71,7 +72,7 @@ export function CategorySection({ value, allCats, onAddCategory, onChange }: any
         onChange={e => onChange(e.target.value)}
       >
         <option value="">— none —</option>
-        {allCats.map(c => <option key={c} value={c}>{c}</option>)}
+        {allCats.map((c: string) => <option key={c} value={c}>{c}</option>)}
       </select>
     </div>
   );

--- a/src/ui/EventFormSections/CustomFieldsSection.tsx
+++ b/src/ui/EventFormSections/CustomFieldsSection.tsx
@@ -1,4 +1,5 @@
 import styles from '../EventForm.module.css';
+import type { ChangeEvent } from 'react';
 
 /**
  * CustomFieldsSection — dynamic schema-driven custom field rendering.
@@ -18,13 +19,13 @@ export function CustomFieldsSection({ category, customFields, metaValues, errors
   return (
     <div className={styles.customSection}>
       <div className={styles.customSectionLabel}>{category} fields</div>
-      {customFields.map(f => (
+      {customFields.map((f: any) => (
         <CustomField
           key={f.name}
           field={f}
           value={metaValues[f.name] ?? ''}
           error={errors[`meta_${f.name}`]}
-          onChange={val => onMetaChange(f.name, val)}
+          onChange={(val: string | boolean) => onMetaChange(f.name, val)}
         />
       ))}
     </div>
@@ -35,7 +36,7 @@ export function CustomFieldsSection({ category, customFields, metaValues, errors
 
 function CustomField({ field, value, error, onChange }: any) {
   const opts = field.options
-    ? field.options.split(',').map(s => s.trim()).filter(Boolean)
+    ? field.options.split(',').map((s: string) => s.trim()).filter(Boolean)
     : [];
   // checkbox uses the wrapping-label pattern; all other types need an explicit id/htmlFor pair
   const fieldId = field.type === 'checkbox'
@@ -54,7 +55,7 @@ function CustomField({ field, value, error, onChange }: any) {
           id={fieldId}
           className={[styles.input, error && styles.inputError].filter(Boolean).join(' ')}
           value={value}
-          onChange={e => onChange(e.target.value)}
+          onChange={(e: ChangeEvent<HTMLInputElement>) => onChange(e.target.value)}
         />
       )}
       {field.type === 'number' && (
@@ -63,7 +64,7 @@ function CustomField({ field, value, error, onChange }: any) {
           type="number"
           className={[styles.input, error && styles.inputError].filter(Boolean).join(' ')}
           value={value}
-          onChange={e => onChange(e.target.value)}
+          onChange={(e: ChangeEvent<HTMLInputElement>) => onChange(e.target.value)}
         />
       )}
       {field.type === 'date' && (
@@ -72,12 +73,12 @@ function CustomField({ field, value, error, onChange }: any) {
           type="date"
           className={[styles.input, error && styles.inputError].filter(Boolean).join(' ')}
           value={value}
-          onChange={e => onChange(e.target.value)}
+          onChange={(e: ChangeEvent<HTMLInputElement>) => onChange(e.target.value)}
         />
       )}
       {field.type === 'checkbox' && (
         <label className={styles.checkRow}>
-          <input type="checkbox" checked={!!value} onChange={e => onChange(e.target.checked)} />
+          <input type="checkbox" checked={!!value} onChange={(e: ChangeEvent<HTMLInputElement>) => onChange(e.target.checked)} />
           Yes
         </label>
       )}
@@ -86,10 +87,10 @@ function CustomField({ field, value, error, onChange }: any) {
           id={fieldId}
           className={[styles.select, error && styles.inputError].filter(Boolean).join(' ')}
           value={value}
-          onChange={e => onChange(e.target.value)}
+          onChange={(e: ChangeEvent<HTMLSelectElement>) => onChange(e.target.value)}
         >
           <option value="">— select —</option>
-          {opts.map(o => <option key={o} value={o}>{o}</option>)}
+          {opts.map((o: string) => <option key={o} value={o}>{o}</option>)}
         </select>
       )}
       {field.type === 'textarea' && (
@@ -97,7 +98,7 @@ function CustomField({ field, value, error, onChange }: any) {
           id={fieldId}
           className={[styles.textarea, error && styles.inputError].filter(Boolean).join(' ')}
           value={value}
-          onChange={e => onChange(e.target.value)}
+          onChange={(e: ChangeEvent<HTMLTextAreaElement>) => onChange(e.target.value)}
           rows={3}
         />
       )}

--- a/src/ui/EventFormSections/RecurrenceSection.tsx
+++ b/src/ui/EventFormSections/RecurrenceSection.tsx
@@ -1,4 +1,5 @@
 import styles from '../EventForm.module.css';
+import type { ChangeEvent } from 'react';
 
 const RECURRENCE_PRESETS = [
   { id: 'none',        label: 'Does not repeat'       },
@@ -19,7 +20,7 @@ const RECURRENCE_PRESETS = [
  *   onCustomRruleChange (str) => void
  */
 export function RecurrenceSection({ preset, customRrule, onPresetChange, onCustomRruleChange }: any) {
-  function handlePresetChange(e) {
+  function handlePresetChange(e: ChangeEvent<HTMLSelectElement>) {
     const next = e.target.value;
     onPresetChange(next);
     if (next !== 'custom') onCustomRruleChange('');

--- a/src/ui/HoverCard.tsx
+++ b/src/ui/HoverCard.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef, useEffect } from 'react';
+import { useState, useRef, useEffect, type ChangeEvent, type MouseEvent } from 'react';
 import { format, isSameDay } from 'date-fns';
 import { X, Clock, Tag, Anchor, FileText, StickyNote, Pencil } from 'lucide-react';
 import { useFocusTrap } from '../hooks/useFocusTrap';
@@ -7,14 +7,14 @@ import styles from './HoverCard.module.css';
 export default function HoverCard({ event, config, note, onClose, onNoteSave, onNoteDelete, onEdit, anchor, resolveResourceLabel }: any) {
   const [noteText, setNoteText] = useState(note?.body || '');
   const [editing, setEditing] = useState(false);
-  const cardRef = useRef(null);
+  const cardRef = useRef<HTMLDivElement | null>(null);
   const trapRef = useFocusTrap(onClose);
   const hc = config?.hoverCard ?? {};
 
   // Close on click outside
   useEffect(() => {
-    function handler(e) {
-      if (cardRef.current && !cardRef.current.contains(e.target)) onClose();
+    function handler(e: globalThis.MouseEvent) {
+      if (cardRef.current && !cardRef.current.contains(e.target as Node)) onClose();
     }
     document.addEventListener('mousedown', handler);
     return () => document.removeEventListener('mousedown', handler);
@@ -40,7 +40,7 @@ export default function HoverCard({ event, config, note, onClose, onNoteSave, on
         <div className={styles.titleRow}>
           <h3 className={styles.title}>{event.title}</h3>
           {onEdit && (
-            <button className={styles.editBtn} onClick={e => { e.stopPropagation(); onEdit(event); }} aria-label="Edit event" title="Edit">
+            <button className={styles.editBtn} onClick={(e: MouseEvent<HTMLButtonElement>) => { e.stopPropagation(); onEdit(event); }} aria-label="Edit event" title="Edit">
               <Pencil size={13} />
             </button>
           )}
@@ -107,7 +107,7 @@ export default function HoverCard({ event, config, note, onClose, onNoteSave, on
                   id="hc-note"
                   className={styles.noteTextarea}
                   value={noteText}
-                  onChange={e => setNoteText(e.target.value)}
+                  onChange={(e: ChangeEvent<HTMLTextAreaElement>) => setNoteText(e.target.value)}
                   placeholder="Add a note…"
                   autoFocus
                   rows={3}

--- a/src/ui/ICSFeedPanel.tsx
+++ b/src/ui/ICSFeedPanel.tsx
@@ -9,7 +9,7 @@
  *   onUpdate    — (id: string, patch: Partial<StoredFeed>) => void
  *   onToggle    — (id: string) => void
  */
-import { useState, useRef } from 'react';
+import { useState, useRef, type ChangeEvent, type KeyboardEvent } from 'react';
 import { Plus, Trash2, RefreshCw, AlertCircle, CheckCircle, Link } from 'lucide-react';
 import { fetchAndParseICS } from '../core/icalParser';
 import styles from './ConfigPanel.module.css';
@@ -30,7 +30,7 @@ const REFRESH_OPTIONS = [
   { label: 'Manual',     value: null       },
 ];
 
-function colorDot(color, size = 10) {
+function colorDot(color: string, size = 10) {
   return (
     <span style={{
       display: 'inline-block',
@@ -94,9 +94,9 @@ function FeedRow({ feed, error, onToggle, onRemove, onUpdate }: any) {
             autoFocus
             className={styles.input}
             value={draft}
-            onChange={e => setDraft(e.target.value)}
+            onChange={(e: ChangeEvent<HTMLInputElement>) => setDraft(e.target.value)}
             onBlur={commitEdit}
-            onKeyDown={e => { if (e.key === 'Enter') commitEdit(); if (e.key === 'Escape') { setDraft(feed.label); setEditing(false); } }}
+            onKeyDown={(e: KeyboardEvent<HTMLInputElement>) => { if (e.key === 'Enter') commitEdit(); if (e.key === 'Escape') { setDraft(feed.label); setEditing(false); } }}
             style={{ width: '100%', padding: '3px 6px', fontSize: 12 }}
           />
         ) : (
@@ -219,9 +219,9 @@ function AddFeedForm({ onAdd }: any) {
           style={{ flex: 1, fontSize: 12 }}
           type="url"
           value={url}
-          onChange={e => { setUrl(e.target.value); setValidation(null); }}
+          onChange={(e: ChangeEvent<HTMLInputElement>) => { setUrl(e.target.value); setValidation(null); }}
           placeholder="https://calendar.google.com/calendar/ical/…/basic.ics"
-          onKeyDown={e => e.key === 'Enter' && validate()}
+          onKeyDown={(e: KeyboardEvent<HTMLInputElement>) => e.key === 'Enter' && validate()}
         />
         <button
           onClick={validate}
@@ -272,7 +272,7 @@ function AddFeedForm({ onAdd }: any) {
           style={{ fontSize: 12 }}
           type="text"
           value={label}
-          onChange={e => setLabel(e.target.value)}
+          onChange={(e: ChangeEvent<HTMLInputElement>) => setLabel(e.target.value)}
           placeholder="My Work Calendar"
         />
       </label>
@@ -304,7 +304,7 @@ function AddFeedForm({ onAdd }: any) {
             className={styles.select}
             style={{ fontSize: 12 }}
             value={refreshInterval ?? 'null'}
-            onChange={e => setRefreshInterval(e.target.value === 'null' ? null : +e.target.value)}
+            onChange={(e: ChangeEvent<HTMLSelectElement>) => setRefreshInterval(e.target.value === 'null' ? null : +e.target.value)}
           >
             {REFRESH_OPTIONS.map(o => (
               <option key={String(o.value)} value={String(o.value)}>{o.label}</option>
@@ -349,10 +349,10 @@ function AddFeedForm({ onAdd }: any) {
 export default function ICSFeedPanel({ feeds, feedErrors, onAdd, onRemove, onToggle, onUpdate }: any) {
   // Build a quick error lookup by URL
   const errorByUrl = Object.fromEntries(
-    (feedErrors ?? []).map(({ feed, err }) => [feed.url, err])
+    (feedErrors ?? []).map(({ feed, err }: { feed: { url: string }; err: Error }) => [feed.url, err])
   );
 
-  const enabledCount  = feeds.filter(f => f.enabled).length;
+  const enabledCount  = feeds.filter((f: any) => f.enabled).length;
   const errorCount    = Object.keys(errorByUrl).length;
 
   return (
@@ -378,7 +378,7 @@ export default function ICSFeedPanel({ feeds, feedErrors, onAdd, onRemove, onTog
         </div>
       ) : (
         <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
-          {feeds.map(feed => (
+          {feeds.map((feed: any) => (
             <FeedRow
               key={feed.id}
               feed={feed}
@@ -405,7 +405,7 @@ export default function ICSFeedPanel({ feeds, feedErrors, onAdd, onRemove, onTog
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
-function _suggestLabel(url) {
+function _suggestLabel(url: string) {
   try {
     const u = new URL(url.replace(/^webcal:/, 'https:'));
     // Strip common ICS path suffixes to get a readable hostname

--- a/src/ui/ImportZone.tsx
+++ b/src/ui/ImportZone.tsx
@@ -4,7 +4,7 @@
  * .ics files → parsed and shown in ImportPreview for confirmation.
  * .csv files → routed to CSVImportDialog for column mapping + preview.
  */
-import { useState, useRef } from 'react';
+import { useState, useRef, type ChangeEvent, type DragEvent } from 'react';
 import { Upload } from 'lucide-react';
 import { parseICS } from '../core/icalParser';
 import ImportPreview from './ImportPreview';
@@ -13,12 +13,12 @@ import styles from './ImportZone.module.css';
 
 export default function ImportZone({ onImport, onClose }: any) {
   const [dragging,  setDragging]  = useState(false);
-  const [parsed,    setParsed]    = useState(null); // ICS parsed events
+  const [parsed,    setParsed]    = useState<any>(null); // ICS parsed events
   const [csvMode,   setCsvMode]   = useState(false); // switch to CSV dialog
-  const [error,     setError]     = useState(null);
-  const inputRef = useRef(null);
+  const [error,     setError]     = useState<string | null>(null);
+  const inputRef = useRef<HTMLInputElement | null>(null);
 
-  function processFile(file) {
+  function processFile(file: File | undefined) {
     if (!file) return;
     setError(null);
 
@@ -38,7 +38,7 @@ export default function ImportZone({ onImport, onClose }: any) {
 
     // ICS path (original behaviour)
     const reader = new FileReader();
-    reader.onload = e => {
+    reader.onload = (e: ProgressEvent<FileReader>) => {
       try {
         const events = parseICS(e.target.result as string);
         if (!events.length) { setError('No events found in this file.'); return; }
@@ -66,10 +66,10 @@ export default function ImportZone({ onImport, onClose }: any) {
       <div
         className={[styles.zone, dragging && styles.dragging].filter(Boolean).join(' ')}
         onClick={e => e.stopPropagation()}
-        onDrop={e => { e.preventDefault(); setDragging(false); processFile(e.dataTransfer.files[0]); }}
-        onDragOver={e => { e.preventDefault(); setDragging(true); }}
+        onDrop={(e: DragEvent<HTMLDivElement>) => { e.preventDefault(); setDragging(false); processFile(e.dataTransfer.files[0]); }}
+        onDragOver={(e: DragEvent<HTMLDivElement>) => { e.preventDefault(); setDragging(true); }}
         onDragLeave={() => setDragging(false)}
-        onDragEnter={e => { e.preventDefault(); setDragging(true); }}
+        onDragEnter={(e: DragEvent<HTMLDivElement>) => { e.preventDefault(); setDragging(true); }}
       >
         <div className={styles.iconWrap}>
           <Upload size={32} />
@@ -113,7 +113,7 @@ export default function ImportZone({ onImport, onClose }: any) {
           type="file"
           accept=".ics,.csv,text/calendar,text/csv"
           className={styles.hiddenInput}
-          onChange={e => processFile(e.target.files[0])}
+          onChange={(e: ChangeEvent<HTMLInputElement>) => processFile(e.target.files?.[0])}
         />
 
         <button className={styles.cancelLink} onClick={onClose}>Cancel</button>

--- a/src/ui/InlineEventEditor.tsx
+++ b/src/ui/InlineEventEditor.tsx
@@ -4,7 +4,7 @@
  * Activated when the owner clicks an event in Edit Mode.
  * Lets owners tweak title, color, bold, and size without opening the full form.
  */
-import { useState, useRef, useEffect } from 'react';
+import { useState, useRef, useEffect, type ChangeEvent, type KeyboardEvent } from 'react';
 import { X } from 'lucide-react';
 import styles from './InlineEventEditor.module.css';
 
@@ -18,8 +18,8 @@ export default function InlineEventEditor({ event, x, y, onSave, onClose }: any)
   const [color, setColor] = useState(event.color ?? PRESET_COLORS[0]);
   const [bold,  setBold]  = useState(!!(event.meta?._display?.bold));
   const [large, setLarge] = useState(!!(event.meta?._display?.large));
-  const panelRef = useRef(null);
-  const inputRef = useRef(null);
+  const panelRef = useRef<HTMLDivElement | null>(null);
+  const inputRef = useRef<HTMLInputElement | null>(null);
 
   useEffect(() => {
     inputRef.current?.focus();
@@ -35,14 +35,14 @@ export default function InlineEventEditor({ event, x, y, onSave, onClose }: any)
 
   // Close on outside click
   useEffect(() => {
-    function handler(e) {
-      if (panelRef.current && !panelRef.current.contains(e.target)) onClose();
+    function handler(e: MouseEvent) {
+      if (panelRef.current && !panelRef.current.contains(e.target as Node)) onClose();
     }
     document.addEventListener('mousedown', handler);
     return () => document.removeEventListener('mousedown', handler);
   }, [onClose]);
 
-  function handleKeyDown(e) {
+  function handleKeyDown(e: KeyboardEvent<HTMLDivElement>) {
     if (e.key === 'Escape') { e.stopPropagation(); onClose(); }
     if (e.key === 'Enter' && !e.shiftKey) { e.preventDefault(); handleSave(); }
   }
@@ -96,7 +96,7 @@ export default function InlineEventEditor({ event, x, y, onSave, onClose }: any)
         ref={inputRef}
         className={styles.titleInput}
         value={title}
-        onChange={e => setTitle(e.target.value)}
+        onChange={(e: ChangeEvent<HTMLInputElement>) => setTitle(e.target.value)}
         placeholder="Event title…"
         aria-label="Event title"
       />

--- a/src/ui/OwnerLock.tsx
+++ b/src/ui/OwnerLock.tsx
@@ -14,7 +14,7 @@ export default function OwnerLock({ isOwner, authError, isAuthLoading, onAuthent
     }
   }
 
-  function handleAuthenticate(password) {
+  function handleAuthenticate(password: string) {
     onAuthenticate(password);
     // The modal stays mounted while the parent decides whether the password
     // was valid. When isOwner flips true, the parent unmounts us; otherwise

--- a/src/ui/OwnerLoginModal.tsx
+++ b/src/ui/OwnerLoginModal.tsx
@@ -6,7 +6,7 @@
  * password field so screen-reader users land on a dedicated dialog rather
  * than a floating menu attached to the toolbar.
  */
-import { useState } from 'react';
+import { useState, type FormEvent, type MouseEvent } from 'react';
 import { Eye, EyeOff, Lock, X } from 'lucide-react';
 import { useFocusTrap } from '../hooks/useFocusTrap';
 import styles from './OwnerLoginModal.module.css';
@@ -16,7 +16,7 @@ export default function OwnerLoginModal({ authError, isAuthLoading, onAuthentica
   const [password, setPassword] = useState('');
   const [showPw, setShowPw] = useState(false);
 
-  function handleSubmit(e) {
+  function handleSubmit(e: FormEvent<HTMLFormElement>) {
     e.preventDefault();
     onAuthenticate(password);
   }
@@ -24,7 +24,7 @@ export default function OwnerLoginModal({ authError, isAuthLoading, onAuthentica
   return (
     <div
       className={styles.overlay}
-      onClick={e => { if (e.target === e.currentTarget) onClose(); }}
+      onClick={(e: MouseEvent<HTMLDivElement>) => { if (e.target === e.currentTarget) onClose(); }}
     >
       <div
         ref={trapRef}

--- a/src/ui/ScreenReaderAnnouncer.tsx
+++ b/src/ui/ScreenReaderAnnouncer.tsx
@@ -35,7 +35,7 @@ const srOnly: React.CSSProperties = {
  * A single live region with two alternating slots.
  * `politeness` must be 'polite' or 'assertive'.
  */
-function LiveRegion({ politeness, slots }: any) {
+function LiveRegion({ politeness, slots }: { politeness: 'polite' | 'assertive'; slots: readonly string[] }) {
   return (
     <div aria-live={politeness} aria-atomic="true" style={srOnly}>
       <span>{slots[0]}</span>
@@ -44,15 +44,18 @@ function LiveRegion({ politeness, slots }: any) {
   );
 }
 
-const ScreenReaderAnnouncer = forwardRef(function ScreenReaderAnnouncer(_, ref) {
+type AnnouncePoliteness = 'polite' | 'assertive';
+type AnnouncerRef = { announce: (message: string, politeness?: AnnouncePoliteness) => void };
+
+const ScreenReaderAnnouncer = forwardRef<AnnouncerRef, object>(function ScreenReaderAnnouncer(_, ref) {
   // Separate state for polite and assertive regions.
   const [politeSlot,    setPoliteSlot]    = useState(0);
   const [politeMsgs,    setPoliteMsgs]    = useState(['', '']);
   const [assertiveSlot, setAssertiveSlot] = useState(0);
   const [assertiveMsgs, setAssertiveMsgs] = useState(['', '']);
 
-  const politeTimer    = useRef(null);
-  const assertiveTimer = useRef(null);
+  const politeTimer    = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const assertiveTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const mountedRef = useRef(true);
 
   useEffect(() => () => {
@@ -66,7 +69,7 @@ const ScreenReaderAnnouncer = forwardRef(function ScreenReaderAnnouncer(_, ref) 
      * @param {string}  message    The text to announce.
      * @param {'polite'|'assertive'} [politeness='polite']
      */
-    announce(message, politeness = 'polite') {
+    announce(message: string, politeness: AnnouncePoliteness = 'polite') {
       if (politeness === 'assertive') {
         if (assertiveTimer.current) clearTimeout(assertiveTimer.current);
         assertiveTimer.current = setTimeout(() => {

--- a/src/ui/ValidationAlert.tsx
+++ b/src/ui/ValidationAlert.tsx
@@ -1,4 +1,5 @@
 import { useFocusTrap } from '../hooks/useFocusTrap';
+import type { MouseEvent } from 'react';
 import styles from './ValidationAlert.module.css';
 
 /**
@@ -12,7 +13,7 @@ export default function ValidationAlert({ violations, isHard, onConfirm, onCance
   return (
     <div
       className={styles.overlay}
-      onClick={e => { if (e.target === e.currentTarget) onCancel(); }}
+      onClick={(e: MouseEvent<HTMLDivElement>) => { if (e.target === e.currentTarget) onCancel(); }}
     >
       <div
         ref={trapRef}
@@ -29,7 +30,7 @@ export default function ValidationAlert({ violations, isHard, onConfirm, onCance
         </div>
 
         <ul className={styles.list}>
-          {violations.map((v, i) => (
+          {violations.map((v: any, i: number) => (
             <li key={i} className={styles.item}>{v.message}</li>
           ))}
         </ul>

--- a/src/ui/ViewsDropdown.tsx
+++ b/src/ui/ViewsDropdown.tsx
@@ -21,6 +21,7 @@ const VIEW_ICON_MAP = {
   schedule: CalendarRange,
   assets:   Boxes,
 };
+type ViewKey = keyof typeof VIEW_ICON_MAP;
 
 export default function ViewsDropdown({
   views,
@@ -77,7 +78,7 @@ export default function ViewsDropdown({
           ) : (
             <ul className={styles.dropdownList}>
               {views.map((view: any) => {
-                const ViewIcon = view.view ? VIEW_ICON_MAP[view.view] : null;
+                const ViewIcon = view.view ? VIEW_ICON_MAP[view.view as ViewKey] : null;
                 const isActive = view.id === activeId;
                 const isHidden = !!view.hiddenFromStrip;
                 const color = view.color ?? '#64748b';

--- a/src/ui/WorkflowSimulator.tsx
+++ b/src/ui/WorkflowSimulator.tsx
@@ -66,7 +66,7 @@ export function WorkflowSimulator(
   const [simClockMs, setSimClockMs] = useState<number>(Date.parse(SIM_EPOCH_ISO))
   const seqRef = useRef<number>(0)
 
-  const { variables, parseError } = useMemo(() => {
+  const { variables, parseError } = useMemo<{ variables: Record<string, unknown>; parseError: string | null }>(() => {
     try {
       const parsed = JSON.parse(variablesText) as unknown
       // Arrays are typeof 'object' in JS, so filter them explicitly —

--- a/src/ui/__tests__/ProfileBar.redesign.test.tsx
+++ b/src/ui/__tests__/ProfileBar.redesign.test.tsx
@@ -14,7 +14,7 @@ import '@testing-library/jest-dom';
 
 import ProfileBar from '../ProfileBar';
 
-const VIEW_VISIBLE = {
+const VIEW_VISIBLE: any = {
   id: 'v-vis',
   name: 'Work Week',
   createdAt: new Date().toISOString(),
@@ -24,7 +24,7 @@ const VIEW_VISIBLE = {
   hiddenFromStrip: false,
 };
 
-const VIEW_HIDDEN = {
+const VIEW_HIDDEN: any = {
   id: 'v-hid',
   name: 'Archive',
   createdAt: new Date().toISOString(),
@@ -34,8 +34,8 @@ const VIEW_HIDDEN = {
   hiddenFromStrip: true,
 };
 
-function renderBar(overrides: any = {}) {
-  const props = {
+function renderBar(overrides: Record<string, unknown> = {}) {
+  const props: any = {
     views: [VIEW_VISIBLE, VIEW_HIDDEN],
     activeId: null,
     isDirty: false,


### PR DESCRIPTION
### Motivation
- Complete the Sprint 3 scope by finishing the strict `noImplicitAny` pass for the remaining non-view `src/ui/**` components so the UI typing ratchet can move forward without touching view files.  
- Reduce UI debt and noise by annotating event handlers, DOM refs, and small helper signatures to avoid transitive type churn when the view pass starts.  
- Keep the `ProfileBar` redesign test strict-clean as a checkpoint for the header/quick-views work.  

### Description
- Added explicit parameter and return types for event handlers, DOM `ref`s, and small helpers across the remaining non-view UI components (representative files: `src/ui/ApprovalActionMenu.tsx`, `src/ui/AssetRequestForm.tsx`, `src/ui/AvailabilityForm.tsx`, `src/ui/EventForm.tsx`, `src/ui/HoverCard.tsx`, `src/ui/InlineEventEditor.tsx`, `src/ui/ICSFeedPanel.tsx`, `src/ui/ImportZone.tsx`, `src/ui/ValidationAlert.tsx`, and others).  
- Hardened the accessibility announcer API by typing the live-region helper and `forwardRef` contract in `src/ui/ScreenReaderAnnouncer.tsx`.  
- Tightened a handful of component internals (e.g. typed color/option mappings and feed validation state) and fixed DOM `EventTarget`→`Node` usages in click-outside handlers to satisfy strict checks.  
- Updated the strict migration ratchet by adding the Sprint 3 non-view UI files and the `ProfileBar` redesign test to `MIGRATED_PATHS` in `scripts/typecheck-strict.mjs` so this slice is enforced by `type-check:strict`.  

### Testing
- Ran `npm run -s type-check:strict` and the strict ratchet reported `Strict type check GREEN.` for the updated allowlist.  
- Ran `npx tsc --noEmit -p tsconfig.json` (root advisory check) and it completed successfully.  
- Ran the redesigned test with `npx vitest run src/ui/__tests__/ProfileBar.redesign.test.tsx` and it passed (`1 file, 13 tests`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8c1c2ab70832c87c9be7de2758687)