### PR TITLE
stage7: tighten ui import and external form nullability

### DIFF
--- a/src/ui/AssetRequestForm.tsx
+++ b/src/ui/AssetRequestForm.tsx
@@ -15,17 +15,17 @@ import { X } from 'lucide-react';
 import { useFocusTrap } from '../hooks/useFocusTrap';
 import styles from './EventForm.module.css';
 
-type AssetRequestAsset = {
+type AssetOption = {
   id: string;
-  label?: string;
+  label?: string | null;
 };
 
 type AssetRequestCategory = {
   id: string;
-  label?: string;
+  label?: string | null;
 };
 
-type AssetRequestPayload = {
+type AssetRequestSubmitPayload = {
   title: string;
   start: Date;
   end: Date;
@@ -42,11 +42,11 @@ type AssetRequestPayload = {
 };
 
 type AssetRequestFormProps = {
-  assets: AssetRequestAsset[];
+  assets: AssetOption[];
   categories: AssetRequestCategory[];
-  initialStart?: Date;
-  initialAssetId?: string;
-  onSubmit: (payload: AssetRequestPayload) => void;
+  initialStart?: Date | null;
+  initialAssetId?: string | null;
+  onSubmit: (payload: AssetRequestSubmitPayload) => void;
   onClose: () => void;
 };
 
@@ -57,9 +57,9 @@ function toLocalInput(date: Date): string {
 
 function fromLocalInput(value: string): Date {
   // Interpret as local time (same convention as EventForm's fromDatetimeLocal).
-  const [datePart, timePart] = value.split('T');
-  const [y, m, d] = datePart.split('-').map(Number);
-  const [hh, mm] = (timePart || '00:00').split(':').map(Number);
+  const [datePart = '', timePart = '00:00'] = value.split('T');
+  const [y = 0, m = 1, d = 1] = datePart.split('-').map(Number);
+  const [hh = 0, mm = 0] = timePart.split(':').map(Number);
   return new Date(y, m - 1, d, hh, mm, 0, 0);
 }
 
@@ -76,8 +76,8 @@ export default function AssetRequestForm({
   const start = initialStart instanceof Date ? initialStart : new Date();
   const defaultEnd = new Date(start.getTime() + 60 * 60 * 1000);
 
-  const [assetId,  setAssetId]  = useState(initialAssetId || assets[0]?.id || '');
-  const [category, setCategory] = useState(categories[0]?.id || '');
+  const [assetId, setAssetId] = useState<string>(initialAssetId ?? assets[0]?.id ?? '');
+  const [category, setCategory] = useState<string>(categories[0]?.id ?? '');
   const [title,    setTitle]    = useState('');
   const [startStr, setStartStr] = useState(toLocalInput(start));
   const [endStr,   setEndStr]   = useState(toLocalInput(defaultEnd));
@@ -85,7 +85,7 @@ export default function AssetRequestForm({
   const [errors,   setErrors]   = useState<Record<string, string>>({});
 
   const assetOptions = useMemo(
-    () => assets.map((a) => ({ value: a.id, label: a.label || a.id })),
+    () => assets.map((a) => ({ value: a.id, label: a.label ?? a.id })),
     [assets],
   );
 
@@ -170,7 +170,9 @@ export default function AssetRequestForm({
                 onChange={(e: ChangeEvent<HTMLSelectElement>) => setCategory(e.target.value)}
               >
                 {categories.map((c) => (
-                  <option key={c.id} value={c.id}>{c.label || c.id}</option>
+                  <option key={c.id} value={c.id}>
+                    {c.label ?? c.id}
+                  </option>
                 ))}
               </select>
               {errors.category && <span className={styles.error}>{errors.category}</span>}

--- a/src/ui/CalendarExternalForm.tsx
+++ b/src/ui/CalendarExternalForm.tsx
@@ -146,12 +146,12 @@ export default function CalendarExternalForm({
   const normalizedFields = normalizeFields(fields);
 
   const mergedInitialValues = useMemo(() => {
-    const fromFields = normalizeFields(fields).reduce<ExternalFormValues>((acc, field) => {
+    const fromFields = normalizedFields.reduce<ExternalFormValues>((acc, field) => {
       acc[field.name] = field.type === 'checkbox' ? false : '';
       return acc;
     }, {});
     return { ...fromFields, ...initialValues };
-  }, [fields, initialValues]);
+  }, [normalizedFields, initialValues]);
 
   const [values, setValues] = useState(mergedInitialValues);
   const [errors, setErrors] = useState<Record<string, string>>({});

--- a/src/ui/ImportZone.tsx
+++ b/src/ui/ImportZone.tsx
@@ -12,27 +12,14 @@ import ImportPreview from './ImportPreview';
 import CSVImportDialog from './CSVImportDialog';
 import styles from './ImportZone.module.css';
 
-type ImportedEvent = {
-  id?: string;
-  title: string;
-  start: Date | string;
-  end?: Date | string;
-  category?: string;
-  resource?: string;
-  status?: string;
-  color?: string;
-  allDay?: boolean;
-  meta?: Record<string, unknown>;
-};
-
 type ImportZoneProps = {
-  onImport: (events: ImportedEvent[], metadata?: { label?: string }) => void;
+  onImport: (events: WorksCalendarEvent[], metadata?: { label?: string }) => void;
   onClose: () => void;
 };
 
 export default function ImportZone({ onImport, onClose }: ImportZoneProps) {
   const [dragging, setDragging] = useState(false);
-  const [parsed, setParsed] = useState<ImportedEvent[] | null>(null); // ICS parsed events
+  const [parsed, setParsed] = useState<WorksCalendarEvent[] | null>(null); // ICS parsed events
   const [csvMode, setCsvMode] = useState(false); // switch to CSV dialog
   const [error, setError] = useState<string | null>(null);
   const inputRef = useRef<HTMLInputElement | null>(null);
@@ -62,7 +49,7 @@ export default function ImportZone({ onImport, onClose }: ImportZoneProps) {
         const text = typeof e.target?.result === 'string' ? e.target.result : '';
         const events = parseICS(text);
         if (!events.length) { setError('No events found in this file.'); return; }
-        setParsed(events as ImportedEvent[]);
+        setParsed(events);
       } catch (err: unknown) {
         const message = err instanceof Error ? err.message : String(err);
         setError(`Could not parse file: ${message}`);
@@ -74,7 +61,7 @@ export default function ImportZone({ onImport, onClose }: ImportZoneProps) {
 
   // ICS preview
   if (parsed) {
-    return <ImportPreview events={parsed as WorksCalendarEvent[]} onImport={onImport} onClose={onClose} />;
+    return <ImportPreview events={parsed} onImport={onImport} onClose={onClose} />;
   }
 
   // CSV multi-step dialog — mounts fresh with its own file picker


### PR DESCRIPTION
### Motivation
- Reduce type duplication and eliminate unsafe casts when handing parsed import events to the preview component.
- Avoid redundant work by reusing normalized field data for initial value derivation in the external form.
- Tighten `AssetRequestForm` prop and payload types and harden null/undefined handling and date parsing to improve runtime safety.

### Description
- In `src/ui/ImportZone.tsx` removed the local `ImportedEvent` type and switched the parsed state and `onImport` to use `WorksCalendarEvent[] | null`, removing the `as` cast when rendering `ImportPreview`.
- In `src/ui/CalendarExternalForm.tsx` updated the `useMemo` that builds `mergedInitialValues` to reuse `normalizedFields` and changed the memo dependency to `[normalizedFields, initialValues]` to avoid double-normalization.
- In `src/ui/AssetRequestForm.tsx` added explicit types (`AssetOption`, nullable labels, `AssetRequestSubmitPayload`, and `AssetRequestFormProps`), switched fallback logic to nullish coalescing (`??`), replaced `||` label fallbacks with `??`, and hardened `fromLocalInput` with safe defaults for splitting/parsing.

### Testing
- Ran `npm run test -- src/ui/__tests__/AssetRequestForm.test.tsx src/ui/__tests__/CalendarExternalForm.test.tsx` and all tests passed (2 files, 14 tests passed).
- Ran `npm run type-check:strict-null` and the strict-null typecheck passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9f2550164832c93ee3f4aec34ab56)