### PR TITLE
stage7 pr2: normalize SourcePanel refresh interval nullability

### DIFF
--- a/src/ui/SourcePanel.tsx
+++ b/src/ui/SourcePanel.tsx
@@ -300,7 +300,7 @@ function AddFeedForm({ onAdd }: { onAdd: (source: Partial<CalendarSource>) => vo
   const [url,             setUrl]             = useState('');
   const [label,           setLabel]           = useState('');
   const [color,           setColor]           = useState(PRESET_COLORS[0]);
-  const [refreshInterval, setRefreshInterval] = useState(300_000);
+  const [refreshInterval, setRefreshInterval] = useState<number | null>(300_000);
   const [validating,      setValidating]      = useState(false);
   const [validation,      setValidation]      = useState<{ ok: boolean; count?: number; error?: string; corsLikely?: boolean } | null>(null);
 


### PR DESCRIPTION
### Motivation
- The `AddFeedForm` select supports a `Manual` option that sets `refreshInterval` to `null`, so the state must be typed as `number | null` to satisfy strict-null type checks.

### Description
- Change `const [refreshInterval, setRefreshInterval] = useState(300_000);` to `const [refreshInterval, setRefreshInterval] = useState<number | null>(300_000);` in `src/ui/SourcePanel.tsx`, preserving existing runtime behavior.

### Testing
- Ran TypeScript checking with `npm run type-check`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e988038204832c9fc8dfc8e65b16b1)