### PR TITLE
stage7: tighten null guards in useFocusTrap tests

### DIFF
--- a/src/hooks/__tests__/useFocusTrap.test.tsx
+++ b/src/hooks/__tests__/useFocusTrap.test.tsx
@@ -27,12 +27,25 @@ function Trap({ onEscape, children, active = true }: {
 
 /* ── helpers ────────────────────────────────────────────────────────────── */
 
-function tabForward(element = document.activeElement) {
-  fireEvent.keyDown(element, { key: 'Tab', shiftKey: false });
+function requireElement<T>(value: T | null | undefined, message: string): T {
+  if (value == null) {
+    throw new Error(message);
+  }
+  return value;
 }
 
-function tabBackward(element = document.activeElement) {
-  fireEvent.keyDown(element, { key: 'Tab', shiftKey: true });
+function tabForward(element: Element | null = document.activeElement) {
+  fireEvent.keyDown(requireElement(element, 'Expected focused element for Tab'), {
+    key: 'Tab',
+    shiftKey: false,
+  });
+}
+
+function tabBackward(element: Element | null = document.activeElement) {
+  fireEvent.keyDown(requireElement(element, 'Expected focused element for Shift+Tab'), {
+    key: 'Tab',
+    shiftKey: true,
+  });
 }
 
 /* ═══════════════════════════════════════════════════════════════════════════
@@ -57,7 +70,10 @@ describe('useFocusTrap — basic behaviour', () => {
         <button>OK</button>
       </Trap>,
     );
-    fireEvent.keyDown(document.activeElement, { key: 'Escape' });
+    fireEvent.keyDown(
+      requireElement(document.activeElement, 'Expected active element for Escape'),
+      { key: 'Escape' },
+    );
     expect(onEscape).toHaveBeenCalledOnce();
   });
 });


### PR DESCRIPTION
## Summary
Describe exactly what this PR changes.

## Scope
- Stage: 
- Planned PR number in sprint: 
- Target files/directories: 
- Why this slice is isolated: 

## Lessons Learned Check (REQUIRED)
Confirm these were actively used while building this PR:

- [ ] PR is intentionally small and isolated
- [ ] Boundary typing was prioritized over internal perfection
- [ ] No silent spread of `any`
- [ ] Advisory root `tsc` was used to catch integration issues
- [ ] I did not assume “looks typed” means “safe”
- [ ] I stopped and isolated typing cascades instead of expanding scope

## Definition of Done (ALL REQUIRED)
This PR is not done unless every box is checked.

- [ ] `npm run type-check:strict` passes
- [ ] Root advisory `tsc --noEmit` passes
- [ ] Tests pass for touched scope at minimum
- [ ] No uncontrolled increase in `any`
- [ ] All new types are intentional and named
- [ ] Public interfaces and exported functions are explicitly typed
- [ ] PR scope matches the sprint plan with no scope creep
- [ ] Any new `any` has an adjacent justification comment
- [ ] No file-wide `: any`
- [ ] No implicit `any` in exported functions

## What Was Typed
List exactly what was typed in this PR.

- 
- 
- 

## What Was Intentionally Left Loose
List anything intentionally not tightened yet.

- 
- 
- 

## `any` Ledger (REQUIRED)
- New `any` added: 
- Existing `any` removed: 
- Net change: 

For every new `any`, explain why it is required and why a safer type was not used yet.

1. 
2. 
3. 

## Boundary Notes
Document any public seams, caller-protection choices, or compatibility decisions.

- 
- 
- 

## Risk Level
- [ ] Low
- [ ] Medium
- [ ] High

Why:

## Validation Evidence
Paste the exact commands run and a short result summary.

```bash
npm run type-check:strict
npx tsc --noEmit -p tsconfig.json
```

Test commands run:

```bash
# paste commands here
```

## Stop Conditions Check
If any item below happened, explain how scope was reduced before merge.

- [ ] `any` started spreading across files
- [ ] Root `tsc` broke repeatedly
- [ ] Types required cross-module rewrites
- [ ] Scope was reduced to keep the PR reviewable

Notes:

## Reviewer Focus
What should reviewers look at first?

- 
- 
- 
