### PR TITLE
Tighten strict-null typing in external and asset request forms

### DIFF
--- a/src/ui/AssetRequestForm.tsx
+++ b/src/ui/AssetRequestForm.tsx
@@ -15,6 +15,41 @@ import { X } from 'lucide-react';
 import { useFocusTrap } from '../hooks/useFocusTrap';
 import styles from './EventForm.module.css';
 
+type AssetRequestAsset = {
+  id: string;
+  label?: string;
+};
+
+type AssetRequestCategory = {
+  id: string;
+  label?: string;
+};
+
+type AssetRequestPayload = {
+  title: string;
+  start: Date;
+  end: Date;
+  allDay: false;
+  category: string;
+  resource: string;
+  meta: {
+    notes?: string;
+    approvalStage: {
+      stage: 'requested';
+      updatedAt: string;
+    };
+  };
+};
+
+type AssetRequestFormProps = {
+  assets: AssetRequestAsset[];
+  categories: AssetRequestCategory[];
+  initialStart?: Date;
+  initialAssetId?: string;
+  onSubmit: (payload: AssetRequestPayload) => void;
+  onClose: () => void;
+};
+
 function toLocalInput(date: Date): string {
   const pad = (n: number): string => String(n).padStart(2, '0');
   return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}T${pad(date.getHours())}:${pad(date.getMinutes())}`;
@@ -35,7 +70,7 @@ export default function AssetRequestForm({
   initialAssetId,
   onSubmit,
   onClose,
-}: any) {
+}: AssetRequestFormProps) {
   const trapRef = useFocusTrap<HTMLDivElement>(onClose);
 
   const start = initialStart instanceof Date ? initialStart : new Date();
@@ -50,7 +85,7 @@ export default function AssetRequestForm({
   const [errors,   setErrors]   = useState<Record<string, string>>({});
 
   const assetOptions = useMemo(
-    () => assets.map((a: any) => ({ value: a.id, label: a.label || a.id })),
+    () => assets.map((a) => ({ value: a.id, label: a.label || a.id })),
     [assets],
   );
 
@@ -122,7 +157,7 @@ export default function AssetRequestForm({
                 value={assetId}
                 onChange={(e: ChangeEvent<HTMLSelectElement>) => setAssetId(e.target.value)}
               >
-                {assetOptions.map((o: { value: string; label: string }) => <option key={o.value} value={o.value}>{o.label}</option>)}
+                {assetOptions.map((o) => <option key={o.value} value={o.value}>{o.label}</option>)}
               </select>
               {errors.assetId && <span className={styles.error}>{errors.assetId}</span>}
             </div>
@@ -134,7 +169,7 @@ export default function AssetRequestForm({
                 value={category}
                 onChange={(e: ChangeEvent<HTMLSelectElement>) => setCategory(e.target.value)}
               >
-                {categories.map((c: any) => (
+                {categories.map((c) => (
                   <option key={c.id} value={c.id}>{c.label || c.id}</option>
                 ))}
               </select>

--- a/src/ui/CalendarExternalForm.tsx
+++ b/src/ui/CalendarExternalForm.tsx
@@ -1,9 +1,16 @@
 import { useMemo, useState, type FormEvent } from 'react';
 import styles from './CalendarExternalForm.module.css';
 
-const SUPPORTED_FIELD_TYPES = new Set(['text', 'textarea', 'datetime-local', 'date', 'checkbox', 'select']);
-
 type ExternalFormFieldType = 'text' | 'textarea' | 'datetime-local' | 'date' | 'checkbox' | 'select';
+
+const SUPPORTED_FIELD_TYPES = new Set<ExternalFormFieldType>([
+  'text',
+  'textarea',
+  'datetime-local',
+  'date',
+  'checkbox',
+  'select',
+]);
 
 type ExternalFormOption = {
   value: string;
@@ -45,7 +52,7 @@ function normalizeFields(fields: ExternalFormField[]): ExternalFormField[] {
     throw new Error('CalendarExternalForm requires at least one field.');
   }
 
-  const names = new Set();
+  const names = new Set<string>();
   return fields.map((field) => {
     if (!field?.name || typeof field.name !== 'string') {
       throw new Error('Each field requires a string `name`.');
@@ -229,13 +236,13 @@ export default function CalendarExternalForm({
                   onChange={(e) => setValue(field.name, e.target.checked)}
                 />
               )}
-              {!['textarea', 'select', 'checkbox'].includes(field.type) && (
+              {field.type !== 'textarea' && field.type !== 'select' && field.type !== 'checkbox' && (
                 <input
                   id={inputId}
                   className={styles.input}
-                  type={field.type || 'text'}
+                  type={field.type}
                   value={toInputValue(value)}
-                  placeholder={field.placeholder}
+                  placeholder={field.placeholder ?? ''}
                   onChange={(e) => setValue(field.name, e.target.value)}
                 />
               )}


### PR DESCRIPTION
### Motivation
- Reduce `strict-null`/TypeScript noise by tightening types around external form field handling and the asset request form props.
- Ensure the runtime guarantees from `normalizeFields()` are reflected in types so the compiler can narrow `field.type` without fallbacks.

### Description
- Typed `SUPPORTED_FIELD_TYPES` as `Set<ExternalFormFieldType>` and `names` as `Set<string>` in `CalendarExternalForm.tsx` to enforce valid field types and name tracking at compile time.
- Replaced the generic `includes()` fallback input branch with explicit checks (`field.type !== 'textarea' && field.type !== 'select' && field.type !== 'checkbox'`), removed the unnecessary `|| 'text'` fallback for `type`, and used `placeholder={field.placeholder ?? ''}` to avoid `string | undefined` complaints.
- Added explicit types for `AssetRequestForm` props and payload (`AssetRequestAsset`, `AssetRequestCategory`, `AssetRequestPayload`, `AssetRequestFormProps`) and removed `any` annotations in option/category mapping in `AssetRequestForm.tsx`.

### Testing
- Ran `npm run -s type-check` and it completed successfully without type errors.
- Ran `npm run -s test -- src/ui/__tests__/AssetRequestForm.test.tsx` and the test file passed (`8 tests, 8 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9eeb3305c832cb94b96da580c280d)