### PR TITLE
docs: kick off Stage 7 PR Batch 3.1 and record hook strict-null snapshot

### DIFF
--- a/docs/stage7-strict-null-roadmap.md
+++ b/docs/stage7-strict-null-roadmap.md
@@ -87,11 +87,20 @@ Goals:
 ### PR Batch 3.1
 Files:
 - src/hooks/useFocusTrap.ts
-- src/hooks/useSomethingElse.ts
+- src/hooks/useEventDraftState.ts
 
 Goals:
 - Fix generic refs
 - Remove HTMLElement mismatches
+- Narrow nullable template defaults in draft state logic
+
+Start checklist (2026-04-23):
+- `src/hooks/useFocusTrap.ts`: 0 strict-null diagnostics
+- `src/hooks/useEventDraftState.ts`: 12 strict-null diagnostics (`TS18047`, `template.defaults` possibly null at lines 201–207)
+
+Validation commands for this batch:
+- `npm run -s type-check:strict-null`
+- `node_modules/.bin/tsc --noEmit --pretty false --strictNullChecks true 2>&1 | rg "^src/hooks/(useFocusTrap|useEventDraftState)\\.ts"`
 
 ### PR Batch 3.2
 Files:


### PR DESCRIPTION
### Motivation
- Replace a placeholder entry with the real hook target and capture a dated strict-null diagnostics snapshot to drive the small, targeted migration batch.

### Description
- Updated `docs/stage7-strict-null-roadmap.md` to replace `src/hooks/useSomethingElse.ts` with `src/hooks/useEventDraftState.ts`, added a goal to narrow nullable `template.defaults`, added a start checklist noting `useFocusTrap.ts: 0` and `useEventDraftState.ts: 12` `TS18047` diagnostics, and added explicit validation commands for the batch.

### Testing
- Executed `npm run -s type-check:strict-null` and a strict `tsc` invocation filtered to the two hook files; the global strict-null diagnostics were reported as 236 (baseline 324) and the strict-null ratchet passed, while `src/hooks/useEventDraftState.ts` produced 12 `TS18047` diagnostics (lines ~201–207).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea630764f8832caa57ad152c82973b)