### PR TITLE
layout: collapse toolbar view buttons and ProfileBar header into a single row

### DIFF
--- a/src/WorksCalendar.module.css
+++ b/src/WorksCalendar.module.css
@@ -323,7 +323,7 @@
   min-width: 0;
 }
 
-/* View switcher */
+/* View switcher (legacy 7-button group — retained for potential custom toolbars) */
 .viewGroup {
   display: flex;
   background: var(--wc-surface);
@@ -331,6 +331,12 @@
   border-radius: var(--wc-radius-sm);
   overflow: hidden;
   margin-left: auto;
+}
+
+/* View picker (single-dropdown replacement) sits next to the date label;
+   .actions picks up margin-left: auto so secondary controls flow right. */
+.viewPickerWrap {
+  display: flex;
 }
 
 .viewBtn {
@@ -358,6 +364,7 @@
   display: flex;
   align-items: center;
   gap: 6px;
+  margin-left: auto;
 }
 
 .devBadge {

--- a/src/WorksCalendar.tsx
+++ b/src/WorksCalendar.tsx
@@ -47,6 +47,7 @@ import { captureSavedViewFields, type ViewId } from './core/viewScope';
 import { buildActiveFilterPills, buildFilterSummary, hasActiveFilters } from './filters/filterState';
 import FilterBar              from './ui/FilterBar';
 import ProfileBar             from './ui/ProfileBar';
+import ViewPicker             from './ui/ViewPicker';
 import FilterGroupSidebar, { SidebarToggleButton } from './ui/FilterGroupSidebar';
 import FocusChips, { DEFAULT_FOCUS_CHIPS, resolveActiveChipLabels } from './ui/FocusChips';
 import type { FocusChipDef } from './ui/FocusChips';
@@ -2119,18 +2120,12 @@ export const WorksCalendar = forwardRef<CalendarApi, WorksCalendarProps>(functio
               {fetchLoading && <span className={styles['loadingDot']} title="Loading…" aria-label="Loading events" role="status" />}
             </div>
 
-            <div className={styles['viewGroup']} role="group" aria-label="Calendar view">
-              {VIEWS.map(v => (
-                <button
-                  key={v.id}
-                  className={[styles['viewBtn'], cal.view === v.id && styles['activeView']].filter(Boolean).join(' ')}
-                  onClick={() => cal.setView(v.id)}
-                  aria-pressed={cal.view === v.id}
-                  title={v.hint}
-                >
-                  {v.label}
-                </button>
-              ))}
+            <div className={styles['viewPickerWrap']}>
+              <ViewPicker
+                views={VIEWS}
+                activeView={cal.view}
+                onChange={(id) => cal.setView(id as ViewId)}
+              />
             </div>
 
             <div className={styles['actions']}>
@@ -2227,6 +2222,7 @@ export const WorksCalendar = forwardRef<CalendarApi, WorksCalendarProps>(functio
             })
           : (
             <ProfileBar
+              compact
               views={savedViews.views}
               activeId={savedViewActiveId}
               isDirty={savedViewDirty}

--- a/src/__tests__/WorksCalendar.employees.sync.test.tsx
+++ b/src/__tests__/WorksCalendar.employees.sync.test.tsx
@@ -40,7 +40,8 @@ describe('WorksCalendar employees ↔ TeamTab bidirectional sync (issue #101)', 
     );
 
     // Switch to schedule/timeline view.
-    fireEvent.click(screen.getByRole('button', { name: 'Schedule' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Change view' }));
+    fireEvent.click(screen.getByRole('menuitem', { name: /Schedule/ }));
 
     // Open the add-person form from the timeline header.
     fireEvent.click(await screen.findByRole('button', { name: 'Add person' }));
@@ -77,7 +78,8 @@ describe('WorksCalendar employees ↔ TeamTab bidirectional sync (issue #101)', 
       />,
     );
 
-    fireEvent.click(screen.getByRole('button', { name: 'Schedule' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Change view' }));
+    fireEvent.click(screen.getByRole('menuitem', { name: /Schedule/ }));
     fireEvent.click(await screen.findByRole('button', { name: 'Add person' }));
 
     const nameInput = await screen.findByPlaceholderText('Name');

--- a/src/__tests__/WorksCalendar.scheduleModel.integration.test.tsx
+++ b/src/__tests__/WorksCalendar.scheduleModel.integration.test.tsx
@@ -62,7 +62,8 @@ describe('WorksCalendar schedule model integration', () => {
     const apiRef = createRef<any>();
     render(<WorksCalendar ref={apiRef} employees={employees} events={[baseShift]} />);
 
-    fireEvent.click(screen.getByRole('button', { name: 'Schedule' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Change view' }));
+    fireEvent.click(screen.getByRole('menuitem', { name: /Schedule/ }));
     await requestPtoForAlex();
 
     await waitFor(() => {
@@ -85,7 +86,8 @@ describe('WorksCalendar schedule model integration', () => {
       />,
     );
 
-    fireEvent.click(screen.getByRole('button', { name: 'Schedule' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Change view' }));
+    fireEvent.click(screen.getByRole('menuitem', { name: /Schedule/ }));
     await requestPtoForAlex();
 
     await waitFor(() => {
@@ -105,7 +107,8 @@ describe('WorksCalendar schedule model integration', () => {
     const apiRef = createRef<any>();
     render(<WorksCalendar ref={apiRef} employees={employees} events={[baseShift]} />);
 
-    fireEvent.click(screen.getByRole('button', { name: 'Schedule' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Change view' }));
+    fireEvent.click(screen.getByRole('menuitem', { name: /Schedule/ }));
     await requestPtoForAlex();
     await screen.findByRole('button', { name: 'Shift not covered — click to assign coverage' });
     await requestPtoForAlex();
@@ -123,7 +126,8 @@ describe('WorksCalendar schedule model integration', () => {
     const apiRef = createRef<any>();
     render(<WorksCalendar ref={apiRef} employees={employees} events={[baseShift]} />);
 
-    fireEvent.click(screen.getByRole('button', { name: 'Schedule' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Change view' }));
+    fireEvent.click(screen.getByRole('menuitem', { name: /Schedule/ }));
     await requestPtoForAlex();
     await screen.findByRole('button', { name: 'Shift not covered — click to assign coverage' });
     await assignCoverageTo(/^Bailey Chen — RN$/);
@@ -149,7 +153,8 @@ describe('WorksCalendar schedule model integration', () => {
     const apiRef = createRef<any>();
     render(<WorksCalendar ref={apiRef} employees={employees} events={[baseShift]} />);
 
-    fireEvent.click(screen.getByRole('button', { name: 'Schedule' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Change view' }));
+    fireEvent.click(screen.getByRole('menuitem', { name: /Schedule/ }));
     await requestPtoForAlex();
     await assignCoverageTo(/^Bailey Chen — RN$/);
 
@@ -184,7 +189,8 @@ describe('WorksCalendar schedule model integration', () => {
       />,
     );
 
-    fireEvent.click(screen.getByRole('button', { name: 'Schedule' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Change view' }));
+    fireEvent.click(screen.getByRole('menuitem', { name: /Schedule/ }));
     await requestPtoForAlex();
     await assignCoverageTo(/^Bailey Chen — RN$/);
     fireEvent.click(screen.getByRole('button', { name: 'Set shift availability' }));
@@ -209,7 +215,8 @@ describe('WorksCalendar schedule model integration', () => {
     const apiRef = createRef<any>();
     render(<WorksCalendar ref={apiRef} employees={employees} events={[baseShift]} />);
 
-    fireEvent.click(screen.getByRole('button', { name: 'Schedule' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Change view' }));
+    fireEvent.click(screen.getByRole('menuitem', { name: /Schedule/ }));
     await requestPtoForAlex();
 
     await assignCoverageTo(/^Bailey Chen — RN$/);
@@ -237,7 +244,8 @@ describe('WorksCalendar schedule model integration', () => {
     const apiRef = createRef<any>();
     render(<WorksCalendar ref={apiRef} employees={employees} events={[baseShift]} />);
 
-    fireEvent.click(screen.getByRole('button', { name: 'Schedule' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Change view' }));
+    fireEvent.click(screen.getByRole('menuitem', { name: /Schedule/ }));
     await requestPtoForAlex();
     await assignCoverageTo(/^Bailey Chen — RN$/);
 

--- a/src/__tests__/WorksCalendar.scheduleWorkflow.test.tsx
+++ b/src/__tests__/WorksCalendar.scheduleWorkflow.test.tsx
@@ -12,7 +12,8 @@ describe('WorksCalendar schedule workflow entry points', () => {
   it('opens employee action card when employee name is clicked', async () => {
     render(<WorksCalendar events={[]} employees={employees} />);
 
-    fireEvent.click(screen.getByRole('button', { name: 'Schedule' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Change view' }));
+    fireEvent.click(screen.getByRole('menuitem', { name: /Schedule/ }));
     fireEvent.click(await screen.findByRole('button', { name: 'Actions for Alex Rivera' }));
 
     expect(await screen.findByRole('menu', { name: 'Actions for Alex Rivera' })).toBeInTheDocument();
@@ -22,7 +23,8 @@ describe('WorksCalendar schedule workflow entry points', () => {
   it('routes empty schedule-cell click to ScheduleEditorForm instead of EventForm', async () => {
     render(<WorksCalendar events={[]} employees={employees} showAddButton />);
 
-    fireEvent.click(screen.getByRole('button', { name: 'Schedule' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Change view' }));
+    fireEvent.click(screen.getByRole('menuitem', { name: /Schedule/ }));
     fireEvent.click(await screen.findByRole('gridcell', { name: /^Alex Rivera, April 1, empty/ }));
 
     expect(await screen.findByRole('dialog', { name: 'Create schedule for Alex Rivera' })).toBeInTheDocument();
@@ -35,7 +37,8 @@ describe('WorksCalendar schedule workflow entry points', () => {
     render(<WorksCalendar events={[]} employees={employees} showAddButton />);
 
     expect(screen.getByRole('button', { name: 'Add new event' })).toBeInTheDocument();
-    fireEvent.click(screen.getByRole('button', { name: 'Schedule' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Change view' }));
+    fireEvent.click(screen.getByRole('menuitem', { name: /Schedule/ }));
 
     expect(screen.queryByRole('button', { name: 'Add new event' })).not.toBeInTheDocument();
   });
@@ -43,7 +46,8 @@ describe('WorksCalendar schedule workflow entry points', () => {
   it('opens PTO-focused form when Request PTO is selected', async () => {
     render(<WorksCalendar events={[]} employees={employees} />);
 
-    fireEvent.click(screen.getByRole('button', { name: 'Schedule' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Change view' }));
+    fireEvent.click(screen.getByRole('menuitem', { name: /Schedule/ }));
     fireEvent.click(await screen.findByRole('button', { name: 'Actions for Alex Rivera' }));
     fireEvent.click(await screen.findByRole('button', { name: 'Request PTO' }));
 
@@ -55,7 +59,8 @@ describe('WorksCalendar schedule workflow entry points', () => {
   it('opens unavailable-focused form when Mark Unavailable is selected', async () => {
     render(<WorksCalendar events={[]} employees={employees} />);
 
-    fireEvent.click(screen.getByRole('button', { name: 'Schedule' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Change view' }));
+    fireEvent.click(screen.getByRole('menuitem', { name: /Schedule/ }));
     fireEvent.click(await screen.findByRole('button', { name: 'Actions for Alex Rivera' }));
     fireEvent.click(await screen.findByRole('button', { name: 'Mark Unavailable' }));
 
@@ -82,7 +87,8 @@ describe('WorksCalendar schedule workflow entry points', () => {
       />,
     );
 
-    fireEvent.click(screen.getByRole('button', { name: 'Schedule' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Change view' }));
+    fireEvent.click(screen.getByRole('menuitem', { name: /Schedule/ }));
     fireEvent.click(await screen.findByRole('button', { name: 'Actions for Alex Rivera' }));
     fireEvent.click(await screen.findByRole('button', { name: 'Set Availability' }));
 

--- a/src/ui/ProfileBar.module.css
+++ b/src/ui/ProfileBar.module.css
@@ -6,6 +6,64 @@
   background: var(--wc-surface);
 }
 
+/* Compact mode: chip strip only, no header action row.
+   Power-user controls (Customize, Clear, Save-view) live inline at the
+   strip tail, so the bar renders as a single slim row. */
+.barCompact {
+  background: var(--wc-bg);
+}
+.barCompact .strip {
+  padding: 4px 12px;
+}
+
+.stripTail {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  margin-left: auto;
+  padding-left: 8px;
+  flex-shrink: 0;
+}
+
+.tailSaveBtn {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 4px 10px;
+  border-radius: var(--wc-radius-sm);
+  border: 1px dashed var(--wc-border);
+  background: transparent;
+  color: var(--wc-text-muted);
+  font-size: 12px;
+  font-weight: 500;
+  font-family: inherit;
+  cursor: pointer;
+  transition: border-color 0.15s, color 0.15s;
+}
+.tailSaveBtn:hover {
+  border-color: var(--wc-accent);
+  color: var(--wc-accent);
+}
+
+.tailClearBtn {
+  display: inline-flex;
+  align-items: center;
+  padding: 4px 10px;
+  border-radius: var(--wc-radius-sm);
+  border: 1px solid var(--wc-border);
+  background: transparent;
+  color: var(--wc-text-muted);
+  font-size: 12px;
+  font-weight: 500;
+  font-family: inherit;
+  cursor: pointer;
+  transition: all 0.15s;
+}
+.tailClearBtn:hover {
+  border-color: var(--wc-danger, var(--wc-accent));
+  color: var(--wc-danger, var(--wc-accent));
+}
+
 /* Top row: All views ▾ | Customize | Clear all filters | + Save view */
 .headerRow {
   display: flex;

--- a/src/ui/ProfileBar.tsx
+++ b/src/ui/ProfileBar.tsx
@@ -50,6 +50,7 @@ export default function ProfileBar({
   enabledViews,
   locationLabel = 'Base',
   hasActiveFilters = false,
+  compact = false,
   onApply,
   onAdd,
   onResave,
@@ -91,40 +92,42 @@ export default function ProfileBar({
   const nonEmpty = [...grouped.entries()].filter(([, list]) => list.length > 0);
 
   return (
-    <div className={styles['bar']}>
-      <div className={styles['headerRow']}>
-        <ViewsDropdown
-          views={views}
-          activeId={activeId}
-          onApply={(sv: any) => { onApply(sv); setSaveOpen(false); }}
-          onToggleVisibility={onToggleVisibility}
-        />
+    <div className={[styles['bar'], compact && styles['barCompact']].filter(Boolean).join(' ')}>
+      {!compact && (
+        <div className={styles['headerRow']}>
+          <ViewsDropdown
+            views={views}
+            activeId={activeId}
+            onApply={(sv: any) => { onApply(sv); setSaveOpen(false); }}
+            onToggleVisibility={onToggleVisibility}
+          />
 
-        <CustomizeQuickViewsPanel
-          views={views}
-          onRename={(id: string, name: string) => onUpdate(id, { name })}
-          onColorChange={(id: string, color: string) => onUpdate(id, { color })}
-          onResave={(id: string) => onResave(id)}
-          onDelete={(id: string) => onDelete(id)}
-          onToggleVisibility={onToggleVisibility}
-          onEditConditions={onEditConditions}
-        />
+          <CustomizeQuickViewsPanel
+            views={views}
+            onRename={(id: string, name: string) => onUpdate(id, { name })}
+            onColorChange={(id: string, color: string) => onUpdate(id, { color })}
+            onResave={(id: string) => onResave(id)}
+            onDelete={(id: string) => onDelete(id)}
+            onToggleVisibility={onToggleVisibility}
+            onEditConditions={onEditConditions}
+          />
 
-        <ClearFiltersButton
-          hasActiveFilters={hasActiveFilters}
-          onClear={onClearFilters}
-        />
+          <ClearFiltersButton
+            hasActiveFilters={hasActiveFilters}
+            onClear={onClearFilters}
+          />
 
-        <button
-          type="button"
-          className={styles['addChip']}
-          onClick={() => setSaveOpen(v => !v)}
-          title="Save current filters as a new saved view"
-        >
-          <Plus size={13} />
-          Save view
-        </button>
-      </div>
+          <button
+            type="button"
+            className={styles['addChip']}
+            onClick={() => setSaveOpen(v => !v)}
+            title="Save current filters as a new saved view"
+          >
+            <Plus size={13} />
+            Save view
+          </button>
+        </div>
+      )}
 
       {nonEmpty.length > 0 && (
         <div className={styles['strip']}>
@@ -160,6 +163,55 @@ export default function ProfileBar({
               </div>
             );
           })}
+          {compact && (
+            <div className={styles['stripTail']}>
+              {hasActiveFilters && (
+                <button
+                  type="button"
+                  className={styles['tailClearBtn']}
+                  onClick={onClearFilters}
+                  title="Clear all filters"
+                >
+                  Clear filters
+                </button>
+              )}
+              <button
+                type="button"
+                className={styles['tailSaveBtn']}
+                onClick={() => setSaveOpen(v => !v)}
+                title="Save current filters as a new saved view"
+                aria-label="Save current view"
+              >
+                <Plus size={13} aria-hidden="true" />
+                <span>Save</span>
+              </button>
+            </div>
+          )}
+        </div>
+      )}
+      {compact && nonEmpty.length === 0 && (
+        <div className={styles['strip']}>
+          <div className={styles['stripTail']}>
+            {hasActiveFilters && (
+              <button
+                type="button"
+                className={styles['tailClearBtn']}
+                onClick={onClearFilters}
+                title="Clear all filters"
+              >
+                Clear filters
+              </button>
+            )}
+            <button
+              type="button"
+              className={styles['tailSaveBtn']}
+              onClick={() => setSaveOpen(v => !v)}
+              title="Save current filters as a new saved view"
+            >
+              <Plus size={13} aria-hidden="true" />
+              <span>Save view</span>
+            </button>
+          </div>
         </div>
       )}
 

--- a/src/ui/ViewPicker.module.css
+++ b/src/ui/ViewPicker.module.css
@@ -1,0 +1,103 @@
+.root {
+  position: relative;
+  display: inline-flex;
+}
+
+.trigger {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 0 10px;
+  height: 32px;
+  border-radius: var(--wc-radius-sm);
+  background: var(--wc-surface);
+  border: var(--wc-border-width, 1px) solid var(--wc-border);
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--wc-text);
+  cursor: pointer;
+  font-family: inherit;
+  white-space: nowrap;
+  transition: all 0.15s;
+}
+.trigger:hover {
+  border-color: var(--wc-border-dark);
+  background: var(--wc-surface-2, var(--wc-surface));
+}
+.trigger[aria-expanded="true"] {
+  border-color: var(--wc-accent);
+  color: var(--wc-accent);
+}
+
+.label {
+  min-width: 44px;
+  text-align: left;
+}
+
+.menu {
+  position: absolute;
+  top: calc(100% + 4px);
+  left: 0;
+  z-index: 50;
+  min-width: 220px;
+  background: var(--wc-bg);
+  border: var(--wc-border-width, 1px) solid var(--wc-border);
+  border-radius: var(--wc-radius);
+  box-shadow: var(--wc-shadow, 0 4px 12px rgba(0, 0, 0, 0.12));
+  padding: 4px;
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+}
+
+.item {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  grid-template-rows: auto auto;
+  column-gap: 8px;
+  row-gap: 1px;
+  align-items: center;
+  padding: 6px 8px;
+  border: none;
+  background: transparent;
+  border-radius: var(--wc-radius-sm);
+  text-align: left;
+  cursor: pointer;
+  font-family: inherit;
+  color: var(--wc-text);
+  transition: background 0.12s;
+}
+.item:hover { background: var(--wc-surface); }
+.item:focus-visible {
+  outline: 2px solid var(--wc-accent);
+  outline-offset: -2px;
+}
+
+.itemActive {
+  background: var(--wc-accent-dim, var(--wc-surface));
+  color: var(--wc-accent);
+}
+.itemActive:hover { background: var(--wc-accent-dim, var(--wc-surface)); }
+
+.itemIcon {
+  grid-row: 1 / 3;
+  align-self: center;
+  color: var(--wc-text-muted);
+}
+.itemActive .itemIcon { color: var(--wc-accent); }
+
+.itemLabel {
+  font-size: 13px;
+  font-weight: 500;
+  grid-column: 2;
+  grid-row: 1;
+}
+
+.itemHint {
+  font-size: 11px;
+  color: var(--wc-text-muted);
+  grid-column: 2;
+  grid-row: 2;
+  white-space: normal;
+  line-height: 1.3;
+}

--- a/src/ui/ViewPicker.tsx
+++ b/src/ui/ViewPicker.tsx
@@ -1,0 +1,103 @@
+/**
+ * ViewPicker — Single dropdown replacing the 7-button calendar view switcher.
+ *
+ * Shows the current view label with a chevron; opens a menu of all enabled
+ * views (each with its icon + optional hint). Intended to keep the toolbar
+ * chrome slim so more horizontal space stays available for the saved-view
+ * chip strip.
+ */
+import { useEffect, useRef, useState } from 'react';
+import {
+  ChevronDown,
+  CalendarDays, Calendar, Columns3, List, CalendarRange, Boxes, MapPin,
+} from 'lucide-react';
+import styles from './ViewPicker.module.css';
+
+const VIEW_ICON_MAP: Record<string, any> = {
+  month:    CalendarDays,
+  week:     Columns3,
+  day:      Calendar,
+  agenda:   List,
+  schedule: CalendarRange,
+  base:     MapPin,
+  assets:   Boxes,
+};
+
+type ViewOption = {
+  id: string;
+  label: string;
+  hint?: string;
+};
+
+type Props = {
+  views: readonly ViewOption[];
+  activeView: string;
+  onChange: (id: string) => void;
+};
+
+export default function ViewPicker({ views, activeView, onChange }: Props) {
+  const [open, setOpen] = useState(false);
+  const rootRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    function handleClick(e: MouseEvent) {
+      if (rootRef.current && !rootRef.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    }
+    function handleKey(e: KeyboardEvent) {
+      if (e.key === 'Escape') setOpen(false);
+    }
+    document.addEventListener('mousedown', handleClick);
+    document.addEventListener('keydown', handleKey);
+    return () => {
+      document.removeEventListener('mousedown', handleClick);
+      document.removeEventListener('keydown', handleKey);
+    };
+  }, [open]);
+
+  const active = views.find(v => v.id === activeView) ?? views[0];
+  const ActiveIcon = active ? VIEW_ICON_MAP[active.id] : null;
+
+  return (
+    <div ref={rootRef} className={styles['root']}>
+      <button
+        type="button"
+        className={styles['trigger']}
+        onClick={() => setOpen(v => !v)}
+        aria-haspopup="menu"
+        aria-expanded={open}
+        aria-label="Change view"
+        title={active?.hint ?? active?.label}
+      >
+        {ActiveIcon && <ActiveIcon size={14} aria-hidden="true" />}
+        <span className={styles['label']}>{active?.label ?? 'View'}</span>
+        <ChevronDown size={13} aria-hidden="true" />
+      </button>
+
+      {open && (
+        <div className={styles['menu']} role="menu" aria-label="Calendar view">
+          {views.map(v => {
+            const Icon = VIEW_ICON_MAP[v.id];
+            const isActive = v.id === activeView;
+            return (
+              <button
+                key={v.id}
+                type="button"
+                role="menuitem"
+                className={[styles['item'], isActive && styles['itemActive']].filter(Boolean).join(' ')}
+                onClick={() => { onChange(v.id); setOpen(false); }}
+                aria-label={v.label}
+              >
+                {Icon && <Icon size={14} aria-hidden="true" className={styles['itemIcon']} />}
+                <span className={styles['itemLabel']}>{v.label}</span>
+                {v.hint && <span className={styles['itemHint']}>{v.hint}</span>}
+              </button>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
The header area stacked six bands deep before the calendar was visible
(toolbar, edit banner, ProfileBar header row, strip, context summary,
focus chips). This first pass targets the two noisiest contributors:

- Replace the 7-button view switcher with a single ViewPicker dropdown.
  Keeps every view one click away while freeing horizontal space.
- Add a compact mode to ProfileBar that hides the Views/Customize/Clear/
  Save action row; Save + Clear move inline at the strip tail so they
  stay discoverable without a dedicated band.

WorksCalendar renders the compact ProfileBar by default. Custom
`renderSavedViewsBar` overrides continue to work unchanged.

Test clicks on the old view buttons (`{ name: 'Schedule' }`) are
updated to the new two-step pattern against the ViewPicker's menu.