### PR TITLE
Stage 7 Sprint 2: reduce strict-null debt in UI seams, TimelineView, and sync tests

### DIFF
--- a/src/api/v1/__tests__/sync.test.ts
+++ b/src/api/v1/__tests__/sync.test.ts
@@ -21,6 +21,7 @@ import {
 } from '../sync/conflictStrategies';
 import { SyncManager }         from '../sync/SyncManager';
 import type { CalendarAdapter } from '../adapters/CalendarAdapter';
+import type { AdapterChange } from '../adapters/CalendarAdapter';
 import type { CalendarEventV1 } from '../types';
 
 // ─── Fixtures ─────────────────────────────────────────────────────────────────
@@ -32,7 +33,9 @@ function ev(overrides: Partial<CalendarEventV1> = {}): CalendarEventV1 {
   return { id: 'ev-1', title: 'Meeting', start: S, end: E, ...overrides };
 }
 
-function makeAdapter(overrides: Partial<CalendarAdapter> = {}): CalendarAdapter {
+type TestAdapter = CalendarAdapter & Required<Pick<CalendarAdapter, 'createEvent' | 'updateEvent' | 'deleteEvent' | 'subscribe'>>;
+
+function makeAdapter(overrides: Partial<TestAdapter> = {}): TestAdapter {
   return {
     loadRange:   vi.fn().mockResolvedValue([]),
     createEvent: vi.fn().mockImplementation(async (e: CalendarEventV1) => ({ ...e, id: 'server-1' })),
@@ -296,7 +299,7 @@ describe('SyncManager', () => {
   });
 
   it('createEvent with no adapter.createEvent marks synced immediately', async () => {
-    const readOnlyAdapter = makeAdapter({ createEvent: undefined });
+    const readOnlyAdapter = { ...makeAdapter(), createEvent: undefined } as CalendarAdapter;
     const m = new SyncManager({ adapter: readOnlyAdapter });
     await m.createEvent(ev());
     expect(m.queue.pendingCount).toBe(0);
@@ -400,7 +403,10 @@ describe('SyncManager', () => {
     await Promise.resolve();
 
     expect(onError).toHaveBeenCalledOnce();
-    const [opId, err] = onError.mock.calls[0];
+    const firstCall = onError.mock.calls[0];
+    expect(firstCall).toBeDefined();
+    if (!firstCall) return;
+    const [opId, err] = firstCall;
     expect(typeof opId).toBe('string');
     expect(err.message).toBe('network');
   });
@@ -486,27 +492,33 @@ describe('SyncManager', () => {
   // ── connectLive ─────────────────────────────────────────────────────────────
 
   it('connectLive merges insert change into events', () => {
-    let pushChange: ((c: import('../adapters/CalendarAdapter.js').AdapterChange) => void) | null = null;
-    vi.mocked(adapter.subscribe).mockImplementation((cb) => {
+    let pushChange: ((c: AdapterChange) => void) | null = null;
+    vi.mocked(adapter.subscribe).mockImplementation((cb: import('../adapters/CalendarAdapter').AdapterChangeCallback) => {
       pushChange = cb;
       return () => {};
     });
 
     manager.connectLive();
-    pushChange!({ type: 'insert', event: ev() });
+    const emit = pushChange;
+    expect(emit).not.toBeNull();
+    if (typeof emit !== 'function') return;
+    (emit as (c: AdapterChange) => void)({ type: 'insert', event: ev() });
     expect(manager.events.get('ev-1')).toMatchObject({ title: 'Meeting' });
     manager.disconnectLive();
   });
 
   it('connectLive handles reload change', () => {
-    let pushChange: ((c: import('../adapters/CalendarAdapter.js').AdapterChange) => void) | null = null;
-    vi.mocked(adapter.subscribe).mockImplementation((cb) => {
+    let pushChange: ((c: AdapterChange) => void) | null = null;
+    vi.mocked(adapter.subscribe).mockImplementation((cb: import('../adapters/CalendarAdapter').AdapterChangeCallback) => {
       pushChange = cb;
       return () => {};
     });
 
     manager.connectLive();
-    pushChange!({ type: 'reload', events: [ev(), ev({ id: 'ev-2', title: 'Other' })] });
+    const emit = pushChange;
+    expect(emit).not.toBeNull();
+    if (typeof emit !== 'function') return;
+    (emit as (c: AdapterChange) => void)({ type: 'reload', events: [ev(), ev({ id: 'ev-2', title: 'Other' })] });
     expect(manager.events.size).toBe(2);
     manager.disconnectLive();
   });
@@ -515,14 +527,17 @@ describe('SyncManager', () => {
     vi.mocked(adapter.loadRange).mockResolvedValue([ev()]);
     await manager.loadRange(S, E);
 
-    let pushChange: ((c: import('../adapters/CalendarAdapter.js').AdapterChange) => void) | null = null;
-    vi.mocked(adapter.subscribe).mockImplementation((cb) => {
+    let pushChange: ((c: AdapterChange) => void) | null = null;
+    vi.mocked(adapter.subscribe).mockImplementation((cb: import('../adapters/CalendarAdapter').AdapterChangeCallback) => {
       pushChange = cb;
       return () => {};
     });
 
     manager.connectLive();
-    pushChange!({ type: 'delete', id: 'ev-1' });
+    const emit = pushChange;
+    expect(emit).not.toBeNull();
+    if (typeof emit !== 'function') return;
+    (emit as (c: AdapterChange) => void)({ type: 'delete', id: 'ev-1' });
     expect(manager.events.has('ev-1')).toBe(false);
     manager.disconnectLive();
   });

--- a/src/core/CalendarContext.ts
+++ b/src/core/CalendarContext.ts
@@ -3,9 +3,24 @@
  * Avoids prop-drilling renderEvent, colorRules, businessHours, etc.
  */
 import { createContext, useContext } from 'react';
+import type { ReactNode } from 'react';
 import type { NormalizedEvent } from '../types/events';
 
-export const CalendarContext = createContext(null);
+type CalendarContextRenderOptions = {
+  view?: string;
+  isCompact?: boolean;
+  onClick?: () => void;
+  color?: string | undefined;
+};
+
+export type CalendarContextValue = {
+  colorRules?: Array<Record<string, unknown>>;
+  renderEvent?: (event: NormalizedEvent, options: CalendarContextRenderOptions) => ReactNode;
+  emptyState?: ReactNode;
+  [key: string]: unknown;
+} | null;
+
+export const CalendarContext = createContext<CalendarContextValue>(null);
 
 export function useCalendarContext() {
   return useContext(CalendarContext);

--- a/src/ui/AvailabilityForm.tsx
+++ b/src/ui/AvailabilityForm.tsx
@@ -1,4 +1,4 @@
-import { useState, type ChangeEvent, type FormEvent, type MouseEvent } from 'react';
+import { useState, type ChangeEvent, type FormEvent, type MouseEvent, type RefObject } from 'react';
 import { format, parseISO, isValid } from 'date-fns';
 import { X } from 'lucide-react';
 import { useFocusTrap } from '../hooks/useFocusTrap';
@@ -84,7 +84,7 @@ function fromInput(str: string, allDay: boolean): Date | null {
  *   onClose    () => void
  */
 export default function AvailabilityForm({ emp, kind: initialKind, initialStart, initialEvent = null, onSave, onClose }: any) {
-  const trapRef = useFocusTrap<HTMLDivElement>(onClose);
+  const trapRef = useFocusTrap<HTMLDivElement>(onClose) as RefObject<HTMLDivElement>;
 
   const kind = (initialKind ?? 'pto') as string;
   const meta = KIND_META[kind as keyof typeof KIND_META] ?? KIND_META.pto;
@@ -107,6 +107,14 @@ export default function AvailabilityForm({ emp, kind: initialKind, initialStart,
   const [end,    setEnd]    = useState(toDateInput(endDefault, initialAllDay));
   const [notes,  setNotes]  = useState(initialEvent?.meta?.notes ?? '');
   const [errors, setErrors] = useState<Record<string, string>>({});
+
+  function clearError(...keys: string[]) {
+    setErrors((prev) => {
+      const next = { ...prev };
+      for (const key of keys) delete next[key];
+      return next;
+    });
+  }
 
   function validate() {
     const errs: Record<string, string> = {};
@@ -176,7 +184,7 @@ export default function AvailabilityForm({ emp, kind: initialKind, initialStart,
               id="af-title"
               className={[styles.input, errors.title && styles.inputError].filter(Boolean).join(' ')}
               value={title}
-              onChange={(e: ChangeEvent<HTMLInputElement>) => { setTitle(e.target.value); setErrors((v: Record<string, string>) => ({ ...v, title: undefined })); }}
+              onChange={(e: ChangeEvent<HTMLInputElement>) => { setTitle(e.target.value); clearError('title'); }}
               placeholder="e.g. Vacation, Doctor appointment…"
               autoFocus
             />
@@ -216,7 +224,7 @@ export default function AvailabilityForm({ emp, kind: initialKind, initialStart,
                 type={allDay ? 'date' : 'datetime-local'}
                 className={[styles.input, errors.start && styles.inputError].filter(Boolean).join(' ')}
                 value={start}
-                onChange={(e: ChangeEvent<HTMLInputElement>) => { setStart(e.target.value); setErrors((v: Record<string, string>) => ({ ...v, start: undefined, end: undefined })); }}
+                onChange={(e: ChangeEvent<HTMLInputElement>) => { setStart(e.target.value); clearError('start', 'end'); }}
               />
               {errors.start && <span className={styles.error}>{errors.start}</span>}
             </div>
@@ -229,7 +237,7 @@ export default function AvailabilityForm({ emp, kind: initialKind, initialStart,
                 type={allDay ? 'date' : 'datetime-local'}
                 className={[styles.input, errors.end && styles.inputError].filter(Boolean).join(' ')}
                 value={end}
-                onChange={(e: ChangeEvent<HTMLInputElement>) => { setEnd(e.target.value); setErrors((v: Record<string, string>) => ({ ...v, end: undefined })); }}
+                onChange={(e: ChangeEvent<HTMLInputElement>) => { setEnd(e.target.value); clearError('end'); }}
               />
               {errors.end && <span className={styles.error}>{errors.end}</span>}
             </div>

--- a/src/ui/CalendarExternalForm.tsx
+++ b/src/ui/CalendarExternalForm.tsx
@@ -71,6 +71,13 @@ function normalizeFields(fields: ExternalFormField[]): ExternalFormField[] {
   });
 }
 
+function clearFieldError(prev: Record<string, string>, name: string): Record<string, string> {
+  if (!(name in prev)) return prev;
+  const next = { ...prev };
+  delete next[name];
+  return next;
+}
+
 function ensureAdapter(adapter: unknown): ExternalFormAdapter {
   if (!adapter || typeof (adapter as { submitEvent?: unknown }).submitEvent !== 'function') {
     throw new Error('CalendarExternalForm adapter must define submitEvent(payload, context).');
@@ -158,7 +165,7 @@ export default function CalendarExternalForm({
 
   function setValue(name: string, value: string | boolean) {
     setValues((prev) => ({ ...prev, [name]: value }));
-    setErrors((prev) => ({ ...prev, [name]: undefined }));
+    setErrors((prev) => clearFieldError(prev, name));
     setSubmitError('');
   }
 
@@ -225,7 +232,7 @@ export default function CalendarExternalForm({
                   onChange={(e) => setValue(field.name, e.target.checked)}
                 />
               )}
-              {!['textarea', 'select', 'checkbox'].includes(field.type) && (
+              {!['textarea', 'select', 'checkbox'].includes(field.type ?? 'text') && (
                 <input
                   id={inputId}
                   className={styles.input}

--- a/src/ui/ICSFeedPanel.tsx
+++ b/src/ui/ICSFeedPanel.tsx
@@ -73,7 +73,7 @@ function isFeedEnabled(feed: StoredFeed): boolean {
 function isValidationFailure(
   validation: FeedValidationState
 ): validation is { ok: false; error: string; corsLikely: boolean; count?: undefined } {
-  return Boolean(validation) && validation.ok === false;
+  return validation !== null && validation.ok === false;
 }
 
 function colorDot(color: string, size = 10) {

--- a/src/ui/SourcePanel.tsx
+++ b/src/ui/SourcePanel.tsx
@@ -65,6 +65,16 @@ type SourceHandlers = {
   onUpdate: (id: string, patch: Partial<CalendarSource>) => void;
 };
 
+type FeedValidationState = {
+  ok: true;
+  count: number;
+} | {
+  ok: false;
+  error: string;
+  corsLikely: boolean;
+  count?: undefined;
+} | null;
+
 function ColorDot({ color, size = 12, onClick }: { color: string; size?: number; onClick: () => void }) {
   return (
     <button
@@ -302,7 +312,7 @@ function AddFeedForm({ onAdd }: { onAdd: (source: Partial<CalendarSource>) => vo
   const [color,           setColor]           = useState(PRESET_COLORS[0]);
   const [refreshInterval, setRefreshInterval] = useState<number | null>(300_000);
   const [validating,      setValidating]      = useState(false);
-  const [validation,      setValidation]      = useState<{ ok: boolean; count?: number; error?: string; corsLikely?: boolean } | null>(null);
+  const [validation,      setValidation]      = useState<FeedValidationState>(null);
 
   function reset() {
     setUrl(''); setLabel(''); setColor(PRESET_COLORS[0]);

--- a/src/views/TimelineView.tsx
+++ b/src/views/TimelineView.tsx
@@ -81,6 +81,10 @@ interface TimelineViewProps {
   bases?: TimelineBase[];
 }
 
+type MenuState = { ev: LooseEvent; rect: DOMRect } | null;
+type EmpCardState = { emp: TimelineEmployee; rect: DOMRect } | null;
+type DragState = { ev: LooseEvent; sourceRowKey: string } | null;
+
 // ─── Helpers ─────────────────────────────────────────────────────────────────
 
 function getInitials(name: string) {
@@ -166,11 +170,11 @@ export default function TimelineView({
   const ctx        = useCalendarContext();
 
   // ── Shift coverage menu state ─────────────────────────────────────────────
-  const [shiftMenu, setShiftMenu] = useState(null); // { ev, rect } | null
-  const [coverMenu, setCoverMenu] = useState(null); // { ev, rect } | null
-  const [empCard,   setEmpCard]   = useState(null); // { emp, rect } | null
-  const shiftMenuRef = useRef(null);
-  const coverMenuRef = useRef(null);
+  const [shiftMenu, setShiftMenu] = useState<MenuState>(null); // { ev, rect } | null
+  const [coverMenu, setCoverMenu] = useState<MenuState>(null); // { ev, rect } | null
+  const [empCard,   setEmpCard]   = useState<EmpCardState>(null); // { emp, rect } | null
+  const shiftMenuRef = useRef<HTMLDivElement | null>(null);
+  const coverMenuRef = useRef<HTMLDivElement | null>(null);
 
   const triggerEmployeeAction = useCallback((empId: string, action: string | Record<string, unknown>, options: Record<string, unknown> = {}) => {
     if (!onEmployeeAction) return false;
@@ -182,8 +186,9 @@ export default function TimelineView({
   useEffect(() => {
     if (!anyMenuOpen) return;
     function handler(e: globalThis.MouseEvent) {
-      if (shiftMenuRef.current && !shiftMenuRef.current.contains(e.target)) setShiftMenu(null);
-      if (coverMenuRef.current && !coverMenuRef.current.contains(e.target)) setCoverMenu(null);
+      const target = e.target as Node | null;
+      if (shiftMenuRef.current && !shiftMenuRef.current.contains(target)) setShiftMenu(null);
+      if (coverMenuRef.current && !coverMenuRef.current.contains(target)) setCoverMenu(null);
     }
     document.addEventListener('mousedown', handler);
     return () => document.removeEventListener('mousedown', handler);
@@ -194,7 +199,7 @@ export default function TimelineView({
   const [addName,     setAddName]       = useState('');
   const [addRole,     setAddRole]       = useState('');
   const [addBase,     setAddBase]       = useState('');
-  const nameInputRef                    = useRef(null);
+  const nameInputRef                    = useRef<HTMLInputElement | null>(null);
 
   // ── Base filter ───────────────────────────────────────────────────────────
   const [baseFilter, setBaseFilter]     = useState('');
@@ -209,15 +214,15 @@ export default function TimelineView({
   // ── Keyboard grid navigation ───────────────────────────────────────────────
   const [focusedCell, setFocusedCell] = useState({ rowIdx: 0, dayIdx: 0 });
   const lastKeyNavCell = useRef(false);
-  const gridRef        = useRef(null); // ref on .inner (for querySelector)
-  const wrapRef        = useRef(null); // ref on .wrap (scroll container)
+  const gridRef        = useRef<HTMLDivElement | null>(null); // ref on .inner (for querySelector)
+  const wrapRef        = useRef<HTMLDivElement | null>(null); // ref on .wrap (scroll container)
 
   // ── DnD: drag an event from one row to another to reassign it. ────────────
   // The drag source is the <button> around an event; the drop target is the
   // owning row.  dragRef carries { ev, sourceRowKey } across handler calls so
   // onDrop can skip same-row drops.
-  const dragRef = useRef(null);
-  const [dropTargetKey, setDropTargetKey] = useState(null);
+  const dragRef = useRef<DragState>(null);
+  const [dropTargetKey, setDropTargetKey] = useState<string | null>(null);
 
   // Touch-drag pathway (mobile).  Mirrors the HTML5 DnD branch using long-press
   // + elementFromPoint hit-testing.  Drop targets are rows with `data-wc-drop`.
@@ -373,7 +378,7 @@ export default function TimelineView({
       });
     }
 
-    return resourceList.map((resource: string) => {
+    return (resourceList ?? []).map((resource: string) => {
       const resEvents = events.filter(
         e => (e.resource ?? '(Unassigned)') === resource,
       );
@@ -507,7 +512,7 @@ export default function TimelineView({
     // then via rAF after any scroll-triggered re-render.
     const tryFocus = () => {
       const el = gridRef.current?.querySelector(`[data-cell="${rowIdx}-${dayIdx}"]`);
-      el?.focus({ preventScroll: false });
+      if (el instanceof HTMLElement) el.focus({ preventScroll: false });
     };
     tryFocus();
     if (!gridRef.current?.querySelector(`[data-cell="${rowIdx}-${dayIdx}"]`)) {
@@ -836,7 +841,7 @@ export default function TimelineView({
                         >
                           <div
                             className={styles.empAvatar}
-                            style={{ background: color }}
+                            style={{ background: color ?? undefined }}
                             aria-hidden="true"
                           >
                             {emp.avatar
@@ -857,7 +862,7 @@ export default function TimelineView({
                         <>
                           <div
                             className={styles.empAvatar}
-                            style={{ background: color }}
+                            style={{ background: color ?? undefined }}
                             aria-hidden="true"
                           >
                             {emp.avatar
@@ -972,7 +977,7 @@ export default function TimelineView({
                       : undefined;
 
                     if (ctx?.renderEvent) {
-                      const custom = ctx.renderEvent(ev, {
+                      const custom = ctx.renderEvent(ev as any, {
                         view: 'timeline', isCompact: true, onClick, color: evColor,
                       });
                       if (custom != null) {
@@ -997,7 +1002,8 @@ export default function TimelineView({
 
                     // On-call events: wrapper div so we can nest the status-toggle button
                     if (isOnCall && onShiftStatusChange) {
-                      const hasStatus = !!ev.meta?.shiftStatus;
+                      const shiftStatus = ev.meta?.shiftStatus;
+                      const hasStatus = Boolean(shiftStatus);
                       return (
                         <div
                           key={ev.id}
@@ -1018,7 +1024,7 @@ export default function TimelineView({
                             <span className={styles.evTitle}>{ev.title}</span>
                             {hasStatus && (
                               <span className={styles.shiftStatusBadge}>
-                                {ev.meta.shiftStatus === 'pto' ? 'PTO' : 'Unavail.'}
+                                {shiftStatus === 'pto' ? 'PTO' : 'Unavail.'}
                               </span>
                             )}
                           </button>
@@ -1027,7 +1033,7 @@ export default function TimelineView({
                             onClick={(e: ReactMouseEvent<HTMLButtonElement>) => {
                               e.stopPropagation();
                               const rect = e.currentTarget.getBoundingClientRect();
-                              setShiftMenu((prev: { ev?: LooseEvent } | null) => prev?.ev?.id === ev.id ? null : { ev, rect });
+                              setShiftMenu((prev) => prev?.ev?.id === ev.id ? null : { ev, rect });
                             }}
                             title="Shift-only availability shortcut"
                             aria-label="Set shift availability"
@@ -1076,9 +1082,10 @@ export default function TimelineView({
                       const left  = pillDayStart * DAY_W + 2;
                       const width = Math.max(DAY_W - 4, (pillDayEnd - pillDayStart + 1) * DAY_W - 4);
                       const top   = baseH + 3;
-                      const isCovered = !!ev.meta?.coveredBy;
+                      const coveredBy = ev.meta?.coveredBy;
+                      const isCovered = Boolean(coveredBy);
                       const coveredByEmp = isCovered
-                        ? employees.find(e => String(e.id) === String(ev.meta.coveredBy))
+                        ? employees.find(e => String(e.id) === String(coveredBy))
                         : null;
                       const coveredByName = coveredByEmp?.name ?? 'Someone';
 
@@ -1091,7 +1098,7 @@ export default function TimelineView({
                             onClick={(e: ReactMouseEvent<HTMLButtonElement>) => {
                               e.stopPropagation();
                               const rect = e.currentTarget.getBoundingClientRect();
-                              setCoverMenu((prev: { ev?: LooseEvent } | null) => prev?.ev?.id === ev.id ? null : { ev, rect });
+                              setCoverMenu((prev) => prev?.ev?.id === ev.id ? null : { ev, rect });
                             }}
                             title={`Shift covered by ${coveredByName}`}
                             aria-label={`Shift covered by ${coveredByName} — click to edit coverage`}
@@ -1108,7 +1115,7 @@ export default function TimelineView({
                           onClick={(e: ReactMouseEvent<HTMLButtonElement>) => {
                             e.stopPropagation();
                             const rect = e.currentTarget.getBoundingClientRect();
-                            setCoverMenu((prev: { ev?: LooseEvent } | null) => prev?.ev?.id === ev.id ? null : { ev, rect });
+                            setCoverMenu((prev) => prev?.ev?.id === ev.id ? null : { ev, rect });
                           }}
                           aria-label="Shift not covered — click to assign coverage"
                           title="Click to assign coverage"


### PR DESCRIPTION
### Motivation
- Reduce the repo-wide `strictNullChecks` diagnostic count by addressing high-ROI, low-risk UI seams and mechanical test debt without touching the large root composition file. 
- Stabilize a small TimelineView micro-slice so view-level typing no longer cascades `never`/null diagnostics into the rest of the view layer.

### Description
- Narrowed feed validation unions and null checks in `ICSFeedPanel.tsx` and `SourcePanel.tsx` to avoid ambiguous `null`/`boolean` narrowing (`validation !== null` and explicit `FeedValidationState`).
- Replaced writes of `undefined` into `Record<string, string>` error maps with helper-based deletions in `AvailabilityForm.tsx` and `CalendarExternalForm.tsx` and made the focus-trap ref explicit to satisfy strict null checks.
- Added a typed `CalendarContext` value (`CalendarContextValue`) in `src/core/CalendarContext.ts` so consumers (e.g. `TimelineView`) can safely use optional members like `renderEvent`, `colorRules`, and `emptyState` under `--strictNullChecks`.
- Performed a targeted TimelineView micro-slice in `TimelineView.tsx` adding local types for menu/drag state, explicit `useRef` generics, guarded DOM access, and small guards around `ev.meta` to eliminate `never` cascades while preserving render behavior.
- Hardened `src/api/v1/__tests__/sync.test.ts` test fixtures and mocks by introducing a `TestAdapter` shape, guarding mock callback extraction, and using the `AdapterChange` type for live-change emissions.

### Testing
- Ran the strict-null type check with `npm run -s type-check:strict-null`, which reduced strict-null diagnostics from 351 to 251 and passed the ratchet check against baseline.
- Executed the sync unit tests with `npx vitest run src/api/v1/__tests__/sync.test.ts`, and all tests passed (49 tests in the file).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9cf8f54b4832ca9be1a69172d0c22)