### PR TITLE
[codex] Tighten strict-null focus trap ratchet

### DIFF
--- a/scripts/strict-null-baseline.json
+++ b/scripts/strict-null-baseline.json
@@ -1,5 +1,5 @@
 {
-  "baselineTotal": 386,
-  "recordedAt": "2026-04-22",
-  "source": "docs/stage-7-strict-null-checks-audit.md root strictNullChecks flip trial"
+  "baselineTotal": 324,
+  "recordedAt": "2026-04-23",
+  "source": "strict-null focus-trap ratchet sprint"
 }

--- a/scripts/typecheck-strict-null.mjs
+++ b/scripts/typecheck-strict-null.mjs
@@ -20,15 +20,29 @@ const STRICT_NULL_ERROR_CODES = new Set([
 const MIGRATED_PATHS = [
   'src/grouping/groupRows.ts',
   'src/grouping/__tests__/groupRows.test.ts',
+  'src/hooks/useFocusTrap.ts',
+  'src/hooks/__tests__/useFocusTrap.test.tsx',
 ];
 
 const BASELINE_PATH = path.resolve(process.cwd(), 'scripts/strict-null-baseline.json');
 
+const tscBin = path.resolve(process.cwd(), 'node_modules/typescript/bin/tsc');
+
+if (!fs.existsSync(tscBin)) {
+  console.error('❌ Local TypeScript compiler not found. Run npm install before strict-null checking.');
+  process.exit(1);
+}
+
 const tscResult = spawnSync(
-  'npx',
-  ['tsc', '--noEmit', '--pretty', 'false', '--strictNullChecks', 'true'],
+  process.execPath,
+  [tscBin, '--noEmit', '--pretty', 'false', '--strictNullChecks', 'true'],
   { encoding: 'utf8' },
 );
+
+if (tscResult.error) {
+  console.error(`❌ Failed to run TypeScript compiler: ${tscResult.error.message}`);
+  process.exit(1);
+}
 
 const output = `${tscResult.stdout ?? ''}${tscResult.stderr ?? ''}`;
 const repoRoot = process.cwd();
@@ -51,6 +65,14 @@ const diagnostics = output
     };
   })
   .filter((entry) => entry !== null);
+
+if (tscResult.status !== 0 && diagnostics.length === 0) {
+  console.error('❌ TypeScript compiler failed without parseable diagnostics.');
+  if (output.trim()) {
+    console.error(output.trim());
+  }
+  process.exit(1);
+}
 
 // === GLOBAL COUNTER RATchet ===
 const strictNullDiagnostics = diagnostics.filter((entry) =>

--- a/src/hooks/useFocusTrap.ts
+++ b/src/hooks/useFocusTrap.ts
@@ -37,8 +37,8 @@ function canFocus(value: Element | null): value is HTMLElement {
 export function useFocusTrap<T extends HTMLElement = HTMLElement>(
   onEscape?: (() => void) | null,
   active = true,
-): RefObject<T | null> {
-  const containerRef = useRef<T | null>(null);
+): RefObject<T> {
+  const containerRef = useRef<T>(null);
   const onEscapeRef = useRef<(() => void) | null | undefined>(onEscape);
 
   useEffect(() => {
@@ -48,18 +48,19 @@ export function useFocusTrap<T extends HTMLElement = HTMLElement>(
   useEffect(() => {
     if (!active) return;
 
-    const el = containerRef.current;
-    if (!el) return;
+    const container = containerRef.current;
+    if (!container) return;
+    const activeContainer: T = container;
 
     const previouslyFocused = document.activeElement;
 
-    if (!el.contains(document.activeElement)) {
-      const first = getFocusableElements(el)[0];
+    if (!activeContainer.contains(document.activeElement)) {
+      const first = getFocusableElements(activeContainer)[0];
       first?.focus();
     }
 
     function handleKeyDown(e: KeyboardEvent): void {
-      if (!el.contains(document.activeElement)) return;
+      if (!activeContainer.contains(document.activeElement)) return;
 
       if (e.key === 'Escape') {
         e.preventDefault();
@@ -70,7 +71,7 @@ export function useFocusTrap<T extends HTMLElement = HTMLElement>(
 
       if (e.key !== 'Tab') return;
 
-      const focusables = getFocusableElements(el);
+      const focusables = getFocusableElements(activeContainer);
       const first = focusables[0];
       const last = focusables.at(-1);
 


### PR DESCRIPTION
﻿## Summary
- make the strict-null ratchet invoke the local TypeScript compiler through Node instead of `npx`, so Windows automation shells report real diagnostics
- add `useFocusTrap` and its test to the migrated strict-null path set
- adjust the focus-trap ref typing/captured element binding and tighten the strict-null baseline to 324

## Verification
- `npm run type-check:strict-null`
- `npm test -- --run src/hooks/__tests__/useFocusTrap.test.tsx`
- `npm run build`
- `npm run build:demo`
- `TZ=UTC npm test -- --run src/core/__tests__/csvParser.test.ts src/core/__tests__/layout.test.ts src/ui/__tests__/a11y.test.tsx`
- `TZ=UTC npm test -- --run src/core/__tests__/conflictEngine.test.ts src/__tests__/WorksCalendar.scheduleModel.integration.test.tsx`
- `TZ=UTC npm test -- --run src/__tests__/WorksCalendar.employees.sync.test.tsx`

## Notes
- Default local `npm test` under America/Denver failed in unrelated timezone-sensitive date tests and slow schedule/employee tests; the same failing files passed when rerun under `TZ=UTC`, except the full UTC suite had one suite-level timeout that passed in file isolation.
