### PR TITLE
Sprint 3: focus chips UX rewrite + live context summary bar

### DIFF
--- a/src/WorksCalendar.tsx
+++ b/src/WorksCalendar.tsx
@@ -45,8 +45,10 @@ import { buildActiveFilterPills, buildFilterSummary, hasActiveFilters } from './
 import FilterBar              from './ui/FilterBar';
 import ProfileBar             from './ui/ProfileBar';
 import FilterGroupSidebar, { SidebarToggleButton } from './ui/FilterGroupSidebar';
-import FocusChips, { DEFAULT_FOCUS_CHIPS } from './ui/FocusChips';
+import FocusChips, { DEFAULT_FOCUS_CHIPS, resolveActiveChipLabels } from './ui/FocusChips';
 import type { FocusChipDef } from './ui/FocusChips';
+import ContextSummary from './ui/ContextSummary';
+import { resolvePresetLabel } from './ui/ViewPanel';
 import type { GroupLevel } from './ui/GroupsPanel';
 import HoverCard              from './ui/HoverCard';
 import OwnerLock              from './ui/OwnerLock';
@@ -2145,14 +2147,27 @@ export const WorksCalendar = forwardRef<CalendarApi, WorksCalendarProps>(functio
           )
         }
 
-        {/* ── Focus chips (visible quick filters, opt-in) ── */}
-        {focusChips && (
-          <FocusChips
-            chips={Array.isArray(focusChips) ? focusChips : DEFAULT_FOCUS_CHIPS}
-            activeCategories={cal.filters?.categories as Set<string> | undefined}
-            onCategoriesChange={(next) => cal.setFilter('categories', next)}
-          />
-        )}
+        {/* ── Focus chips + context summary (opt-in via focusChips prop) ── */}
+        {focusChips && (() => {
+          const resolvedChips: FocusChipDef[] = Array.isArray(focusChips)
+            ? focusChips
+            : DEFAULT_FOCUS_CHIPS;
+          const activeCategories = cal.filters?.categories as Set<string> | undefined;
+          return (
+            <>
+              <ContextSummary
+                viewLabel={resolvePresetLabel(sidebarGroupLevels)}
+                chipLabels={resolveActiveChipLabels(resolvedChips, activeCategories)}
+                scope="All regions"
+              />
+              <FocusChips
+                chips={resolvedChips}
+                activeCategories={activeCategories}
+                onCategoriesChange={(next) => cal.setFilter('categories', next)}
+              />
+            </>
+          );
+        })()}
 
         {/* ── Filter Bar (legacy, kept for renderFilterBar override) ── */}
         {renderFilterBar && renderFilterBar({

--- a/src/ui/ContextSummary.module.css
+++ b/src/ui/ContextSummary.module.css
@@ -1,0 +1,38 @@
+.bar {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 4px 8px;
+  padding: 5px 14px;
+  background: var(--wc-surface, #f8f9fa);
+  border-bottom: 1px solid var(--wc-border, #e5e7eb);
+  font-size: 11px;
+  color: var(--wc-text-muted, #6b7280);
+  line-height: 1;
+  user-select: none;
+}
+
+.segment {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.key {
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  font-size: 10px;
+  color: var(--wc-text-muted, #9ca3af);
+}
+
+.value {
+  font-weight: 500;
+  color: var(--wc-text, #374151);
+}
+
+.dot {
+  color: var(--wc-border, #d1d5db);
+  font-size: 13px;
+  line-height: 1;
+}

--- a/src/ui/ContextSummary.tsx
+++ b/src/ui/ContextSummary.tsx
@@ -1,0 +1,48 @@
+/**
+ * ContextSummary — live one-line readout of the calendar's current state.
+ *
+ * Renders: "View: By Base  ·  Focus: Aircraft Requests  ·  Scope: All regions"
+ * Updates every render via props; no internal state needed.
+ */
+import styles from './ContextSummary.module.css';
+
+export type ContextSummaryProps = {
+  /** Label of the active view preset, e.g. "By Base". Null = "Custom". */
+  viewLabel: string | null;
+  /** Labels of all currently active focus chips. Empty = "All". */
+  chipLabels: string[];
+  /** Scope/region label, e.g. "All regions". */
+  scope: string;
+};
+
+export default function ContextSummary({
+  viewLabel,
+  chipLabels,
+  scope,
+}: ContextSummaryProps) {
+  const focusText: string = chipLabels.length > 0 ? chipLabels.join(' + ') : 'All';
+  const viewText: string = viewLabel !== null ? viewLabel : 'Custom';
+
+  return (
+    <div
+      className={styles.bar}
+      aria-live="polite"
+      aria-label="Current calendar context"
+    >
+      <Segment label="View" value={viewText} />
+      <span className={styles.dot} aria-hidden="true">·</span>
+      <Segment label="Focus" value={focusText} />
+      <span className={styles.dot} aria-hidden="true">·</span>
+      <Segment label="Scope" value={scope} />
+    </div>
+  );
+}
+
+function Segment({ label, value }: { label: string; value: string }) {
+  return (
+    <span className={styles.segment}>
+      <span className={styles.key}>{label}</span>
+      <span className={styles.value}>{value}</span>
+    </span>
+  );
+}

--- a/src/ui/FocusChips.tsx
+++ b/src/ui/FocusChips.tsx
@@ -11,36 +11,53 @@
  * When any chip is active, only events in the union of active chips'
  * categories render.
  */
-import { Radio, Plane, Wrench, FileText } from 'lucide-react';
+import { MapPin, Plane, Package } from 'lucide-react';
 import styles from './FocusChips.module.css';
 
 export type FocusChipDef = {
   /** Stable id, used for keys and aria. */
   id: string;
-  /** Short label, e.g. "Dispatch". */
+  /** Short label, e.g. "Region". */
   label: string;
   /** Categories this chip toggles on the `categories` filter. */
   categories: string[];
   /** Optional icon name (bundled set). Falls back to no icon. */
-  icon?: 'radio' | 'plane' | 'wrench' | 'file';
+  icon?: 'map-pin' | 'plane' | 'package';
 };
 
 /**
- * Default chip list for operational calendars. Hosts can override via the
- * `focusChips` prop on <WorksCalendar />. The Air EMS demo uses exactly these.
+ * Default chip list for operational Air EMS calendars. Hosts can override via
+ * the `focusChips` prop on <WorksCalendar />.
+ *
+ * - Region        → base-context events (anchor events per base/region)
+ * - Aircraft Type → aviation flight-operation categories
+ * - Asset Requests → request events only
  */
 export const DEFAULT_FOCUS_CHIPS: FocusChipDef[] = [
-  { id: 'dispatch',    label: 'Dispatch',    categories: ['dispatch'],                 icon: 'radio' },
-  { id: 'flights',     label: 'Flights',     categories: ['mission', 'shift'],         icon: 'plane' },
-  { id: 'maintenance', label: 'Maintenance', categories: ['maintenance'],              icon: 'wrench' },
-  { id: 'requests',    label: 'Requests',    categories: ['request'],                  icon: 'file' },
+  {
+    id: 'region',
+    label: 'Region',
+    categories: ['base-event'],
+    icon: 'map-pin',
+  },
+  {
+    id: 'aircraft-type',
+    label: 'Aircraft Type',
+    categories: ['pilot-shift', 'mission-assignment', 'training'],
+    icon: 'plane',
+  },
+  {
+    id: 'asset-requests',
+    label: 'Asset Requests',
+    categories: ['aircraft-request', 'asset-request'],
+    icon: 'package',
+  },
 ];
 
 const ICON_MAP = {
-  radio: Radio,
+  'map-pin': MapPin,
   plane: Plane,
-  wrench: Wrench,
-  file: FileText,
+  package: Package,
 } as const;
 
 export type FocusChipsProps = {
@@ -50,6 +67,16 @@ export type FocusChipsProps = {
   /** Replace the active-categories set. */
   onCategoriesChange: (next: Set<string>) => void;
 };
+
+/** Returns the labels of all chips whose categories are fully active. */
+export function resolveActiveChipLabels(
+  chips: FocusChipDef[],
+  active: Set<string> | null | undefined,
+): string[] {
+  return chips
+    .filter(chip => chipIsActive(chip, active))
+    .map(chip => chip.label);
+}
 
 /** A chip is "active" only when every one of its categories is in the set. */
 function chipIsActive(chip: FocusChipDef, active: Set<string> | null | undefined): boolean {

--- a/src/ui/ViewPanel.tsx
+++ b/src/ui/ViewPanel.tsx
@@ -166,3 +166,9 @@ export default function ViewPanel(props: ViewPanelProps) {
 function matchesAnyPreset(levels: GroupLevel[]): boolean {
   return PRESETS.some(p => levelsMatch(p.levels, levels));
 }
+
+/** Returns the label of the first matching preset, or null if no match. */
+export function resolvePresetLabel(levels: GroupLevel[]): string | null {
+  const match = PRESETS.find(p => levelsMatch(p.levels, levels));
+  return match !== undefined ? match.label : null;
+}


### PR DESCRIPTION
- Replace department-label chips (Dispatch/Flights/Maintenance/Requests) with operational filters: Region / Aircraft Type / Asset Requests, matching Sprint 3 spec (issue #305). New icons: MapPin, Plane, Package.
- Export resolveActiveChipLabels() from FocusChips for context summary.
- Export resolvePresetLabel() from ViewPanel to derive active view name from current group levels without duplicating preset definitions.
- Add ContextSummary component (+ module CSS) that renders a live one-line readout: "View: By Base · Focus: Aircraft Requests · Scope: All regions". Uses aria-live="polite" so screen readers hear state changes.
- Wire ContextSummary into WorksCalendar above the FocusChips row, rendered together when focusChips prop is truthy.

https://claude.ai/code/session_01BjSanhei7rk75wuoDE4a5X

## Summary
Describe exactly what this PR changes.

## Scope
- Stage: 
- Planned PR number in sprint: 
- Target files/directories: 
- Why this slice is isolated: 

## Lessons Learned Check (REQUIRED)
Confirm these were actively used while building this PR:

- [ ] PR is intentionally small and isolated
- [ ] Boundary typing was prioritized over internal perfection
- [ ] No silent spread of `any`
- [ ] Advisory root `tsc` was used to catch integration issues
- [ ] I did not assume “looks typed” means “safe”
- [ ] I stopped and isolated typing cascades instead of expanding scope

## Definition of Done (ALL REQUIRED)
This PR is not done unless every box is checked.

- [ ] `npm run type-check:strict` passes
- [ ] Root advisory `tsc --noEmit` passes
- [ ] Tests pass for touched scope at minimum
- [ ] No uncontrolled increase in `any`
- [ ] All new types are intentional and named
- [ ] Public interfaces and exported functions are explicitly typed
- [ ] PR scope matches the sprint plan with no scope creep
- [ ] Any new `any` has an adjacent justification comment
- [ ] No file-wide `: any`
- [ ] No implicit `any` in exported functions

## What Was Typed
List exactly what was typed in this PR.

- 
- 
- 

## What Was Intentionally Left Loose
List anything intentionally not tightened yet.

- 
- 
- 

## `any` Ledger (REQUIRED)
- New `any` added: 
- Existing `any` removed: 
- Net change: 

For every new `any`, explain why it is required and why a safer type was not used yet.

1. 
2. 
3. 

## Boundary Notes
Document any public seams, caller-protection choices, or compatibility decisions.

- 
- 
- 

## Risk Level
- [ ] Low
- [ ] Medium
- [ ] High

Why:

## Validation Evidence
Paste the exact commands run and a short result summary.

```bash
npm run type-check:strict
npx tsc --noEmit -p tsconfig.json
```

Test commands run:

```bash
# paste commands here
```

## Stop Conditions Check
If any item below happened, explain how scope was reduced before merge.

- [ ] `any` started spreading across files
- [ ] Root `tsc` broke repeatedly
- [ ] Types required cross-module rewrites
- [ ] Scope was reduced to keep the PR reviewable

Notes:

## Reviewer Focus
What should reviewers look at first?

- 
- 
- 
