### PR TITLE
Sprint 5: eliminate remaining implicit-any debt and capture final Stage 6 blockers

### DIFF
--- a/docs/stage-6-readiness-audit.md
+++ b/docs/stage-6-readiness-audit.md
@@ -340,6 +340,49 @@ Stage 6 should only happen when the repository is ready for repo-wide enforcemen
 
 ---
 
+## Audit Rerun — Sprint 5 Final pre-Stage-6 cleanup (2026-04-22)
+
+This section captures the strict rerun after the Sprint 5 final cleanup pass.
+
+### Commands Run
+
+```bash
+npx tsc --noEmit -p tsconfig.json --pretty false
+npx tsc --noEmit -p tsconfig.strict.json --pretty false
+npm run type-check:strict
+```
+
+### 1) Current Root Baseline (`tsconfig.json`)
+
+- **Result:** Pass
+- **TypeScript diagnostics:** 0
+
+### 2) Repo-wide Implicit-any Debt (`tsconfig.strict.json`)
+
+- **Result:** Fail (`exit 2`) due to non-implicit-any diagnostics
+- **Implicit-any diagnostics (TS7005/7006/7011/7018/7023/7031/7034/7053):** **0**
+- **Unique files with implicit-any diagnostics:** **0**
+
+### 3) Remaining blockers under strict config
+
+Only two non-implicit-any diagnostics remain, both in `src/WorksCalendar.tsx`:
+
+- `TS2345` at line 1773 (legacy event assignment mismatch: `start/end` allow `number` in source shape)
+- `TS2322` at line 2353 (instantiate preview return contract mismatch: readonly vs mutable array shape)
+
+### 4) Migrated-path ratchet status
+
+- `npm run type-check:strict`: **GREEN**
+- Implicit-any diagnostics in migrated paths: **0**
+- Implicit-any diagnostics outside migrated paths: **0**
+
+### 5) Stage 6 readiness decision update
+
+- **Decision:** **NEAR-READY (BLOCKED)**
+- **Rationale:** The previously broad implicit-any debt is now eliminated. The only strict blockers left are two concrete, reviewable `src/WorksCalendar.tsx` type-contract mismatches, which are Stage 6-sized and suitable for a dedicated final blocker PR.
+
+---
+
 ## Audit Rerun — Post PR3 (2026-04-22)
 
 This section captures the requested post-PR3 full rerun.

--- a/src/hooks/__tests__/useDrag.test.ts
+++ b/src/hooks/__tests__/useDrag.test.ts
@@ -22,7 +22,7 @@ function fakeGrid(top = 0, width = 200, gutterWidth = 0) {
   };
 }
 
