### PR TITLE
Sprint 3: tab view specialization — add purpose hints to view switcher

### DIFF
--- a/src/WorksCalendar.tsx
+++ b/src/WorksCalendar.tsx
@@ -256,14 +256,14 @@ function opAnnouncement(op: LooseValue) {
   }
 }
 
-type ViewDef = { id: ViewId; label: string; alwaysOn: boolean };
+type ViewDef = { id: ViewId; label: string; alwaysOn: boolean; hint?: string };
 const ALL_VIEWS: readonly ViewDef[] = [
-  { id: 'month',    label: 'Month',    alwaysOn: true  },
-  { id: 'week',     label: 'Week',     alwaysOn: true  },
+  { id: 'month',    label: 'Month',    alwaysOn: true,  hint: 'Scheduled events — appointments, missions, PTO' },
+  { id: 'week',     label: 'Week',     alwaysOn: true,  hint: 'Scheduled events by day — not staffing or on-call' },
   { id: 'day',      label: 'Day',      alwaysOn: false },
   { id: 'agenda',   label: 'Agenda',   alwaysOn: false },
-  { id: 'schedule', label: 'Schedule', alwaysOn: false },
-  { id: 'base',     label: 'Base',     alwaysOn: false },
+  { id: 'schedule', label: 'Schedule', alwaysOn: false, hint: 'Staffing — day/night shifts, on-call rotation, duty status' },
+  { id: 'base',     label: 'Base',     alwaysOn: false, hint: 'Gantt-style — employees, aircraft, and base events side by side' },
   { id: 'assets',   label: 'Assets',   alwaysOn: false },
 ];
 
@@ -2024,6 +2024,7 @@ export const WorksCalendar = forwardRef<CalendarApi, WorksCalendarProps>(functio
                   className={[styles.viewBtn, cal.view === v.id && styles.activeView].filter(Boolean).join(' ')}
                   onClick={() => cal.setView(v.id)}
                   aria-pressed={cal.view === v.id}
+                  title={v.hint}
                 >
                   {v.label}
                 </button>


### PR DESCRIPTION
Add a `hint` field to ViewDef and populate descriptions for the specialized views so the tab strip signals differentiated intent on hover:
- Month/Week: "Scheduled events — appointments, missions, PTO"
- Schedule: "Staffing — day/night shifts, on-call rotation, duty status"
- Base: "Gantt-style — employees, aircraft, and base events side by side"

Satisfies Sprint 3 AC: "Do not imply all tabs do the same job."

https://claude.ai/code/session_01BjSanhei7rk75wuoDE4a5X

## Summary
Describe exactly what this PR changes.

## Scope
- Stage: 
- Planned PR number in sprint: 
- Target files/directories: 
- Why this slice is isolated: 

## Lessons Learned Check (REQUIRED)
Confirm these were actively used while building this PR:

- [ ] PR is intentionally small and isolated
- [ ] Boundary typing was prioritized over internal perfection
- [ ] No silent spread of `any`
- [ ] Advisory root `tsc` was used to catch integration issues
- [ ] I did not assume “looks typed” means “safe”
- [ ] I stopped and isolated typing cascades instead of expanding scope

## Definition of Done (ALL REQUIRED)
This PR is not done unless every box is checked.

- [ ] `npm run type-check:strict` passes
- [ ] Root advisory `tsc --noEmit` passes
- [ ] Tests pass for touched scope at minimum
- [ ] No uncontrolled increase in `any`
- [ ] All new types are intentional and named
- [ ] Public interfaces and exported functions are explicitly typed
- [ ] PR scope matches the sprint plan with no scope creep
- [ ] Any new `any` has an adjacent justification comment
- [ ] No file-wide `: any`
- [ ] No implicit `any` in exported functions

## What Was Typed
List exactly what was typed in this PR.

- 
- 
- 

## What Was Intentionally Left Loose
List anything intentionally not tightened yet.

- 
- 
- 

## `any` Ledger (REQUIRED)
- New `any` added: 
- Existing `any` removed: 
- Net change: 

For every new `any`, explain why it is required and why a safer type was not used yet.

1. 
2. 
3. 

## Boundary Notes
Document any public seams, caller-protection choices, or compatibility decisions.

- 
- 
- 

## Risk Level
- [ ] Low
- [ ] Medium
- [ ] High

Why:

## Validation Evidence
Paste the exact commands run and a short result summary.

```bash
npm run type-check:strict
npx tsc --noEmit -p tsconfig.json
```

Test commands run:

```bash
# paste commands here
```

## Stop Conditions Check
If any item below happened, explain how scope was reduced before merge.

- [ ] `any` started spreading across files
- [ ] Root `tsc` broke repeatedly
- [ ] Types required cross-module rewrites
- [ ] Scope was reduced to keep the PR reviewable

Notes:

## Reviewer Focus
What should reviewers look at first?

- 
- 
- 
