### PR TITLE
stage7 sprint4 pr9: escape-hatch cleanup — drop production `!` + 9 `a…

### DIFF
--- a/src/core/engine/validation/validateEventConstraints.ts
+++ b/src/core/engine/validation/validateEventConstraints.ts
@@ -28,8 +28,7 @@ export function validateEventConstraints(
   // (change.event may be the old state; constraints don't change during move/resize).
   const events    = ctx.events ?? [];
   const canonical = events.find(e => e.id === ev.id) ?? ev;
-  const constraints = (canonical as any).constraints as
-    import('../schema/constraintSchema.js').EventConstraint[] | undefined;
+  const constraints = (canonical as { constraints?: readonly import('../schema/constraintSchema.js').EventConstraint[] }).constraints;
 
   if (!constraints || constraints.length === 0) return null;
 

--- a/src/core/viewScope.ts
+++ b/src/core/viewScope.ts
@@ -95,7 +95,7 @@ export const VIEW_SCOPES: Record<ViewId, ViewScope> = Object.freeze({
 });
 
 export function getViewScope(view: string): ViewScope {
-  return (VIEW_SCOPES as any)[view] ?? VIEW_SCOPES.month;
+  return (VIEW_SCOPES as Record<string, ViewScope>)[view] ?? VIEW_SCOPES.month;
 }
 
 /**

--- a/src/core/workflow/layout.ts
+++ b/src/core/workflow/layout.ts
@@ -61,8 +61,9 @@ export function layoutWorkflow(
     overrides.workflowId === workflow.id &&
     overrides.workflowVersion === workflow.version
   const positions: Record<string, NodePosition> = {}
+  const overridePositions = overridesMatch && overrides ? overrides.positions : null
   for (const node of workflow.nodes) {
-    const override = overridesMatch ? overrides!.positions[node.id] : undefined
+    const override = overridePositions ? overridePositions[node.id] : undefined
     const resolved = override ?? auto[node.id]
     if (resolved !== undefined) positions[node.id] = resolved
   }

--- a/src/filters/filterSchema.ts
+++ b/src/filters/filterSchema.ts
@@ -157,7 +157,8 @@ export function priorityField(overrides: Partial<FilterField> = {}): FilterField
     ],
     operators: defaultOperatorsForType('select'),
     predicate: (item: any, value: any) =>
-      ((item as any).priority ?? (item as any).meta?.priority) === value,
+      ((item as { priority?: unknown; meta?: { priority?: unknown } }).priority
+        ?? (item as { priority?: unknown; meta?: { priority?: unknown } }).meta?.priority) === value,
     ...overrides,
   }
 }
@@ -268,7 +269,7 @@ export function makeResourceResolver({ employees, assets }: ResolverInput = {}):
   for (const e of employees ?? []) {
     if (e && e.id != null) {
       const key = String(e.id)
-      const label = (e as any).name ?? e.label ?? key
+      const label = (e as { name?: string; label?: string }).name ?? e.label ?? key
       lookup.set(key, label)
     }
   }
@@ -277,7 +278,7 @@ export function makeResourceResolver({ employees, assets }: ResolverInput = {}):
     if (a && a.id != null) {
       const key = String(a.id)
       if (lookup.has(key)) continue
-      const label = a.label ?? (a as any).name ?? key
+      const label = a.label ?? (a as { name?: string; label?: string }).name ?? key
       lookup.set(key, label)
     }
   }

--- a/src/hooks/useCalendar.ts
+++ b/src/hooks/useCalendar.ts
@@ -79,7 +79,7 @@ export function useCalendar(
 
   const toggleCategory = useCallback((cat: string) => {
     setFilters((f: CalendarFilters) => {
-      const next = new Set((f as any).categories);
+      const next = new Set<string>(f['categories']);
       next.has(cat) ? next.delete(cat) : next.add(cat);
       return { ...f, categories: next };
     });
@@ -87,7 +87,7 @@ export function useCalendar(
 
   const toggleResource = useCallback((res: string) => {
     setFilters((f: CalendarFilters) => {
-      const next = new Set((f as any).resources);
+      const next = new Set<string>(f['resources']);
       next.has(res) ? next.delete(res) : next.add(res);
       return { ...f, resources: next };
     });
@@ -95,7 +95,7 @@ export function useCalendar(
 
   const toggleSourceFilter = useCallback((id: string) => {
     setFilters((f: CalendarFilters) => {
-      const next = new Set((f as any).sources);
+      const next = new Set<string>(f['sources']);
       next.has(id) ? next.delete(id) : next.add(id);
       return { ...f, sources: next };
     });

--- a/src/hooks/useSyncedCalendar.ts
+++ b/src/hooks/useSyncedCalendar.ts
@@ -67,7 +67,7 @@ export function useSyncedCalendar({
   adapter,
   start,
   end,
-  conflictResolution = 'server-wins' as any,
+  conflictResolution = 'server-wins' as const,
   onConflict,
   onError,
   maxRetries,
@@ -134,37 +134,34 @@ export function useSyncedCalendar({
   }, [manager, live]);
 
   // ── Stable mutation callbacks ───────────────────────────────────────────────
+  // `manager` is the singleton narrowed from managerRef above — safe to close
+  // over in callbacks because the init block makes it stable across renders.
   const createEvent = useCallback(
-    /** @param {CalendarEventV1} event */
-    (event: CalendarEventV1) => managerRef.current!.createEvent(event),
-    [],
+    (event: CalendarEventV1) => manager.createEvent(event),
+    [manager],
   );
 
   const updateEvent = useCallback(
-    /** @param {string} id @param {Partial<CalendarEventV1>} patch */
-    (id: string, patch: Partial<CalendarEventV1>) => managerRef.current!.updateEvent(id, patch),
-    [],
+    (id: string, patch: Partial<CalendarEventV1>) => manager.updateEvent(id, patch),
+    [manager],
   );
 
   const deleteEvent = useCallback(
-    /** @param {string} id */
-    (id: string) => managerRef.current!.deleteEvent(id),
-    [],
+    (id: string) => manager.deleteEvent(id),
+    [manager],
   );
 
-  const retryFailed = useCallback(() => managerRef.current!.retryFailed(), []);
-  const clearErrors = useCallback(() => managerRef.current!.clearErrors(), []);
+  const retryFailed = useCallback(() => manager.retryFailed(), [manager]);
+  const clearErrors = useCallback(() => manager.clearErrors(), [manager]);
 
   const statusFor = useCallback(
-    /** @param {string} eventId */
-    (eventId: string) => managerRef.current!.statusFor(eventId),
-    [],
+    (eventId: string) => manager.statusFor(eventId),
+    [manager],
   );
 
   const errorFor = useCallback(
-    /** @param {string} eventId */
-    (eventId: string) => managerRef.current!.errorFor(eventId),
-    [],
+    (eventId: string) => manager.errorFor(eventId),
+    [manager],
   );
 
   // ── Derived convenience values ──────────────────────────────────────────────

--- a/src/ui/WorkflowNodeInspector.tsx
+++ b/src/ui/WorkflowNodeInspector.tsx
@@ -412,10 +412,10 @@ function JoinFields({
           onChange={e => onChange({ pairedWith: e.target.value })}
         >
           {/* Show the current value first so a stale pairing still renders. */}
-          {!parallelNodeIds!.includes(node.pairedWith) && (
+          {parallelNodeIds !== undefined && !parallelNodeIds.includes(node.pairedWith) && (
             <option value={node.pairedWith}>{node.pairedWith} (missing)</option>
           )}
-          {parallelNodeIds!.map(id => (
+          {(parallelNodeIds ?? []).map(id => (
             <option key={id} value={id}>{id}</option>
           ))}
         </select>


### PR DESCRIPTION
…s any`