-function fakePointer(clientX = 10, clientY) {
+function fakePointer(clientX = 10, clientY: number) {
   return { clientX, clientY, button: 0, pointerId: 1,
     preventDefault: () => {}, stopPropagation: () => {} };
 }

--- a/src/hooks/__tests__/useTouchDnd.test.tsx
+++ b/src/hooks/__tests__/useTouchDnd.test.tsx
@@ -60,8 +60,8 @@ function fireTouch(
 }
 
 describe('useTouchDnd', () => {
-  let origElementFromPoint;
-  let pointTarget = null;
+  let origElementFromPoint: Document['elementFromPoint'];
+  let pointTarget: Element | null = null;
 
   beforeEach(() => {
     vi.useFakeTimers();

--- a/src/ui/__tests__/ConfigPanel.approvalsTab.test.tsx
+++ b/src/ui/__tests__/ConfigPanel.approvalsTab.test.tsx
@@ -31,8 +31,8 @@ const seededConfig = {
   approvals: {
     enabled: false,
     tiers: [
-      { id: 'tier-1', label: 'Supervisor', requires: 'any', roles: [] },
-      { id: 'tier-2', label: 'Director',   requires: 'any', roles: [] },
+      { id: 'tier-1', label: 'Supervisor', requires: 'any', roles: [] as string[] },
+      { id: 'tier-2', label: 'Director',   requires: 'any', roles: [] as string[] },
     ],
     rules: {
       requested:      { allow: ['approve', 'deny'], prefix: 'Req' },
@@ -110,7 +110,7 @@ describe('ApprovalsTab — tiers', () => {
     const { getConfig, rerender } = renderTab({ initialConfig: seededConfig });
     fireEvent.click(screen.getByLabelText('Move Supervisor down'));
     rerender();
-    expect(getConfig().approvals.tiers.map(t => t.id)).toEqual(['tier-2', 'tier-1']);
+    expect(getConfig().approvals.tiers.map((t: { id: string }) => t.id)).toEqual(['tier-2', 'tier-1']);
   });
 
   it('Move tier up on the topmost row is a no-op (button disabled)', () => {

--- a/src/ui/__tests__/ConfigPanel.assetsTab.test.tsx
+++ b/src/ui/__tests__/ConfigPanel.assetsTab.test.tsx
@@ -163,7 +163,7 @@ describe('AssetsTab — mutations', () => {
     });
     fireEvent.click(screen.getByRole('button', { name: 'Remove Bravo' }));
     rerender();
-    const ids = getConfig().assets.map(a => a.id);
+    const ids = getConfig().assets.map((a: { id: string }) => a.id);
     expect(ids).toEqual(['a', 'c']);
   });
 });
@@ -181,14 +181,14 @@ describe('AssetsTab — reorder', () => {
     const { getConfig, rerender } = renderTab({ initialConfig });
     fireEvent.click(screen.getByRole('button', { name: 'Move Alpha down' }));
     rerender();
-    expect(getConfig().assets.map(a => a.id)).toEqual(['b', 'a', 'c']);
+    expect(getConfig().assets.map((a: { id: string }) => a.id)).toEqual(['b', 'a', 'c']);
   });
 
   it('Move up swaps with the previous entry', () => {
     const { getConfig, rerender } = renderTab({ initialConfig });
     fireEvent.click(screen.getByRole('button', { name: 'Move Charlie up' }));
     rerender();
-    expect(getConfig().assets.map(a => a.id)).toEqual(['a', 'c', 'b']);
+    expect(getConfig().assets.map((a: { id: string }) => a.id)).toEqual(['a', 'c', 'b']);
   });
 
   it('Move up is disabled on the first row', () => {

--- a/src/ui/__tests__/ConfigPanel.categoriesTab.test.tsx
+++ b/src/ui/__tests__/ConfigPanel.categoriesTab.test.tsx
@@ -49,7 +49,7 @@ describe('CategoriesTab — mutations', () => {
     fireEvent.change(labelInput, { target: { value: 'Pilot Training' } });
 
     const cats = getConfig().categoriesConfig.categories;
-    const training = cats.find(c => c.id === 'training');
+    const training = cats.find((c: { id: string; label: string }) => c.id === 'training');
     expect(training.label).toBe('Pilot Training');
   });
 
@@ -59,7 +59,7 @@ describe('CategoriesTab — mutations', () => {
     fireEvent.change(colorInput, { target: { value: '#ff0000' } });
 
     const cats = getConfig().categoriesConfig.categories;
-    expect(cats.find(c => c.id === 'training').color).toBe('#ff0000');
+    expect(cats.find((c: { id: string; color: string }) => c.id === 'training')?.color).toBe('#ff0000');
   });
 
   it('toggling disabled flag persists', () => {
@@ -81,7 +81,7 @@ describe('CategoriesTab — mutations', () => {
     const { getConfig } = renderTab();
     fireEvent.click(screen.getByRole('button', { name: 'Remove Training' }));
     const cats = getConfig().categoriesConfig.categories;
-    expect(cats.find(c => c.id === 'training')).toBeUndefined();
+    expect(cats.find((c: { id: string }) => c.id === 'training')).toBeUndefined();
     expect(cats).toHaveLength(DEFAULT_CATEGORIES.length - 1);
   });
 

--- a/src/ui/__tests__/ConfigPanel.requestFormTab.test.tsx
+++ b/src/ui/__tests__/ConfigPanel.requestFormTab.test.tsx
@@ -99,7 +99,7 @@ describe('RequestFormTab — CRUD', () => {
     const { getConfig, rerender } = renderTab({ initialConfig: seededConfig });
     fireEvent.click(screen.getByLabelText('Move Title down'));
     rerender();
-    expect(getConfig().requestForm.fields.map(f => f.key)).toEqual([
+    expect(getConfig().requestForm.fields.map((f: { key: string }) => f.key)).toEqual([
       'start', 'title', 'notes',
     ]);
   });
@@ -115,6 +115,6 @@ describe('RequestFormTab — CRUD', () => {
     rerender();
     const { fields } = getConfig().requestForm;
     expect(fields).toHaveLength(2);
-    expect(fields.map(f => f.key)).toEqual(['title', 'start']);
+    expect(fields.map((f: { key: string }) => f.key)).toEqual(['title', 'start']);
   });
 });

--- a/src/ui/__tests__/ConfigPanel.teamTab.test.tsx
+++ b/src/ui/__tests__/ConfigPanel.teamTab.test.tsx
@@ -115,7 +115,7 @@ describe('TeamTab bidirectional sync (issue #101)', () => {
     const pending = inputs.find(el => (el as HTMLInputElement).value === '');
     fireEvent.change(pending, { target: { value: 'Nora' } });
     fireEvent.keyDown(pending, { key: 'Enter' });
-    expect(getConfig().team.members.map(m => m.id)).toEqual([5, 6]);
+    expect(getConfig().team.members.map((m: { id: number }) => m.id)).toEqual([5, 6]);
   });
 
   it('keeps role/base optional when roles and bases exist', () => {

--- a/src/ui/__tests__/a11y.test.tsx
+++ b/src/ui/__tests__/a11y.test.tsx
@@ -27,11 +27,19 @@ import { CalendarContext } from '../../core/CalendarContext';
 
 // ─── Helpers ───────────────────────────────────────────────────────────────────
 
-function d(y, mo, day, h = 9, m = 0) {
+function d(y: number, mo: number, day: number, h = 9, m = 0) {
   return new Date(y, mo - 1, day, h, m, 0, 0);
 }
 
-function makeEvent(id, overrides: any = {}) {
+type A11yEventOverrides = Partial<{
+  title: string;
+  start: Date;
+  end: Date;
+  allDay: boolean;
+  color: string;
+}> & Record<string, unknown>;
+
+function makeEvent(id: string, overrides: A11yEventOverrides = {}) {
   return {
     id,
     title: overrides.title ?? `Event ${id}`,
@@ -43,9 +51,9 @@ function makeEvent(id, overrides: any = {}) {
   };
 }
 
-const calCtx = null; // CalendarContext.Provider value (null = default)
+const calCtx: React.ContextType<typeof CalendarContext> = null; // CalendarContext.Provider value (null = default)
 
-function CalCtxWrap({ children }: any) {
+function CalCtxWrap({ children }: { children: React.ReactNode }) {
   return (
     <CalendarContext.Provider value={calCtx}>
       {children}
@@ -140,7 +148,7 @@ describe('ScreenReaderAnnouncer', () => {
 // ─── useFocusTrap ─────────────────────────────────────────────────────────────
 
 describe('useFocusTrap', () => {
-  function TrapFixture({ onEscape }) {
+  function TrapFixture({ onEscape }: { onEscape: () => void }) {
     const trapRef = useFocusTrap(onEscape);
     return (
       <div ref={trapRef} data-testid="trap">


### PR DESCRIPTION
### Motivation

- Finish the Sprint 5 pre-Stage-6 cleanup by removing remaining implicit-any sites so the Stage 6 readiness audit can measure only true Stage-6 blockers. 
- Narrow the remaining strict failures to a small, reviewable set so a dedicated final PR can complete the root `noImplicitAny` flip. 

### Description

- Added explicit TypeScript typings to test helpers and fixtures to remove implicit-anys, including `fakePointer` parameter typing, `document.elementFromPoint`/`pointTarget` types, mapped callback param types in multiple `ConfigPanel` tests, and typed test helpers in the accessibility suite (`d`, `makeEvent`, `CalCtxWrap`, `TrapFixture`).
- Annotated array/map callback shapes (e.g. assets/fields/tiers/team members) in `src/ui/__tests__/*` and `src/hooks/__tests__/*` to eliminate implicit-any diagnostics in test code.
- Updated `docs/stage-6-readiness-audit.md` with a new "Sprint 5 Final pre-Stage-6 cleanup (2026-04-22)" section that records the strict rerun outcome and documents the two remaining non-implicit-any blockers in `src/WorksCalendar.tsx`.

### Testing

- Ran `npx tsc --noEmit -p tsconfig.json --pretty false` which passed with 0 root diagnostics. ✅
- Ran `npx tsc --noEmit -p tsconfig.strict.json --pretty false` which still fails but now reports **0 implicit-any diagnostics** and only two concrete non-implicit-any diagnostics (the documented `TS2345` and `TS2322` in `src/WorksCalendar.tsx`). (expected / documented) ❌
- Ran `npm run type-check:strict` (the ratcheted CI filter script) which is **GREEN** (no implicit-any failures in migrated paths). ✅

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8cf1e2b88832c8fcaa8db3b8a3bb6)