### PR TITLE
test: finish Stage 7 strict-null PR4–PR6 cleanup batches

### DIFF
--- a/scripts/typecheck-strict-null.mjs
+++ b/scripts/typecheck-strict-null.mjs
@@ -22,6 +22,11 @@ const MIGRATED_PATHS = [
   'src/grouping/__tests__/groupRows.test.ts',
   'src/hooks/useFocusTrap.ts',
   'src/hooks/__tests__/useFocusTrap.test.tsx',
+  'src/__tests__/WorksCalendar.employees.sync.test.tsx',
+  'src/__tests__/WorksCalendar.recurringScopedEdit.test.tsx',
+  'src/__tests__/groupingFilteringSorting.integration.test.ts',
+  'src/__tests__/phaseB.integration.test.tsx',
+  'src/api/v1/__tests__/sync.test.ts',
 ];
 
 const BASELINE_PATH = path.resolve(process.cwd(), 'scripts/strict-null-baseline.json');

--- a/src/__tests__/WorksCalendar.employees.sync.test.tsx
+++ b/src/__tests__/WorksCalendar.employees.sync.test.tsx
@@ -54,7 +54,9 @@ describe('WorksCalendar employees ↔ TeamTab bidirectional sync (issue #101)', 
 
     // Owner config was patched with the new member as well.
     await waitFor(() => expect(onConfigSave).toHaveBeenCalled());
-    const lastConfig = onConfigSave.mock.calls.at(-1)[0];
+    const lastCall = onConfigSave.mock.calls.at(-1);
+    expect(lastCall).toBeDefined();
+    const [lastConfig] = lastCall!;
     expect(lastConfig.team?.members ?? []).toEqual(
       expect.arrayContaining([expect.objectContaining({ name: 'Dana Morgan' })]),
     );
@@ -83,7 +85,9 @@ describe('WorksCalendar employees ↔ TeamTab bidirectional sync (issue #101)', 
     fireEvent.keyDown(nameInput, { key: 'Enter' });
 
     await waitFor(() => expect(onEmployeeAdd).toHaveBeenCalled());
-    const lastConfig = onConfigSave.mock.calls.at(-1)[0];
+    const lastCall = onConfigSave.mock.calls.at(-1);
+    expect(lastCall).toBeDefined();
+    const [lastConfig] = lastCall!;
     const echoCount = (lastConfig.team?.members ?? []).filter((m: TeamMemberLike) => m.name === 'Echo').length;
     expect(echoCount).toBe(1);
   });

