### PR TITLE
pools: richer error diagnostics + indexOf guard (#386 items 2/3/5/13)

### DIFF
--- a/docs/ResourcePools.md
+++ b/docs/ResourcePools.md
@@ -116,9 +116,24 @@ engine advances the cursor atomically with the booking commit and
 includes the updated pool in the next `onPoolsChange`.
 
 If every member is in hard conflict, the submit is rejected with a
-`POOL_EXHAUSTED` violation — nothing is written and no member rotates.
-An unknown pool id rejects with `POOL_UNKNOWN`; a disabled pool rejects
-with `POOL_DISABLED`.
+`NO_AVAILABLE_MEMBER` violation — nothing is written and no member
+rotates. An unknown pool id rejects with `POOL_UNKNOWN`; a disabled
+pool rejects with `POOL_DISABLED`; a pool with zero members rejects
+with `POOL_EMPTY`. Every rejection carries `details.evaluated`, the
+ordered list of members the resolver actually attempted (empty for
+`POOL_DISABLED` / `POOL_EMPTY`, populated for `NO_AVAILABLE_MEMBER`).
+
+## Sharing members across pools
+
+Two pools may list the same member id. Pools are independent: the
+resolver for pool A does not know or care that member `M` also belongs
+to pool B. If your host submits two pool-backed bookings in parallel
+against overlapping time windows and both happen to resolve to `M`,
+the normal `resource-overlap` rule will reject the second submit —
+but only when the second submit actually runs. There is **no
+cross-pool mutual exclusion or holding phase**; if you need one, do
+it at your host layer (queue submits, or wrap them in an optimistic
+transaction).
 
 ## Disabled pools
 

--- a/src/core/engine/__tests__/resolvePoolOnSubmit.test.ts
+++ b/src/core/engine/__tests__/resolvePoolOnSubmit.test.ts
@@ -214,4 +214,40 @@ describe('applyMutation — pool resolve on submit', () => {
     expect(engine.state.events.size).toBe(0);
     expect(engine.getPool('agents')?.rrCursor).toBeUndefined();
   });
+
+  it('rejects a submit against an empty pool with POOL_EMPTY and an empty evaluated trail', () => {
+    const engine = new CalendarEngine({
+      pools: [pool({ id: 'drivers', memberIds: [] })],
+    });
+
+    const before = engine.state.events;
+    const result = engine.applyMutation(createOp({ resourcePoolId: 'drivers' }));
+
+    expect(result.status).toBe('rejected');
+    expect(result.validation.severity).toBe('hard');
+    expect(result.validation.violations[0]?.rule).toBe('pool-unresolvable');
+    expect(result.validation.violations[0]?.details?.['code']).toBe('POOL_EMPTY');
+    expect(result.validation.violations[0]?.details?.['evaluated']).toEqual([]);
+    expect(engine.state.events).toBe(before); // state unchanged
+  });
+
+  it('surfaces the actual evaluated trail on NO_AVAILABLE_MEMBER rejections', () => {
+    const engine = new CalendarEngine({
+      events: [
+        makeEvent('b1', { title: 'x', start: START, end: END, resourceId: 'd1' }),
+        makeEvent('b2', { title: 'y', start: START, end: END, resourceId: 'd2' }),
+      ],
+      pools:  [pool({ id: 'drivers', memberIds: ['d1', 'd2'] })],
+    });
+
+    const result = engine.applyMutation(createOp({ resourcePoolId: 'drivers' }));
+
+    expect(result.status).toBe('rejected');
+    expect(result.validation.violations[0]?.details?.['code']).toBe('NO_AVAILABLE_MEMBER');
+    // Previously this returned pool.memberIds unconditionally, which
+    // was correct only for this code. Now it must equal the ordered
+    // resolver trail — which, for a two-member exhaustion, is the full
+    // member list.
+    expect(result.validation.violations[0]?.details?.['evaluated']).toEqual(['d1', 'd2']);
+  });
 });

