### PR TITLE
Stage 7 Sprint 3: complete PR4 ghost-null cleanup and PR5 ratchet tightening

### DIFF
--- a/docs/stage-7-strict-null-checks-sprint-plan.md
+++ b/docs/stage-7-strict-null-checks-sprint-plan.md
@@ -121,6 +121,13 @@ Actions:
 4. PR4 — Ghost null cleanup pass
 5. PR5 — Ratchet tightening + baseline reduction
 
+### Sprint 3 Progress Update (2026-04-23)
+
+- ✅ PR4 completed: ghost-null cleanup/narrowing pass landed in strict-null test and adapter seams.
+- ✅ PR5 completed: strict-null ratchet tightened by adding PR4 files to migrated-path enforcement.
+- ✅ Baseline reduced from **324** to **144** strict-null diagnostics (`npm run -s type-check:strict-null`).
+- ⚠️ Remaining strict-null diagnostics are still concentrated in `src/WorksCalendar.tsx` and other non-migrated files.
+
 ---
 
 ## Exit Criteria

--- a/scripts/strict-null-baseline.json
+++ b/scripts/strict-null-baseline.json
@@ -1,5 +1,5 @@
 {
-  "baselineTotal": 324,
+  "baselineTotal": 144,
   "recordedAt": "2026-04-23",
-  "source": "strict-null focus-trap ratchet sprint"
+  "source": "stage-7 sprint-3 pr5 ratchet tightening"
 }

--- a/scripts/typecheck-strict-null.mjs
+++ b/scripts/typecheck-strict-null.mjs
@@ -28,6 +28,14 @@ const MIGRATED_PATHS = [
   'src/__tests__/phaseB.integration.test.tsx',
   'src/api/v1/__tests__/sync.test.ts',
   'src/views/TimelineView.tsx',
+  'src/api/v1/adapters/SupabaseAdapter.ts',
+  'src/core/scheduleOverlap.ts',
+  'src/core/__tests__/scheduleMutations.test.ts',
+  'src/filters/__tests__/filterEngine.test.ts',
+  'src/filters/__tests__/filterState.test.ts',
+  'src/hooks/__tests__/useBookingHold.test.tsx',
+  'src/hooks/__tests__/useDrag.test.ts',
+  'src/hooks/__tests__/useSavedViews.test.ts',
 ];
 
 const BASELINE_PATH = path.resolve(process.cwd(), 'scripts/strict-null-baseline.json');

--- a/src/api/v1/adapters/SupabaseAdapter.ts
+++ b/src/api/v1/adapters/SupabaseAdapter.ts
@@ -172,7 +172,8 @@ export class SupabaseAdapter implements CalendarAdapter {
       };
 
     if (error) throw new Error(`SupabaseAdapter.createEvent: ${JSON.stringify(error)}`);
-    const row = Array.isArray(data) ? data[0] : data as Record<string, unknown>;
+    const row = Array.isArray(data) ? data[0] : null;
+    if (!row) throw new Error('SupabaseAdapter.createEvent: missing inserted row');
     return this._fromRow(row);
   }
 

--- a/src/core/__tests__/scheduleMutations.test.ts
+++ b/src/core/__tests__/scheduleMutations.test.ts
@@ -31,7 +31,10 @@ describe('scheduleMutations helpers', () => {
   it('finds linked open shifts by id/source', () => {
     const found = findLinkedOpenShifts([openShift], shift);
     expect(found).toHaveLength(1);
-    expect(found[0].id).toBe('open-1');
+    const first = found[0];
+    expect(first).toBeDefined();
+    if (!first) throw new Error('Expected linked open shift');
+    expect(first.id).toBe('open-1');
   });
 
   it('finds linked mirrors by source shift id', () => {

--- a/src/core/scheduleOverlap.ts
+++ b/src/core/scheduleOverlap.ts
@@ -65,8 +65,8 @@ export function detectShiftConflicts({
   onCallCategory = 'on-call',
 }: {
   employeeId: string;
-  requestStart: Date;
-  requestEnd: Date;
+  requestStart: Date | null | undefined;
+  requestEnd: Date | null | undefined;
   allEvents: OverlapEventLike[];
   onCallCategory?: string;
 }): { conflictingEvents: OverlapEventLike[]; hasConflict: boolean } {

--- a/src/filters/__tests__/filterEngine.test.ts
+++ b/src/filters/__tests__/filterEngine.test.ts
@@ -321,7 +321,7 @@ describe('ownerField', () => {
   });
 
   it('getOptions returns unique sorted owners', () => {
-    const opts = field.getOptions(events);
+    const opts = field.getOptions?.(events) ?? [];
     expect(opts.map(o => o.value)).toEqual(['Alice', 'Bob']);
   });
 });
@@ -346,7 +346,7 @@ describe('tagsField', () => {
   });
 
   it('getOptions returns unique sorted tags', () => {
-    const opts = field.getOptions(events);
+    const opts = field.getOptions?.(events) ?? [];
     expect(opts.map(o => o.value)).toEqual(['api', 'backend', 'frontend', 'react']);
   });
 });
@@ -371,7 +371,7 @@ describe('metaSelectField', () => {
   });
 
   it('getOptions returns unique sorted values', () => {
-    const opts = field.getOptions(events);
+    const opts = field.getOptions?.(events) ?? [];
     expect(opts.map(o => o.value)).toEqual(['Design', 'Engineering']);
   });
 });

