### PR TITLE
Strict-null: ghost-null cleanup, template narrowing, SupabaseAdapter safety, and baseline reduction to 148

### DIFF
--- a/docs/stage-7-strict-null-checks-sprint-plan.md
+++ b/docs/stage-7-strict-null-checks-sprint-plan.md
@@ -26,7 +26,7 @@ This created a lower-noise environment for deeper structural work.
 
 ## Sprint 3 — Core Boundary Hardening & Type Flow Control
 
-**Status:** READY
+**Status:** IN PROGRESS (PR4 + PR5 update recorded on 2026-04-23)
 
 ### Goal
 
@@ -120,6 +120,19 @@ Actions:
 3. PR3 — Context hardening
 4. PR4 — Ghost null cleanup pass
 5. PR5 — Ratchet tightening + baseline reduction
+
+### PR4 / PR5 Execution Notes (2026-04-23)
+
+- **PR4 (Ghost null cleanup):**
+  - Eliminated strict-null "ghost null" dereference noise in `useEventDraftState` by narrowing template defaults once and reusing the narrowed object.
+  - Hardened adapter create-path null handling in `SupabaseAdapter` by rejecting missing inserted rows explicitly.
+- **PR5 (Ratchet tightening + baseline reduction):**
+  - Added the above files to Stage 7 `MIGRATED_PATHS`.
+  - Reduced strict-null baseline from `324` to `148` based on latest run.
+  - Validation command: `npm run -s type-check:strict-null`.
+  - Current result: strict-null diagnostics total `148`, migrated paths clean.
+- **Ordering note:**
+  - This section records only PR4/PR5 outcomes and does not imply PR1–PR3 ordering or sprint closure.
 
 ---
 

--- a/scripts/strict-null-baseline.json
+++ b/scripts/strict-null-baseline.json
@@ -1,5 +1,5 @@
 {
-  "baselineTotal": 324,
+  "baselineTotal": 148,
   "recordedAt": "2026-04-23",
   "source": "strict-null focus-trap ratchet sprint"
 }

--- a/scripts/typecheck-strict-null.mjs
+++ b/scripts/typecheck-strict-null.mjs
@@ -21,11 +21,13 @@ const MIGRATED_PATHS = [
   'src/grouping/groupRows.ts',
   'src/grouping/__tests__/groupRows.test.ts',
   'src/hooks/useFocusTrap.ts',
+  'src/hooks/useEventDraftState.ts',
   'src/hooks/__tests__/useFocusTrap.test.tsx',
   'src/__tests__/WorksCalendar.employees.sync.test.tsx',
   'src/__tests__/WorksCalendar.recurringScopedEdit.test.tsx',
   'src/__tests__/groupingFilteringSorting.integration.test.ts',
   'src/__tests__/phaseB.integration.test.tsx',
+  'src/api/v1/adapters/SupabaseAdapter.ts',
   'src/api/v1/__tests__/sync.test.ts',
   'src/views/TimelineView.tsx',
 ];

--- a/src/api/v1/adapters/SupabaseAdapter.ts
+++ b/src/api/v1/adapters/SupabaseAdapter.ts
@@ -172,7 +172,8 @@ export class SupabaseAdapter implements CalendarAdapter {
       };
 
     if (error) throw new Error(`SupabaseAdapter.createEvent: ${JSON.stringify(error)}`);
-    const row = Array.isArray(data) ? data[0] : data as Record<string, unknown>;
+    const row = Array.isArray(data) ? data[0] : data;
+    if (!row) throw new Error('SupabaseAdapter.createEvent: missing inserted row');
     return this._fromRow(row);
   }
 

--- a/src/hooks/useEventDraftState.ts
+++ b/src/hooks/useEventDraftState.ts
@@ -188,6 +188,7 @@ export function useEventDraftState(event: EventDraftInput | null | undefined, ca
     setTemplateId(nextTemplateId);
     const template = getEventTemplateById(nextTemplateId);
     if (!template?.defaults) return;
+    const defaults = template.defaults;
     setValues((v) => {
       const startDate = fromDatetimeLocal(v.start);
       const next: DraftValues = {
@@ -198,21 +199,21 @@ export function useEventDraftState(event: EventDraftInput | null | undefined, ca
           templateVersion: template.version,
         },
       };
-      if (template.defaults.title) next.title = template.defaults.title;
-      if (template.defaults.category) next.category = template.defaults.category;
-      if (template.defaults.resource) next.resource = String(template.defaults.resource);
-      if (template.defaults.color) next.color = template.defaults.color;
-      if (typeof template.defaults.allDay === 'boolean') next.allDay = template.defaults.allDay;
-      if (startDate && Number.isFinite(template.defaults.durationMinutes)) {
-        const durationMinutes = template.defaults.durationMinutes ?? 0;
+      if (defaults.title) next.title = defaults.title;
+      if (defaults.category) next.category = defaults.category;
+      if (defaults.resource) next.resource = String(defaults.resource);
+      if (defaults.color) next.color = defaults.color;
+      if (typeof defaults.allDay === 'boolean') next.allDay = defaults.allDay;
+      if (startDate && Number.isFinite(defaults.durationMinutes)) {
+        const durationMinutes = defaults.durationMinutes ?? 0;
         const nextEnd = new Date(startDate.getTime() + durationMinutes * 60 * 1000);
         next.end = toDatetimeLocal(nextEnd);
       }
       return next;
     });
-    if (template.defaults.recurrencePreset) {
-      setRecurrencePreset(template.defaults.recurrencePreset);
-      if (template.defaults.recurrencePreset !== 'custom') setCustomRrule('');
+    if (defaults.recurrencePreset) {
+      setRecurrencePreset(defaults.recurrencePreset);
+      if (defaults.recurrencePreset !== 'custom') setCustomRrule('');
     }
   }
 


### PR DESCRIPTION
### Motivation

- Reduce strict-null diagnostic noise by addressing 'ghost null' dereferences and hardening core adapter behavior.
- Narrow template default usage in the event draft hook to avoid repeated optional chaining and preserve narrowed values. 
- Move forward with the Stage 7 ratchet by marking migrated paths and lowering the strict-null diagnostics baseline. 

### Description

- Narrowed `template.defaults` once in `useEventDraftState` and reused it when applying template defaults to eliminate repeated optional chaining. 
- Added an explicit missing-row rejection in `SupabaseAdapter.createEvent` by throwing when the inserted `data` row is absent. 
- Added `src/hooks/useEventDraftState.ts` and `src/api/v1/adapters/SupabaseAdapter.ts` to the strict-null `MIGRATED_PATHS` in `scripts/typecheck-strict-null.mjs`. 
- Updated the strict-null baseline file `scripts/strict-null-baseline.json` to set `baselineTotal` to `148` and recorded the run date. 

### Testing

- Ran the strict-null validation with `npm run -s type-check:strict-null`, which produced a total of `148` strict-null diagnostics and reported the migrated paths as clean. 
- Type-check step completed successfully under the updated baseline with no additional regressions recorded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea821e9cbc832c966d78e6cbc2f59a)