### PR TITLE
demo: drop Focus row; hide Category/Resource/Source from grouping; re…

### DIFF
--- a/demo/App.tsx
+++ b/demo/App.tsx
@@ -10,6 +10,7 @@ import {
 import { saveProfiles } from '../src/core/profileStore';
 import { loadConfig, saveConfig, DEFAULT_CONFIG } from '../src/core/configSchema';
 import { loadPools, savePools } from '../src/core/pools/poolStore';
+import { buildDefaultFilterSchema } from '../src/filters/filterSchema';
 import {
   regions,
   bases,
@@ -203,13 +204,17 @@ const INITIAL_EVENTS = allEvents.map(e => ({
 
 /* ─── Resource pools (#212) ─────────────────────────────────────── */
 // Group aircraft by region so bookings can target a pool instead of a tail
-// number; the round-robin cursor persists in localStorage.
+// number; the round-robin cursor persists in localStorage. Resynced on the
+// demo seed bump so returning visitors don't keep stale pool names (e.g.
+// "Mountain Fleet" / "Southwest Fleet") from earlier demo identities.
 const DEMO_POOLS_DEFAULT = [
   { id: 'pool-pnw', name: 'Pacific Northwest Fleet', memberIds: ['ac-n801aw', 'ac-n803lj'], strategy: 'round-robin'     },
   { id: 'pool-rm',  name: 'Rocky Mountain Fleet',   memberIds: ['ac-n804aw', 'ac-n805pc'], strategy: 'first-available' },
 ];
 const _storedPools = loadPools(DEMO_CALENDAR_ID);
-if (_storedPools.length === 0) savePools(DEMO_CALENDAR_ID, DEMO_POOLS_DEFAULT);
+if (_storedPools.length === 0 || storedSeedVer < DEMO_SEED_VERSION) {
+  savePools(DEMO_CALENDAR_ID, DEMO_POOLS_DEFAULT);
+}
 
 /* ─── Categories ────────────────────────────────────────────────── */
 const UNIFIED_CATEGORIES = [
@@ -233,6 +238,24 @@ const UNIFIED_CATEGORIES_CONFIG = {
   pillStyle: 'hue',
   defaultCategoryId: 'other',
 };
+
+/* ─── Filter schema ─────────────────────────────────────────────── */
+// The Air EMS demo uses the predefined saved views (By Base / Dispatch /
+// Maintenance / Flight Crew / Requests / Mission Timeline) as the primary
+// organization model. The stock group builder's default options —
+// Category, Resource, Source — aren't meaningful pivots here: Category is
+// already the filter chip axis, Resource lists raw employee ids, and
+// Source is an adapter/plumbing concept the demo doesn't use. Keep them
+// available as *filters* (so AdvancedFilterBuilder still works) but hide
+// them from the grouping builder.
+const DEMO_FILTER_SCHEMA = buildDefaultFilterSchema({
+  employees: INITIAL_EMPLOYEES,
+  assets:    AIRCRAFT_RESOURCES,
+}).map(f => (
+  f.key === 'categories' || f.key === 'resources' || f.key === 'sources'
+    ? { ...f, groupable: false }
+    : f
+));
 
 /* ─── Approval state machine (demo) ─────────────────────────────── */
 function nextStageFor(currentStage, actionId) {
@@ -464,7 +487,7 @@ function App() {
             showAddButton={true}
             categoriesConfig={UNIFIED_CATEGORIES_CONFIG}
             locationProvider={assetLocationProvider}
-            focusChips
+            filterSchema={DEMO_FILTER_SCHEMA}
           />
         </div>
       </div>

--- a/src/filters/filterSchema.ts
+++ b/src/filters/filterSchema.ts
@@ -104,6 +104,14 @@ export type FilterField = {
   hidden?: boolean | ((ctx: { items: unknown[]; filters: Record<string, unknown> }) => boolean)
   /** Operators available for this field. Defaults to defaultOperatorsForType(type). */
   operators?: FilterOperator[]
+  /**
+   * Whether this field appears as a grouping option in the group builder.
+   * Defaults to `true` when the field type is groupable (select / multi-select /
+   * text). Set to `false` to allow filtering on a field without offering it
+   * as a grouping pivot — useful for "Source" / noisy resource ids that make
+   * lousy group headers but are still valuable to filter on.
+   */
+  groupable?: boolean
 }
 
 /** Generic filter state — one key per FilterField, value shape depends on type. */

--- a/src/ui/GroupsPanel.tsx
+++ b/src/ui/GroupsPanel.tsx
@@ -46,10 +46,12 @@ export type GroupsPanelProps = {
   onShowAllGroupsChange: (show: boolean) => void;
 };
 
-/** Derive groupable fields from schema: multi-select and select types. */
+/** Derive groupable fields from schema: multi-select and select types,
+ *  minus any field that explicitly opts out via `groupable: false`. */
 function getGroupableFields(schema: FilterField[]) {
   return schema.filter(
-    f => f.type === 'multi-select' || f.type === 'select' || f.type === 'text',
+    f => (f.type === 'multi-select' || f.type === 'select' || f.type === 'text')
+      && f.groupable !== false,
   );
 }
 


### PR DESCRIPTION
…sync pools

Three UX paper cuts in the Air EMS demo, all reported against the sidebar / filter-builder surface:

1. The Focus row ("Region · Aircraft Type · Asset Requests") was three on/off chips. "Aircraft Type" as a single toggle reads like a multi-select that isn't actually multi. The row as a whole duplicates what the saved-view picker already does better — drop it. (Host API is unchanged; the library still supports focusChips as a prop for consumers who want it.)

2. The custom-grouping builder offered Category, Resource, and Source as group pivots. Category is already covered by the filter chips, Resource lists raw employee ids, and Source is an internal adapter/plumbing concept the demo doesn't use. Add an opt-out FilterField.groupable flag (default true, type-safe) and have the demo mark those three groupable: false. They still work as filters in the AdvancedFilterBuilder, they just don't clutter the grouping picker.

3. Returning visitors kept stale pool names ("Mountain Fleet" / "Southwest Fleet") from an earlier demo identity because the pool seed only ran when the stored list was empty. Gate the seed on the demo seed version so the bump from v4 → v5 resyncs pool names alongside the base resync landed in the previous commit.

https://claude.ai/code/session_01TsUYncc8wXWAtbNwa1VJDf

## Summary
Describe exactly what this PR changes.

## Scope
- Stage: 
- Planned PR number in sprint: 
- Target files/directories: 
- Why this slice is isolated: 

## Lessons Learned Check (REQUIRED)
Confirm these were actively used while building this PR:

- [ ] PR is intentionally small and isolated
- [ ] Boundary typing was prioritized over internal perfection
- [ ] No silent spread of `any`
- [ ] Advisory root `tsc` was used to catch integration issues
- [ ] I did not assume “looks typed” means “safe”
- [ ] I stopped and isolated typing cascades instead of expanding scope

## Definition of Done (ALL REQUIRED)
This PR is not done unless every box is checked.

- [ ] `npm run type-check:strict` passes
- [ ] Root advisory `tsc --noEmit` passes
- [ ] Tests pass for touched scope at minimum
- [ ] No uncontrolled increase in `any`
- [ ] All new types are intentional and named
- [ ] Public interfaces and exported functions are explicitly typed
- [ ] PR scope matches the sprint plan with no scope creep
- [ ] Any new `any` has an adjacent justification comment
- [ ] No file-wide `: any`
- [ ] No implicit `any` in exported functions

## What Was Typed
List exactly what was typed in this PR.

- 
- 
- 

## What Was Intentionally Left Loose
List anything intentionally not tightened yet.

- 
- 
- 

## `any` Ledger (REQUIRED)
- New `any` added: 
- Existing `any` removed: 
- Net change: 

For every new `any`, explain why it is required and why a safer type was not used yet.

1. 
2. 
3. 

## Boundary Notes
Document any public seams, caller-protection choices, or compatibility decisions.

- 
- 
- 

## Risk Level
- [ ] Low
- [ ] Medium
- [ ] High

Why:

## Validation Evidence
Paste the exact commands run and a short result summary.

```bash
npm run type-check:strict
npx tsc --noEmit -p tsconfig.json
```

Test commands run:

```bash
# paste commands here
```

## Stop Conditions Check
If any item below happened, explain how scope was reduced before merge.

- [ ] `any` started spreading across files
- [ ] Root `tsc` broke repeatedly
- [ ] Types required cross-module rewrites
- [ ] Scope was reduced to keep the PR reviewable

Notes:

## Reviewer Focus
What should reviewers look at first?

- 
- 
- 