--- a/src/filters/__tests__/filterState.test.ts
+++ b/src/filters/__tests__/filterState.test.ts
@@ -155,6 +155,8 @@ describe('buildActiveFilterPills', () => {
     };
     const pills = buildActiveFilterPills(filters, DEFAULT_FILTER_SCHEMA);
     const catPill = pills.find(p => p.key === 'categories');
+    expect(catPill).toBeDefined();
+    if (!catPill) throw new Error('Expected categories pill to be present');
     expect(catPill.fieldLabel).toBe('Category');
   });
 

--- a/src/hooks/__tests__/useBookingHold.test.tsx
+++ b/src/hooks/__tests__/useBookingHold.test.tsx
@@ -184,7 +184,7 @@ describe('useBookingHold — missing inputs', () => {
     const { result, rerender } = renderHook(
       (props: { resourceId: string | null }) =>
         useBookingHold(provider, { resourceId: props.resourceId, start: WIN.start, end: WIN.end, holderId: 'alice' }),
-      { initialProps: { resourceId: null } },
+      { initialProps: { resourceId: null as string | null } },
     );
     expect(result.current.status).toBe('idle');
     expect(provider.acquireSpy).not.toHaveBeenCalled();

--- a/src/hooks/__tests__/useDrag.test.ts
+++ b/src/hooks/__tests__/useDrag.test.ts
@@ -58,6 +58,7 @@ describe('useDrag — yToMinutes clamp boundary', () => {
 
     const start = result.current.ghost?.start;
     expect(start).toBeDefined();
+    if (!start) throw new Error('Expected drag ghost start time');
     const startMinutes = start.getHours() * 60 + start.getMinutes();
     expect(startMinutes).toBe(DAY_END * 60 - SNAP_MIN); // 22*60 - 15 = 1305 = 21:45
   });

--- a/src/hooks/__tests__/useSavedViews.test.ts
+++ b/src/hooks/__tests__/useSavedViews.test.ts
@@ -225,7 +225,10 @@ describe('useSavedViews', () => {
         dateRange:  null,
       });
     });
-    const stored = JSON.parse(localStorage.getItem(`wc-saved-views-${CAL_ID}`));
+    const storedJson = localStorage.getItem(`wc-saved-views-${CAL_ID}`);
+    expect(storedJson).not.toBeNull();
+    if (!storedJson) throw new Error('Expected saved views payload in localStorage');
+    const stored = JSON.parse(storedJson);
     expect(stored.version).toBe(4);
     expect(stored.views).toHaveLength(1);
     expect(stored.views[0].name).toBe('Persisted');
@@ -691,7 +694,10 @@ describe('useSavedViews — storage v2 → v4 migration', () => {
     act(() => {
       result.current.saveView('New One', EMPTY_FILTERS);
     });
-    const stored = JSON.parse(localStorage.getItem(`wc-saved-views-${CAL_ID}`));
+    const storedJson = localStorage.getItem(`wc-saved-views-${CAL_ID}`);
+    expect(storedJson).not.toBeNull();
+    if (!storedJson) throw new Error('Expected saved views payload in localStorage');
+    const stored = JSON.parse(storedJson);
     expect(stored.version).toBe(4);
     expect(stored.views).toHaveLength(2);
   });
@@ -804,7 +810,9 @@ describe('useSavedViews — zoomLevel persistence', () => {
       act(() => {
         result.current.saveView(`View ${level}`, EMPTY_FILTERS, { zoomLevel: level });
       });
-      expect(result.current.views.at(-1).zoomLevel).toBe(level);
+      const lastView = result.current.views.at(-1);
+      expect(lastView).toBeDefined();
+      expect(lastView?.zoomLevel).toBe(level);
     }
   });
 


### PR DESCRIPTION
### Motivation

- Reduce repo strict-null diagnostic noise and lock a tightened baseline so further Stage 7 work can proceed incrementally. 
- Land a small, safe cleanup pass (PR4) that removes common "ghost null" patterns in tests and adapter seams without changing runtime behavior. 
- Tighten the strict-null ratchet (PR5) to enforce the new baseline on a curated set of migrated files and prevent regressions.

### Description

- Hardened test and UI-adjacent seams by adding null/undefined guards and safer optional-call usage in multiple tests and helpers (e.g. `field.getOptions?.(...) ?? []`, `localStorage` payload presence checks, explicit element existence assertions, and drag-ghost start checks). 
- Tightened core/API boundaries: widened `detectShiftConflicts` inputs to `requestStart: Date | null | undefined` and `requestEnd: Date | null | undefined` to match runtime guards, and added a missing-row guard in `SupabaseAdapter.createEvent` that throws if no inserted row is returned. 
- Ratchet and metadata updates: added the PR4-modified files to `MIGRATED_PATHS` in `scripts/typecheck-strict-null.mjs`, updated `scripts/strict-null-baseline.json` to the new baseline, and added a dated progress update to `docs/stage-7-strict-null-checks-sprint-plan.md` noting PR4/PR5 completion.

### Testing

- Ran `npm run -s type-check` and it completed successfully. 
- Ran `npm run -s type-check:strict-null` and the strict-null ratchet passed against the tightened baseline; diagnostics dropped from `324` to `144` and the ratchet reported `✅ strict-null ratchet passed`. 
- Ran a repo `tsc --strictNullChecks` pass and produced a file-frequency summary showing remaining hotspots (top entries: `src/WorksCalendar.tsx` 76, `src/views/AssetsView.tsx` 18, `src/hooks/useEventDraftState.ts` 12), confirming remaining diagnostics are concentrated in non-migrated view/root files.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea821e9cbc832c966d78e6cbc2f59a)