### PR TITLE
Stage 7 Sprint 2: PR1–PR3 strict-null fixes for ICSFeedPanel, SourcePanel, and forms

### DIFF
--- a/src/ui/AvailabilityForm.tsx
+++ b/src/ui/AvailabilityForm.tsx
@@ -128,6 +128,14 @@ export default function AvailabilityForm({ emp, kind: initialKind, initialStart,
 
     const s = fromInput(start, allDay);
     const en = fromInput(end, allDay);
+    if (!s || !en) {
+      setErrors((prev) => ({
+        ...prev,
+        start: prev.start ?? `Enter a valid ${allDay ? 'start date' : 'start date/time'}`,
+        end: prev.end ?? `Enter a valid ${allDay ? 'end date' : 'end date/time'}`,
+      }));
+      return;
+    }
 
     onSave({
       id:         initialEvent?.id ?? createId('avail'),

--- a/src/ui/CalendarExternalForm.tsx
+++ b/src/ui/CalendarExternalForm.tsx
@@ -78,6 +78,17 @@ function normalizeFields(fields: ExternalFormField[]): ExternalFormField[] {
   });
 }
 
+
+function normalizeInitialValues(values: ExternalFormValues, fields: ExternalFormField[]): ExternalFormValues {
+  const normalized: ExternalFormValues = { ...values };
+  fields.forEach((field) => {
+    if (normalized[field.name] === undefined) {
+      normalized[field.name] = field.type === 'checkbox' ? false : '';
+    }
+  });
+  return normalized;
+}
+
 function ensureAdapter(adapter: unknown): ExternalFormAdapter {
   if (!adapter || typeof (adapter as { submitEvent?: unknown }).submitEvent !== 'function') {
     throw new Error('CalendarExternalForm adapter must define submitEvent(payload, context).');
@@ -146,12 +157,12 @@ export default function CalendarExternalForm({
   const normalizedFields = normalizeFields(fields);
 
   const mergedInitialValues = useMemo(() => {
-    const fromFields = normalizeFields(fields).reduce<ExternalFormValues>((acc, field) => {
+    const fromFields = normalizedFields.reduce<ExternalFormValues>((acc, field) => {
       acc[field.name] = field.type === 'checkbox' ? false : '';
       return acc;
     }, {});
-    return { ...fromFields, ...initialValues };
-  }, [fields, initialValues]);
+    return normalizeInitialValues({ ...fromFields, ...initialValues }, normalizedFields);
+  }, [initialValues, normalizedFields]);
 
   const [values, setValues] = useState(mergedInitialValues);
   const [errors, setErrors] = useState<Record<string, string>>({});

--- a/src/ui/ICSFeedPanel.tsx
+++ b/src/ui/ICSFeedPanel.tsx
@@ -73,7 +73,7 @@ function isFeedEnabled(feed: StoredFeed): boolean {
 function isValidationFailure(
   validation: FeedValidationState
 ): validation is { ok: false; error: string; corsLikely: boolean; count?: undefined } {
-  return Boolean(validation) && validation.ok === false;
+  return validation != null && validation.ok === false;
 }
 
 function colorDot(color: string, size = 10) {

--- a/src/ui/SourcePanel.tsx
+++ b/src/ui/SourcePanel.tsx
@@ -59,6 +59,23 @@ type FeedErrorEntry = {
   err?: unknown;
 };
 
+
+type FeedValidationState = {
+  ok: true;
+  count: number;
+} | {
+  ok: false;
+  error: string;
+  corsLikely: boolean;
+  count?: undefined;
+} | null;
+
+function isValidationFailure(
+  validation: FeedValidationState,
+): validation is { ok: false; error: string; corsLikely: boolean; count?: undefined } {
+  return validation != null && validation.ok === false;
+}
+
 type SourceHandlers = {
   onToggle: (id: string) => void;
   onRemove: (id: string) => void;
@@ -302,7 +319,7 @@ function AddFeedForm({ onAdd }: { onAdd: (source: Partial<CalendarSource>) => vo
   const [color,           setColor]           = useState(PRESET_COLORS[0]);
   const [refreshInterval, setRefreshInterval] = useState<number | null>(300_000);
   const [validating,      setValidating]      = useState(false);
-  const [validation,      setValidation]      = useState<{ ok: boolean; count?: number; error?: string; corsLikely?: boolean } | null>(null);
+  const [validation,      setValidation]      = useState<FeedValidationState>(null);
 
   function reset() {
     setUrl(''); setLabel(''); setColor(PRESET_COLORS[0]);
@@ -403,9 +420,11 @@ function AddFeedForm({ onAdd }: { onAdd: (source: Partial<CalendarSource>) => vo
           <span>
             {validation.ok
               ? `Found ${validation.count} event${validation.count === 1 ? '' : 's'} — feed looks good.`
-              : validation.corsLikely
+              : isValidationFailure(validation) && validation.corsLikely
                 ? `Could not verify from browser (${validation.error}). This may be a CORS restriction — you can still add the feed and it may work.`
-                : `Error: ${validation.error}`}
+                : isValidationFailure(validation)
+                  ? `Error: ${validation.error}`
+                  : 'Unable to validate feed.'}
           </span>
         </div>
       )}
@@ -533,10 +552,13 @@ export default function SourcePanel({ sources, feedErrors, onAdd, onRemove, onTo
   const csvSources = normalizedSources.filter((s: CalendarSource) => s.type === 'csv');
 
   const errorByUrl = Object.fromEntries(
-    (feedErrors ?? []).map((entry) => {
-      const value = entry as FeedErrorEntry;
-      return [value.feed?.url ?? '', value.err];
-    }),
+    (feedErrors ?? [])
+      .map((entry) => {
+        const value = entry as FeedErrorEntry;
+        const url = value.feed?.url ?? '';
+        return [url, value.err] as const;
+      })
+      .filter((entry): entry is readonly [string, unknown] => entry[0] !== ''),
   );
 
   const icsErrors = icsSources.filter((s: CalendarSource) => {


### PR DESCRIPTION
### Motivation
- Reduce `strictNullChecks` diagnostics for Sprint 2 by targeting three low-risk UI/form seams (`ICSFeedPanel`, `SourcePanel`, and form normalization) so future view/root work has less cascade pressure.
- Make validation and initial-value handling explicit at component boundaries to avoid nullable state flowing into rendering or saved payloads.

### Description
- `ICSFeedPanel`: tightened the nullable check in `isValidationFailure` to `validation != null` so `validation.ok` is only accessed when non-null and rendering paths are safe (`src/ui/ICSFeedPanel.tsx`).
- `SourcePanel`: added a discriminated `FeedValidationState` union and `isValidationFailure` type guard, typed the `validation` state accordingly, guarded error-path rendering, and normalized `feedErrors` into `errorByUrl` while filtering empty URL keys (`src/ui/SourcePanel.tsx`).
- Forms: in `AvailabilityForm` added a runtime non-null guard before building the submit payload so `start`/`end` cannot be null after validation, and in `CalendarExternalForm` added `normalizeInitialValues` and used `normalizedFields` to ensure undefined initial values are normalized to `''`/`false` before calling hooks (`src/ui/AvailabilityForm.tsx`, `src/ui/CalendarExternalForm.tsx`).

### Testing
- Ran the sprint typecheck script `npm run -s type-check:strict-null` which reports the strict-null diagnostics count and enforces the migrated-path ratchet, and it passed with diagnostics reduced from **324** to **323** and the ratchet succeeded.
- Ran a full strict TypeScript check (`node node_modules/typescript/bin/tsc --noEmit --strictNullChecks true`) to snapshot remaining failures, which produced a broader set of errors and a top-of-tree failure summary (highest counts: `src/WorksCalendar.tsx`: 77, `src/views/TimelineView.tsx`: 58, `src/views/WeekView.tsx`: 25), confirming remaining work is concentrated in root/views and out of scope for PR1–PR3.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea4da952e8832c97cb7f2d4514a88f)