### PR TITLE
stage7: tighten null guards in focus trap tests

### DIFF
--- a/src/hooks/__tests__/useFocusTrap.test.tsx
+++ b/src/hooks/__tests__/useFocusTrap.test.tsx
@@ -27,12 +27,25 @@ function Trap({ onEscape, children, active = true }: {
 
 /* ── helpers ────────────────────────────────────────────────────────────── */
 
-function tabForward(element = document.activeElement) {
-  fireEvent.keyDown(element, { key: 'Tab', shiftKey: false });
+function requireElement<T>(value: T | null | undefined, message: string): T {
+  if (value == null) {
+    throw new Error(message);
+  }
+  return value;
 }
 
-function tabBackward(element = document.activeElement) {
-  fireEvent.keyDown(element, { key: 'Tab', shiftKey: true });
+function tabForward(element: Element | null = document.activeElement) {
+  fireEvent.keyDown(requireElement(element, 'Expected focused element for Tab'), {
+    key: 'Tab',
+    shiftKey: false,
+  });
+}
+
+function tabBackward(element: Element | null = document.activeElement) {
+  fireEvent.keyDown(requireElement(element, 'Expected focused element for Shift+Tab'), {
+    key: 'Tab',
+    shiftKey: true,
+  });
 }
 
 /* ═══════════════════════════════════════════════════════════════════════════
@@ -57,7 +70,10 @@ describe('useFocusTrap — basic behaviour', () => {
         <button>OK</button>
       </Trap>,
     );
-    fireEvent.keyDown(document.activeElement, { key: 'Escape' });
+    fireEvent.keyDown(
+      requireElement(document.activeElement, 'Expected active element for Escape'),
+      { key: 'Escape' },
+    );
     expect(onEscape).toHaveBeenCalledOnce();
   });
 });

--- a/src/ui/__tests__/ConfigPanel.focusTrap.test.tsx
+++ b/src/ui/__tests__/ConfigPanel.focusTrap.test.tsx
@@ -13,6 +13,13 @@ import '@testing-library/jest-dom';
 import ConfigPanel from '../ConfigPanel';
 import { DEFAULT_CONFIG } from '../../core/configSchema';
 
+function requireElement<T>(value: T | null | undefined, message: string): T {
+  if (value == null) {
+    throw new Error(message);
+  }
+  return value;
+}
+
 function mount(props = {}) {
   return render(
     <ConfigPanel
@@ -35,7 +42,10 @@ describe('ConfigPanel — focus trap & accordion', () => {
   it('Escape calls onClose', () => {
     const onClose = vi.fn();
     mount({ onClose });
-    fireEvent.keyDown(document.activeElement, { key: 'Escape' });
+    fireEvent.keyDown(
+      requireElement(document.activeElement, 'Expected active element for Escape'),
+      { key: 'Escape' },
+    );
     expect(onClose).toHaveBeenCalledOnce();
   });
 
@@ -49,8 +59,13 @@ describe('ConfigPanel — focus trap & accordion', () => {
     mount();
     const dialog = screen.getByRole('dialog', { name: 'Calendar settings' });
     for (let i = 0; i < 25; i++) {
-      fireEvent.keyDown(document.activeElement, { key: 'Tab' });
-      expect(dialog.contains(document.activeElement)).toBe(true);
+      fireEvent.keyDown(
+        requireElement(document.activeElement, 'Expected active element for Tab'),
+        { key: 'Tab' },
+      );
+      expect(
+        dialog.contains(requireElement(document.activeElement, 'Expected active element after Tab')),
+      ).toBe(true);
     }
   });
 

--- a/src/ui/__tests__/EventForm.focusTrap.test.tsx
+++ b/src/ui/__tests__/EventForm.focusTrap.test.tsx
@@ -10,6 +10,13 @@ import { render, fireEvent } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import EventForm from '../EventForm';
 
+function requireElement<T>(value: T | null | undefined, message: string): T {
+  if (value == null) {
+    throw new Error(message);
+  }
+  return value;
+}
+
 function renderForm(extra: any = {}) {
   render(
     <EventForm
@@ -28,15 +35,24 @@ function renderForm(extra: any = {}) {
       permissions={{}}
     />,
   );
-  return document.querySelector('[role="dialog"]');
+  return requireElement(
+    document.querySelector('[role="dialog"]'),
+    'Expected EventForm dialog',
+  );
 }
 
 function tabForward() {
-  fireEvent.keyDown(document.activeElement, { key: 'Tab', shiftKey: false });
+  fireEvent.keyDown(
+    requireElement(document.activeElement, 'Expected active element for Tab'),
+    { key: 'Tab', shiftKey: false },
+  );
 }
 
 function tabBackward() {
-  fireEvent.keyDown(document.activeElement, { key: 'Tab', shiftKey: true });
+  fireEvent.keyDown(
+    requireElement(document.activeElement, 'Expected active element for Shift+Tab'),
+    { key: 'Tab', shiftKey: true },
+  );
 }
 
 describe('EventForm focus trap', () => {
@@ -78,7 +94,10 @@ describe('EventForm focus trap', () => {
         permissions={{}}
       />,
     );
-    fireEvent.keyDown(document.activeElement, { key: 'Escape' });
+    fireEvent.keyDown(
+      requireElement(document.activeElement, 'Expected active element for Escape'),
+      { key: 'Escape' },
+    );
     expect(onClose).toHaveBeenCalledOnce();
   });
 
@@ -89,15 +108,21 @@ describe('EventForm focus trap', () => {
       onDelete,
     });
 
-    const deleteBtn = [...dialog.querySelectorAll('button')]
-      .find(b => b.textContent.trim() === 'Delete');
-    expect(deleteBtn).not.toBeUndefined();
+    const deleteBtn = requireElement(
+      [...dialog.querySelectorAll('button')].find(
+        (b) => b.textContent?.trim() === 'Delete',
+      ),
+      'Expected Delete button',
+    );
 
     fireEvent.click(deleteBtn);
 
     // ConfirmDialog must appear with alertdialog role
-    const confirmDialog = document.querySelector('[role="alertdialog"]');
-    expect(confirmDialog).not.toBeNull();
+    const confirmDialog = requireElement(
+      document.querySelector('[role="alertdialog"]'),
+      'Expected confirm dialog',
+    );
+    expect(confirmDialog).toBeInTheDocument();
     // onDelete not yet called — user must click the confirm button
     expect(onDelete).not.toHaveBeenCalled();
   });


### PR DESCRIPTION
### Motivation
- Eliminate nullable DOM values being passed into event helpers and assertions in focus-trap tests to satisfy strict-null checks and make failures explicit.
- Prevent intermittent test errors caused by `document.activeElement` or `querySelector(...)` returning `null` or `undefined` when used directly in `fireEvent` or `.contains(...)` checks.

### Description
- Added a local `requireElement` helper to `src/hooks/__tests__/useFocusTrap.test.tsx`, `src/ui/__tests__/ConfigPanel.focusTrap.test.tsx`, and `src/ui/__tests__/EventForm.focusTrap.test.tsx` to convert `T | null | undefined` results into guaranteed values or throw clear errors.
- Rewrote Tab/Shift+Tab helpers to accept `Element | null` and call `requireElement` before invoking `fireEvent.keyDown`, and guarded Escape key dispatches with `requireElement` where `document.activeElement` was used.
- Updated `EventForm.focusTrap.test.tsx` to have `renderForm()` return a non-null dialog via `requireElement`, replaced the Delete button `.find(...)` result with a `requireElement` wrapper, and guarded the confirm dialog lookup similarly.
- Kept behavior unchanged; changes are test-only null-safety guards and explicit error messages for missing DOM targets.

### Testing
- Ran `npm run type-check` which executed `tsc --noEmit`, and the type check completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9c5b9f76c832cbbe0b469edb19e56)