### PR TITLE
Stage 7 Sprint 3: harden core normalization, adapter boundaries, and context defaults

### DIFF
--- a/src/api/v1/adapters/SupabaseAdapter.ts
+++ b/src/api/v1/adapters/SupabaseAdapter.ts
@@ -172,7 +172,10 @@ export class SupabaseAdapter implements CalendarAdapter {
       };
 
     if (error) throw new Error(`SupabaseAdapter.createEvent: ${JSON.stringify(error)}`);
-    const row = Array.isArray(data) ? data[0] : data as Record<string, unknown>;
+    const row = Array.isArray(data) ? data[0] : data;
+    if (!row) {
+      throw new Error('SupabaseAdapter.createEvent: insert did not return a row');
+    }
     return this._fromRow(row);
   }
 

--- a/src/core/CalendarContext.ts
+++ b/src/core/CalendarContext.ts
@@ -5,15 +5,17 @@
 import { createContext, useContext } from 'react';
 import type { NormalizedEvent } from '../types/events';
 
-type CalendarContextValue = {
+export type CalendarContextValue = {
   renderEvent?: (...args: any[]) => any;
   [key: string]: any;
-} | null;
+};
 
-export const CalendarContext = createContext<CalendarContextValue>(null);
+const DEFAULT_CALENDAR_CONTEXT: CalendarContextValue = {};
 
-export function useCalendarContext() {
-  return useContext(CalendarContext);
+export const CalendarContext = createContext<CalendarContextValue | null>(null);
+
+export function useCalendarContext(): CalendarContextValue {
+  return useContext(CalendarContext) ?? DEFAULT_CALENDAR_CONTEXT;
 }
 
 /**

--- a/src/core/scheduleMutations.ts
+++ b/src/core/scheduleMutations.ts
@@ -15,27 +15,32 @@ type ShiftEventLike = {
   kind?: unknown;
 } | null | undefined;
 
+type ShiftEventRecord = Exclude<ShiftEventLike, null | undefined>;
+
 export function resolveEventId(ev: ShiftEventLike): string {
   return String(ev?._eventId ?? ev?.id ?? '');
 }
 
-export function findLinkedOpenShifts(events: ShiftEventLike[], shiftEvent: ShiftEventLike): ShiftEventLike[] {
+export function findLinkedOpenShifts(events: ShiftEventLike[], shiftEvent: ShiftEventLike): ShiftEventRecord[] {
   const shiftId = resolveEventId(shiftEvent);
   if (!shiftId) return [];
-  return events.filter((candidate) => {
+  return events.filter((candidate): candidate is ShiftEventRecord => {
+    if (!candidate) return false;
     if (!isOpenShiftEvent(candidate)) return false;
     const candidateId = resolveEventId(candidate);
-    const linkedById = shiftEvent?.meta?.openShiftId && candidateId === String(shiftEvent.meta.openShiftId);
+    const linkedById = Boolean(shiftEvent?.meta?.openShiftId)
+      && candidateId === String(shiftEvent?.meta?.openShiftId);
     const linkedBySource = String(candidate?.meta?.sourceShiftId ?? '') === shiftId;
     return linkedById || linkedBySource;
   });
 }
 
-export function findLinkedMirroredCoverage(events: ShiftEventLike[], shiftEvent: ShiftEventLike): ShiftEventLike[] {
+export function findLinkedMirroredCoverage(events: ShiftEventLike[], shiftEvent: ShiftEventLike): ShiftEventRecord[] {
   const shiftId = resolveEventId(shiftEvent);
   if (!shiftId) return [];
   return events.filter(
-    (candidate) => isCoveringEvent(candidate)
+    (candidate): candidate is ShiftEventRecord => Boolean(candidate)
+      && isCoveringEvent(candidate)
       && String(candidate?.meta?.sourceShiftId ?? '') === shiftId,
   );
 }
@@ -72,7 +77,13 @@ export function buildOpenShiftPatch(
   existingOpenShift: ShiftEventLike,
   shiftEvent: ShiftEventLike,
   reason: string,
-): Record<string, any> {
+): {
+  title: string;
+  start: Date;
+  end: Date;
+  resource: null;
+  meta: MutableMeta;
+} {
   const shiftId = resolveEventId(shiftEvent);
   return {
     title: `Open: ${shiftEvent?.title ?? 'Shift'}`,

--- a/src/core/scheduleOverlap.ts
+++ b/src/core/scheduleOverlap.ts
@@ -65,8 +65,8 @@ export function detectShiftConflicts({
   onCallCategory = 'on-call',
 }: {
   employeeId: string;
-  requestStart: Date;
-  requestEnd: Date;
+  requestStart: Date | null | undefined;
+  requestEnd: Date | null | undefined;
   allEvents: OverlapEventLike[];
   onCallCategory?: string;
 }): { conflictingEvents: OverlapEventLike[]; hasConflict: boolean } {


### PR DESCRIPTION
### Motivation
- Implement the first three Sprint 3 items from the strict-null plan to prevent nulls from leaking across core boundaries and reduce strict-null diagnostic noise. 
- Harden core helper contracts and adapter edges so downstream code can rely on normalized, non-null inputs. 
- Provide a safe, non-optional `useCalendarContext()` return to eliminate defensive optional-chaining in consumers.

### Description
- Broadened `detectShiftConflicts` input contract to accept `requestStart`/`requestEnd` as `Date | null | undefined` and normalize at the function boundary to avoid propagating nulls (`src/core/scheduleOverlap.ts`).
- Tightened `scheduleMutations` helper types by introducing `ShiftEventRecord`, adding type guards to `findLinkedOpenShifts`/`findLinkedMirroredCoverage`, and making `buildOpenShiftPatch` return an explicit shape instead of `any` (`src/core/scheduleMutations.ts`).
- Hardened the Supabase adapter to explicitly check `insert` results and throw if no row was returned instead of unsafely casting nullable responses (`src/api/v1/adapters/SupabaseAdapter.ts`).
- Exported `CalendarContextValue`, introduced a `DEFAULT_CALENDAR_CONTEXT`, changed the context provider type to `CalendarContextValue | null`, and made `useCalendarContext()` return a concrete `CalendarContextValue` (fallback to default) so callers no longer receive `null` (`src/core/CalendarContext.ts`).
- Minor defensive boolean normalization in linked-event logic to avoid nullable truthiness checks.

### Testing
- Ran unit tests for the changed helpers with `npx vitest run src/core/__tests__/scheduleMutations.test.ts src/core/__tests__/scheduleOverlap.test.ts`, with both test files passing (24 tests total) and no failures. 
- Ran the strict-null ratchet via `npm run -s type-check:strict-null`, which passed and showed strict-null diagnostics improved (global count reduced from 160 → 156) with no migrated-path regressions. 
- Additionally ran a full `tsc --noEmit --strictNullChecks` pass during iteration to validate type changes; remaining strict-null clusters are reported separately (largest remaining clusters are in `src/WorksCalendar.tsx`, `src/views/AssetsView.tsx`, and several view/hooks files).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea7f59c81c832c854db5a84dd1d46b)