### PR TITLE
Claude/document resource scheduling pim8 q

### DIFF
--- a/demo/App.tsx
+++ b/demo/App.tsx
@@ -60,7 +60,15 @@ const DEMO_BASES = bases.map(b => ({ id: b.id, name: b.name }));
 /* ─── Config seed ───────────────────────────────────────────────── */
 // Bumped for the Air EMS identity change. Existing visitors on the IHC seed
 // see the new defaults on their next load without a manual storage wipe.
-const DEMO_SEED_VERSION = 4;
+//
+// Seed v5 — force-resync `team.bases` to DEMO_BASES on upgrade. Earlier
+// versions preserved any non-empty `existing.team.bases`, which left
+// returning visitors with stale base ids (e.g. IHC-era numeric ids) that
+// no longer matched the employee `basedAt` / aircraft `meta.base`
+// values. The result was a By-Base view counting 0 people / 0 assets at
+// every base. Bases are demo-controlled identity, not user data, so
+// overwriting them is safe.
+const DEMO_SEED_VERSION = 5;
 const SEED_VER_KEY      = `wc-demo-seed-v-${DEMO_CALENDAR_ID}`;
 const storedCfg         = localStorage.getItem(`wc-config-${DEMO_CALENDAR_ID}`);
 const storedSeedVer     = Number(localStorage.getItem(SEED_VER_KEY) ?? 0);
@@ -81,7 +89,7 @@ if (!storedCfg) {
     ...existing,
     title:     existing.title ?? 'Air EMS Operations',
     setup:     { ...existing.setup, preferredTheme: existing.setup?.preferredTheme ?? 'ops-dark' },
-    team:      { ...existing.team, bases: existing.team?.bases?.length ? existing.team.bases : DEMO_BASES },
+    team:      { ...existing.team, bases: DEMO_BASES },
     approvals: { ...existing.approvals, enabled: true },
   });
   localStorage.setItem(SEED_VER_KEY, String(DEMO_SEED_VERSION));

--- a/demo/App.tsx
+++ b/demo/App.tsx
@@ -15,6 +15,7 @@ import {
   bases,
   assets as EMS_ASSETS,
   crew,
+  dispatchers,
   medicalCrew,
   mechanics,
   allEvents,
@@ -97,8 +98,16 @@ const PILOT_COLOR    = '#3b82f6';
 const MEDICAL_COLOR  = '#10b981';
 const SPECIAL_COLOR  = '#a855f7'; // ECMO specialist
 const MECHANIC_COLOR = '#f97316';
+const DISPATCHER_COLOR = '#0ea5e9';
 
 const INITIAL_EMPLOYEES = [
+  ...dispatchers.map(d => ({
+    id:    d.id,
+    name:  d.name,
+    role:  `Dispatcher (${d.shiftType})`,
+    color: DISPATCHER_COLOR,
+    base:  d.basedAt,
+  })),
   ...crew.map(c => ({
     id:    c.id,
     name:  c.name,


### PR DESCRIPTION
## Summary
Describe exactly what this PR changes.

## Scope
- Stage: 
- Planned PR number in sprint: 
- Target files/directories: 
- Why this slice is isolated: 

## Lessons Learned Check (REQUIRED)
Confirm these were actively used while building this PR:

- [ ] PR is intentionally small and isolated
- [ ] Boundary typing was prioritized over internal perfection
- [ ] No silent spread of `any`
- [ ] Advisory root `tsc` was used to catch integration issues
- [ ] I did not assume “looks typed” means “safe”
- [ ] I stopped and isolated typing cascades instead of expanding scope

## Definition of Done (ALL REQUIRED)
This PR is not done unless every box is checked.

- [ ] `npm run type-check:strict` passes
- [ ] Root advisory `tsc --noEmit` passes
- [ ] Tests pass for touched scope at minimum
- [ ] No uncontrolled increase in `any`
- [ ] All new types are intentional and named
- [ ] Public interfaces and exported functions are explicitly typed
- [ ] PR scope matches the sprint plan with no scope creep
- [ ] Any new `any` has an adjacent justification comment
- [ ] No file-wide `: any`
- [ ] No implicit `any` in exported functions

## What Was Typed
List exactly what was typed in this PR.

- 
- 
- 

## What Was Intentionally Left Loose
List anything intentionally not tightened yet.

- 
- 
- 

## `any` Ledger (REQUIRED)
- New `any` added: 
- Existing `any` removed: 
- Net change: 

For every new `any`, explain why it is required and why a safer type was not used yet.

1. 
2. 
3. 

## Boundary Notes
Document any public seams, caller-protection choices, or compatibility decisions.

- 
- 
- 

## Risk Level
- [ ] Low
- [ ] Medium
- [ ] High

Why:

## Validation Evidence
Paste the exact commands run and a short result summary.

```bash
npm run type-check:strict
npx tsc --noEmit -p tsconfig.json
```

Test commands run:

```bash
# paste commands here
```

## Stop Conditions Check
If any item below happened, explain how scope was reduced before merge.

- [ ] `any` started spreading across files
- [ ] Root `tsc` broke repeatedly
- [ ] Types required cross-module rewrites
- [ ] Scope was reduced to keep the PR reviewable

Notes:

## Reviewer Focus
What should reviewers look at first?

- 
- 
- 
