### PR TITLE
feat(sprint-5): mission request workflow hover card (#307)

### DIFF
--- a/demo/App.tsx
+++ b/demo/App.tsx
@@ -20,6 +20,8 @@ import {
   allEvents,
   mission,
 } from './emsData';
+import MissionHoverCard, { allRequirementsMet } from './MissionHoverCard';
+import missionStyles from './MissionHoverCard.module.css';
 
 /* ─── Demo identity ─────────────────────────────────────────────── */
 // Air EMS demo: new calendar id so the IHC Fleet localStorage doesn't bleed
@@ -124,6 +126,9 @@ const INITIAL_EMPLOYEES = [
 // Fleet rows rendered by the Assets view. `group` is the region so the
 // assets view can pivot by region; `meta.base` ties into the base column.
 const REGION_BY_BASE = Object.fromEntries(bases.map(b => [b.id, regions.find(r => r.id === b.regionId)?.name ?? '']));
+
+// Employees eligible for mission slot assignment (pilots + medical)
+const MISSION_EMPLOYEES = [...crew, ...medicalCrew];
 
 const AIRCRAFT_RESOURCES = EMS_ASSETS.map(a => ({
   id:    a.id,
@@ -284,12 +289,17 @@ function UpdateToast({ onUpdate, onDismiss }) {
 
 /* ─── Demo App ──────────────────────────────────────────────────── */
 function App() {
-  const [events,       setEvents]       = useState(INITIAL_EVENTS);
-  const [notes,        setNotes]        = useState({});
-  const [theme,        setTheme]        = useState(INITIAL_THEME);
-  const [employees,    setEmployees]    = useState(INITIAL_EMPLOYEES);
-  const [eventLog,     setEventLog]     = useState([]);
-  const [needsRefresh, setNeedsRefresh] = useState(false);
+  const [events,            setEvents]            = useState(INITIAL_EVENTS);
+  const [notes,             setNotes]             = useState({});
+  const [theme,             setTheme]             = useState(INITIAL_THEME);
+  const [employees,         setEmployees]         = useState(INITIAL_EMPLOYEES);
+  const [eventLog,          setEventLog]          = useState([]);
+  const [needsRefresh,      setNeedsRefresh]      = useState(false);
+  const [missionAssignments, setMissionAssignments] = useState({
+    ...mission.assignments,
+    aircraft: null, // starts unassigned so the pulsing badge is visible on load
+  });
+  const [missionOpen,       setMissionOpen]       = useState(false);
   const [pools, setPools] = useState(() => {
     const persisted = loadPools(DEMO_CALENDAR_ID);
     return persisted.length > 0 ? persisted : DEMO_POOLS_DEFAULT;
@@ -382,6 +392,27 @@ function App() {
     log(`Approval: ${event.title} → ${nextStage}`);
   }, []);
 
+  const handleEventClick = useCallback((ev) => {
+    log(`Clicked: ${ev.title}`);
+    if (ev.category === 'mission-assignment' || ev.category === 'aircraft-request') {
+      setMissionOpen(true);
+    }
+  }, []);
+
+  // Appends pulsing "REQS UNMET" badge to mission pills when not fully staffed
+  const renderEvent = useCallback((ev) => {
+    if (ev.category !== 'mission-assignment' && ev.category !== 'aircraft-request') return null;
+    if (allRequirementsMet(missionAssignments, mission, EMS_ASSETS)) return null;
+    return (
+      <span style={{ display: 'flex', alignItems: 'center', gap: 6, overflow: 'hidden', width: '100%' }}>
+        <span style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', flex: 1, minWidth: 0 }}>
+          {ev.title}
+        </span>
+        <span className={missionStyles.unmetBadge}>REQS UNMET</span>
+      </span>
+    );
+  }, [missionAssignments]);
+
   return (
     <div style={{ height: '100vh', display: 'flex', flexDirection: 'column', background: '#060d1a' }}>
       <div style={{ flex: 1, padding: 0, minHeight: 0 }}>
@@ -409,7 +440,8 @@ function App() {
             onScheduleSave={handleEventSave}
             onAvailabilitySave={handleEventSave}
             onApprovalAction={handleApprovalAction}
-            onEventClick={ev => log(`Clicked: ${ev.title}`)}
+            onEventClick={handleEventClick}
+            renderEvent={renderEvent}
             theme={theme}
             showAddButton={true}
             categoriesConfig={UNIFIED_CATEGORIES_CONFIG}
@@ -426,6 +458,18 @@ function App() {
       }}>
         pw: <code style={{ background: 'rgba(0,0,0,.06)', padding: '1px 4px', borderRadius: 3 }}>demo1234</code>
       </div>
+
+      {/* Mission workflow modal — shown when a mission-assignment or aircraft-request is clicked */}
+      {missionOpen && (
+        <MissionHoverCard
+          mission={mission}
+          assignments={missionAssignments}
+          employees={MISSION_EMPLOYEES}
+          aircraft={EMS_ASSETS}
+          onAssignmentChange={setMissionAssignments}
+          onClose={() => setMissionOpen(false)}
+        />
+      )}
 
       {needsRefresh && (
         <UpdateToast

--- a/demo/MissionHoverCard.module.css
+++ b/demo/MissionHoverCard.module.css
@@ -1,0 +1,392 @@
+/* ── Overlay ──────────────────────────────────────────────────────────────── */
+
+.backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(6, 13, 26, 0.72);
+  backdrop-filter: blur(6px);
+  -webkit-backdrop-filter: blur(6px);
+  z-index: 1200;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  animation: backdropIn 200ms ease forwards;
+}
+
+@keyframes backdropIn {
+  from { opacity: 0; }
+  to   { opacity: 1; }
+}
+
+.card {
+  background: var(--wc-bg, #0f1729);
+  border: 1px solid var(--wc-border, #1e3a5f);
+  border-radius: 16px;
+  width: min(92vw, 960px);
+  max-height: 88vh;
+  overflow-y: auto;
+  box-shadow: 0 24px 80px rgba(0, 0, 0, 0.6), 0 0 0 1px rgba(6, 182, 212, 0.08);
+  animation: cardIn 220ms cubic-bezier(0.16, 1, 0.3, 1) forwards;
+  display: flex;
+  flex-direction: column;
+}
+
+@keyframes cardIn {
+  from { opacity: 0; transform: scale(0.93) translateY(12px); }
+  to   { opacity: 1; transform: scale(1)    translateY(0);    }
+}
+
+/* ── Header ───────────────────────────────────────────────────────────────── */
+
+.header {
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+  padding: 20px 24px 16px;
+  border-bottom: 1px solid var(--wc-border, #1e3a5f);
+}
+
+.missionIcon {
+  width: 36px;
+  height: 36px;
+  border-radius: 8px;
+  background: linear-gradient(135deg, #0ea5e9, #6366f1);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  color: #fff;
+}
+
+.headerText { flex: 1; min-width: 0; }
+
+.missionTitle {
+  font-size: 16px;
+  font-weight: 700;
+  color: var(--wc-text, #e2e8f0);
+  margin: 0 0 4px;
+  line-height: 1.3;
+}
+
+.missionMeta {
+  font-size: 12px;
+  color: var(--wc-text-muted, #64748b);
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.closeBtn {
+  width: 32px;
+  height: 32px;
+  border-radius: 8px;
+  border: none;
+  background: transparent;
+  color: var(--wc-text-muted, #64748b);
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  transition: background 0.15s, color 0.15s;
+}
+.closeBtn:hover { background: rgba(255,255,255,0.06); color: var(--wc-text, #e2e8f0); }
+
+/* ── Requirements map ─────────────────────────────────────────────────────── */
+
+.mapArea {
+  padding: 28px 24px;
+  flex: 1;
+  overflow: auto;
+}
+
+.diagram {
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
+  gap: 0 32px;
+  align-items: center;
+  min-height: 260px;
+}
+
+.centerNode {
+  background: linear-gradient(135deg, rgba(14,165,233,0.12), rgba(99,102,241,0.12));
+  border: 2px solid rgba(14,165,233,0.5);
+  border-radius: 12px;
+  padding: 16px 20px;
+  text-align: center;
+  position: relative;
+}
+
+.centerTitle {
+  font-size: 13px;
+  font-weight: 700;
+  color: var(--wc-text, #e2e8f0);
+  margin: 0 0 6px;
+}
+
+.centerSub {
+  font-size: 11px;
+  color: var(--wc-text-muted, #64748b);
+}
+
+/* Horizontal connector lines from center */
+.centerNode::before,
+.centerNode::after {
+  content: '';
+  position: absolute;
+  top: 50%;
+  width: 32px;
+  height: 2px;
+  background: rgba(14,165,233,0.35);
+}
+.centerNode::before { right: 100%; }
+.centerNode::after  { left: 100%; }
+
+/* ── Slot columns ─────────────────────────────────────────────────────────── */
+
+.leftCol {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  align-items: flex-end;
+}
+
+.rightCol {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.slotGroup { display: flex; flex-direction: column; gap: 8px; }
+
+.groupLabel {
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--wc-text-muted, #64748b);
+  margin-bottom: 2px;
+}
+
+/* ── Individual slot ──────────────────────────────────────────────────────── */
+
+.slot {
+  width: 200px;
+  min-height: 48px;
+  border-radius: 8px;
+  border: 2px dashed rgba(100,116,139,0.4);
+  background: rgba(255,255,255,0.02);
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 12px;
+  cursor: pointer;
+  transition: border-color 0.15s, background 0.15s;
+  position: relative;
+}
+
+.slot:hover {
+  border-color: rgba(14,165,233,0.5);
+  background: rgba(14,165,233,0.06);
+}
+
+.slotFilled {
+  border-style: solid;
+  border-color: rgba(14,165,233,0.5);
+  background: rgba(14,165,233,0.08);
+  cursor: default;
+}
+
+.slotUnmet {
+  border-color: rgba(239,68,68,0.45);
+  background: rgba(239,68,68,0.04);
+}
+
+.slotDot {
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  background: rgba(100,116,139,0.15);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  font-size: 12px;
+  color: var(--wc-text-muted, #64748b);
+}
+
+.slotFilledDot {
+  background: linear-gradient(135deg, #0ea5e9, #6366f1);
+  color: #fff;
+}
+
+.slotText { flex: 1; min-width: 0; }
+
+.slotName {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--wc-text, #e2e8f0);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.slotRole {
+  font-size: 10px;
+  color: var(--wc-text-muted, #64748b);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.slotEmpty .slotName { color: var(--wc-text-muted, #64748b); font-weight: 400; }
+
+.removeBtn {
+  width: 20px;
+  height: 20px;
+  border-radius: 4px;
+  border: none;
+  background: transparent;
+  color: var(--wc-text-muted, #64748b);
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  opacity: 0;
+  transition: opacity 0.15s, background 0.15s;
+  flex-shrink: 0;
+}
+.slot:hover .removeBtn { opacity: 1; }
+.removeBtn:hover { background: rgba(239,68,68,0.15); color: #ef4444; }
+
+/* ── Candidate picker ─────────────────────────────────────────────────────── */
+
+.candidatePopover {
+  position: fixed;
+  background: var(--wc-bg, #0f1729);
+  border: 1px solid var(--wc-border, #1e3a5f);
+  border-radius: 10px;
+  box-shadow: 0 8px 32px rgba(0,0,0,0.5);
+  z-index: 1300;
+  width: 240px;
+  max-height: 280px;
+  overflow-y: auto;
+  animation: popIn 140ms cubic-bezier(0.16,1,0.3,1) forwards;
+}
+
+@keyframes popIn {
+  from { opacity: 0; transform: scale(0.95) translateY(-4px); }
+  to   { opacity: 1; transform: scale(1) translateY(0); }
+}
+
+.candidateHeader {
+  padding: 8px 12px 6px;
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--wc-text-muted, #64748b);
+  border-bottom: 1px solid var(--wc-border, #1e3a5f);
+}
+
+.candidateItem {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 12px;
+  cursor: pointer;
+  transition: background 0.12s;
+}
+.candidateItem:hover { background: rgba(14,165,233,0.08); }
+
+.candidateItemDisabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+.candidateItemDisabled:hover { background: transparent; }
+
+.candidateName { font-size: 12px; font-weight: 600; color: var(--wc-text, #e2e8f0); }
+.candidateSub  { font-size: 10px; color: var(--wc-text-muted, #64748b); }
+
+/* ── Validation error ─────────────────────────────────────────────────────── */
+
+.errorBanner {
+  margin: 0 24px 12px;
+  padding: 8px 12px;
+  background: rgba(239,68,68,0.1);
+  border: 1px solid rgba(239,68,68,0.35);
+  border-radius: 8px;
+  font-size: 12px;
+  color: #f87171;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+/* ── Compliance strip ─────────────────────────────────────────────────────── */
+
+.complianceStrip {
+  padding: 14px 24px 20px;
+  border-top: 1px solid var(--wc-border, #1e3a5f);
+}
+
+.complianceTitle {
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--wc-text-muted, #64748b);
+  margin: 0 0 8px;
+}
+
+.complianceList {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.complianceItem {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  padding: 4px 10px;
+  border-radius: 999px;
+  font-size: 11px;
+  font-weight: 500;
+}
+
+.complianceApproved {
+  background: rgba(16,185,129,0.1);
+  border: 1px solid rgba(16,185,129,0.35);
+  color: #34d399;
+}
+
+.compliancePending {
+  background: rgba(245,158,11,0.1);
+  border: 1px solid rgba(245,158,11,0.35);
+  color: #fbbf24;
+}
+
+/* ── Requirements-not-met badge (used on pill via renderEvent) ────────────── */
+
+.unmetBadge {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 2px 6px;
+  border-radius: 4px;
+  background: rgba(239,68,68,0.18);
+  border: 1px solid rgba(239,68,68,0.45);
+  color: #f87171;
+  font-size: 9px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  animation: pulse 2s ease-in-out infinite;
+  white-space: nowrap;
+}
+
+@keyframes pulse {
+  0%,100% { opacity: 1; }
+  50%      { opacity: 0.5; }
+}

--- a/demo/MissionHoverCard.tsx
+++ b/demo/MissionHoverCard.tsx
@@ -1,0 +1,427 @@
+/**
+ * MissionHoverCard — full-screen mission workflow modal (Sprint 5, issue #307).
+ *
+ * Replaces the standard HoverCard when a mission-assignment or aircraft-request
+ * event is clicked. Shows a Lucidchart-style requirements map with assignment
+ * slots for pilots, medical crew, and aircraft. Clicking an empty slot opens a
+ * role-filtered candidate list with certification validation.
+ */
+
+import { useState, useEffect, useCallback, useRef } from 'react';
+import { X, Plane, AlertCircle, CheckCircle, Circle } from 'lucide-react';
+import type { DemoMissionRequest, DemoEmployee, DemoAircraft } from './types';
+import type { MissionAssignments, AssignedResource } from '../src/types/mission';
+import styles from './MissionHoverCard.module.css';
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+
+type SlotKind = 'pilot' | 'medical' | 'aircraft';
+
+interface ActiveSlot {
+  kind: SlotKind;
+  index: number;
+  anchorRect: DOMRect;
+}
+
+export interface MissionHoverCardProps {
+  mission: DemoMissionRequest;
+  assignments: MissionAssignments;
+  employees: DemoEmployee[];
+  aircraft: DemoAircraft[];
+  onAssignmentChange: (next: MissionAssignments) => void;
+  onClose: () => void;
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function pilotById(id: string, employees: DemoEmployee[]): DemoEmployee | undefined {
+  return employees.find(e => e.id === id && e.role === 'pilot');
+}
+
+function medicalById(id: string, employees: DemoEmployee[]): DemoEmployee | undefined {
+  return employees.find(e => e.id === id && (e.role === 'rn' || e.role === 'rt' || e.role === 'medic'));
+}
+
+function aircraftById(id: string, fleet: DemoAircraft[]): DemoAircraft | undefined {
+  return fleet.find(a => a.id === id);
+}
+
+function meetsAircraftReqs(ac: DemoAircraft, mission: DemoMissionRequest): boolean {
+  if (ac.hoursRemaining < mission.requirements.aircraft.minHoursRemaining) return false;
+  const caps = mission.requirements.aircraft.requiredCapabilities ?? [];
+  return caps.every(c => ac.capabilities.includes(c));
+}
+
+// ── Slot component ────────────────────────────────────────────────────────────
+
+interface SlotProps {
+  label: string;
+  subtitle: string;
+  filledId: string | null;
+  employees: DemoEmployee[];
+  fleet: DemoAircraft[];
+  onOpen: (rect: DOMRect) => void;
+  onRemove: () => void;
+}
+
+function Slot({ label, subtitle, filledId, employees, fleet, onOpen, onRemove }: SlotProps) {
+  const btnRef = useRef<HTMLButtonElement>(null);
+  const pilot  = filledId ? pilotById(filledId, employees) : null;
+  const med    = filledId ? medicalById(filledId, employees) : null;
+  const ac     = filledId ? aircraftById(filledId, fleet) : null;
+  const filled = pilot ?? med ?? (ac ? { name: ac.name, role: ac.type } : null);
+
+  const handleClick = () => {
+    if (filled) return;
+    if (btnRef.current) onOpen(btnRef.current.getBoundingClientRect());
+  };
+
+  return (
+    <button
+      ref={btnRef}
+      type="button"
+      className={[styles.slot, filled ? styles.slotFilled : styles.slotEmpty].filter(Boolean).join(' ')}
+      onClick={handleClick}
+      aria-label={filled ? `${filled.name} assigned` : `Assign ${label}`}
+    >
+      <span className={[styles.slotDot, filled ? styles.slotFilledDot : ''].filter(Boolean).join(' ')}>
+        {filled ? <CheckCircle size={14} /> : <Circle size={14} />}
+      </span>
+      <span className={styles.slotText}>
+        <span className={styles.slotName}>{filled ? filled.name : label}</span>
+        <span className={styles.slotRole}>{filled ? (pilot?.certifications.slice(0,2).join(' · ') ?? med?.certifications.slice(0,1).join('') ?? ac?.tail ?? '') : subtitle}</span>
+      </span>
+      {filled && (
+        <button
+          type="button"
+          className={styles.removeBtn}
+          onClick={e => { e.stopPropagation(); onRemove(); }}
+          aria-label="Remove assignment"
+        >
+          <X size={12} />
+        </button>
+      )}
+    </button>
+  );
+}
+
+// ── Candidate popover ─────────────────────────────────────────────────────────
+
+interface CandidatePopoverProps {
+  slot: ActiveSlot;
+  employees: DemoEmployee[];
+  fleet: DemoAircraft[];
+  mission: DemoMissionRequest;
+  onSelect: (id: string, valid: boolean, reason: string) => void;
+  onDismiss: () => void;
+}
+
+function CandidatePopover({ slot, employees, fleet, mission, onSelect, onDismiss }: CandidatePopoverProps) {
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const handler = (e: MouseEvent) => {
+      if (ref.current && !ref.current.contains(e.target as Node)) onDismiss();
+    };
+    document.addEventListener('mousedown', handler);
+    return () => document.removeEventListener('mousedown', handler);
+  }, [onDismiss]);
+
+  const rect = slot.anchorRect;
+  const top  = Math.min(rect.bottom + 6, window.innerHeight - 300);
+  const left = Math.max(8, Math.min(rect.left, window.innerWidth - 256));
+
+  let candidates: { id: string; name: string; sub: string; valid: boolean; reason: string }[] = [];
+
+  if (slot.kind === 'pilot') {
+    const req = mission.requirements.crew.pilots;
+    candidates = employees
+      .filter(e => e.role === 'pilot')
+      .map(e => {
+        const hasAll = req.certifications.every(c => e.certifications.includes(c));
+        return {
+          id: e.id, name: e.name,
+          sub: e.certifications.slice(0, 3).join(' · '),
+          valid: hasAll,
+          reason: hasAll ? '' : `Missing: ${req.certifications.filter(c => !e.certifications.includes(c)).join(', ')}`,
+        };
+      });
+  } else if (slot.kind === 'medical') {
+    const medSlot = mission.requirements.crew.medical[slot.index];
+    const roleMap: Record<string, DemoEmployee['role'][]> = {
+      RN: ['rn'], RT: ['rt'], Medic: ['medic'],
+    };
+    const allowedRoles = roleMap[medSlot?.role ?? 'RN'] ?? ['rn'];
+    candidates = employees
+      .filter(e => allowedRoles.includes(e.role))
+      .map(e => {
+        const hasAll = medSlot.certifications.every(c => e.certifications.some(ec => ec.includes(c)));
+        return {
+          id: e.id, name: e.name,
+          sub: e.certifications.slice(0, 2).join(' · '),
+          valid: hasAll,
+          reason: hasAll ? '' : `Missing certification for this slot`,
+        };
+      });
+  } else {
+    candidates = fleet.map(a => {
+      const ok = meetsAircraftReqs(a, mission);
+      return {
+        id: a.id, name: a.name,
+        sub: `${a.hoursRemaining}hr remaining · ${a.capabilities.slice(0,2).join(', ')}`,
+        valid: ok && a.status !== 'maintenance',
+        reason: !ok
+          ? `Insufficient hours (need ${mission.requirements.aircraft.minHoursRemaining}hr)`
+          : a.status === 'maintenance' ? 'In maintenance' : '',
+      };
+    });
+  }
+
+  return (
+    <div
+      ref={ref}
+      className={styles.candidatePopover}
+      style={{ top, left }}
+      role="listbox"
+      aria-label="Select candidate"
+    >
+      <div className={styles.candidateHeader}>
+        {slot.kind === 'pilot' ? 'Select Pilot' : slot.kind === 'medical' ? 'Select Medical Crew' : 'Select Aircraft'}
+      </div>
+      {candidates.map(c => (
+        <div
+          key={c.id}
+          role="option"
+          aria-selected="false"
+          className={[styles.candidateItem, !c.valid ? styles.candidateItemDisabled : ''].filter(Boolean).join(' ')}
+          onClick={() => onSelect(c.id, c.valid, c.reason)}
+        >
+          <div>
+            <div className={styles.candidateName}>{c.name}</div>
+            <div className={styles.candidateSub}>{c.sub}</div>
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+// ── Main component ────────────────────────────────────────────────────────────
+
+export default function MissionHoverCard({
+  mission,
+  assignments,
+  employees,
+  aircraft,
+  onAssignmentChange,
+  onClose,
+}: MissionHoverCardProps) {
+  const [activeSlot, setActiveSlot] = useState<ActiveSlot | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  // ESC to close
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => { if (e.key === 'Escape') onClose(); };
+    document.addEventListener('keydown', handler);
+    return () => document.removeEventListener('keydown', handler);
+  }, [onClose]);
+
+  const openSlot = useCallback((kind: SlotKind, index: number, rect: DOMRect) => {
+    setError(null);
+    setActiveSlot({ kind, index, anchorRect: rect });
+  }, []);
+
+  const handleSelect = useCallback((id: string, valid: boolean, reason: string) => {
+    if (!activeSlot) return;
+    if (!valid) {
+      setError(reason || 'Employee missing requirements for this task');
+      setActiveSlot(null);
+      return;
+    }
+    setError(null);
+    const resource: AssignedResource = {
+      resourceId: id,
+      resourceType: activeSlot.kind === 'aircraft' ? 'aircraft'
+        : activeSlot.kind === 'pilot' ? 'pilot' : 'medical',
+    };
+    if (activeSlot.kind === 'pilot') {
+      const next = [...assignments.pilots];
+      next[activeSlot.index] = resource;
+      onAssignmentChange({ ...assignments, pilots: next });
+    } else if (activeSlot.kind === 'medical') {
+      const next = [...assignments.medical];
+      next[activeSlot.index] = resource;
+      onAssignmentChange({ ...assignments, medical: next });
+    } else {
+      onAssignmentChange({ ...assignments, aircraft: resource });
+    }
+    setActiveSlot(null);
+  }, [activeSlot, assignments, onAssignmentChange]);
+
+  const removePilot = useCallback((i: number) => {
+    const next = [...assignments.pilots];
+    next.splice(i, 1);
+    onAssignmentChange({ ...assignments, pilots: next });
+  }, [assignments, onAssignmentChange]);
+
+  const removeMedical = useCallback((i: number) => {
+    const next = [...assignments.medical];
+    next.splice(i, 1);
+    onAssignmentChange({ ...assignments, medical: next });
+  }, [assignments, onAssignmentChange]);
+
+  const removeAircraft = useCallback(() => {
+    onAssignmentChange({ ...assignments, aircraft: null });
+  }, [assignments, onAssignmentChange]);
+
+  const pilotCount  = mission.requirements.crew.pilots.count;
+  const medSlots    = mission.requirements.crew.medical;
+  const assignedAc  = assignments.aircraft ? aircraftById(assignments.aircraft.resourceId, aircraft) : null;
+  const acMeetsReqs = assignedAc ? meetsAircraftReqs(assignedAc, mission) : false;
+
+  const metaText = `${mission.legs.length} legs · ${mission.requirements.durationDays} days`;
+
+  return (
+    <div className={styles.backdrop} role="dialog" aria-modal="true" aria-label={`Mission: ${mission.title}`}>
+      <div className={styles.card}>
+
+        {/* Header */}
+        <div className={styles.header}>
+          <div className={styles.missionIcon}><Plane size={18} /></div>
+          <div className={styles.headerText}>
+            <h2 className={styles.missionTitle}>{mission.title}</h2>
+            <div className={styles.missionMeta}>
+              <span>{mission.start.slice(0,10)} – {mission.end.slice(0,10)}</span>
+              <span>{metaText}</span>
+            </div>
+          </div>
+          <button className={styles.closeBtn} onClick={onClose} aria-label="Close"><X size={16} /></button>
+        </div>
+
+        {/* Validation error */}
+        {error && (
+          <div className={styles.errorBanner}>
+            <AlertCircle size={14} />
+            {error}
+          </div>
+        )}
+
+        {/* Requirements diagram */}
+        <div className={styles.mapArea}>
+          <div className={styles.diagram}>
+
+            {/* Left: Pilots */}
+            <div className={styles.leftCol}>
+              <div className={styles.slotGroup}>
+                <div className={styles.groupLabel}>Pilots ({pilotCount} required)</div>
+                {Array.from({ length: pilotCount }).map((_, i) => (
+                  <Slot
+                    key={i}
+                    label={`Pilot ${i + 1}`}
+                    subtitle={mission.requirements.crew.pilots.certifications.join(' · ')}
+                    filledId={assignments.pilots[i]?.resourceId ?? null}
+                    employees={employees}
+                    fleet={aircraft}
+                    onOpen={rect => openSlot('pilot', i, rect)}
+                    onRemove={() => removePilot(i)}
+                  />
+                ))}
+              </div>
+            </div>
+
+            {/* Center: mission node */}
+            <div className={styles.centerNode}>
+              <div className={styles.centerTitle}>{mission.title.split('→')[0].trim()}</div>
+              <div className={styles.centerSub}>→ {mission.title.split('→')[1]?.trim()}</div>
+            </div>
+
+            {/* Right: Medical + Aircraft */}
+            <div className={styles.rightCol}>
+              <div className={styles.slotGroup}>
+                <div className={styles.groupLabel}>Medical Crew</div>
+                {medSlots.map((slot, i) => (
+                  <Slot
+                    key={i}
+                    label={`${slot.role}: ${slot.certifications.join(' · ')}`}
+                    subtitle={slot.certifications.join(' · ')}
+                    filledId={assignments.medical[i]?.resourceId ?? null}
+                    employees={employees}
+                    fleet={aircraft}
+                    onOpen={rect => openSlot('medical', i, rect)}
+                    onRemove={() => removeMedical(i)}
+                  />
+                ))}
+              </div>
+
+              <div className={styles.slotGroup}>
+                <div className={styles.groupLabel}>Aircraft</div>
+                <Slot
+                  label="Assign Aircraft"
+                  subtitle={`min ${mission.requirements.aircraft.minHoursRemaining}hr · ${(mission.requirements.aircraft.requiredCapabilities ?? []).join(', ')}`}
+                  filledId={assignments.aircraft?.resourceId ?? null}
+                  employees={employees}
+                  fleet={aircraft}
+                  onOpen={rect => openSlot('aircraft', 0, rect)}
+                  onRemove={removeAircraft}
+                />
+                {assignedAc && !acMeetsReqs && (
+                  <div style={{ fontSize: 11, color: '#f87171', marginTop: 4 }}>
+                    ⚠ Aircraft does not meet all requirements
+                  </div>
+                )}
+                {assignedAc && (
+                  <div style={{ fontSize: 10, color: '#64748b', marginTop: 4 }}>
+                    {assignedAc.hoursRemaining}hr remaining · {assignedAc.capabilities.join(' · ')}
+                  </div>
+                )}
+              </div>
+            </div>
+          </div>
+        </div>
+
+        {/* Compliance strip */}
+        <div className={styles.complianceStrip}>
+          <div className={styles.complianceTitle}>Country clearances &amp; compliance</div>
+          <div className={styles.complianceList}>
+            {mission.compliance.map(c => (
+              <span
+                key={c.id}
+                className={[styles.complianceItem, c.status === 'approved' ? styles.complianceApproved : styles.compliancePending].join(' ')}
+              >
+                {c.status === 'approved' ? <CheckCircle size={11} /> : <AlertCircle size={11} />}
+                {c.label}
+              </span>
+            ))}
+          </div>
+        </div>
+      </div>
+
+      {/* Candidate popover (renders outside card to avoid clipping) */}
+      {activeSlot && (
+        <CandidatePopover
+          slot={activeSlot}
+          employees={employees}
+          fleet={aircraft}
+          mission={mission}
+          onSelect={handleSelect}
+          onDismiss={() => setActiveSlot(null)}
+        />
+      )}
+    </div>
+  );
+}
+
+// ── Standalone helper: are all requirements met? ──────────────────────────────
+
+export function allRequirementsMet(
+  assignments: MissionAssignments,
+  mission: DemoMissionRequest,
+  fleet: DemoAircraft[],
+): boolean {
+  if (assignments.pilots.length < mission.requirements.crew.pilots.count) return false;
+  if (assignments.medical.length < mission.requirements.crew.medical.length) return false;
+  if (!assignments.aircraft) return false;
+  const ac = fleet.find(a => a.id === assignments.aircraft?.resourceId);
+  if (!ac) return false;
+  return meetsAircraftReqs(ac, mission);
+}


### PR DESCRIPTION
Adds a full-screen MissionHoverCard modal that opens when any mission-assignment or aircraft-request event is clicked. The card renders a Lucidchart-style 3-column diagram with interactive assignment slots for pilots, medical crew, and aircraft; each empty slot opens a role-filtered candidate popover with certification validation. Invalid selections surface an inline error banner. A pulsing "REQS UNMET" badge is appended to mission pill labels via renderEvent whenever the missionAssignments state has unmet requirements.

- demo/MissionHoverCard.tsx: Slot, CandidatePopover, MissionHoverCard components; allRequirementsMet() helper (strict TS)
- demo/MissionHoverCard.module.css: backdrop blur overlay, diagram grid, slot/popover/compliance styles, unmetBadge pulse animation
- demo/App.tsx: missionAssignments useState (aircraft starts null to show badge on load), missionOpen toggle, handleEventClick, renderEvent callback, MissionHoverCard render portal

https://claude.ai/code/session_01BjSanhei7rk75wuoDE4a5X

## Summary
Describe exactly what this PR changes.

## Scope
- Stage: 
- Planned PR number in sprint: 
- Target files/directories: 
- Why this slice is isolated: 

## Lessons Learned Check (REQUIRED)
Confirm these were actively used while building this PR:

- [ ] PR is intentionally small and isolated
- [ ] Boundary typing was prioritized over internal perfection
- [ ] No silent spread of `any`
- [ ] Advisory root `tsc` was used to catch integration issues
- [ ] I did not assume “looks typed” means “safe”
- [ ] I stopped and isolated typing cascades instead of expanding scope

## Definition of Done (ALL REQUIRED)
This PR is not done unless every box is checked.

- [ ] `npm run type-check:strict` passes
- [ ] Root advisory `tsc --noEmit` passes
- [ ] Tests pass for touched scope at minimum
- [ ] No uncontrolled increase in `any`
- [ ] All new types are intentional and named
- [ ] Public interfaces and exported functions are explicitly typed
- [ ] PR scope matches the sprint plan with no scope creep
- [ ] Any new `any` has an adjacent justification comment
- [ ] No file-wide `: any`
- [ ] No implicit `any` in exported functions

## What Was Typed
List exactly what was typed in this PR.

- 
- 
- 

## What Was Intentionally Left Loose
List anything intentionally not tightened yet.

- 
- 
- 

## `any` Ledger (REQUIRED)
- New `any` added: 
- Existing `any` removed: 
- Net change: 

For every new `any`, explain why it is required and why a safer type was not used yet.

1. 
2. 
3. 

## Boundary Notes
Document any public seams, caller-protection choices, or compatibility decisions.

- 
- 
- 

## Risk Level
- [ ] Low
- [ ] Medium
- [ ] High

Why:

## Validation Evidence
Paste the exact commands run and a short result summary.

```bash
npm run type-check:strict
npx tsc --noEmit -p tsconfig.json
```

Test commands run:

```bash
# paste commands here
```

## Stop Conditions Check
If any item below happened, explain how scope was reduced before merge.

- [ ] `any` started spreading across files
- [ ] Root `tsc` broke repeatedly
- [ ] Types required cross-module rewrites
- [ ] Scope was reduced to keep the PR reviewable

Notes:

## Reviewer Focus
What should reviewers look at first?

- 
- 
- 