--- a/src/core/engine/resolvePoolOnSubmit.ts
+++ b/src/core/engine/resolvePoolOnSubmit.ts
@@ -122,6 +122,11 @@ export function resolvePoolForOp(
 
   if (result.ok === false) {
     const err = result.error;
+    // `err.evaluated` reflects the actual strategy trail: empty for
+    // POOL_DISABLED / POOL_EMPTY (no member was ever attempted) and the
+    // ordered attempt list for NO_AVAILABLE_MEMBER. Previously this
+    // payload returned `pool.memberIds` unconditionally, which
+    // over-reported evaluation for the first two codes.
     return { kind: 'rejected', result: rejectedFor(op, {
       rule:    'pool-unresolvable',
       severity:'hard',
@@ -129,7 +134,7 @@ export function resolvePoolForOp(
       details: {
         poolId:    err.poolId,
         code:      err.code,
-        evaluated: pool.memberIds,
+        evaluated: err.evaluated,
       },
     }) };
   }

--- a/src/core/pools/__tests__/resolvePool.test.ts
+++ b/src/core/pools/__tests__/resolvePool.test.ts
@@ -197,4 +197,62 @@ describe('resolvePool — evaluated trail', () => {
     expect(result.ok).toBe(true)
     if (result.ok) expect(result.evaluated).toEqual(['a', 'b', 'c'])
   })
+
+  it('returns an empty evaluated trail on POOL_DISABLED (no member attempted)', () => {
+    const pool: ResourcePool = {
+      id: 'p', name: 'Off', memberIds: ['a', 'b'], strategy: 'first-available', disabled: true,
+    }
+    const result = resolvePool({ pool, proposed, events: [], rules: [] })
+    expect(result.ok).toBe(false)
+    if (!result.ok) {
+      expect(result.error.code).toBe('POOL_DISABLED')
+      expect(result.error.evaluated).toEqual([])
+    }
+  })
+
+  it('returns an empty evaluated trail on POOL_EMPTY (no member to attempt)', () => {
+    const pool: ResourcePool = {
+      id: 'p', name: 'Empty', memberIds: [], strategy: 'first-available',
+    }
+    const result = resolvePool({ pool, proposed, events: [], rules: [] })
+    expect(result.ok).toBe(false)
+    if (!result.ok) {
+      expect(result.error.code).toBe('POOL_EMPTY')
+      expect(result.error.evaluated).toEqual([])
+    }
+  })
+
+  it('returns the full attempt list on NO_AVAILABLE_MEMBER', () => {
+    const pool: ResourcePool = {
+      id: 'p', name: 'Slammed', memberIds: ['a', 'b', 'c'], strategy: 'first-available',
+    }
+    const events: ConflictEvent[] = [
+      { id: 'e1', start: winStart, end: winEnd, resource: 'a' },
+      { id: 'e2', start: winStart, end: winEnd, resource: 'b' },
+      { id: 'e3', start: winStart, end: winEnd, resource: 'c' },
+    ]
+    const result = resolvePool({ pool, proposed, events, rules: [overlapRule] })
+    expect(result.ok).toBe(false)
+    if (!result.ok) {
+      expect(result.error.code).toBe('NO_AVAILABLE_MEMBER')
+      expect(result.error.evaluated).toEqual(['a', 'b', 'c'])
+    }
+  })
+})
+
+describe('resolvePool — round-robin cursor normalization', () => {
+  it('wraps a stale cursor that points past the end of the member list', () => {
+    // Pool was 5 members when cursor was stored as 4; members have
+    // since been trimmed to 3. `((4 ?? -1) + 1) % 3 === 2` → start at c.
+    const pool: ResourcePool = {
+      id: 'p', name: 'Shrunk', memberIds: ['a', 'b', 'c'],
+      strategy: 'round-robin', rrCursor: 4,
+    }
+    const result = resolvePool({ pool, proposed, events: [], rules: [] })
+    expect(result.ok).toBe(true)
+    if (result.ok) {
+      expect(result.resourceId).toBe('c')
+      expect(result.rrCursor).toBe(2)
+    }
+  })
 })