--- a/src/__tests__/WorksCalendar.recurringScopedEdit.test.tsx
+++ b/src/__tests__/WorksCalendar.recurringScopedEdit.test.tsx
@@ -74,9 +74,9 @@ afterEach(() => {
 function firstOccurrenceId(api: CalendarApi, masterId: string): string {
   const occ = api
     .getVisibleEvents()
-    .find((e: any) => (e as any)._eventId === masterId || e.id.startsWith(masterId));
+    .find((e: any) => (e as any)._eventId === masterId || String(e.id ?? '').startsWith(masterId));
   if (!occ) throw new Error('No expanded occurrence found for master ' + masterId);
-  return occ.id;
+  return String(occ.id);
 }
 
 describe('WorksCalendar recurring-event cluster (issues #149, #146, #150)', () => {

--- a/src/__tests__/groupingFilteringSorting.integration.test.ts
+++ b/src/__tests__/groupingFilteringSorting.integration.test.ts
@@ -42,6 +42,12 @@ function pipeline({ filters = {}, sort = [], groupBy = null }: any = {}) {
   return { filtered, sorted, tree };
 }
 
+function mustFindGroup(tree: any[], key: string) {
+  const group = tree.find((entry) => entry.key === key);
+  expect(group).toBeDefined();
+  return group!;
+}
+
 // ── Sort + group (no filter) ────────────────────────────────────────────────
 
 describe('integration — sort × group', () => {
@@ -51,9 +57,9 @@ describe('integration — sort × group', () => {
       groupBy: 'category',
     });
     // category groups sort alphabetically (maintenance, pr, training).
-    const maintenanceTitles = tree.find(g => g.key === 'maintenance').events.map(e => e.title);
+    const maintenanceTitles = mustFindGroup(tree, 'maintenance').events.map((e: any) => e.title);
     expect(maintenanceTitles).toEqual(['Bravo Flight', 'Foxtrot Flight']);
-    const trainingTitles = tree.find(g => g.key === 'training').events.map(e => e.title);
+    const trainingTitles = mustFindGroup(tree, 'training').events.map((e: any) => e.title);
     expect(trainingTitles).toEqual(['Alpha Flight', 'Charlie Flight', 'Echo Flight']);
   });
 
@@ -62,7 +68,7 @@ describe('integration — sort × group', () => {
       sort: [{ field: 'title', direction: 'desc' }],
       groupBy: 'category',
     });
-    const trainingTitles = tree.find(g => g.key === 'training').events.map(e => e.title);
+    const trainingTitles = mustFindGroup(tree, 'training').events.map((e: any) => e.title);
     expect(trainingTitles).toEqual(['Echo Flight', 'Charlie Flight', 'Alpha Flight']);
   });
 
@@ -75,7 +81,7 @@ describe('integration — sort × group', () => {
       ],
       groupBy: 'category',
     });
-    const training = tree.find(g => g.key === 'training').events.map(e => ({
+    const training = mustFindGroup(tree, 'training').events.map((e: any) => ({
       title: e.title, priority: e.meta.priority,
     }));
     expect(training).toEqual([
@@ -91,10 +97,10 @@ describe('integration — sort × group', () => {
       groupBy: ['region', 'category'],
     });
     // East → training: [Alpha only]; East → pr: [Delta]; East → maintenance: [Foxtrot].
-    const east = tree.find(g => g.key === 'East');
-    expect(east.children.map(c => c.key)).toEqual(['maintenance', 'pr', 'training']);
-    expect(east.children.find(c => c.key === 'training').events.map(e => e.id)).toEqual(['e2']);
-    expect(east.children.find(c => c.key === 'maintenance').events.map(e => e.id)).toEqual(['e6']);
+    const east = mustFindGroup(tree, 'East');
+    expect(east.children.map((c: any) => c.key)).toEqual(['maintenance', 'pr', 'training']);
+    expect(mustFindGroup(east.children, 'training').events.map((e: any) => e.id)).toEqual(['e2']);
+    expect(mustFindGroup(east.children, 'maintenance').events.map((e: any) => e.id)).toEqual(['e6']);
   });
 });
 
@@ -172,10 +178,10 @@ describe('integration — filter × group', () => {
       filters: { categories: ['training'] },
       groupBy: ['region', 'category'],
     });
-    const east = tree.find(g => g.key === 'East');
-    const west = tree.find(g => g.key === 'West');
-    expect(east.children.map(c => c.key)).toEqual(['training']);
-    expect(west.children.map(c => c.key)).toEqual(['training']);
+    const east = mustFindGroup(tree, 'East');
+    const west = mustFindGroup(tree, 'West');
+    expect(east.children.map((c: any) => c.key)).toEqual(['training']);
+    expect(west.children.map((c: any) => c.key)).toEqual(['training']);
   });
 });
 
@@ -189,10 +195,10 @@ describe('integration — filter × sort × group', () => {
       groupBy: 'region',
     });
     // Only training events survive; sorted by start desc; grouped by region.