Removes every unsafe non-null assertion in production code and the subset of `as any` casts that had trivially-typeable replacements. Remaining 16 `as any` sites involve engine-boundary type widening (fromLegacyEvents / toLegacyEvent / resolveColor / buildGroupTree) that need upstream type changes out of scope for this sweep — they're tracked for a follow-up.

Before → after:
- `!.` in src/ (prod): 10 → 0
- `as any` in src/ (prod): 25 → 16

Per-file fixes:
- src/hooks/useSyncedCalendar.ts: replaces `managerRef.current!.method(...)` callbacks with a `manager` closure (already narrowed at the top of the hook via init-invariant). Also swaps `'server-wins' as any` for `as const` so the default literal narrows to the ConflictStrategy union.
- src/ui/WorkflowNodeInspector.tsx: guards `parallelNodeIds` with `!== undefined` / `?? []` instead of `parallelNodeIds!`.
- src/core/workflow/layout.ts: hoists `overrides.positions` into a narrowed local so the loop body doesn't need `overrides!`.
- src/core/viewScope.ts: `(VIEW_SCOPES as any)[view]` → `(VIEW_SCOPES as Record<string, ViewScope>)[view]`.
- src/core/engine/validation/validateEventConstraints.ts: replaces `(canonical as any).constraints` with a structural cast naming the expected readonly EventConstraint[] shape.
- src/filters/filterSchema.ts: two loose-field lookups typed via structural `{ priority?: unknown; meta?: { priority?: unknown } }` and `{ name?: string; label?: string }` rather than `as any`.
- src/hooks/useCalendar.ts: `(f as any).categories/resources/sources` → `f['categories']` bracket access (the Record<string, any> index signature already carries `any`, no cast needed).

