### PR TITLE
polish(sprints-1-6): harden types, eliminate duplication, wire useCon…

### DIFF
--- a/src/WorksCalendar.module.css
+++ b/src/WorksCalendar.module.css
@@ -45,11 +45,7 @@
 }
 
 
-/* ── Importance-based event priority ──────────────────────────────────────────
- * [data-wc-priority="muted"]  Normal recurring ops (shifts, on-call) — recede.
- * [data-wc-priority="high"]   Planning exceptions (PTO, missions) — stand out.
- * Themes override these in their own CSS files for glow / border treatments.
- * ─────────────────────────────────────────────────────────────────────────── */
+/* ── Event importance — themes override in family/*.css for glow/border ─────── */
 .root :global([data-wc-priority="muted"]) {
   opacity: 0.55;
 }

--- a/src/core/engine/adapters/fromLegacyEvents.ts
+++ b/src/core/engine/adapters/fromLegacyEvents.ts
@@ -10,6 +10,7 @@
  */
 
 import type { EngineEvent, EventStatus } from '../schema/eventSchema';
+import { isVisualPriority } from '../../../types/view';
 
 // ─── Legacy shape (from normalizeEvent output) ────────────────────────────────
 
@@ -79,9 +80,8 @@ export function fromLegacyEvent(raw: LegacyEvent): EngineEvent {
     hasRrule              ? id :
     null;
 
-  const vp = raw.visualPriority;
   const metaBase: Record<string, unknown> = { ...(raw.meta ?? {}) };
-  if (vp === 'muted' || vp === 'high') metaBase._visualPriority = vp;
+  if (isVisualPriority(raw.visualPriority)) metaBase._visualPriority = raw.visualPriority;
 
   return {
     id,

--- a/src/core/engine/adapters/toLegacyEvents.ts
+++ b/src/core/engine/adapters/toLegacyEvents.ts
@@ -8,6 +8,7 @@
 
 import type { EngineEvent } from '../schema/eventSchema';
 import type { EngineOccurrence } from '../schema/occurrenceSchema';
+import { isVisualPriority } from '../../../types/view';
 
 // ─── Legacy shape ─────────────────────────────────────────────────────────────
 
@@ -65,7 +66,7 @@ export function toLegacyEvent(ev: EngineEvent): LegacyEventOut {
     rrule:         ev.rrule,
     exdates:       Array.from(ev.exdates),
     meta:          { ...ev.meta },
-    visualPriority: vp === 'muted' || vp === 'high' ? vp : undefined,
+    visualPriority: isVisualPriority(vp) ? vp : undefined,
     _seriesId:     ev.seriesId,
     _recurring:    isRecurring,
   };

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@
 export * from './api/v1/index';
 
 export type { WorksCalendarEvent, NormalizedEvent, EventStatus, EventVisualPriority } from './types/events';
+export { isVisualPriority } from './types/events';
 export type {
   ConfigPanelProps,
   ConfigPanelTabId,

--- a/src/types/events.ts
+++ b/src/types/events.ts
@@ -6,8 +6,10 @@
  */
 
 import type { EventVisualPriority } from './view';
+import { isVisualPriority } from './view';
 
 export type { EventVisualPriority };
+export { isVisualPriority };
 export type EventStatus = 'confirmed' | 'tentative' | 'cancelled';
 
 export interface WorksCalendarEvent {

--- a/src/types/ui.ts
+++ b/src/types/ui.ts
@@ -1,5 +1,6 @@
 import type { ReactNode } from 'react';
 import type { EventStatus } from './events';
+import type { EventVisualPriority } from './view';
 
 export type AnyRecord = Record<string, any>;
 
@@ -112,7 +113,7 @@ export interface CalendarViewEvent {
   category?: string | null;
   resource?: string | null;
   status?: EventStatus;
-  visualPriority?: 'muted' | 'high' | null;
+  visualPriority?: EventVisualPriority | null;
   meta?: Record<string, unknown>;
   _col?: number;
   _numCols?: number;

--- a/src/types/view.ts
+++ b/src/types/view.ts
@@ -18,6 +18,11 @@
  */
 export type EventVisualPriority = 'muted' | 'high';
 
+/** Type guard — narrows `unknown` to `EventVisualPriority`. */
+export function isVisualPriority(v: unknown): v is EventVisualPriority {
+  return v === 'muted' || v === 'high';
+}
+
 /** Exhaustive set of operational event categories for the Air EMS demo. */
 export type EventCategory =
   | 'dispatch-shift'

--- a/src/ui/AdvancedFilterBuilder.tsx
+++ b/src/ui/AdvancedFilterBuilder.tsx
@@ -1,5 +1,5 @@
 /**
- * AdvancedFilterBuilder.jsx — Visual AND/OR condition builder for Smart Views.
+ * AdvancedFilterBuilder — Visual AND/OR condition builder for Smart Views.
  *
  * Lets users compose multi-condition filters with explicit AND / OR logic
  * between each row, then save the result as a named Smart View.
@@ -28,50 +28,36 @@
  */
 import { useState, useEffect, useRef, useMemo } from 'react';
 import { Plus, X, Check } from 'lucide-react';
-import { createId } from '../core/createId';
-import { DEFAULT_FILTER_SCHEMA, defaultOperatorsForType } from '../filters/filterSchema';
-import { conditionsToFilters } from '../filters/conditionEngine';
-import type { FilterField, FilterOperator, FilterOption } from '../filters/filterSchema';
+import { DEFAULT_FILTER_SCHEMA } from '../filters/filterSchema';
+import type { FilterField, FilterOption } from '../filters/filterSchema';
+import { useConditionBuilder } from '../hooks/useConditionBuilder';
+import type { Condition } from '../hooks/useConditionBuilder';
 import styles from './AdvancedFilterBuilder.module.css';
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
-type ConditionLogic = 'AND' | 'OR';
-
-type BuilderCondition = {
-  id: string;
-  field: string;
-  operator: string;
-  value: string;
-  logic: ConditionLogic;
-};
-
 type AdvancedFilterBuilderProps = {
   schema?: FilterField[];
   items?: unknown[];
-  onSave?: (name: string, filters: Record<string, unknown>, conditions: BuilderCondition[]) => void;
+  onSave?: (name: string, filters: Record<string, unknown>, conditions: Condition[]) => void;
   categories?: unknown[];
   resources?: unknown[];
   initialName?: string;
   initialConditions?: unknown[] | null;
   editingId?: string | null;
-  onUpdate?: (id: string, name: string, filters: Record<string, unknown>, conditions: BuilderCondition[]) => void;
+  onUpdate?: (id: string, name: string, filters: Record<string, unknown>, conditions: Condition[]) => void;
   onCancelEdit?: () => void;
 };
 
-function makeCondition(logic: ConditionLogic = 'AND', firstFieldKey = 'categories'): BuilderCondition {
-  return { id: createId('cond'), field: firstFieldKey, operator: 'is', value: '', logic };
-}
-
-function toBuilderCondition(input: unknown, fallbackFieldKey: string): BuilderCondition {
-  const candidate = (input ?? {}) as Partial<BuilderCondition>;
-  const logic: ConditionLogic = candidate.logic === 'OR' ? 'OR' : 'AND';
+/** Safely coerce an unknown value from persisted storage into a typed Condition. */
+function toCondition(input: unknown, fallbackFieldKey: string): Condition {
+  const c = (input ?? {}) as Partial<Condition>;
   return {
-    id: createId('cond'),
-    field: typeof candidate.field === 'string' ? candidate.field : fallbackFieldKey,
-    operator: typeof candidate.operator === 'string' ? candidate.operator : 'is',
-    value: typeof candidate.value === 'string' ? candidate.value : '',
-    logic,
+    id:       '',   // hook assigns a fresh id in its useState initializer
+    field:    typeof c.field    === 'string' ? c.field    : fallbackFieldKey,
+    operator: typeof c.operator === 'string' ? c.operator : 'is',
+    value:    typeof c.value    === 'string' ? c.value    : '',
+    logic:    c.logic === 'OR' ? 'OR' : 'AND',
   };
 }
 
@@ -92,31 +78,24 @@ export default function AdvancedFilterBuilder({
   void categories;
   void resources;
 
-  // Exclude date-range fields from the condition builder field list
-  const fieldOptions = useMemo(
-    () => schema.filter((f) => f.type !== 'date-range'),
-    [schema]
-  );
+  // Pre-process unknown initial conditions into typed Condition[] for the hook.
+  // Computed once on mount — the parent remounts via key={editingId} on switch.
+  // eslint-disable-next-line react-hooks/exhaustive-deps -- mount-only initializer
+  const safeInitialConditions = useMemo<Condition[] | null>(() => {
+    if (!initialConditions || initialConditions.length === 0) return null;
+    const firstKey = schema.filter(f => f.type !== 'date-range')[0]?.key ?? 'categories';
+    return initialConditions.map(c => toCondition(c, firstKey));
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
-  // Operator map keyed by field.key — falls back to defaultOperatorsForType
-  const operatorMap = useMemo<Record<string, FilterOperator[]>>(() => {
-    const map: Record<string, FilterOperator[]> = {};
-    for (const f of fieldOptions) {
-      map[f.key] = f.operators ?? defaultOperatorsForType(f.type);
-    }
-    return map;
-  }, [fieldOptions]);
+  const {
+    conditions, fieldOptions, operatorMap,
+    addCondition, updateCondition, removeCondition,
+    clearConditions, toFilters,
+  } = useConditionBuilder({ schema, initialConditions: safeInitialConditions });
 
-  const firstFieldKey = fieldOptions[0]?.key ?? 'categories';
-
-  const [conditions, setConditions] = useState<BuilderCondition[]>(() =>
-    initialConditions && initialConditions.length > 0
-      ? initialConditions.map((c) => toBuilderCondition(c, firstFieldKey))
-      : [makeCondition('AND', firstFieldKey)]
-  );
-  const [viewName,   setViewName]   = useState(initialName);
-  const [nameError,  setNameError]  = useState('');
-  const [saved,      setSaved]      = useState(false);
+  const [viewName,  setViewName]  = useState(initialName);
+  const [nameError, setNameError] = useState('');
+  const [saved,     setSaved]     = useState(false);
   const savedTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const rootRef       = useRef<HTMLDivElement | null>(null);
   const nameInputRef  = useRef<HTMLInputElement | null>(null);
@@ -138,51 +117,27 @@ export default function AdvancedFilterBuilder({
     // eslint-disable-next-line react-hooks/exhaustive-deps -- mount-only on edit open
   }, []);
 
-  // ── Condition mutations ─────────────────────────────────────────────────
-
-  const addCondition = (logic: ConditionLogic) => {
-    setConditions(prev => [...prev, makeCondition(logic, firstFieldKey)]);
-  };
-
-  const updateCondition = (id: string, updates: Partial<BuilderCondition>) => {
-    setConditions(prev => prev.map(c => {
-      if (c.id !== id) return c;
-      const next = { ...c, ...updates };
-      // Reset operator + value when field changes
-      if (updates.field && updates.field !== c.field) {
-        next.operator = operatorMap[updates.field]?.[0]?.value ?? 'is';
-        next.value    = '';
-      }
-      return next;
-    }));
-  };
-
-  const removeCondition = (id: string) => {
-    setConditions(prev => prev.length > 1 ? prev.filter(c => c.id !== id) : prev);
-  };
-
   // ── Save ────────────────────────────────────────────────────────────────
+
+  const showSaved = () => {
+    setSaved(true);
+    clearTimeout(savedTimerRef.current);
+    savedTimerRef.current = setTimeout(() => setSaved(false), 2000);
+  };
 
   const handleSave = () => {
     const name = viewName.trim();
-    if (!name) {
-      setNameError('Enter a name for this Smart View.');
-      return;
-    }
+    if (!name) { setNameError('Enter a name for this Smart View.'); return; }
     setNameError('');
-    const filters = conditionsToFilters(conditions, schema);
+    const filters = toFilters();
     if (editingId && onUpdate) {
       onUpdate(editingId, name, filters, conditions);
-      setSaved(true);
-      clearTimeout(savedTimerRef.current);
-      savedTimerRef.current = setTimeout(() => setSaved(false), 2000);
+      showSaved();
     } else {
       onSave?.(name, filters, conditions);
-      setSaved(true);
-      clearTimeout(savedTimerRef.current);
-      savedTimerRef.current = setTimeout(() => setSaved(false), 2000);
+      showSaved();
       setViewName('');
-      setConditions([makeCondition('AND', firstFieldKey)]);
+      clearConditions();
     }
   };
 

--- a/src/ui/AssetRequestForm.tsx
+++ b/src/ui/AssetRequestForm.tsx
@@ -13,20 +13,30 @@ import { useMemo, useState } from 'react';
 import type { FormEvent, ChangeEvent, MouseEvent } from 'react';
 import { X } from 'lucide-react';
 import { useFocusTrap } from '../hooks/useFocusTrap';
+import { toDatetimeLocal, fromDatetimeLocal } from '../hooks/useEventDraftState';
 import styles from './EventForm.module.css';
 
-function toLocalInput(date: Date): string {
-  const pad = (n: number): string => String(n).padStart(2, '0');
-  return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}T${pad(date.getHours())}:${pad(date.getMinutes())}`;
-}
+type AssetEntry = { id: string; label: string; group?: string; meta?: Record<string, unknown> };
+type CategoryEntry = { id: string; label?: string; color?: string };
 
-function fromLocalInput(value: string): Date {
-  // Interpret as local time (same convention as EventForm's fromDatetimeLocal).
-  const [datePart, timePart] = value.split('T');
-  const [y, m, d] = datePart.split('-').map(Number);
-  const [hh, mm] = (timePart || '00:00').split(':').map(Number);
-  return new Date(y, m - 1, d, hh, mm, 0, 0);
-}
+type AssetRequestPayload = {
+  title: string;
+  start: Date;
+  end: Date;
+  allDay: false;
+  category: string;
+  resource: string;
+  meta: Record<string, unknown>;
+};
+
+type AssetRequestFormProps = {
+  assets: AssetEntry[];
+  categories: CategoryEntry[];
+  initialStart?: Date;
+  initialAssetId?: string;
+  onSubmit: (payload: AssetRequestPayload) => void;
+  onClose: () => void;
+};
 
 export default function AssetRequestForm({
   assets,
@@ -35,34 +45,36 @@ export default function AssetRequestForm({
   initialAssetId,
   onSubmit,
   onClose,
-}: any) {
+}: AssetRequestFormProps) {
   const trapRef = useFocusTrap<HTMLDivElement>(onClose);
 
   const start = initialStart instanceof Date ? initialStart : new Date();
   const defaultEnd = new Date(start.getTime() + 60 * 60 * 1000);
 
-  const [assetId,  setAssetId]  = useState(initialAssetId || assets[0]?.id || '');
-  const [category, setCategory] = useState(categories[0]?.id || '');
+  const [assetId,  setAssetId]  = useState(initialAssetId ?? assets[0]?.id ?? '');
+  const [category, setCategory] = useState(categories[0]?.id ?? '');
   const [title,    setTitle]    = useState('');
-  const [startStr, setStartStr] = useState(toLocalInput(start));
-  const [endStr,   setEndStr]   = useState(toLocalInput(defaultEnd));
+  const [startStr, setStartStr] = useState(toDatetimeLocal(start));
+  const [endStr,   setEndStr]   = useState(toDatetimeLocal(defaultEnd));
   const [notes,    setNotes]    = useState('');
   const [errors,   setErrors]   = useState<Record<string, string>>({});
 
   const assetOptions = useMemo(
-    () => assets.map((a: any) => ({ value: a.id, label: a.label || a.id })),
+    () => assets.map((a) => ({ value: a.id, label: a.label || a.id })),
     [assets],
   );
 
   function validate() {
     const e: Record<string, string> = {};
-    if (!title.trim())      e.title    = 'Title is required';
-    if (!assetId)           e.assetId  = 'Select an asset';
-    if (!category)          e.category = 'Select a category';
-    if (!startStr)          e.start    = 'Start is required';
-    if (!endStr)            e.end      = 'End is required';
-    if (startStr && endStr && fromLocalInput(endStr) <= fromLocalInput(startStr)) {
-      e.end = 'End must be after start';
+    if (!title.trim()) e.title    = 'Title is required';
+    if (!assetId)      e.assetId  = 'Select an asset';
+    if (!category)     e.category = 'Select a category';
+    if (!startStr)     e.start    = 'Start is required';
+    if (!endStr)       e.end      = 'End is required';
+    if (startStr && endStr) {
+      const s = fromDatetimeLocal(startStr);
+      const en = fromDatetimeLocal(endStr);
+      if (s && en && en <= s) e.end = 'End must be after start';
     }
     setErrors(e);
     return Object.keys(e).length === 0;
@@ -71,17 +83,19 @@ export default function AssetRequestForm({
   function handleSubmit(e: FormEvent<HTMLFormElement>) {
     e.preventDefault();
     if (!validate()) return;
-    const now = new Date().toISOString();
+    const s = fromDatetimeLocal(startStr);
+    const en = fromDatetimeLocal(endStr);
+    if (!s || !en) return;
     onSubmit({
       title:    title.trim(),
-      start:    fromLocalInput(startStr),
-      end:      fromLocalInput(endStr),
+      start:    s,
+      end:      en,
       allDay:   false,
       category,
       resource: assetId,
       meta: {
         ...(notes.trim() ? { notes: notes.trim() } : {}),
-        approvalStage: { stage: 'requested', updatedAt: now },
+        approvalStage: { stage: 'requested', updatedAt: new Date().toISOString() },
       },
     });
   }
@@ -122,7 +136,7 @@ export default function AssetRequestForm({
                 value={assetId}
                 onChange={(e: ChangeEvent<HTMLSelectElement>) => setAssetId(e.target.value)}
               >
-                {assetOptions.map((o: { value: string; label: string }) => <option key={o.value} value={o.value}>{o.label}</option>)}
+                {assetOptions.map((o) => <option key={o.value} value={o.value}>{o.label}</option>)}
               </select>
               {errors.assetId && <span className={styles.error}>{errors.assetId}</span>}
             </div>
@@ -134,8 +148,8 @@ export default function AssetRequestForm({
                 value={category}
                 onChange={(e: ChangeEvent<HTMLSelectElement>) => setCategory(e.target.value)}
               >
-                {categories.map((c: any) => (
-                  <option key={c.id} value={c.id}>{c.label || c.id}</option>
+                {categories.map((c) => (
+                  <option key={c.id} value={c.id}>{c.label ?? c.id}</option>
                 ))}
               </select>
               {errors.category && <span className={styles.error}>{errors.category}</span>}

--- a/src/views/ScheduleView.tsx
+++ b/src/views/ScheduleView.tsx
@@ -100,7 +100,7 @@ export default function ScheduleView({ currentDate, events, onEventClick, weekSt
                           return (
                             <div key={ev.id} className={[styles.eventPill, statusClass].filter(Boolean).join(' ')}
                               style={{ '--ev-color': color }}
-                              data-wc-priority={(ev.visualPriority as string | undefined) ?? undefined}
+                              data-wc-priority={ev.visualPriority as string | undefined}
                               onClick={() => onEventClick?.(ev)}>
                               {custom}
                             </div>
@@ -112,7 +112,7 @@ export default function ScheduleView({ currentDate, events, onEventClick, weekSt
                         <button key={ev.id}
                           className={[styles.eventPill, statusClass].filter(Boolean).join(' ')}
                           style={{ '--ev-color': color }}
-                          data-wc-priority={(ev.visualPriority as string | undefined) ?? undefined}
+                          data-wc-priority={ev.visualPriority as string | undefined}
                           onClick={() => onEventClick?.(ev)}
                           title={ev.title}
                         >


### PR DESCRIPTION
…ditionBuilder

Type safety:
- AssetRequestForm: replace `any` props with typed interfaces (AssetEntry, CategoryEntry, AssetRequestPayload); reuse toDatetimeLocal/fromDatetimeLocal from useEventDraftState instead of duplicating the helpers locally
- CalendarViewEvent.visualPriority: use EventVisualPriority | null instead of inline 'muted' | 'high' | null literal

Shared type guard:
- Add isVisualPriority(v): v is EventVisualPriority to src/types/view.ts and re-export through types/events and the public barrel; eliminates the v === 'muted' || v === 'high' guard duplicated across fromLegacyEvents and toLegacyEvents (was written inline 3 times)

Code reuse:
- AdvancedFilterBuilder: wire up useConditionBuilder hook (was extracted for exactly this purpose but never connected); removes 50+ lines of duplicated state management (conditions, fieldOptions, operatorMap, addCondition, updateCondition, removeCondition, makeCondition); extract showSaved() to eliminate duplicated setTimeout block; rename .jsx → .tsx in file docstring

Style:
- WorksCalendar.module.css: condense 5-line comment to single-line header
- ScheduleView: remove no-op `?? undefined` after string cast

https://claude.ai/code/session_01BjSanhei7rk75wuoDE4a5X

## Summary
Describe exactly what this PR changes.

## Scope
- Stage: 
- Planned PR number in sprint: 
- Target files/directories: 
- Why this slice is isolated: 

## Lessons Learned Check (REQUIRED)
Confirm these were actively used while building this PR:

- [ ] PR is intentionally small and isolated
- [ ] Boundary typing was prioritized over internal perfection
- [ ] No silent spread of `any`
- [ ] Advisory root `tsc` was used to catch integration issues
- [ ] I did not assume “looks typed” means “safe”
- [ ] I stopped and isolated typing cascades instead of expanding scope

## Definition of Done (ALL REQUIRED)
This PR is not done unless every box is checked.

- [ ] `npm run type-check:strict` passes
- [ ] Root advisory `tsc --noEmit` passes
- [ ] Tests pass for touched scope at minimum
- [ ] No uncontrolled increase in `any`
- [ ] All new types are intentional and named
- [ ] Public interfaces and exported functions are explicitly typed
- [ ] PR scope matches the sprint plan with no scope creep
- [ ] Any new `any` has an adjacent justification comment
- [ ] No file-wide `: any`
- [ ] No implicit `any` in exported functions

## What Was Typed
List exactly what was typed in this PR.

- 
- 
- 

## What Was Intentionally Left Loose
List anything intentionally not tightened yet.

- 
- 
- 

## `any` Ledger (REQUIRED)
- New `any` added: 
- Existing `any` removed: 
- Net change: 

For every new `any`, explain why it is required and why a safer type was not used yet.

1. 
2. 
3. 

## Boundary Notes
Document any public seams, caller-protection choices, or compatibility decisions.

- 
- 
- 

## Risk Level
- [ ] Low
- [ ] Medium
- [ ] High

Why:

## Validation Evidence
Paste the exact commands run and a short result summary.

```bash
npm run type-check:strict
npx tsc --noEmit -p tsconfig.json
```

Test commands run:

```bash
# paste commands here
```

## Stop Conditions Check
If any item below happened, explain how scope was reduced before merge.

- [ ] `any` started spreading across files
- [ ] Root `tsc` broke repeatedly
- [ ] Types required cross-module rewrites
- [ ] Scope was reduced to keep the PR reviewable

Notes:

## Reviewer Focus
What should reviewers look at first?

- 
- 
- 
