### PR TITLE
Stage 7: strict-null fixes for UI batches 3.2/3.3

### DIFF
--- a/src/core/CalendarContext.ts
+++ b/src/core/CalendarContext.ts
@@ -5,7 +5,12 @@
 import { createContext, useContext } from 'react';
 import type { NormalizedEvent } from '../types/events';
 
-export const CalendarContext = createContext(null);
+type CalendarContextValue = {
+  renderEvent?: (...args: unknown[]) => unknown;
+  [key: string]: unknown;
+} | null;
+
+export const CalendarContext = createContext<CalendarContextValue>(null);
 
 export function useCalendarContext() {
   return useContext(CalendarContext);

--- a/src/core/CalendarContext.ts
+++ b/src/core/CalendarContext.ts
@@ -6,8 +6,8 @@ import { createContext, useContext } from 'react';
 import type { NormalizedEvent } from '../types/events';
 
 type CalendarContextValue = {
-  renderEvent?: (...args: unknown[]) => unknown;
-  [key: string]: unknown;
+  renderEvent?: (...args: any[]) => any;
+  [key: string]: any;
 } | null;
 
 export const CalendarContext = createContext<CalendarContextValue>(null);

--- a/src/ui/ConfigPanel.tsx
+++ b/src/ui/ConfigPanel.tsx
@@ -328,10 +328,10 @@ export default function ConfigPanel({
             <SourcePanel
               sources={sources ?? []}
               feedErrors={feedErrors ?? []}
-              onAdd={onAddSource}
-              onRemove={onRemoveSource}
-              onToggle={onToggleSource}
-              onUpdate={onUpdateSource}
+              onAdd={(source) => onAddSource?.(source)}
+              onRemove={(id) => onRemoveSource?.(id)}
+              onToggle={(id) => onToggleSource?.(id)}
+              onUpdate={(id, patch) => onUpdateSource?.(id, patch)}
             />
           )}
           {tab === 'templates'   && (

--- a/src/ui/RequestForm.tsx
+++ b/src/ui/RequestForm.tsx
@@ -54,7 +54,8 @@ function normalizeField(field: RequestFormFieldDraft, idx: number): RequestFormF
   const key = typeof field?.key === 'string' && field.key.trim()
     ? field.key.trim()
     : `field-${idx + 1}`;
-  const type = INPUT_TYPES.has(field?.type) ? field.type : 'text';
+  const draftType = field?.type;
+  const type: RequestFormFieldType = draftType && INPUT_TYPES.has(draftType) ? draftType : 'text';
   return {
     key,
     label:       typeof field?.label === 'string' ? field.label : key,

--- a/src/ui/ScheduleTemplateDialog.tsx
+++ b/src/ui/ScheduleTemplateDialog.tsx
@@ -207,7 +207,7 @@ export default function ScheduleTemplateDialog({
                     >
                       <div className={styles.previewSummary}>
                         <span>{ev.title ?? '(untitled)'}</span>
-                        <span>{toDatetimeLocal(ev.start)}</span>
+                        <span>{ev.start == null ? '' : toDatetimeLocal(ev.start)}</span>
                       </div>
                       {conflictsByIndex.has(idx) && (
                         <ul className={styles.conflictList}>

--- a/src/ui/__tests__/ConfigPanel.teamTab.test.tsx
+++ b/src/ui/__tests__/ConfigPanel.teamTab.test.tsx
@@ -113,6 +113,10 @@ describe('TeamTab bidirectional sync (issue #101)', () => {
     // The pending input is the newly-added one (empty value); filter it out.
     const inputs = screen.getAllByPlaceholderText('Employee name');
     const pending = inputs.find(el => (el as HTMLInputElement).value === '');
+    expect(pending).toBeDefined();
+    if (!pending) {
+      throw new Error('Expected a pending employee input to exist');
+    }
     fireEvent.change(pending, { target: { value: 'Nora' } });
     fireEvent.keyDown(pending, { key: 'Enter' });
     expect(getConfig().team.members.map((m: { id: number }) => m.id)).toEqual([5, 6]);

--- a/src/ui/__tests__/KeyboardHelpOverlay.test.tsx
+++ b/src/ui/__tests__/KeyboardHelpOverlay.test.tsx
@@ -8,6 +8,11 @@ import '@testing-library/jest-dom';
 
 import KeyboardHelpOverlay from '../KeyboardHelpOverlay';
 
+function requireElement<T>(value: T | null, message: string): T {
+  if (value == null) throw new Error(message);
+  return value;
+}
+
 describe('KeyboardHelpOverlay', () => {
   it('renders an aria-modal dialog labelled "Keyboard shortcuts"', () => {
     render(<KeyboardHelpOverlay onClose={vi.fn()} />);
@@ -25,7 +30,7 @@ describe('KeyboardHelpOverlay', () => {
   it('Escape calls onClose', () => {
     const onClose = vi.fn();
     render(<KeyboardHelpOverlay onClose={onClose} />);
-    fireEvent.keyDown(document.activeElement, { key: 'Escape' });
+    fireEvent.keyDown(requireElement(document.activeElement, 'Expected active element'), { key: 'Escape' });
     expect(onClose).toHaveBeenCalledOnce();
   });
 

--- a/src/ui/__tests__/OwnerLoginModal.test.tsx
+++ b/src/ui/__tests__/OwnerLoginModal.test.tsx
@@ -12,6 +12,11 @@ import '@testing-library/jest-dom';
 
 import OwnerLoginModal from '../OwnerLoginModal';
 
+function requireElement<T>(value: T | null, message: string): T {
+  if (value == null) throw new Error(message);
+  return value;
+}
+
 function mount(props = {}) {
   return render(
     <OwnerLoginModal
@@ -40,7 +45,7 @@ describe('OwnerLoginModal', () => {
   it('Escape calls onClose', () => {
     const onClose = vi.fn();
     mount({ onClose });
-    fireEvent.keyDown(document.activeElement, { key: 'Escape' });
+    fireEvent.keyDown(requireElement(document.activeElement, 'Expected active element'), { key: 'Escape' });
     expect(onClose).toHaveBeenCalledOnce();
   });
 
@@ -78,7 +83,7 @@ describe('OwnerLoginModal', () => {
     mount();
     const dialog = screen.getByRole('dialog', { name: 'Owner settings' });
     for (let i = 0; i < 10; i++) {
-      fireEvent.keyDown(document.activeElement, { key: 'Tab' });
+      fireEvent.keyDown(requireElement(document.activeElement, 'Expected active element'), { key: 'Tab' });
       expect(dialog.contains(document.activeElement)).toBe(true);
     }
   });

--- a/src/ui/__tests__/ThemeCustomizer.test.tsx
+++ b/src/ui/__tests__/ThemeCustomizer.test.tsx
@@ -6,6 +6,12 @@ import { render, fireEvent, screen, cleanup } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import ThemeCustomizer from '../ThemeCustomizer';
 
+function getLatestConfig(setConfig: ReturnType<typeof vi.fn>) {
+  const latestCall = setConfig.mock.calls.at(-1);
+  if (!latestCall) throw new Error('Expected ThemeCustomizer to emit an onChange update');
+  return latestCall[0];
+}
+
 function renderWithConfig(customTheme = {}) {
   const setConfig = vi.fn();
 
@@ -29,7 +35,7 @@ describe('ThemeCustomizer', () => {
     const accent = screen.getByLabelText('Accent');
     fireEvent.change(accent, { target: { value: '#111111' } });
 
-    const latest = setConfig.mock.calls.at(-1)[0];
+    const latest = getLatestConfig(setConfig);
     expect(latest.customTheme.colors.accent).toBe('#111111');
   });
 
@@ -39,7 +45,7 @@ describe('ThemeCustomizer', () => {
     const density = screen.getByLabelText(/Density/);
     fireEvent.change(density, { target: { value: '1.15' } });
 
-    const latest = setConfig.mock.calls.at(-1)[0];
+    const latest = getLatestConfig(setConfig);
     expect(latest.customTheme.spacing.density).toBe(1.15);
   });
 
@@ -50,7 +56,7 @@ describe('ThemeCustomizer', () => {
       target: { value: "'Roboto', 'Helvetica Neue', Arial, sans-serif" },
     });
 
-    const latest = setConfig.mock.calls.at(-1)[0];
+    const latest = getLatestConfig(setConfig);
     expect(latest.customTheme.typography.fontFamily).toBe("'Roboto', 'Helvetica Neue', Arial, sans-serif");
   });
 
@@ -62,7 +68,7 @@ describe('ThemeCustomizer', () => {
       target: { value: "Georgia, 'Times New Roman', serif" },
     });
 
-    const headingLatest = heading.setConfig.mock.calls.at(-1)[0];
+    const headingLatest = getLatestConfig(heading.setConfig);
     expect(headingLatest.customTheme.typography.headingFontFamily).toBe("Georgia, 'Times New Roman', serif");
 
     cleanup();
@@ -72,7 +78,7 @@ describe('ThemeCustomizer', () => {
       target: { value: "'JetBrains Mono', 'Roboto Mono', 'Courier New', monospace" },
     });
 
-    const monoLatest = mono.setConfig.mock.calls.at(-1)[0];
+    const monoLatest = getLatestConfig(mono.setConfig);
     expect(monoLatest.customTheme.typography.monoFontFamily).toBe("'JetBrains Mono', 'Roboto Mono', 'Courier New', monospace");
   });
 
@@ -81,7 +87,7 @@ describe('ThemeCustomizer', () => {
 
     fireEvent.click(screen.getByRole('button', { name: 'Reset to default' }));
 
-    const latest = setConfig.mock.calls.at(-1)[0];
+    const latest = getLatestConfig(setConfig);
     expect(latest.customTheme).toEqual({});
   });
 
@@ -90,7 +96,7 @@ describe('ThemeCustomizer', () => {
 
     fireEvent.click(screen.getByRole('button', { name: 'Midnight' }));
 
-    const latest = setConfig.mock.calls.at(-1)[0];
+    const latest = getLatestConfig(setConfig);
     expect(latest.customTheme.colors.bg).toBe('#0b1020');
     expect(latest.customTheme.colors.accent).toBe('#8b5cf6');
   });
@@ -103,7 +109,7 @@ describe('ThemeCustomizer', () => {
     });
     fireEvent.click(screen.getByRole('button', { name: 'Apply imported JSON' }));
 
-    const latest = setConfig.mock.calls.at(-1)[0];
+    const latest = getLatestConfig(setConfig);
     expect(latest.customTheme.colors.accent).toBe('#0ea5e9');
     expect(screen.getByRole('status')).toHaveTextContent('Imported and merged');
   });
@@ -117,7 +123,7 @@ describe('ThemeCustomizer', () => {
     });
     fireEvent.click(screen.getByRole('button', { name: 'Apply imported JSON' }));
 
-    const latest = setConfig.mock.calls.at(-1)[0];
+    const latest = getLatestConfig(setConfig);
     expect(latest.customTheme).toEqual({ colors: { accent: '#0ea5e9' } });
     expect(screen.getByRole('status')).toHaveTextContent('Imported and replaced');
   });


### PR DESCRIPTION
### Motivation
- Reduce strict-null TypeScript errors in the UI surface (roadmap batches 3.2 and 3.3) without changing runtime behavior by adding narrowings and null guards. 
- Make optional callbacks and test-time DOM interactions explicit and safe so tests and strict-null checking pass.

### Description
- Tightened `RequestForm` field normalization so `type` is strongly typed (`RequestFormFieldType`) and cannot be implicitly `undefined`.
- Passed safe adapter wrappers for optional feed handlers from `ConfigPanel` into `SourcePanel` so handlers are typed and callable even when upstream props are optional.
- Guarded rendering in `ScheduleTemplateDialog` preview so `ev.start` is checked before calling `toDatetimeLocal` to avoid passing `undefined`/`null` into the helper.
- Typed `CalendarContext` as a nullable object-shaped value to allow typed provider values in components/tests.
- Hardened several UI tests by adding explicit null guards for `document.activeElement`, ensuring pending inputs exist before using them, and extracting the latest mock payload robustly in `ThemeCustomizer` tests.

### Testing
- Ran `npm run -s type-check:strict-null` and observed strict-null diagnostics drop from `236` to `211` and the strict-null ratchet passed.
- Ran `node_modules/.bin/tsc --noEmit --pretty false --strictNullChecks true` with an `rg` filter for UI files and `src/filters/conditionEngine.ts` and observed no remaining diagnostics for the targeted paths.
- All these automated type-check runs completed successfully with the expected reductions and no new strict-null regressions introduced.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea64eb3be8832ca543f9e6ffa6a9d4)