-    const east = tree.find(g => g.key === 'East');
-    const west = tree.find(g => g.key === 'West');
-    expect(east.events.map(e => e.id)).toEqual(['e2']); // Alpha only
-    expect(west.events.map(e => e.id)).toEqual(['e5', 'e1']); // Echo, Charlie (desc)
+    const east = mustFindGroup(tree, 'East');
+    const west = mustFindGroup(tree, 'West');
+    expect(east.events.map((e: any) => e.id)).toEqual(['e2']); // Alpha only
+    expect(west.events.map((e: any) => e.id)).toEqual(['e5', 'e1']); // Echo, Charlie (desc)
   });
 
   it('group order is alphabetical regardless of event sort direction', () => {

--- a/src/__tests__/phaseB.integration.test.tsx
+++ b/src/__tests__/phaseB.integration.test.tsx
@@ -158,7 +158,7 @@ function Pipeline({ config, initialEvents = [seededEvent], onCommit }: { config:
         <div data-testid="committed-pill">
           <span>{committed.title}</span>
           <ApprovalActionMenu
-            stage={committed.meta.approvalStage.stage}
+            stage={committed.meta?.approvalStage?.stage ?? 'requested'}
             approvalsConfig={config.approvals}
             onAction={vi.fn()}
             variant="inline"

--- a/src/api/v1/__tests__/sync.test.ts
+++ b/src/api/v1/__tests__/sync.test.ts
@@ -276,20 +276,22 @@ describe('SyncManager', () => {
     // Immediately (before adapter resolves), optimistic event is in map
     const tempIds = [...manager.events.keys()];
     expect(tempIds.length).toBe(1);
-    expect(manager.events.get(tempIds[0])?.title).toBe('New Event');
+    const firstTempId = tempIds[0];
+    expect(firstTempId).toBeDefined();
+    expect(manager.events.get(firstTempId!)?.title).toBe('New Event');
 
     await promise;
   });
 
   it('createEvent replaces temp id with server id', async () => {
-    vi.mocked(adapter.createEvent).mockResolvedValue({ ...ev(), id: 'server-1', title: 'Meeting' });
+    vi.mocked(adapter.createEvent!).mockResolvedValue({ ...ev(), id: 'server-1', title: 'Meeting' });
     await manager.createEvent(ev({ id: undefined }));
     await Promise.resolve(); // flush microtasks
     expect(manager.events.has('server-1')).toBe(true);
   });
 
   it('createEvent marks status synced after success', async () => {
-    vi.mocked(adapter.createEvent).mockResolvedValue({ ...ev(), id: 'server-1' });
+    vi.mocked(adapter.createEvent!).mockResolvedValue({ ...ev(), id: 'server-1' });
     await manager.createEvent(ev({ id: undefined }));
     await Promise.resolve();
     expect(manager.queue.isSyncing).toBe(false);
@@ -324,7 +326,7 @@ describe('SyncManager', () => {
 
   it('updateEvent merges server response into local map', async () => {
     vi.mocked(adapter.loadRange).mockResolvedValue([ev()]);
-    vi.mocked(adapter.updateEvent).mockResolvedValue(ev({ title: 'Server Title' }));
+    vi.mocked(adapter.updateEvent!).mockResolvedValue(ev({ title: 'Server Title' }));
     await manager.loadRange(S, E);
     await manager.updateEvent('ev-1', { title: 'Local Title' });
     await Promise.resolve();
@@ -351,7 +353,7 @@ describe('SyncManager', () => {
 
   it('deleteEvent rollbacks on adapter error', async () => {
     vi.mocked(adapter.loadRange).mockResolvedValue([ev()]);
-    vi.mocked(adapter.deleteEvent).mockRejectedValue(new Error('server error'));
+    vi.mocked(adapter.deleteEvent!).mockRejectedValue(new Error('server error'));
     await manager.loadRange(S, E);
     await manager.deleteEvent('ev-1');
     await Promise.resolve();
@@ -392,7 +394,7 @@ describe('SyncManager', () => {
   it('onError is called after max retries exceeded', async () => {
     const onError = vi.fn();
     vi.mocked(adapter.loadRange).mockResolvedValue([ev()]);
-    vi.mocked(adapter.updateEvent).mockRejectedValue(new Error('network'));
+    vi.mocked(adapter.updateEvent!).mockRejectedValue(new Error('network'));
     const m = new SyncManager({ adapter, maxRetries: 0, onError });
 
     await m.loadRange(S, E);
@@ -407,7 +409,7 @@ describe('SyncManager', () => {
 
   it('clearErrors removes error operations from queue', async () => {
     vi.mocked(adapter.loadRange).mockResolvedValue([ev()]);
-    vi.mocked(adapter.updateEvent).mockRejectedValue(new Error('fail'));
+    vi.mocked(adapter.updateEvent!).mockRejectedValue(new Error('fail'));
     const m = new SyncManager({ adapter, maxRetries: 0 });
 
     await m.loadRange(S, E);
@@ -426,7 +428,7 @@ describe('SyncManager', () => {
     const serverEv = ev({ title: 'Server', sync: { externalId: 'x', syncSource: 's', version: 2 } });
 
     vi.mocked(adapter.loadRange).mockResolvedValue([localEv]);
-    vi.mocked(adapter.updateEvent).mockResolvedValue(serverEv);
+    vi.mocked(adapter.updateEvent!).mockResolvedValue(serverEv);
 
     const m = new SyncManager({ adapter, conflictResolution: 'server-wins' });
     await m.loadRange(S, E);
@@ -441,7 +443,7 @@ describe('SyncManager', () => {
     const serverEv = ev({ title: 'Server', sync: { externalId: 'x', syncSource: 's', version: 2 } });
 
     vi.mocked(adapter.loadRange).mockResolvedValue([localEv]);
-    vi.mocked(adapter.updateEvent).mockResolvedValue(serverEv);
+    vi.mocked(adapter.updateEvent!).mockResolvedValue(serverEv);
 
     const m = new SyncManager({ adapter, conflictResolution: 'client-wins' });
     await m.loadRange(S, E);
@@ -458,7 +460,7 @@ describe('SyncManager', () => {
     const merged   = ev({ title: 'Merged' });
 
     vi.mocked(adapter.loadRange).mockResolvedValue([localEv]);
-    vi.mocked(adapter.updateEvent).mockResolvedValue(serverEv);
+    vi.mocked(adapter.updateEvent!).mockResolvedValue(serverEv);
 
     const onConflict = vi.fn().mockResolvedValue(merged);
     const m = new SyncManager({ adapter, conflictResolution: 'manual', onConflict });
@@ -487,7 +489,7 @@ describe('SyncManager', () => {
 
   it('connectLive merges insert change into events', () => {
     let pushChange: ((c: import('../adapters/CalendarAdapter.js').AdapterChange) => void) | null = null;
-    vi.mocked(adapter.subscribe).mockImplementation((cb) => {
+    vi.mocked(adapter.subscribe!).mockImplementation((cb) => {
       pushChange = cb;
       return () => {};
     });
@@ -500,7 +502,7 @@ describe('SyncManager', () => {
 
   it('connectLive handles reload change', () => {
     let pushChange: ((c: import('../adapters/CalendarAdapter.js').AdapterChange) => void) | null = null;
-    vi.mocked(adapter.subscribe).mockImplementation((cb) => {
+    vi.mocked(adapter.subscribe!).mockImplementation((cb) => {
       pushChange = cb;
       return () => {};
     });
@@ -516,7 +518,7 @@ describe('SyncManager', () => {
     await manager.loadRange(S, E);
 
     let pushChange: ((c: import('../adapters/CalendarAdapter.js').AdapterChange) => void) | null = null;
-    vi.mocked(adapter.subscribe).mockImplementation((cb) => {
+    vi.mocked(adapter.subscribe!).mockImplementation((cb) => {
       pushChange = cb;
       return () => {};
     });


### PR DESCRIPTION
### Motivation

- Finish the Stage 7 sprint work for PR4–PR6 by removing strict-null violations in targeted test seams to reduce noise for subsequent view-level migrations. 
- Ensure the CI strict-null ratchet treats these cleaned tests as migrated paths so regressions in these files are blocked.

### Description

- Guarded unsafe dereferences of mock call results in `src/__tests__/WorksCalendar.employees.sync.test.tsx` by checking `mock.calls.at(-1)` before indexing. 
- Normalized recurring-occurrence id handling in `src/__tests__/WorksCalendar.recurringScopedEdit.test.tsx` to always return a `string` and avoid `string | undefined` dereference. 
- Added `mustFindGroup` test helper and replaced unsafe `.find(...)` usages in `src/__tests__/groupingFilteringSorting.integration.test.ts` to assert existence before use. 
- Added nullable-safe access for approval stage in `src/__tests__/phaseB.integration.test.tsx` and hardened optional adapter mocks/uses in `src/api/v1/__tests__/sync.test.ts` to avoid optional-method strict-null errors. 
- Updated `scripts/typecheck-strict-null.mjs` `MIGRATED_PATHS` to include the newly cleaned test files so the strict-null ratchet verifies them going forward.

### Testing

- Ran the strict-null ratchet with `npm run -s type-check:strict-null` which reduced strict-null diagnostics from 324 to 294 and reported the ratchet as passed for the migrated paths. 
- Ran the targeted test suites with `npx vitest run` for the modified files which completed successfully (5 files, 81 tests passed). 
- Ran a strict `tsc --noEmit --strictNullChecks` diagnostic pass to produce the global counts used above and verified the updated files have no remaining strict-null failures under the ratchet. 
- Remaining strict-null diagnostics after these changes are 294, with the largest hotspots still in `src/WorksCalendar.tsx`, `src/views/TimelineView.tsx`, `src/views/WeekView.tsx`, `src/views/DayView.tsx`, and `src/views/AssetsView.tsx`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea4fa1a508832c9a3afcab41308866)