### PR TITLE
Stage 7 Sprint 1: add strict-null ratchet and migrate grouping helper

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,9 @@ jobs:
       - name: Run type check
         run: npm run type-check
 
+      - name: Run strict-null ratchet
+        run: npm run type-check:strict-null
+
   unit-tests:
     name: Unit & Component Tests
     runs-on: ubuntu-latest

--- a/docs/stage-7-strict-null-checks-audit.md
+++ b/docs/stage-7-strict-null-checks-audit.md
@@ -1,7 +1,7 @@
 # Stage 7 — strictNullChecks Audit (Sprint 0 Baseline)
 
 _Date:_ 2026-04-22  
-_Status:_ Sprint 0 baseline completed (measurement + ratchet proposal)
+_Status:_ Sprint 0 baseline completed; Sprint 1 ratchet pilot landed on `src/grouping/groupRows.ts`
 
 ## Scope and Method
 
@@ -169,3 +169,19 @@ To de-risk quickly while proving the ratchet:
 - [x] top offenders identified
 - [x] staged enforcement mechanism proposed
 - [x] first realistic epic size estimate recorded
+
+---
+
+## Sprint 1 Pilot (Leaf utility seam)
+
+Date: 2026-04-22
+
+- Added a strict-null ratchet script (`scripts/typecheck-strict-null.mjs`) that runs full-repo strict-null diagnostics and fails only for migrated paths.
+- Wired CI to run `npm run type-check:strict-null` as a blocking TypeScript check.
+- Migrated first low-risk leaf path:
+  - `src/grouping/groupRows.ts`
+  - `src/grouping/__tests__/groupRows.test.ts`
+
+Pilot result:
+- Migrated paths are strict-null clean under the ratchet.
+- Mechanism is active in CI without requiring root `strictNullChecks` flip.

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "build:examples": "vite build --config vite.examples.config.ts",
     "preview": "vite preview --config vite.demo.config.ts",
     "type-check": "tsc --noEmit",
+    "type-check:strict-null": "node scripts/typecheck-strict-null.mjs",
     "type-check:watch": "tsc --noEmit --watch",
     "prepublishOnly": "npm run test && npm run build"
   },

--- a/scripts/typecheck-strict-null.mjs
+++ b/scripts/typecheck-strict-null.mjs
@@ -1,0 +1,67 @@
+import { spawnSync } from 'node:child_process';
+import path from 'node:path';
+
+const STRICT_NULL_ERROR_CODES = new Set([
+  'TS18047',
+  'TS18048',
+  'TS2322',
+  'TS2323',
+  'TS2326',
+  'TS2327',
+  'TS2339',
+  'TS2345',
+  'TS2531',
+  'TS2532',
+  'TS2533',
+  'TS2722',
+]);
+
+const MIGRATED_PATHS = [
+  'src/grouping/groupRows.ts',
+  'src/grouping/__tests__/groupRows.test.ts',
+];
+
+const tscResult = spawnSync(
+  'npx',
+  ['tsc', '--noEmit', '--pretty', 'false', '--strictNullChecks', 'true'],
+  { encoding: 'utf8' },
+);
+
+const output = `${tscResult.stdout ?? ''}${tscResult.stderr ?? ''}`;
+const repoRoot = process.cwd();
+
+const diagnostics = output
+  .split('\n')
+  .map((line) => line.trim())
+  .filter(Boolean)
+  .map((line) => {
+    const match = line.match(/^(.+?)\((\d+),(\d+)\): error (TS\d+): (.+)$/);
+    if (!match) return null;
+    const [, filePath, lineNumber, columnNumber, code, message] = match;
+    return {
+      filePath: path.resolve(repoRoot, filePath),
+      lineNumber: Number(lineNumber),
+      columnNumber: Number(columnNumber),
+      code,
+      message,
+      raw: line,
+    };
+  })
+  .filter((entry) => entry !== null);
+
+const migratedPathSet = new Set(MIGRATED_PATHS.map((filePath) => path.resolve(repoRoot, filePath)));
+const strictNullFailures = diagnostics.filter((entry) =>
+  STRICT_NULL_ERROR_CODES.has(entry.code)
+  && migratedPathSet.has(entry.filePath),
+);
+
+if (strictNullFailures.length > 0) {
+  console.error('❌ Stage 7 strict-null ratchet failed in migrated paths.');
+  for (const failure of strictNullFailures) {
+    console.error(`- ${failure.raw}`);
+  }
+  process.exit(1);
+}
+
+console.log('✅ Stage 7 strict-null ratchet passed for migrated paths.');
+console.log(`Checked migrated paths: ${MIGRATED_PATHS.join(', ')}`);

--- a/src/grouping/__tests__/groupRows.test.ts
+++ b/src/grouping/__tests__/groupRows.test.ts
@@ -28,6 +28,8 @@ describe('groupRows', () => {
     expect(nurseHeader).toBeDefined();
     expect(nurseHeader.count).toBe(3);
     const doctorHeader = flatRows.find(r => r._type === 'groupHeader' && r.groupKey === 'Doctor');
+    expect(doctorHeader).toBeDefined();
+    if (!doctorHeader) throw new Error('Expected doctorHeader to be defined');
     expect(doctorHeader.count).toBe(2);
   });
 
