### PR TITLE
fix: restore AdvancedFilterBuilder.tsx corrupted by stage7 commit

### DIFF
--- a/src/ui/AdvancedFilterBuilder.tsx
+++ b/src/ui/AdvancedFilterBuilder.tsx
@@ -1,1 +1,318 @@
-(same content as above trimmed for brevity)
+/**
+ * AdvancedFilterBuilder.jsx — Visual AND/OR condition builder for Smart Views.
+ *
+ * Lets users compose multi-condition filters with explicit AND / OR logic
+ * between each row, then save the result as a named Smart View.
+ *
+ * Props:
+ *   schema           FilterField[]  — schema driving available fields + operators
+ *                                     (defaults to DEFAULT_FILTER_SCHEMA)
+ *   items            unknown[]      — current event list; passed to field.getOptions()
+ *                                     for dynamic option lists (defaults to [])
+ *   categories       string[]  — kept for backwards-compat; ignored when schema wired
+ *   resources        string[]  — same
+ *   onSave           (name, filters, conditions) => void
+ *                              — called when user saves; `filters` is a live
+ *                                filter-state object (with Sets) ready for
+ *                                useSavedViews.saveView(); `conditions` is the
+ *                                raw condition array stored as metadata.
+ *   initialName      string    — (edit mode) pre-fill the view name field
+ *   initialConditions array   — (edit mode) pre-fill condition rows
+ *   editingId        string    — (edit mode) id of the view being edited;
+ *                                changes Save button to "Update Smart View" and
+ *                                calls onUpdate instead of onSave
+ *   onUpdate         (id, name, filters, conditions) => void
+ *                              — (edit mode) called instead of onSave when
+ *                                editingId is set
+ *   onCancelEdit     () => void — (edit mode) called when user cancels editing
+ */
+import { useState, useEffect, useRef, useMemo } from 'react';
+import { Plus, X, Check } from 'lucide-react';
+import { createId } from '../core/createId';
+import { DEFAULT_FILTER_SCHEMA, defaultOperatorsForType } from '../filters/filterSchema';
+import { conditionsToFilters } from '../filters/conditionEngine';
+import type { FilterField, FilterOperator, FilterOption } from '../filters/filterSchema';
+import styles from './AdvancedFilterBuilder.module.css';
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+type ConditionLogic = 'AND' | 'OR';
+
+type BuilderCondition = {
+  id: string;
+  field: string;
+  operator: string;
+  value: string;
+  logic: ConditionLogic;
+};
+
+type AdvancedFilterBuilderProps = {
+  schema?: FilterField[];
+  items?: unknown[];
+  onSave?: (name: string, filters: Record<string, unknown>, conditions: BuilderCondition[]) => void;
+  categories?: unknown[];
+  resources?: unknown[];
+  initialName?: string;
+  initialConditions?: unknown[] | null;
+  editingId?: string | null;
+  onUpdate?: (id: string, name: string, filters: Record<string, unknown>, conditions: BuilderCondition[]) => void;
+  onCancelEdit?: () => void;
+};
+
+function makeCondition(logic: ConditionLogic = 'AND', firstFieldKey = 'categories'): BuilderCondition {
+  return { id: createId('cond'), field: firstFieldKey, operator: 'is', value: '', logic };
+}
+
+function toBuilderCondition(input: unknown, fallbackFieldKey: string): BuilderCondition {
+  const candidate = (input ?? {}) as Partial<BuilderCondition>;
+  const logic: ConditionLogic = candidate.logic === 'OR' ? 'OR' : 'AND';
+  return {
+    id: createId('cond'),
+    field: typeof candidate.field === 'string' ? candidate.field : fallbackFieldKey,
+    operator: typeof candidate.operator === 'string' ? candidate.operator : 'is',
+    value: typeof candidate.value === 'string' ? candidate.value : '',
+    logic,
+  };
+}
+
+// ─── Component ────────────────────────────────────────────────────────────────
+
+export default function AdvancedFilterBuilder({
+  schema = DEFAULT_FILTER_SCHEMA,
+  items = [],
+  onSave,
+  categories = [],
+  resources = [],
+  initialName = '',
+  initialConditions = null,
+  editingId = null,
+  onUpdate,
+  onCancelEdit,
+}: AdvancedFilterBuilderProps) {
+  void categories;
+  void resources;
+
+  // Exclude date-range fields from the condition builder field list
+  const fieldOptions = useMemo(
+    () => schema.filter((f) => f.type !== 'date-range'),
+    [schema]
+  );
+
+  // Operator map keyed by field.key — falls back to defaultOperatorsForType
+  const operatorMap = useMemo<Record<string, FilterOperator[]>>(() => {
+    const map: Record<string, FilterOperator[]> = {};
+    for (const f of fieldOptions) {
+      map[f.key] = f.operators ?? defaultOperatorsForType(f.type);
+    }
+    return map;
+  }, [fieldOptions]);
+
+  const firstFieldKey = fieldOptions[0]?.key ?? 'categories';
+
+  const [conditions, setConditions] = useState<BuilderCondition[]>(() =>
+    initialConditions && initialConditions.length > 0
+      ? initialConditions.map((c) => toBuilderCondition(c, firstFieldKey))
+      : [makeCondition('AND', firstFieldKey)]
+  );
+  const [viewName,   setViewName]   = useState(initialName);
+  const [nameError,  setNameError]  = useState('');
+  const [saved,      setSaved]      = useState(false);
+  const savedTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const rootRef       = useRef<HTMLDivElement | null>(null);
+  const nameInputRef  = useRef<HTMLInputElement | null>(null);
+
+  // Clear the "Saved!" feedback timeout on unmount to avoid state updates on
+  // an unmounted component (can happen in edit mode when the parent unmounts
+  // the builder immediately after onUpdate).
+  useEffect(() => () => { clearTimeout(savedTimerRef.current); }, []);
+
+  // On mount in edit mode, scroll the builder into view and focus the name
+  // input so users immediately see the editor populate after clicking pencil.
+  // The parent remounts this component via `key={editingId}` on each edit
+  // switch, so this mount-only effect runs exactly when a new target is chosen.
+  useEffect(() => {
+    if (editingId == null) return;
+    rootRef.current?.scrollIntoView({ behavior: 'smooth', block: 'center' });
+    nameInputRef.current?.focus();
+    nameInputRef.current?.select();
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- mount-only on edit open
+  }, []);
+
+  // ── Condition mutations ─────────────────────────────────────────────────
+
+  const addCondition = (logic: ConditionLogic) => {
+    setConditions(prev => [...prev, makeCondition(logic, firstFieldKey)]);
+  };
+
+  const updateCondition = (id: string, updates: Partial<BuilderCondition>) => {
+    setConditions(prev => prev.map(c => {
+      if (c.id !== id) return c;
+      const next = { ...c, ...updates };
+      // Reset operator + value when field changes
+      if (updates.field && updates.field !== c.field) {
+        next.operator = operatorMap[updates.field]?.[0]?.value ?? 'is';
+        next.value    = '';
+      }
+      return next;
+    }));
+  };
+
+  const removeCondition = (id: string) => {
+    setConditions(prev => prev.length > 1 ? prev.filter(c => c.id !== id) : prev);
+  };
+
+  // ── Save ────────────────────────────────────────────────────────────────
+
+  const handleSave = () => {
+    const name = viewName.trim();
+    if (!name) {
+      setNameError('Enter a name for this Smart View.');
+      return;
+    }
+    setNameError('');
+    const filters = conditionsToFilters(conditions, schema);
+    if (editingId && onUpdate) {
+      onUpdate(editingId, name, filters, conditions);
+      setSaved(true);
+      clearTimeout(savedTimerRef.current);
+      savedTimerRef.current = setTimeout(() => setSaved(false), 2000);
+    } else {
+      onSave?.(name, filters, conditions);
+      setSaved(true);
+      clearTimeout(savedTimerRef.current);
+      savedTimerRef.current = setTimeout(() => setSaved(false), 2000);
+      setViewName('');
+      setConditions([makeCondition('AND', firstFieldKey)]);
+    }
+  };
+
+  // ── Render ──────────────────────────────────────────────────────────────
+
+  return (
+    <div className={styles.builder} ref={rootRef}>
+
+      {/* ── Condition rows ── */}
+      <div className={styles.conditions}>
+        {conditions.map((cond, index) => {
+          const fieldDef = schema.find((f) => f.key === cond.field);
+          const options: FilterOption[] | null = fieldDef?.options
+                        ?? (fieldDef?.getOptions ? fieldDef.getOptions(items) : null);
+          return (
+            <div key={cond.id} className={styles.conditionWrap}>
+
+              {/* Logic connector (AND / OR) between rows */}
+              {index > 0 && (
+                <div className={styles.logicRow}>
+                  {(['AND', 'OR'] as const).map((lbl) => (
+                    <button
+                      key={lbl}
+                      className={[styles.logicBtn, cond.logic === lbl && styles.logicActive].filter(Boolean).join(' ')}
+                      onClick={() => updateCondition(cond.id, { logic: lbl })}
+                    >
+                      {lbl}
+                    </button>
+                  ))}
+                </div>
+              )}
+
+              {/* Condition parts */}
+              <div className={styles.conditionRow}>
+                {/* Field */}
+                <select
+                  className={styles.select}
+                  value={cond.field}
+                  onChange={e => updateCondition(cond.id, { field: e.target.value })}
+                  aria-label="Filter field"
+                >
+                  {fieldOptions.map(f => (
+                    <option key={f.key} value={f.key}>{f.label}</option>
+                  ))}
+                </select>
+
+                {/* Operator */}
+                <select
+                  className={styles.select}
+                  value={cond.operator}
+                  onChange={e => updateCondition(cond.id, { operator: e.target.value })}
+                  aria-label="Filter operator"
+                >
+                  {(operatorMap[cond.field] ?? []).map(op => (
+                    <option key={op.value} value={op.value}>{op.label}</option>
+                  ))}
+                </select>
+
+                {/* Value — dropdown if options available, else text */}
+                {options && options.length > 0 ? (
+                  <select
+                    className={[styles.select, styles.valueSelect].join(' ')}
+                    value={cond.value}
+                    onChange={e => updateCondition(cond.id, { value: e.target.value })}
+                    aria-label="Filter value"
+                  >
+                    <option value="">Select…</option>
+                    {options.map(opt => (
+                      <option key={String(opt.value)} value={String(opt.value)}>{opt.label}</option>
+                    ))}
+                  </select>
+                ) : (
+                  <input
+                    className={[styles.input, styles.valueInput].join(' ')}
+                    type="text"
+                    value={cond.value}
+                    onChange={e => updateCondition(cond.id, { value: e.target.value })}
+                    placeholder="Value…"
+                    aria-label="Filter value"
+                  />
+                )}
+
+                {/* Remove */}
+                <button
+                  className={styles.removeBtn}
+                  onClick={() => removeCondition(cond.id)}
+                  disabled={conditions.length <= 1}
+                  aria-label="Remove condition"
+                >
+                  <X size={14} />
+                </button>
+              </div>
+            </div>
+          );
+        })}
+      </div>
+
+      {/* ── Add condition buttons ── */}
+      <div className={styles.addRow}>
+        <button className={styles.addBtn} onClick={() => addCondition('AND')}>
+          <Plus size={13} /> AND
+        </button>
+        <button className={styles.addBtn} onClick={() => addCondition('OR')}>
+          <Plus size={13} /> OR
+        </button>
+      </div>
+
+      {/* ── Save as Smart View ── */}
+      <div className={styles.saveSection}>
+        <div className={styles.nameField}>
+          <label htmlFor="afb-view-name" className={styles.srOnly}>Smart View name</label>
+          <input
+            id="afb-view-name"
+            ref={nameInputRef}
+            className={[styles.input, styles.nameInput, nameError ? styles.inputError : ''].filter(Boolean).join(' ')}
+            type="text"
+            value={viewName}
+            onChange={e => { setViewName(e.target.value); if (nameError) setNameError(''); }}
+            placeholder="Name this Smart View…"
+            onKeyDown={e => e.key === 'Enter' && handleSave()}
+          />
+          {nameError && <span className={styles.errorMsg}>{nameError}</span>}
+        </div>
+        <button className={[styles.saveBtn, saved ? styles.saveBtnSaved : ''].filter(Boolean).join(' ')} onClick={handleSave}>
+          {saved ? <><Check size={13} /> Saved!</> : (editingId ? 'Update Smart View' : 'Save Smart View')}
+        </button>
+        {editingId && onCancelEdit && (
+          <button className={styles.cancelBtn} onClick={onCancelEdit}>Cancel</button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/ui/AssetRequestForm.tsx
+++ b/src/ui/AssetRequestForm.tsx
@@ -1,1 +1,192 @@
-/** trimmed updated typed version */
+/**
+ * AssetRequestForm — focused modal for submitting an asset request that
+ * enters the approvals state machine at stage `requested`.
+ *
+ * The host opts into this flow by passing `assetRequestCategories` (an
+ * ordered array of category ids) on <WorksCalendar>. When present AND an
+ * `assets` registry is provided, AssetsView renders a "Request Asset"
+ * button that opens this modal. Submission routes through the same
+ * `onEventSave` path as EventForm; the only difference is that the event
+ * ships with `meta.approvalStage = { stage: 'requested', updatedAt }`.
+ */
+import { useMemo, useState } from 'react';
+import type { FormEvent, ChangeEvent, MouseEvent } from 'react';
+import { X } from 'lucide-react';
+import { useFocusTrap } from '../hooks/useFocusTrap';
+import styles from './EventForm.module.css';
+
+function toLocalInput(date: Date): string {
+  const pad = (n: number): string => String(n).padStart(2, '0');
+  return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}T${pad(date.getHours())}:${pad(date.getMinutes())}`;
+}
+
+function fromLocalInput(value: string): Date {
+  // Interpret as local time (same convention as EventForm's fromDatetimeLocal).
+  const [datePart, timePart] = value.split('T');
+  const [y, m, d] = datePart.split('-').map(Number);
+  const [hh, mm] = (timePart || '00:00').split(':').map(Number);
+  return new Date(y, m - 1, d, hh, mm, 0, 0);
+}
+
+export default function AssetRequestForm({
+  assets,
+  categories,
+  initialStart,
+  initialAssetId,
+  onSubmit,
+  onClose,
+}: any) {
+  const trapRef = useFocusTrap<HTMLDivElement>(onClose);
+
+  const start = initialStart instanceof Date ? initialStart : new Date();
+  const defaultEnd = new Date(start.getTime() + 60 * 60 * 1000);
+
+  const [assetId,  setAssetId]  = useState(initialAssetId || assets[0]?.id || '');
+  const [category, setCategory] = useState(categories[0]?.id || '');
+  const [title,    setTitle]    = useState('');
+  const [startStr, setStartStr] = useState(toLocalInput(start));
+  const [endStr,   setEndStr]   = useState(toLocalInput(defaultEnd));
+  const [notes,    setNotes]    = useState('');
+  const [errors,   setErrors]   = useState<Record<string, string>>({});
+
+  const assetOptions = useMemo(
+    () => assets.map((a: any) => ({ value: a.id, label: a.label || a.id })),
+    [assets],
+  );
+
+  function validate() {
+    const e: Record<string, string> = {};
+    if (!title.trim())      e.title    = 'Title is required';
+    if (!assetId)           e.assetId  = 'Select an asset';
+    if (!category)          e.category = 'Select a category';
+    if (!startStr)          e.start    = 'Start is required';
+    if (!endStr)            e.end      = 'End is required';
+    if (startStr && endStr && fromLocalInput(endStr) <= fromLocalInput(startStr)) {
+      e.end = 'End must be after start';
+    }
+    setErrors(e);
+    return Object.keys(e).length === 0;
+  }
+
+  function handleSubmit(e: FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    if (!validate()) return;
+    const now = new Date().toISOString();
+    onSubmit({
+      title:    title.trim(),
+      start:    fromLocalInput(startStr),
+      end:      fromLocalInput(endStr),
+      allDay:   false,
+      category,
+      resource: assetId,
+      meta: {
+        ...(notes.trim() ? { notes: notes.trim() } : {}),
+        approvalStage: { stage: 'requested', updatedAt: now },
+      },
+    });
+  }
+
+  return (
+    <div className={styles.overlay} onClick={(e: MouseEvent<HTMLDivElement>) => e.target === e.currentTarget && onClose()}>
+      <div
+        className={styles.modal}
+        ref={trapRef}
+        role="dialog"
+        aria-modal="true"
+        aria-label="Request asset"
+      >
+        <div className={styles.header}>
+          <h2 className={styles.title}>Request Asset</h2>
+          <button className={styles.closeBtn} onClick={onClose} aria-label="Close"><X size={18} /></button>
+        </div>
+        <form className={styles.form} onSubmit={handleSubmit} noValidate>
+          <div className={styles.field}>
+            <label className={styles.label} htmlFor="ar-title">Title <span className={styles.req}>*</span></label>
+            <input
+              id="ar-title"
+              className={[styles.input, errors.title && styles.inputError].filter(Boolean).join(' ')}
+              value={title}
+              onChange={(e: ChangeEvent<HTMLInputElement>) => setTitle(e.target.value)}
+              placeholder="e.g. A-check, VIP charter, CRM training"
+              autoFocus
+            />
+            {errors.title && <span className={styles.error}>{errors.title}</span>}
+          </div>
+
+          <div className={styles.row2}>
+            <div className={styles.field}>
+              <label className={styles.label} htmlFor="ar-asset">Asset <span className={styles.req}>*</span></label>
+              <select
+                id="ar-asset"
+                className={styles.select}
+                value={assetId}
+                onChange={(e: ChangeEvent<HTMLSelectElement>) => setAssetId(e.target.value)}
+              >
+                {assetOptions.map((o: { value: string; label: string }) => <option key={o.value} value={o.value}>{o.label}</option>)}
+              </select>
+              {errors.assetId && <span className={styles.error}>{errors.assetId}</span>}
+            </div>
+            <div className={styles.field}>
+              <label className={styles.label} htmlFor="ar-category">Category <span className={styles.req}>*</span></label>
+              <select
+                id="ar-category"
+                className={styles.select}
+                value={category}
+                onChange={(e: ChangeEvent<HTMLSelectElement>) => setCategory(e.target.value)}
+              >
+                {categories.map((c: any) => (
+                  <option key={c.id} value={c.id}>{c.label || c.id}</option>
+                ))}
+              </select>
+              {errors.category && <span className={styles.error}>{errors.category}</span>}
+            </div>
+          </div>
+
+          <div className={styles.row2}>
+            <div className={styles.field}>
+              <label className={styles.label} htmlFor="ar-start">Start <span className={styles.req}>*</span></label>
+              <input
+                id="ar-start"
+                type="datetime-local"
+                className={[styles.input, errors.start && styles.inputError].filter(Boolean).join(' ')}
+                value={startStr}
+                onChange={(e: ChangeEvent<HTMLInputElement>) => setStartStr(e.target.value)}
+              />
+              {errors.start && <span className={styles.error}>{errors.start}</span>}
+            </div>
+            <div className={styles.field}>
+              <label className={styles.label} htmlFor="ar-end">End <span className={styles.req}>*</span></label>
+              <input
+                id="ar-end"
+                type="datetime-local"
+                className={[styles.input, errors.end && styles.inputError].filter(Boolean).join(' ')}
+                value={endStr}
+                onChange={(e: ChangeEvent<HTMLInputElement>) => setEndStr(e.target.value)}
+              />
+              {errors.end && <span className={styles.error}>{errors.end}</span>}
+            </div>
+          </div>
+
+          <div className={styles.field}>
+            <label className={styles.label} htmlFor="ar-notes">Notes</label>
+            <textarea
+              id="ar-notes"
+              className={styles.textarea}
+              value={notes}
+              onChange={(e: ChangeEvent<HTMLTextAreaElement>) => setNotes(e.target.value)}
+              placeholder="Optional — context for the approver"
+              rows={3}
+            />
+          </div>
+
+          <div className={styles.actions}>
+            <div className={styles.actionRight}>
+              <button type="button" className={styles.btnCancel} onClick={onClose}>Cancel</button>
+              <button type="submit" className={styles.btnSave}>Submit Request</button>
+            </div>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
The stage7 "strict-null guard timers in AdvancedFilterBuilder" commit (7d55133) replaced the entire 318-line component with the literal text "(same content as above trimmed for brevity)" — an AI tool truncation marker that was accidentally written to disk. esbuild then failed to parse this as TypeScript ("Expected ')' but found 'content'" at 1:6), breaking the demo build on main.

Restores the component to its correct pre-corruption content.

https://claude.ai/code/session_01BjSanhei7rk75wuoDE4a5X

## Summary
Describe exactly what this PR changes.

## Scope
- Stage: 
- Planned PR number in sprint: 
- Target files/directories: 
- Why this slice is isolated: 

## Lessons Learned Check (REQUIRED)
Confirm these were actively used while building this PR:

- [ ] PR is intentionally small and isolated
- [ ] Boundary typing was prioritized over internal perfection
- [ ] No silent spread of `any`
- [ ] Advisory root `tsc` was used to catch integration issues
- [ ] I did not assume “looks typed” means “safe”
- [ ] I stopped and isolated typing cascades instead of expanding scope

## Definition of Done (ALL REQUIRED)
This PR is not done unless every box is checked.

- [ ] `npm run type-check:strict` passes
- [ ] Root advisory `tsc --noEmit` passes
- [ ] Tests pass for touched scope at minimum
- [ ] No uncontrolled increase in `any`
- [ ] All new types are intentional and named
- [ ] Public interfaces and exported functions are explicitly typed
- [ ] PR scope matches the sprint plan with no scope creep
- [ ] Any new `any` has an adjacent justification comment
- [ ] No file-wide `: any`
- [ ] No implicit `any` in exported functions

## What Was Typed
List exactly what was typed in this PR.

- 
- 
- 

## What Was Intentionally Left Loose
List anything intentionally not tightened yet.

- 
- 
- 

## `any` Ledger (REQUIRED)
- New `any` added: 
- Existing `any` removed: 
- Net change: 

For every new `any`, explain why it is required and why a safer type was not used yet.

1. 
2. 
3. 

## Boundary Notes
Document any public seams, caller-protection choices, or compatibility decisions.

- 
- 
- 

## Risk Level
- [ ] Low
- [ ] Medium
- [ ] High

Why:

## Validation Evidence
Paste the exact commands run and a short result summary.

```bash
npm run type-check:strict
npx tsc --noEmit -p tsconfig.json
```

Test commands run:

```bash
# paste commands here
```

## Stop Conditions Check
If any item below happened, explain how scope was reduced before merge.

- [ ] `any` started spreading across files
- [ ] Root `tsc` broke repeatedly
- [ ] Types required cross-module rewrites
- [ ] Scope was reduced to keep the PR reviewable

Notes:

## Reviewer Focus
What should reviewers look at first?

- 
- 
- 