Verification:
- `npm run type-check` — clean under all enabled strict flags.
- `npm test` — in progress (previous run at PR8d passed 132/132).

https://claude.ai/code/session_01PdFSxEv7rbANYDmVWTQJmq

## Summary
Describe exactly what this PR changes.

## Scope
- Stage: 
- Planned PR number in sprint: 
- Target files/directories: 
- Why this slice is isolated: 

## Lessons Learned Check (REQUIRED)
Confirm these were actively used while building this PR:

- [ ] PR is intentionally small and isolated
- [ ] Boundary typing was prioritized over internal perfection
- [ ] No silent spread of `any`
- [ ] Advisory root `tsc` was used to catch integration issues
- [ ] I did not assume “looks typed” means “safe”
- [ ] I stopped and isolated typing cascades instead of expanding scope

## Definition of Done (ALL REQUIRED)
This PR is not done unless every box is checked.

- [ ] `npm run type-check:strict` passes
- [ ] Root advisory `tsc --noEmit` passes
- [ ] Tests pass for touched scope at minimum
- [ ] No uncontrolled increase in `any`
- [ ] All new types are intentional and named
- [ ] Public interfaces and exported functions are explicitly typed
- [ ] PR scope matches the sprint plan with no scope creep
- [ ] Any new `any` has an adjacent justification comment
- [ ] No file-wide `: any`
- [ ] No implicit `any` in exported functions

## What Was Typed
List exactly what was typed in this PR.

- 
- 
- 

## What Was Intentionally Left Loose
List anything intentionally not tightened yet.

- 
- 
- 

## `any` Ledger (REQUIRED)
- New `any` added: 
- Existing `any` removed: 
- Net change: 

For every new `any`, explain why it is required and why a safer type was not used yet.

1. 
2. 
3. 

## Boundary Notes
Document any public seams, caller-protection choices, or compatibility decisions.

- 
- 
- 

## Risk Level
- [ ] Low
- [ ] Medium
- [ ] High

Why:

## Validation Evidence
Paste the exact commands run and a short result summary.

```bash
npm run type-check:strict
npx tsc --noEmit -p tsconfig.json
```

Test commands run:

```bash
# paste commands here
```

## Stop Conditions Check
If any item below happened, explain how scope was reduced before merge.

- [ ] `any` started spreading across files
- [ ] Root `tsc` broke repeatedly
- [ ] Types required cross-module rewrites
- [ ] Scope was reduced to keep the PR reviewable

Notes:

## Reviewer Focus
What should reviewers look at first?

- 
- 
- 
