### PR TITLE
sprint 7: make ContextSummary interactive, clarify toolbar, add event…

### DIFF
--- a/src/WorksCalendar.module.css
+++ b/src/WorksCalendar.module.css
@@ -33,7 +33,10 @@
 
   font-family: var(--wc-font);
   font-size: var(--wc-base-font-size, 14px);
-  background: var(--wc-bg);
+  background-color: var(--wc-bg);
+  background-image: var(--wc-bg-image, none);
+  background-size: cover;
+  background-position: center;
   color: var(--wc-text);
   border-radius: var(--wc-radius);
   overflow: hidden;
@@ -250,6 +253,14 @@
   display: flex;
   align-items: center;
   gap: 4px;
+}
+
+.logo {
+  height: 28px;
+  width: auto;
+  object-fit: contain;
+  flex-shrink: 0;
+  margin-right: 4px;
 }
 
 .navBtn {

--- a/src/WorksCalendar.tsx
+++ b/src/WorksCalendar.tsx
@@ -51,6 +51,8 @@ import FilterGroupSidebar, { SidebarToggleButton } from './ui/FilterGroupSidebar
 import FocusChips, { DEFAULT_FOCUS_CHIPS, resolveActiveChipLabels } from './ui/FocusChips';
 import type { FocusChipDef } from './ui/FocusChips';
 import ContextSummary from './ui/ContextSummary';
+import type { ContextSummarySegment } from './ui/ContextSummary';
+import type { SidebarTab } from './ui/FilterGroupSidebar';
 import { resolvePresetLabel } from './ui/ViewPanel';
 import type { GroupLevel } from './ui/GroupsPanel';
 import HoverCard              from './ui/HoverCard';
@@ -268,6 +270,13 @@ export type WorksCalendarProps = {
    * cursor survives page reloads. Omit to skip persistence entirely.
    */
   onPoolsChange?: (pools: ResourcePool[]) => void;
+
+  /** Optional logo image displayed at the left of the toolbar. */
+  logoSrc?: string;
+  /** Alt text for the logo image. Treated as decorative if omitted. */
+  logoAlt?: string;
+  /** Optional background image URL applied to the calendar root. */
+  backgroundImage?: string;
 };
 
 
@@ -500,6 +509,11 @@ export const WorksCalendar = forwardRef<CalendarApi, WorksCalendarProps>(functio
     // ── Resource pools (#212) ──
     pools: rawPools,
     onPoolsChange,
+
+    // ── Branding ──
+    logoSrc,
+    logoAlt,
+    backgroundImage,
   }: WorksCalendarProps,
   ref: ForwardedRef<CalendarApi>,
 ) {
@@ -510,6 +524,10 @@ export const WorksCalendar = forwardRef<CalendarApi, WorksCalendarProps>(functio
   const ownerCfg = useOwnerConfig({ calendarId, ownerPassword, onConfigSave, devMode });
   const weekStartDay = weekStartDayProp ?? ownerCfg.config?.['display']?.weekStartDay ?? 0;
   const customThemeVars = useMemo(() => customThemeToCssVars(ownerCfg.config?.['customTheme']), [ownerCfg.config?.['customTheme']]);
+  const rootStyle = useMemo<React.CSSProperties>(() => ({
+    ...(customThemeVars ?? {}),
+    ...(backgroundImage ? ({ '--wc-bg-image': `url(${backgroundImage})` } as React.CSSProperties) : {}),
+  }), [customThemeVars, backgroundImage]);
   // The raw theme value (from props, owner config, or default). The new theme
   // system uses `family-mode` IDs (see src/styles/themes.ts); the CSS runtime
   // still matches the historical single-word selectors, so we resolve the
@@ -674,6 +692,17 @@ export const WorksCalendar = forwardRef<CalendarApi, WorksCalendarProps>(functio
 
   // ── FilterGroupSidebar state ──
   const [sidebarOpen, setSidebarOpen] = useState(false);
+  const [sidebarInitialTab, setSidebarInitialTab] = useState<SidebarTab>('view');
+
+  const handleContextSegmentClick = useCallback((segment: ContextSummarySegment) => {
+    const tabMap: Record<ContextSummarySegment, SidebarTab> = {
+      view: 'view',
+      focus: 'focus',
+      scope: 'view',
+    };
+    setSidebarInitialTab(tabMap[segment]);
+    setSidebarOpen(true);
+  }, []);
 
   // Derive GroupLevel[] from activeGroupBy for the sidebar's GroupsPanel
   const sidebarGroupLevels = useMemo<GroupLevel[]>(() => {
@@ -2036,7 +2065,7 @@ export const WorksCalendar = forwardRef<CalendarApi, WorksCalendarProps>(functio
           data-wc-theme-family={themeFamily}
           data-wc-theme-mode={themeMode}
           data-testid="works-calendar-setup"
-          style={customThemeVars as React.CSSProperties}
+          style={rootStyle}
         >
           <SetupLanding
             onSkip={handleSetupSkip}
@@ -2052,7 +2081,7 @@ export const WorksCalendar = forwardRef<CalendarApi, WorksCalendarProps>(functio
   return (
     <CalendarErrorBoundary>
       <CalendarContext.Provider value={ctxValue}>
-        <div className={styles['root']} data-wc-theme={effectiveTheme} data-wc-theme-family={themeFamily} data-wc-theme-mode={themeMode} data-testid="works-calendar" data-wc-edit-mode={editMode ? '' : undefined} style={customThemeVars as React.CSSProperties}>
+        <div className={styles['root']} data-wc-theme={effectiveTheme} data-wc-theme-family={themeFamily} data-wc-theme-mode={themeMode} data-testid="works-calendar" data-wc-edit-mode={editMode ? '' : undefined} style={rootStyle}>
 
         {/* ── Toolbar ── */}
         {renderToolbar ? (
@@ -2060,6 +2089,14 @@ export const WorksCalendar = forwardRef<CalendarApi, WorksCalendarProps>(functio
         ) : (
           <div className={styles['toolbar']} role="toolbar" aria-label="Calendar navigation">
             <div className={styles['navGroup']}>
+              {logoSrc && (
+                <img
+                  src={logoSrc}
+                  alt={logoAlt ?? ''}
+                  className={styles['logo']}
+                  aria-hidden={!logoAlt ? 'true' : undefined}
+                />
+              )}
               <button
                 className={styles['navBtn']}
                 onClick={() => cal.navigate(-1)}
@@ -2225,6 +2262,7 @@ export const WorksCalendar = forwardRef<CalendarApi, WorksCalendarProps>(functio
                 viewLabel={resolvePresetLabel(sidebarGroupLevels)}
                 chipLabels={resolveActiveChipLabels(resolvedChips, activeCategories)}
                 scope="All regions"
+                onSegmentClick={handleContextSegmentClick}
               />
               <FocusChips
                 chips={resolvedChips}
@@ -2250,6 +2288,7 @@ export const WorksCalendar = forwardRef<CalendarApi, WorksCalendarProps>(functio
         {/* ── View area (with sidebar overlay) ── */}
         <FilterGroupSidebar
           open={sidebarOpen}
+          initialTab={sidebarInitialTab}
           onClose={() => setSidebarOpen(false)}
           // Groups tab
           groupLevels={sidebarGroupLevels}

--- a/src/styles/family/industrial.css
+++ b/src/styles/family/industrial.css
@@ -60,3 +60,9 @@
   --wc-cat-0: #fb923c; --wc-cat-1: #fcd34d; --wc-cat-2: #fca5a5; --wc-cat-3: #86efac;
   --wc-cat-4: #c4b5fd; --wc-cat-5: #f9a8d4; --wc-cat-6: #67e8f9; --wc-cat-7: #fdba74;
 }
+
+/* Structural accent on high-priority events — rugged outline, no glow. */
+[data-wc-theme-family="industrial"] [data-wc-priority="high"] {
+  outline: 2px solid color-mix(in srgb, var(--ev-color, var(--wc-accent)) 80%, #fff);
+  outline-offset: 1px;
+}

--- a/src/styles/family/neon.css
+++ b/src/styles/family/neon.css
@@ -70,3 +70,12 @@
   outline-offset: 2px;
   box-shadow: 0 0 0 4px rgba(168, 85, 247, 0.25);
 }
+
+/* Event-level glow in neon dark — base for all pills, stronger on high-priority. */
+[data-wc-theme-family="neon"][data-wc-theme-mode="dark"] {
+  --wc-event-glow: 0 0 8px color-mix(in srgb, var(--ev-color, var(--wc-accent)) 60%, transparent);
+}
+[data-wc-theme-family="neon"][data-wc-theme-mode="dark"] [data-wc-priority="high"] {
+  box-shadow: 0 0 16px color-mix(in srgb, var(--ev-color, var(--wc-accent)) 80%, transparent);
+  filter: brightness(1.2) saturate(1.4);
+}

--- a/src/styles/family/ops.css
+++ b/src/styles/family/ops.css
@@ -72,3 +72,14 @@
   filter: brightness(1.15) saturate(1.4);
   box-shadow: 0 0 6px color-mix(in srgb, var(--ev-color, #00d4ff) 55%, transparent);
 }
+
+/* Base glow on all events in ops dark — subtle ambient hum. */
+[data-wc-theme-family="ops"][data-wc-theme-mode="dark"] {
+  --wc-event-glow: 0 0 4px color-mix(in srgb, var(--ev-color, var(--wc-accent)) 30%, transparent);
+}
+
+/* Ops light: subtle shadow lift for high-priority. */
+[data-wc-theme-family="ops"][data-wc-theme-mode="light"] [data-wc-priority="high"] {
+  box-shadow: 0 2px 6px color-mix(in srgb, var(--ev-color, var(--wc-accent)) 35%, transparent);
+  filter: brightness(1.08) saturate(1.3);
+}

--- a/src/ui/ContextSummary.module.css
+++ b/src/ui/ContextSummary.module.css
@@ -36,3 +36,42 @@
   font-size: 13px;
   line-height: 1;
 }
+
+.segmentBtn {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 3px 6px;
+  margin: -3px -6px;
+  border: none;
+  background: none;
+  border-radius: var(--wc-radius-sm, 4px);
+  cursor: pointer;
+  color: inherit;
+  font: inherit;
+  transition: background 0.12s;
+}
+
+.segmentBtn:hover {
+  background: color-mix(in srgb, var(--wc-accent) 12%, transparent);
+}
+
+.segmentBtn:focus-visible {
+  outline: 2px solid var(--wc-accent);
+  outline-offset: 2px;
+}
+
+.segmentBtn .value {
+  color: var(--wc-accent);
+  text-decoration: underline dotted;
+}
+
+.chevron {
+  font-size: 13px;
+  color: var(--wc-text-faint);
+  transition: transform 0.12s;
+}
+
+.segmentBtn:hover .chevron {
+  transform: translateX(2px);
+}

--- a/src/ui/ContextSummary.tsx
+++ b/src/ui/ContextSummary.tsx
@@ -6,6 +6,8 @@
  */
 import styles from './ContextSummary.module.css';
 
+export type ContextSummarySegment = 'view' | 'focus' | 'scope';
+
 export type ContextSummaryProps = {
   /** Label of the active view preset, e.g. "By Base". Null = "Custom". */
   viewLabel: string | null;
@@ -13,12 +15,15 @@ export type ContextSummaryProps = {
   chipLabels: string[];
   /** Scope/region label, e.g. "All regions". */
   scope: string;
+  /** Fires when a segment is clicked; makes segments interactive. */
+  onSegmentClick?: (segment: ContextSummarySegment) => void;
 };
 
 export default function ContextSummary({
   viewLabel,
   chipLabels,
   scope,
+  onSegmentClick,
 }: ContextSummaryProps) {
   const focusText: string = chipLabels.length > 0 ? chipLabels.join(' + ') : 'All';
   const viewText: string = viewLabel !== null ? viewLabel : 'Custom';
@@ -29,18 +34,58 @@ export default function ContextSummary({
       aria-live="polite"
       aria-label="Current calendar context"
     >
-      <Segment label="View" value={viewText} />
+      <Segment
+        label="View"
+        value={viewText}
+        segment="view"
+        onClick={onSegmentClick ? () => onSegmentClick('view') : undefined}
+      />
       <span className={styles['dot']} aria-hidden="true">·</span>
-      <Segment label="Focus" value={focusText} />
+      <Segment
+        label="Focus"
+        value={focusText}
+        segment="focus"
+        onClick={onSegmentClick ? () => onSegmentClick('focus') : undefined}
+      />
       <span className={styles['dot']} aria-hidden="true">·</span>
-      <Segment label="Scope" value={scope} />
+      <Segment
+        label="Scope"
+        value={scope}
+        segment="scope"
+        onClick={onSegmentClick ? () => onSegmentClick('scope') : undefined}
+      />
     </div>
   );
 }
 
-function Segment({ label, value }: { label: string; value: string }) {
+function Segment({
+  label,
+  value,
+  segment,
+  onClick,
+}: {
+  label: string;
+  value: string;
+  segment: ContextSummarySegment;
+  onClick: (() => void) | undefined;
+}) {
+  if (onClick) {
+    return (
+      <button
+        type="button"
+        className={styles['segmentBtn']}
+        onClick={onClick}
+        aria-label={`Edit ${label}: ${value}`}
+        data-segment={segment}
+      >
+        <span className={styles['key']}>{label}</span>
+        <span className={styles['value']}>{value}</span>
+        <span className={styles['chevron']} aria-hidden="true">›</span>
+      </button>
+    );
+  }
   return (
-    <span className={styles['segment']}>
+    <span className={styles['segment']} data-segment={segment}>
       <span className={styles['key']}>{label}</span>
       <span className={styles['value']}>{value}</span>
     </span>

--- a/src/ui/FilterGroupSidebar.module.css
+++ b/src/ui/FilterGroupSidebar.module.css
@@ -166,6 +166,23 @@
   background: var(--wc-accent-dim);
 }
 
+.toggleArrow {
+  font-size: 12px;
+  opacity: 0.6;
+  transition: transform 0.15s, opacity 0.15s;
+}
+
+.toggleBtn:hover .toggleArrow {
+  transform: translateX(3px);
+  opacity: 1;
+}
+
+.toggleBtn.active .toggleArrow {
+  opacity: 0;
+  width: 0;
+  overflow: hidden;
+}
+
 /* Responsive: overlay mode on narrow screens */
 @media (max-width: 1200px) {
   .sidebar {

--- a/src/ui/FilterGroupSidebar.tsx
+++ b/src/ui/FilterGroupSidebar.tsx
@@ -31,6 +31,8 @@ export type FilterGroupSidebarProps = {
   open: boolean;
   /** Called to close the sidebar. */
   onClose: () => void;
+  /** Tab to focus each time the sidebar opens. Defaults to 'view'. */
+  initialTab?: SidebarTab;
 
   // Groups tab
   /** Current group-by levels. */
@@ -80,6 +82,7 @@ export type FilterGroupSidebarProps = {
 export default function FilterGroupSidebar({
   open,
   onClose,
+  initialTab,
   // Groups
   groupLevels,
   onGroupLevelsChange,
@@ -105,8 +108,15 @@ export default function FilterGroupSidebar({
 }: FilterGroupSidebarProps) {
   // Default to the View tab so the perspective picker is the owner's
   // first stop. Focus/Saved open via explicit tab clicks.
-  const [activeTab, setActiveTab] = useState<SidebarTab>('view');
+  const [activeTab, setActiveTab] = useState<SidebarTab>(initialTab ?? 'view');
   const sidebarRef = useRef<HTMLDivElement>(null);
+
+  // Reset to the requested initial tab every time the sidebar opens, so
+  // callers can deep-link to a tab (e.g. clicking "Focus" in ContextSummary).
+  useEffect(() => {
+    if (open) setActiveTab(initialTab ?? 'view');
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- intentional: reset only on each open
+  }, [open]);
 
   // Condition builder for the Filters tab
   const conditionBuilder = useConditionBuilder({
@@ -300,7 +310,8 @@ export function SidebarToggleButton({
       title="Perspective, focus & saved views"
     >
       <SlidersHorizontal size={15} />
-      <span>View Controls</span>
+      <span>Customize View</span>
+      <span className={styles['toggleArrow']} aria-hidden="true">→</span>
       {totalActive > 0 && (
         <span className={styles['badge']}>{totalActive}</span>
       )}

--- a/src/views/MonthView.module.css
+++ b/src/views/MonthView.module.css
@@ -233,6 +233,7 @@
   overflow: hidden;
   text-overflow: ellipsis;
   transition: opacity 0.1s;
+  box-shadow: var(--wc-event-glow, none);
   /* Touch: claim the pointer for move so the browser doesn't fire tap
      through to a date-cell pointer-down. */
   touch-action: none;

--- a/src/views/WeekView.module.css
+++ b/src/views/WeekView.module.css
@@ -86,6 +86,7 @@
   overflow: hidden;
   box-sizing: border-box;
   transition: filter 0.1s;
+  box-shadow: var(--wc-event-glow, none);
   z-index: 2;
   touch-action: none;
 }
@@ -307,6 +308,7 @@
   gap: 1px;
   z-index: 5;
   transition: filter 0.1s;
+  box-shadow: var(--wc-event-glow, none);
   box-sizing: border-box;
   user-select: none;
   -webkit-user-select: none;


### PR DESCRIPTION
… glow + branding

Design review flagged three UX gaps. Fix each without over-reach:

- ContextSummary segments become `<button>`s when `onSegmentClick` is provided; wired in WorksCalendar so clicking View/Focus/Scope opens the sidebar to the matching tab. FilterGroupSidebar gains an `initialTab` prop and resets to it on each open.
- Rename the sidebar toggle from "View Controls" to "Customize View →" with an animated arrow so the entry point is self-evident.
- Introduce `--wc-event-glow` consumed by MonthView/WeekView pills. Neon dark gets a base glow + stronger high-priority glow; industrial gets a structural high-priority outline; ops light gets a shadow lift on high-priority and ops dark gains a base ambient glow. Default fallback is `none` so non-glow families render unchanged.
- Add `logoSrc`/`logoAlt`/`backgroundImage` props. Logo renders left of the nav group; backgroundImage is injected as `--wc-bg-image` on the root and the root's `background` shorthand is split so the color and image layer independently.

## Summary
Describe exactly what this PR changes.

## Scope
- Stage: 
- Planned PR number in sprint: 
- Target files/directories: 
- Why this slice is isolated: 

## Lessons Learned Check (REQUIRED)
Confirm these were actively used while building this PR:

- [ ] PR is intentionally small and isolated
- [ ] Boundary typing was prioritized over internal perfection
- [ ] No silent spread of `any`
- [ ] Advisory root `tsc` was used to catch integration issues
- [ ] I did not assume “looks typed” means “safe”
- [ ] I stopped and isolated typing cascades instead of expanding scope

## Definition of Done (ALL REQUIRED)
This PR is not done unless every box is checked.

- [ ] `npm run type-check:strict` passes
- [ ] Root advisory `tsc --noEmit` passes
- [ ] Tests pass for touched scope at minimum
- [ ] No uncontrolled increase in `any`
- [ ] All new types are intentional and named
- [ ] Public interfaces and exported functions are explicitly typed
- [ ] PR scope matches the sprint plan with no scope creep
- [ ] Any new `any` has an adjacent justification comment
- [ ] No file-wide `: any`
- [ ] No implicit `any` in exported functions

## What Was Typed
List exactly what was typed in this PR.

- 
- 
- 

## What Was Intentionally Left Loose
List anything intentionally not tightened yet.

- 
- 
- 

## `any` Ledger (REQUIRED)
- New `any` added: 
- Existing `any` removed: 
- Net change: 

For every new `any`, explain why it is required and why a safer type was not used yet.

1. 
2. 
3. 

## Boundary Notes
Document any public seams, caller-protection choices, or compatibility decisions.

- 
- 
- 

## Risk Level
- [ ] Low
- [ ] Medium
- [ ] High

Why:

## Validation Evidence
Paste the exact commands run and a short result summary.

```bash
npm run type-check:strict
npx tsc --noEmit -p tsconfig.json
```

Test commands run:

```bash
# paste commands here
```

## Stop Conditions Check
If any item below happened, explain how scope was reduced before merge.

- [ ] `any` started spreading across files
- [ ] Root `tsc` broke repeatedly
- [ ] Types required cross-module rewrites
- [ ] Scope was reduced to keep the PR reviewable

Notes:

## Reviewer Focus
What should reviewers look at first?

- 
- 
- 
