### PR TITLE
Fix strict-null timeout clears in AdvancedFilterBuilder

### DIFF
--- a/src/ui/AdvancedFilterBuilder.tsx
+++ b/src/ui/AdvancedFilterBuilder.tsx
@@ -124,7 +124,13 @@ export default function AdvancedFilterBuilder({
   // Clear the "Saved!" feedback timeout on unmount to avoid state updates on
   // an unmounted component (can happen in edit mode when the parent unmounts
   // the builder immediately after onUpdate).
-  useEffect(() => () => { clearTimeout(savedTimerRef.current); }, []);
+  useEffect(() => {
+    return () => {
+      if (savedTimerRef.current !== null) {
+        clearTimeout(savedTimerRef.current);
+      }
+    };
+  }, []);
 
   // On mount in edit mode, scroll the builder into view and focus the name
   // input so users immediately see the editor populate after clicking pencil.
@@ -174,12 +180,16 @@ export default function AdvancedFilterBuilder({
     if (editingId && onUpdate) {
       onUpdate(editingId, name, filters, conditions);
       setSaved(true);
-      clearTimeout(savedTimerRef.current);
+      if (savedTimerRef.current !== null) {
+        clearTimeout(savedTimerRef.current);
+      }
       savedTimerRef.current = setTimeout(() => setSaved(false), 2000);
     } else {
       onSave?.(name, filters, conditions);
       setSaved(true);
-      clearTimeout(savedTimerRef.current);
+      if (savedTimerRef.current !== null) {
+        clearTimeout(savedTimerRef.current);
+      }
       savedTimerRef.current = setTimeout(() => setSaved(false), 2000);
       setViewName('');
       setConditions([makeCondition('AND', firstFieldKey)]);


### PR DESCRIPTION
### Motivation
- Address strict-null TypeScript errors caused by calling `clearTimeout(savedTimerRef.current)` when `savedTimerRef.current` can be `null`.

### Description
- Update `src/ui/AdvancedFilterBuilder.tsx` to guard all `clearTimeout(savedTimerRef.current)` calls with `if (savedTimerRef.current !== null) { ... }` in the unmount cleanup and both `handleSave` branches.
- Replace the compact cleanup effect with an explicit `return () => { ... }` block that performs the null check before clearing the timer.
- Preserve existing ref typings (`useRef<ReturnType<typeof setTimeout> | null>(null)`) and behavior otherwise.

### Testing
- Ran the strict-null type check with `npm run -s type-check:strict-null` and the ratchet passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9d8440814832c9529811012706c71)