### PR TITLE
Normalize strict-null handling in availability/external/import UI forms

### DIFF
--- a/src/ui/AvailabilityForm.tsx
+++ b/src/ui/AvailabilityForm.tsx
@@ -176,7 +176,14 @@ export default function AvailabilityForm({ emp, kind: initialKind, initialStart,
               id="af-title"
               className={[styles.input, errors.title && styles.inputError].filter(Boolean).join(' ')}
               value={title}
-              onChange={(e: ChangeEvent<HTMLInputElement>) => { setTitle(e.target.value); setErrors((v: Record<string, string>) => ({ ...v, title: undefined })); }}
+              onChange={(e: ChangeEvent<HTMLInputElement>) => {
+                setTitle(e.target.value);
+                setErrors((v: Record<string, string>) => {
+                  const next = { ...v };
+                  delete next.title;
+                  return next;
+                });
+              }}
               placeholder="e.g. Vacation, Doctor appointment…"
               autoFocus
             />
@@ -216,7 +223,15 @@ export default function AvailabilityForm({ emp, kind: initialKind, initialStart,
                 type={allDay ? 'date' : 'datetime-local'}
                 className={[styles.input, errors.start && styles.inputError].filter(Boolean).join(' ')}
                 value={start}
-                onChange={(e: ChangeEvent<HTMLInputElement>) => { setStart(e.target.value); setErrors((v: Record<string, string>) => ({ ...v, start: undefined, end: undefined })); }}
+                onChange={(e: ChangeEvent<HTMLInputElement>) => {
+                  setStart(e.target.value);
+                  setErrors((v: Record<string, string>) => {
+                    const next = { ...v };
+                    delete next.start;
+                    delete next.end;
+                    return next;
+                  });
+                }}
               />
               {errors.start && <span className={styles.error}>{errors.start}</span>}
             </div>
@@ -229,7 +244,14 @@ export default function AvailabilityForm({ emp, kind: initialKind, initialStart,
                 type={allDay ? 'date' : 'datetime-local'}
                 className={[styles.input, errors.end && styles.inputError].filter(Boolean).join(' ')}
                 value={end}
-                onChange={(e: ChangeEvent<HTMLInputElement>) => { setEnd(e.target.value); setErrors((v: Record<string, string>) => ({ ...v, end: undefined })); }}
+                onChange={(e: ChangeEvent<HTMLInputElement>) => {
+                  setEnd(e.target.value);
+                  setErrors((v: Record<string, string>) => {
+                    const next = { ...v };
+                    delete next.end;
+                    return next;
+                  });
+                }}
               />
               {errors.end && <span className={styles.error}>{errors.end}</span>}
             </div>

--- a/src/ui/CSVImportDialog.tsx
+++ b/src/ui/CSVImportDialog.tsx
@@ -104,7 +104,11 @@ function DropStep({ onFile, onClose }: DropStepProps) {
       <div
         className={[styles.zone, dragging && styles.dragging].filter(Boolean).join(' ')}
         onClick={e => e.stopPropagation()}
-        onDrop={e => { e.preventDefault(); setDragging(false); processFile(e.dataTransfer.files[0]); }}
+        onDrop={e => {
+          e.preventDefault();
+          setDragging(false);
+          processFile(e.dataTransfer.files?.[0]);
+        }}
         onDragOver={e => { e.preventDefault(); setDragging(true); }}
         onDragLeave={() => setDragging(false)}
         onDragEnter={e => { e.preventDefault(); setDragging(true); }}
@@ -124,7 +128,7 @@ function DropStep({ onFile, onClose }: DropStepProps) {
         <input
           ref={inputRef} type="file" accept=".csv,text/csv"
           className={styles.hiddenInput}
-          onChange={e => processFile(e.target.files[0])}
+          onChange={e => processFile(e.currentTarget.files?.[0])}
         />
         <button className={styles.cancelLink} onClick={onClose}>Cancel</button>
       </div>

--- a/src/ui/CalendarExternalForm.tsx
+++ b/src/ui/CalendarExternalForm.tsx
@@ -158,7 +158,11 @@ export default function CalendarExternalForm({
 
   function setValue(name: string, value: string | boolean) {
     setValues((prev) => ({ ...prev, [name]: value }));
-    setErrors((prev) => ({ ...prev, [name]: undefined }));
+    setErrors((prev) => {
+      const next = { ...prev };
+      delete next[name];
+      return next;
+    });
     setSubmitError('');
   }
 

--- a/src/ui/ImportZone.tsx
+++ b/src/ui/ImportZone.tsx
@@ -66,7 +66,11 @@ export default function ImportZone({ onImport, onClose }: any) {
       <div
         className={[styles.zone, dragging && styles.dragging].filter(Boolean).join(' ')}
         onClick={e => e.stopPropagation()}
-        onDrop={(e: DragEvent<HTMLDivElement>) => { e.preventDefault(); setDragging(false); processFile(e.dataTransfer.files[0]); }}
+        onDrop={(e: DragEvent<HTMLDivElement>) => {
+          e.preventDefault();
+          setDragging(false);
+          processFile(e.dataTransfer.files?.[0]);
+        }}
         onDragOver={(e: DragEvent<HTMLDivElement>) => { e.preventDefault(); setDragging(true); }}
         onDragLeave={() => setDragging(false)}
         onDragEnter={(e: DragEvent<HTMLDivElement>) => { e.preventDefault(); setDragging(true); }}
@@ -113,7 +117,7 @@ export default function ImportZone({ onImport, onClose }: any) {
           type="file"
           accept=".ics,.csv,text/calendar,text/csv"
           className={styles.hiddenInput}
-          onChange={(e: ChangeEvent<HTMLInputElement>) => processFile(e.target.files?.[0])}
+          onChange={(e: ChangeEvent<HTMLInputElement>) => processFile(e.currentTarget.files?.[0])}
         />
 
         <button className={styles.cancelLink} onClick={onClose}>Cancel</button>


### PR DESCRIPTION
### Motivation
- Prevent storing `undefined` inside `Record<string, string>` error maps which breaks strict-null safety and causes type regressions. 
- Avoid nullable DOM access patterns for file inputs and drag/drop handlers that can produce runtime `null`/`undefined` dereferences.
- Normalize optional string usage before passing to strict string consumers to reduce strict-null violations.

### Description
- AvailabilityForm: clear validation keys (`title`, `start`, `end`) by copying the errors object, `delete`-ing the key(s), and returning the next object instead of assigning `undefined` to keys. (file: `src/ui/AvailabilityForm.tsx`).
- CalendarExternalForm: `setValue` now removes the field key from the `errors` record via `delete next[name]` instead of writing `undefined`. (file: `src/ui/CalendarExternalForm.tsx`).
- CSVImportDialog: made drop and file-picker handlers null-safe by using optional chaining (`e.dataTransfer.files?.[0]` and `e.currentTarget.files?.[0]`) to avoid accessing possibly-null targets. (file: `src/ui/CSVImportDialog.tsx`).
- ImportZone: updated drag/drop and input change handlers to use `files?.[0]` and `e.currentTarget.files?.[0]` for null-safe file access. (file: `src/ui/ImportZone.tsx`).

### Testing
- Ran `npm run type-check` (plain `tsc --noEmit`) and it completed successfully. 
- Ran `npm run type-check:strict-null` and the strict-null ratchet passed with reduced diagnostics (`baseline` decreased).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9d615704c832c9cdcd9067c835703)