### PR TITLE
Refine input render narrowing in CalendarExternalForm

### DIFF
--- a/src/ui/CalendarExternalForm.tsx
+++ b/src/ui/CalendarExternalForm.tsx
@@ -45,7 +45,7 @@ function normalizeFields(fields: ExternalFormField[]): ExternalFormField[] {
     throw new Error('CalendarExternalForm requires at least one field.');
   }
 
-  const names = new Set();
+  const names = new Set<string>();
   return fields.map((field) => {
     if (!field?.name || typeof field.name !== 'string') {
       throw new Error('Each field requires a string `name`.');
@@ -229,13 +229,13 @@ export default function CalendarExternalForm({
                   onChange={(e) => setValue(field.name, e.target.checked)}
                 />
               )}
-              {!['textarea', 'select', 'checkbox'].includes(field.type) && (
+              {field.type !== 'textarea' && field.type !== 'select' && field.type !== 'checkbox' && (
                 <input
                   id={inputId}
                   className={styles.input}
-                  type={field.type || 'text'}
+                  type={field.type}
                   value={toInputValue(value)}
-                  placeholder={field.placeholder}
+                  placeholder={field.placeholder ?? ''}
                   onChange={(e) => setValue(field.name, e.target.value)}
                 />
               )}


### PR DESCRIPTION
### Motivation
- Make the final input render branch strictly narrowed for TypeScript's control-flow analysis and avoid nullable placeholder complaints.

### Description
- Replaced the `.includes(...)` guard with explicit comparisons `field.type !== 'textarea' && field.type !== 'select' && field.type !== 'checkbox'` to improve narrowing in the input render branch in `src/ui/CalendarExternalForm.tsx`.
- Removed the unnecessary fallback `|| 'text'` when setting the input `type` because `normalizeFields()` guarantees a defined `field.type`.
- Changed `placeholder={field.placeholder}` to `placeholder={field.placeholder ?? ''}` to avoid `string | undefined` issues.
- Added a generic to the dedupe set by changing `const names = new Set();` to `const names = new Set<string>();` in field normalization.

### Testing
- Ran `npm run type-check` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9ee406efc832c8d48c43c869ba13f)