--- a/src/core/pools/resolvePool.ts
+++ b/src/core/pools/resolvePool.ts
@@ -51,6 +51,14 @@ export interface ResolvePoolError {
   readonly code: ResolvePoolErrorCode
   readonly message: string
   readonly poolId: string
+  /**
+   * Members that were tried, in the order the strategy attempted them,
+   * before the resolver gave up. Empty for `POOL_DISABLED` and
+   * `POOL_EMPTY` (no member is ever attempted). Populated for
+   * `NO_AVAILABLE_MEMBER` so callers can surface "tried A, B; both
+   * conflicted" instead of a bare "no member available".
+   */
+  readonly evaluated: readonly string[]
 }
 
 export interface ResolvePoolSuccess {
@@ -129,10 +137,10 @@ function workloadFor(
 export function resolvePool(input: ResolvePoolInput): ResolvePoolResult {
   const { pool } = input
   if (pool.disabled) {
-    return { ok: false, error: { code: 'POOL_DISABLED', message: `Pool "${pool.id}" is disabled.`, poolId: pool.id } }
+    return { ok: false, error: { code: 'POOL_DISABLED', message: `Pool "${pool.id}" is disabled.`, poolId: pool.id, evaluated: [] } }
   }
   if (pool.memberIds.length === 0) {
-    return { ok: false, error: { code: 'POOL_EMPTY', message: `Pool "${pool.id}" has no members.`, poolId: pool.id } }
+    return { ok: false, error: { code: 'POOL_EMPTY', message: `Pool "${pool.id}" has no members.`, poolId: pool.id, evaluated: [] } }
   }
 
   const winStart = toTime(input.proposed.start)
@@ -177,6 +185,13 @@ export function resolvePool(input: ResolvePoolInput): ResolvePoolResult {
     }
     if (pool.strategy === 'round-robin') {
       const nextCursor = pool.memberIds.indexOf(candidate)
+      // Invariant: every candidate originates from `pool.memberIds`, so
+      // indexOf cannot return -1 on the current code path. Assert anyway
+      // so a future refactor that projects candidates through a
+      // transform fails loudly instead of persisting `rrCursor: -1`.
+      if (nextCursor < 0) {
+        throw new Error(`resolvePool: round-robin candidate "${candidate}" is not in pool "${pool.id}" memberIds`)
+      }
       return { ...result, rrCursor: nextCursor }
     }
     return result
@@ -188,6 +203,7 @@ export function resolvePool(input: ResolvePoolInput): ResolvePoolResult {
       code: 'NO_AVAILABLE_MEMBER',
       message: `Pool "${pool.id}" has no available member for the requested window.`,
       poolId: pool.id,
+      evaluated,
     },
   }
 }


### PR DESCRIPTION
- Surface `evaluated: readonly string[]` on ResolvePoolError so NO_AVAILABLE_MEMBER carries the actual strategy trail and callers can render "tried A, B; both conflicted" in the conflict drawer. POOL_DISABLED / POOL_EMPTY return an empty trail, since no member is ever attempted.
- Propagate the real trail through resolvePoolOnSubmit so details.evaluated no longer over-reports evaluation for DISABLED and EMPTY (previously returned pool.memberIds unconditionally).
- Assert on indexOf bounds when writing the round-robin cursor so a future refactor that projects candidates through a transform fails loudly instead of persisting rrCursor: -1.
- docs/ResourcePools.md: document that pools do not provide cross-pool mutual exclusion; fix a pre-existing bug that referenced POOL_EXHAUSTED instead of the real NO_AVAILABLE_MEMBER code; call out the new evaluated trail shape.
- Regression tests: per-code evaluated trail, POOL_EMPTY at the engine submit level, stale rrCursor wrapping after member shrink.

Addresses issue #386 items 2, 3, 5, and 13. Items 1, 4, 6, 8-12, 14 deferred — those involve API surface widening or UX decisions.

https://claude.ai/code/session_01TsUYncc8wXWAtbNwa1VJDf

## Summary
Describe exactly what this PR changes.

## Scope
- Stage: 
- Planned PR number in sprint: 
- Target files/directories: 
- Why this slice is isolated: 

## Lessons Learned Check (REQUIRED)
Confirm these were actively used while building this PR:

- [ ] PR is intentionally small and isolated
- [ ] Boundary typing was prioritized over internal perfection
- [ ] No silent spread of `any`
- [ ] Advisory root `tsc` was used to catch integration issues
- [ ] I did not assume “looks typed” means “safe”
- [ ] I stopped and isolated typing cascades instead of expanding scope

## Definition of Done (ALL REQUIRED)
This PR is not done unless every box is checked.

- [ ] `npm run type-check:strict` passes
- [ ] Root advisory `tsc --noEmit` passes
- [ ] Tests pass for touched scope at minimum
- [ ] No uncontrolled increase in `any`
- [ ] All new types are intentional and named
- [ ] Public interfaces and exported functions are explicitly typed
- [ ] PR scope matches the sprint plan with no scope creep
- [ ] Any new `any` has an adjacent justification comment
- [ ] No file-wide `: any`
- [ ] No implicit `any` in exported functions

## What Was Typed
List exactly what was typed in this PR.

- 
- 
- 

## What Was Intentionally Left Loose
List anything intentionally not tightened yet.

- 
- 
- 

## `any` Ledger (REQUIRED)
- New `any` added: 
- Existing `any` removed: 
- Net change: 

For every new `any`, explain why it is required and why a safer type was not used yet.

1. 
2. 
3. 

## Boundary Notes
Document any public seams, caller-protection choices, or compatibility decisions.

- 
- 
- 

## Risk Level
- [ ] Low
- [ ] Medium
- [ ] High

Why:

## Validation Evidence
Paste the exact commands run and a short result summary.

```bash
npm run type-check:strict
npx tsc --noEmit -p tsconfig.json
```

Test commands run:

```bash
# paste commands here
```

## Stop Conditions Check
If any item below happened, explain how scope was reduced before merge.

- [ ] `any` started spreading across files
- [ ] Root `tsc` broke repeatedly
- [ ] Types required cross-module rewrites
- [ ] Scope was reduced to keep the PR reviewable

Notes:

## Reviewer Focus
What should reviewers look at first?

- 
- 
- 