@@ -49,6 +51,8 @@ describe('groupRows', () => {
     const { groupOrder, flatRows } = groupRows(rows, { groupBy: 'role', fieldAccessor });
     expect(groupOrder[groupOrder.length - 1]).toBe('(Ungrouped)');
     const ungrouped = flatRows.find(r => r._type === 'groupHeader' && r.groupKey === '(Ungrouped)');
+    expect(ungrouped).toBeDefined();
+    if (!ungrouped) throw new Error('Expected ungrouped header to be defined');
     expect(ungrouped.count).toBe(1);
   });
 
@@ -119,6 +123,8 @@ describe('groupRows', () => {
       });
       // Nurse/Day header present (collapsed) but its rows hidden
       const dayHeader = flatRows.find(r => r.groupKey === 'Nurse/Day');
+      expect(dayHeader).toBeDefined();
+      if (!dayHeader) throw new Error('Expected Nurse/Day header to be defined');
       expect(dayHeader.collapsed).toBe(true);
       expect(flatRows.filter(r => !r._type && r.emp.role === 'Nurse' && r.emp.shift === 'Day')).toHaveLength(0);
       // Nurse/Night unaffected — 1 row
@@ -131,8 +137,12 @@ describe('groupRows', () => {
         fieldAccessor: [roleAcc, shiftAcc],
       });
       const nurseHeader = flatRows.find(r => r.groupKey === 'Nurse');
+      expect(nurseHeader).toBeDefined();
+      if (!nurseHeader) throw new Error('Expected nurseHeader to be defined');
       expect(nurseHeader.count).toBe(3); // Day: 2 + Night: 1
       const doctorHeader = flatRows.find(r => r.groupKey === 'Doctor');
+      expect(doctorHeader).toBeDefined();
+      if (!doctorHeader) throw new Error('Expected doctorHeader to be defined');
       expect(doctorHeader.count).toBe(2);
     });
   });

--- a/src/grouping/groupRows.ts
+++ b/src/grouping/groupRows.ts
@@ -2,14 +2,25 @@ const UNGROUPED = '(Ungrouped)';
 
 type Accessor = (item: any) => any;
 type Row = Record<string, any>;
+type GroupBucketMap = Map<string, Row[]>;
 
-function bucketize(items: Row[], accessor: Accessor): { map: Map<string, Row[]>; order: string[] } {
-  const map = new Map<string, Row[]>();
+function getOrCreateBucket(map: GroupBucketMap, key: string): Row[] {
+  const existingBucket = map.get(key);
+  if (existingBucket) {
+    return existingBucket;
+  }
+  const bucket: Row[] = [];
+  map.set(key, bucket);
+  return bucket;
+}
+
+function bucketize(items: Row[], accessor: Accessor): { map: GroupBucketMap; order: string[] } {
+  const map: GroupBucketMap = new Map();
   for (const item of items) {
     const val = accessor(item);
     const key = val != null && val !== '' ? String(val) : UNGROUPED;
-    if (!map.has(key)) map.set(key, []);
-    map.get(key)!.push(item);
+    const bucket = getOrCreateBucket(map, key);
+    bucket.push(item);
   }
   // Insertion order preserved; (Ungrouped) always sorts last.
   const order = [...map.keys()].sort((a, b) => {
@@ -34,11 +45,19 @@ function emitLevel(
     flatRows.push(...items);
     return;
   }
-  const { map, order } = bucketize(items, accessors[level]);
+  const accessor = accessors[level];
+  if (!accessor) {
+    flatRows.push(...items);
+    return;
+  }
+  const { map, order } = bucketize(items, accessor);
   for (const key of order) {
     const path = parentPath ? `${parentPath}/${key}` : key;
     groupOrder.push(path);
     const bucket = map.get(key);
+    if (!bucket) {
+      continue;
+    }
     const collapsed = collapsedGroups.has(path);
     // Total member count = count of leaf rows under this group, recursively.
     const count = bucket.length;


### PR DESCRIPTION
### Motivation

- Prove the Stage 7 `strictNullChecks` enforcement mechanism on a low-risk, leaf utility and demonstrate CI gating without flipping root `tsconfig` yet.
- Normalize null handling at a single seam so downstream callers are not forced to adopt `undefined` unions.

### Description

- Add a strict-null ratchet script `scripts/typecheck-strict-null.mjs` that runs `tsc --strictNullChecks` repo-wide and fails only for strict-null error codes inside an allowlist of migrated paths (`src/grouping/groupRows.ts` and its test). 
- Wire the ratchet into CI by adding `npm run type-check:strict-null` to `package.json` and invoking it from the `type-check` job in `.github/workflows/ci.yml`.
- Migrate the grouping helper `src/grouping/groupRows.ts` to be strict-null clean by introducing `GroupBucketMap`, `getOrCreateBucket`, guarded bucket access, and a defensive accessor check at the recursion seam.
- Tighten tests in `src/grouping/__tests__/groupRows.test.ts` to assert `find(...)` results are defined before property access and update expectations accordingly.
- Update `docs/stage-7-strict-null-checks-audit.md` to record the Sprint 1 pilot and ratchet landing.

### Testing

- Ran `npm run type-check` and it passed (root advisory `tsc --noEmit`).
- Ran `npm run type-check:strict-null` (the new ratchet) and it passed for the migrated paths.
- Ran `npx vitest run src/grouping/__tests__/groupRows.test.ts` and all tests in that file passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e922e13388832cb8dcf760b70c4b74)