### PR TITLE
Sprint 4: eliminate remaining strict-any diagnostics across views

### DIFF
--- a/scripts/typecheck-strict.mjs
+++ b/scripts/typecheck-strict.mjs
@@ -73,6 +73,24 @@ const MIGRATED_PATHS = [
   'src/views/BaseGanttView.tsx',
   // Stage 5 PR9
   'src/views/TimelineView.tsx',
+  // Stage 5c PR1 (remaining views pass)
+  'src/views/AuditDrawer.tsx',
+  'src/views/ScheduleView.tsx',
+  'src/views/__tests__/AgendaView.grouping.test.tsx',
+  'src/views/__tests__/AgendaView.touchDnd.test.tsx',
+  'src/views/__tests__/AssetsView.approvalActions.test.tsx',
+  'src/views/__tests__/AssetsView.assetsProp.test.tsx',
+  'src/views/__tests__/AssetsView.grouping.test.tsx',
+  'src/views/__tests__/AssetsView.keyboardNav.test.tsx',
+  'src/views/__tests__/AssetsView.pools.test.tsx',
+  'src/views/__tests__/AssetsView.test.tsx',
+  'src/views/__tests__/AssetsView.toolbar.test.tsx',
+  'src/views/__tests__/AssetsView.virtualization.test.tsx',
+  'src/views/__tests__/AuditDrawer.test.tsx',
+  'src/views/__tests__/BaseGanttView.test.tsx',
+  'src/views/__tests__/TimelineView.grouping.test.tsx',
+  'src/views/__tests__/TimelineView.touchDnd.test.tsx',
+  'src/views/__tests__/WeekDayView.offHoursClipping.test.tsx',
   // Stage 5 PR10
   'src/WorksCalendar.tsx',
   // Stage 5 PR12

--- a/src/views/AuditDrawer.tsx
+++ b/src/views/AuditDrawer.tsx
@@ -17,7 +17,7 @@ import { findNode } from '../core/workflow/workflowSchema';
  * raw input unchanged when the value is falsy or unparseable so the caller
  * never renders "Invalid Date".
  */
-function formatAt(iso) {
+function formatAt(iso: string | undefined | null) {
   if (!iso) return '';
   try {
     const d = new Date(iso);
@@ -41,7 +41,7 @@ const ACTION_LABELS = {
  * Returns null when inapplicable (no instance, not awaiting, no SLA, or
  * the active node isn't in the workflow anymore).
  */
-function computeSlaPill(workflow, workflowInstance, nowMs) {
+function computeSlaPill(workflow: any, workflowInstance: any, nowMs: number) {
   if (!workflow || !workflowInstance) return null;
   if (workflowInstance.status !== 'awaiting') return null;
   const nodeId = workflowInstance.currentNodeId;
@@ -68,7 +68,7 @@ function computeSlaPill(workflow, workflowInstance, nowMs) {
   };
 }
 
-function formatRemaining(ms) {
+function formatRemaining(ms: number) {
   const abs = Math.abs(ms);
   const totalMinutes = Math.max(0, Math.round(abs / 60_000));
   if (totalMinutes < 60) return `${totalMinutes}m`;
@@ -78,13 +78,13 @@ function formatRemaining(ms) {
 }
 
 export default function AuditDrawer({ event, onClose, approvalsConfig, onAction, workflow }: any) {
-  const closeRef = useRef(null);
+  const closeRef = useRef<HTMLButtonElement | null>(null);
   const [nowMs, setNowMs] = useState(() => Date.now());
 
   useEffect(() => {
     if (!event) return;
     closeRef.current?.focus();
-    const onKey = (e) => { if (e.key === 'Escape') onClose?.(); };
+    const onKey = (e: KeyboardEvent) => { if (e.key === 'Escape') onClose?.(); };
     window.addEventListener('keydown', onKey);
     return () => window.removeEventListener('keydown', onKey);
   }, [event, onClose]);
@@ -164,7 +164,7 @@ export default function AuditDrawer({ event, onClose, approvalsConfig, onAction,
             <p className={styles.empty}>No history recorded for this request.</p>
           ) : (
             <ol className={styles.timeline}>
-              {history.map((entry, i) => (
+              {history.map((entry: any, i: number) => (
                 <li
                   key={`${entry.at}-${entry.action}-${i}`}
                   className={styles.entry}
@@ -172,7 +172,7 @@ export default function AuditDrawer({ event, onClose, approvalsConfig, onAction,
                 >
                   <div className={styles.entryHead}>
                     <span className={styles.entryAction}>
-                      {ACTION_LABELS[entry.action] ?? entry.action}
+                      {ACTION_LABELS[entry.action as keyof typeof ACTION_LABELS] ?? entry.action}
                     </span>
                     {entry.tier != null && (
                       <span className={styles.entryTier}>Tier {entry.tier}</span>

--- a/src/views/ScheduleView.tsx
+++ b/src/views/ScheduleView.tsx
@@ -13,12 +13,21 @@ import styles from './ScheduleView.module.css';
 
 const WEEKS = 6;
 
-export default function ScheduleView({ currentDate, events, onEventClick, weekStartDay = 0 }: { currentDate: Date; events: any; onEventClick?: any; weekStartDay?: Day } & Record<string, any>) {
+type ScheduleEvent = {
+  id: string;
+  title: string;
+  start: Date;
+  resource?: string;
+  status?: string;
+  [key: string]: unknown;
+};
+
+export default function ScheduleView({ currentDate, events, onEventClick, weekStartDay = 0 }: { currentDate: Date; events: ScheduleEvent[]; onEventClick?: (event: ScheduleEvent) => void; weekStartDay?: Day } & Record<string, any>) {
   const ctx = useCalendarContext();
 
   const resources = useMemo<string[]>(() => {
     const set = new Set<string>();
-    events.forEach(e => { if (e.resource) set.add(e.resource); });
+    events.forEach((e: ScheduleEvent) => { if (e.resource) set.add(e.resource); });
     return [...set].sort();
   }, [events]);
 
@@ -33,8 +42,8 @@ export default function ScheduleView({ currentDate, events, onEventClick, weekSt
       <div className={styles.fallback}>
         <p className={styles.hint}>Schedule view groups events by resource. Add a <code>resource</code> field to your events.</p>
         <div className={styles.simpleList}>
-          {events.slice(0, 40).map(ev => {
-            const color = resolveColor(ev, ctx?.colorRules);
+          {events.slice(0, 40).map((ev: ScheduleEvent) => {
+            const color = resolveColor(ev as any, ctx?.colorRules);
             return (
               <button key={ev.id} className={styles.simpleEvent} onClick={() => onEventClick?.(ev)}
                 style={{ '--ev-color': color }}>
@@ -74,11 +83,11 @@ export default function ScheduleView({ currentDate, events, onEventClick, weekSt
                 <span className={styles.dayNum}>{format(day, 'MMM d')}</span>
               </div>
               {resources.map(res => {
-                const cellEvents = events.filter(e => e.resource === res && isSameDay(e.start, day));
+                const cellEvents = events.filter((e: ScheduleEvent) => e.resource === res && isSameDay(e.start, day));
                 return (
                   <div key={res} className={styles.cell}>
                     {cellEvents.map(ev => {
-                      const color = resolveColor(ev, ctx?.colorRules);
+                      const color = resolveColor(ev as any, ctx?.colorRules);
                       const statusClass = ev.status === 'cancelled' ? styles.cancelled
                         : ev.status === 'tentative' ? styles.tentative : '';
 

--- a/src/views/__tests__/AgendaView.grouping.test.tsx
+++ b/src/views/__tests__/AgendaView.grouping.test.tsx
@@ -169,13 +169,13 @@ describe('AgendaView grouping', () => {
   });
 
   describe('DnD between groups', () => {
-    function dragAndDrop(source, target) {
+    function dragAndDrop(source: Element | Window | Document, target: Element | Window | Document) {
       const dt = {
         effectAllowed: '',
         dropEffect: '',
-        _data: {},
-        setData(k, v) { this._data[k] = v; },
-        getData(k) { return this._data[k]; },
+        _data: {} as Record<string, string>,
+        setData(k: string, v: string) { this._data[k] = v; },
+        getData(k: string) { return this._data[k]; },
       };
       fireEvent.dragStart(source, { dataTransfer: dt });
       fireEvent.dragOver(target, { dataTransfer: dt });

--- a/src/views/__tests__/AgendaView.touchDnd.test.tsx
+++ b/src/views/__tests__/AgendaView.touchDnd.test.tsx
@@ -12,7 +12,7 @@ const events = [
   { id: 'e2', title: 'Team Meeting', category: 'Work',     start: sameDay, end: sameDay, allDay: true },
 ];
 
-function renderAgenda(props = {}) {
+function renderAgenda(props: Record<string, unknown> = {}) {
   return render(
     <CalendarContext.Provider value={null}>
       <AgendaView
@@ -26,7 +26,7 @@ function renderAgenda(props = {}) {
   );
 }
 
-function fireTouch(type, el, touches = []) {
+function fireTouch(type: string, el: EventTarget, touches: Array<{ x: number; y: number }> = []) {
   const evt = new Event(type, { bubbles: true, cancelable: true });
   Object.defineProperty(evt, 'touches', {
     value: touches.map(t => ({ clientX: t.x, clientY: t.y, target: el })),
@@ -38,8 +38,8 @@ function fireTouch(type, el, touches = []) {
 }
 
 describe('AgendaView touch DnD', () => {
-  let origElementFromPoint;
-  let pointTarget = null;
+  let origElementFromPoint: typeof document.elementFromPoint;
+  let pointTarget: Element | null = null;
 
   beforeEach(() => {
     vi.useFakeTimers();

--- a/src/views/__tests__/AssetsView.approvalActions.test.tsx
+++ b/src/views/__tests__/AssetsView.approvalActions.test.tsx
@@ -25,7 +25,7 @@ const sampleEvents = [
     end:   new Date(2026, 3, 5),
     resource: 'N121AB',
     category: 'training',
-    meta: { approvalStage: { stage: 'approved', updatedAt: '', history: [] } },
+    meta: { approvalStage: { stage: 'approved', updatedAt: '', history: [] as unknown[] } },
   },
   {
     id: 'ev-requested',
@@ -34,7 +34,7 @@ const sampleEvents = [
     end:   new Date(2026, 3, 9),
     resource: 'N121AB',
     category: 'pr',
-    meta: { approvalStage: { stage: 'requested', updatedAt: '', history: [] } },
+    meta: { approvalStage: { stage: 'requested', updatedAt: '', history: [] as unknown[] } },
   },
   {
     id: 'ev-denied',
@@ -43,7 +43,7 @@ const sampleEvents = [
     end:   new Date(2026, 3, 13),
     resource: 'N505CD',
     category: 'maintenance',
-    meta: { approvalStage: { stage: 'denied', updatedAt: '', history: [] } },
+    meta: { approvalStage: { stage: 'denied', updatedAt: '', history: [] as unknown[] } },
   },
 ];
 

--- a/src/views/__tests__/AssetsView.assetsProp.test.tsx
+++ b/src/views/__tests__/AssetsView.assetsProp.test.tsx
@@ -17,9 +17,9 @@ import AssetsView from '../AssetsView';
 import { CalendarContext } from '../../core/CalendarContext';
 
 const currentDate = new Date(2026, 3, 1); // April 2026
-const evOn = (day) => new Date(2026, 3, day);
+const evOn = (day: number) => new Date(2026, 3, day);
 
-function renderView(props = {}) {
+function renderView(props: Record<string, unknown> = {}) {
   return render(
     <CalendarContext.Provider value={null}>
       <AssetsView

--- a/src/views/__tests__/AssetsView.grouping.test.tsx
+++ b/src/views/__tests__/AssetsView.grouping.test.tsx
@@ -13,7 +13,7 @@ import { CalendarContext } from '../../core/CalendarContext';
 
 const currentDate = new Date(2026, 3, 1); // April 2026
 
-const evOn = (day) => new Date(2026, 3, day);
+const evOn = (day: number) => new Date(2026, 3, day);
 
 const events = [
   {
@@ -42,7 +42,7 @@ const events = [
   },
 ];
 
-function renderAssets(props = {}) {
+function renderAssets(props: Record<string, unknown> = {}) {
   return render(
     <CalendarContext.Provider value={null}>
       <AssetsView
@@ -151,8 +151,8 @@ describe('AssetsView grouping — 2-level tree', () => {
 });
 
 describe('AssetsView grouping — controlled collapsedGroups', () => {
-  function Controlled(props) {
-    const [collapsed, setCollapsed] = useState(() => new Set());
+  function Controlled(props: Record<string, unknown>) {
+    const [collapsed, setCollapsed] = useState<Set<string>>(() => new Set());
     return (
       <CalendarContext.Provider value={null}>
         <AssetsView

--- a/src/views/__tests__/AssetsView.keyboardNav.test.tsx
+++ b/src/views/__tests__/AssetsView.keyboardNav.test.tsx
@@ -23,14 +23,14 @@ import AssetsView from '../AssetsView';
 import { CalendarContext } from '../../core/CalendarContext';
 
 const currentDate = new Date(2026, 3, 1);
-const evOn = (day) => new Date(2026, 3, day);
+const evOn = (day: number) => new Date(2026, 3, day);
 
 const events = [
   { id: 'e1', title: 'T1', start: evOn(3),  end: evOn(3),  resource: 'N100', meta: { region: 'West' } },
   { id: 'e2', title: 'T2', start: evOn(5),  end: evOn(5),  resource: 'N200', meta: { region: 'East' } },
 ];
 
-function renderView(props = {}) {
+function renderView(props: Record<string, unknown> = {}) {
   return render(
     <CalendarContext.Provider value={null}>
       <AssetsView

--- a/src/views/__tests__/AssetsView.pools.test.tsx
+++ b/src/views/__tests__/AssetsView.pools.test.tsx
@@ -18,9 +18,9 @@ import AssetsView from '../AssetsView';
 import { CalendarContext } from '../../core/CalendarContext';
 
 const currentDate = new Date(2026, 3, 1); // April 2026
-const evOn = (day) => new Date(2026, 3, day);
+const evOn = (day: number) => new Date(2026, 3, day);
 
-function renderView(props = {}) {
+function renderView(props: Record<string, unknown> = {}) {
   return render(
     <CalendarContext.Provider value={null}>
       <AssetsView

--- a/src/views/__tests__/AssetsView.test.tsx
+++ b/src/views/__tests__/AssetsView.test.tsx
@@ -14,7 +14,7 @@ const baseEvents = [
     end:   new Date(2026, 3, 5),
     resource: 'N121AB',
     category: 'training',
-    meta: { sublabel: 'Citation CJ3', approvalStage: { stage: 'approved', updatedAt: '', history: [] } },
+    meta: { sublabel: 'Citation CJ3', approvalStage: { stage: 'approved', updatedAt: '', history: [] as unknown[] } },
   },
   {
     id: 'ev-2',
@@ -23,7 +23,7 @@ const baseEvents = [
     end:   new Date(2026, 3, 7),
     resource: 'N121AB',
     category: 'pr',
-    meta: { approvalStage: { stage: 'requested', updatedAt: '', history: [] } },
+    meta: { approvalStage: { stage: 'requested', updatedAt: '', history: [] as unknown[] } },
   },
   {
     id: 'ev-3',
@@ -32,7 +32,7 @@ const baseEvents = [
     end:   new Date(2026, 3, 12),
     resource: 'N505CD',
     category: 'maintenance',
-    meta: { approvalStage: { stage: 'denied', updatedAt: '', history: [] } },
+    meta: { approvalStage: { stage: 'denied', updatedAt: '', history: [] as unknown[] } },
   },
   {
     id: 'ev-4',
@@ -41,11 +41,11 @@ const baseEvents = [
     end:   new Date(2026, 3, 16),
     resource: 'N505CD',
     category: 'coverage',
-    meta: { approvalStage: { stage: 'pending_higher', updatedAt: '', history: [] } },
+    meta: { approvalStage: { stage: 'pending_higher', updatedAt: '', history: [] as unknown[] } },
   },
 ];
 
-function renderAssets(props = {}) {
+function renderAssets(props: Record<string, unknown> = {}) {
   return render(
     <CalendarContext.Provider value={null}>
       <AssetsView

--- a/src/views/__tests__/AssetsView.toolbar.test.tsx
+++ b/src/views/__tests__/AssetsView.toolbar.test.tsx
@@ -22,9 +22,9 @@ import AssetsView from '../AssetsView';
 import { CalendarContext } from '../../core/CalendarContext';
 
 const currentDate = new Date(2026, 3, 1); // April 2026
-const evOn = (day) => new Date(2026, 3, day);
+const evOn = (day: number) => new Date(2026, 3, day);
 
-function renderView(props = {}) {
+function renderView(props: Record<string, unknown> = {}) {
   return render(
     <CalendarContext.Provider value={null}>
       <AssetsView

--- a/src/views/__tests__/AssetsView.virtualization.test.tsx
+++ b/src/views/__tests__/AssetsView.virtualization.test.tsx
@@ -48,7 +48,10 @@ function buildAssets(n = 50) {
 }
 
 /** Build M events distributed across asset IDs. */
-function buildEvents(assets, m = 200) {
+function buildEvents(
+  assets: Array<{ id: string; group: string; meta: { fleet: string; base: string; ops: string; status: string } }>,
+  m = 200,
+) {
   return Array.from({ length: m }, (_, i) => {
     const asset   = assets[i % assets.length];
     const dayStart = (i % 28) + 1;

--- a/src/views/__tests__/AuditDrawer.test.tsx
+++ b/src/views/__tests__/AuditDrawer.test.tsx
@@ -67,7 +67,7 @@ describe('AuditDrawer — render', () => {
     const eventNoHistory = {
       id: 'ev-x',
       title: 'Plain',
-      meta: { approvalStage: { stage: 'denied', updatedAt: '', history: [] } },
+      meta: { approvalStage: { stage: 'denied', updatedAt: '', history: [] as unknown[] } },
     };
     render(<AuditDrawer event={eventNoHistory} onClose={vi.fn()} />);
     expect(screen.getByText(/No history recorded/i)).toBeInTheDocument();

--- a/src/views/__tests__/BaseGanttView.test.tsx
+++ b/src/views/__tests__/BaseGanttView.test.tsx
@@ -12,7 +12,7 @@ function d(year: number, month: number, day: number) {
 
 // BaseGanttView accesses ctx.colorRules (no optional chain) when rendering bars.
 // Provide a minimal context so tests with events don't crash.
-const minCtx = { colorRules: [] };
+const minCtx = { colorRules: [] as unknown[] };
 
 function wrap(props: Record<string, any> = {}, ctxValue: any = null) {
   return render(

--- a/src/views/__tests__/TimelineView.grouping.test.tsx
+++ b/src/views/__tests__/TimelineView.grouping.test.tsx
@@ -12,7 +12,7 @@ const employees = [
   { id: 'doc-1',   name: 'Carol Jones', role: 'Doctor' },
 ];
 
-function renderTimeline(props = {}) {
+function renderTimeline(props: Record<string, unknown> = {}) {
   return render(
     <CalendarContext.Provider value={null}>
       <TimelineView
@@ -124,13 +124,13 @@ describe('TimelineView grouping', () => {
   });
 
   describe('DnD row reassignment', () => {
-    function dragAndDrop(source, target) {
+    function dragAndDrop(source: Element | Window | Document, target: Element | Window | Document) {
       const dt = {
         effectAllowed: '',
         dropEffect: '',
-        _data: {},
-        setData(k, v) { this._data[k] = v; },
-        getData(k) { return this._data[k]; },
+        _data: {} as Record<string, string>,
+        setData(k: string, v: string) { this._data[k] = v; },
+        getData(k: string) { return this._data[k]; },
       };
       fireEvent.dragStart(source, { dataTransfer: dt });
       fireEvent.dragOver(target, { dataTransfer: dt });

--- a/src/views/__tests__/TimelineView.touchDnd.test.tsx
+++ b/src/views/__tests__/TimelineView.touchDnd.test.tsx
@@ -18,7 +18,7 @@ const evts = [
   { id: 'shift-1', title: 'Alice Shift', start: shiftStart, end: shiftEnd, resource: 'nurse-1' },
 ];
 
-function renderTimeline(props = {}) {
+function renderTimeline(props: Record<string, unknown> = {}) {
   return render(
     <CalendarContext.Provider value={null}>
       <TimelineView
@@ -32,7 +32,7 @@ function renderTimeline(props = {}) {
   );
 }
 
-function fireTouch(type, el, touches = []) {
+function fireTouch(type: string, el: EventTarget, touches: Array<{ x: number; y: number }> = []) {
   const evt = new Event(type, { bubbles: true, cancelable: true });
   Object.defineProperty(evt, 'touches', {
     value: touches.map(t => ({ clientX: t.x, clientY: t.y, target: el })),
@@ -44,8 +44,8 @@ function fireTouch(type, el, touches = []) {
 }
 
 describe('TimelineView touch DnD', () => {
-  let origElementFromPoint;
-  let pointTarget = null;
+  let origElementFromPoint: typeof document.elementFromPoint;
+  let pointTarget: Element | null = null;
 
   beforeEach(() => {
     vi.useFakeTimers();

--- a/src/views/__tests__/WeekDayView.offHoursClipping.test.tsx
+++ b/src/views/__tests__/WeekDayView.offHoursClipping.test.tsx
@@ -16,7 +16,7 @@ import WeekView from '../WeekView';
 import DayView from '../DayView';
 import { CalendarContext } from '../../core/CalendarContext';
 
-function d(y, mo, day, h = 0, m = 0) {
+function d(y: number, mo: number, day: number, h = 0, m = 0) {
   return new Date(y, mo - 1, day, h, m, 0, 0);
 }
 
@@ -26,14 +26,14 @@ function Wrap({ children }: any) {
   );
 }
 
-function makeEvent(id, start, end) {
+function makeEvent(id: string, start: Date, end: Date) {
   return { id, title: `Event ${id}`, start, end, allDay: false, color: '#3b82f6' };
 }
 
 describe('WeekView off-hours event clipping', () => {
   const monday = d(2026, 4, 6);
 
-  function renderWeek(events, display = { dayStart: 6, dayEnd: 22 }) {
+  function renderWeek(events: any[], display = { dayStart: 6, dayEnd: 22 }) {
     return render(
       <Wrap>
         <WeekView
@@ -106,7 +106,7 @@ describe('WeekView off-hours event clipping', () => {
 describe('DayView off-hours event clipping', () => {
   const currentDate = d(2026, 4, 10);
 
-  function renderDay(events, display = { dayStart: 6, dayEnd: 22 }) {
+  function renderDay(events: any[], display = { dayStart: 6, dayEnd: 22 }) {
     return render(
       <Wrap>
         <DayView


### PR DESCRIPTION
### Motivation
- Finish the Sprint 4 “views pass” by removing implicit-`any` diagnostics in the remaining `src/views` files and their tests so the strict type-ratchet can advance. 
- Keep changes localized to view code and view tests to avoid pulling shared domain/interface rewrites into unrelated modules.

### Description
- Tightened `src/views/AuditDrawer.tsx` by typing date/SLA helpers, the `closeRef`, the key handler, history entries, and safe indexing into `ACTION_LABELS` to remove implicit-any hotspots. 
- Added a local `ScheduleEvent` type and typed the `ScheduleView` event parameter and callbacks, with small casts where the view interacts with existing context helpers. 
- Fixed strict-any issues across view tests by typing helper signatures and fixtures (render props, `evOn`, touch helpers, DnD `dataTransfer` shim, date/event factories) and explicit empty-array literals (e.g. `history: [] as unknown[]`).
- Ratcheted the migration allowlist by adding the cleaned view files/tests to `scripts/typecheck-strict.mjs` so these files are now enforced by the strict checker.

### Testing
- Ran `npm run type-check:strict` and the strict type check completed successfully (GREEN). 
- Ran `npx vitest run src/views/__tests__/AuditDrawer.test.tsx src/views/__tests__/TimelineView.grouping.test.tsx src/views/__tests__/WeekDayView.offHoursClipping.test.tsx` and all targeted tests passed (3 files, 37 tests passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8c6fd8144832ca8a33ac3bd16e0f2)