### PR TITLE
setup: add Assets & Requirements step to guided onboarding

### DIFF
--- a/src/WorksCalendar.tsx
+++ b/src/WorksCalendar.tsx
@@ -634,29 +634,46 @@ export const WorksCalendar = forwardRef<CalendarApi, WorksCalendarProps>(functio
 
   const handleSetupFinish = useCallback((result: SetupLandingResult) => {
     // 1) Persist title / theme / default view / team / setup.completed.
-    ownerCfg.updateConfig(prev => ({
-      ...prev,
-      title: result.calendarName,
-      setup: {
-        ...(prev['setup'] ?? {}),
-        completed: true,
-        preferredTheme: result.theme,
-      },
-      display: {
-        ...(prev['display'] ?? {}),
-        defaultView: result.defaultView,
-        enabledViews: result.enabledViews,
-      },
-      team: {
-        ...(prev['team'] ?? {}),
-        locationLabel: result.locationLabel,
-        members: [
-          ...((prev['team']?.members ?? []) as Array<{ id: unknown }>)
-            .filter(m => !result.teamMembers.some(r => String(r.id) === String(m.id))),
-          ...result.teamMembers,
-        ],
-      },
-    }));
+    ownerCfg.updateConfig(prev => {
+      // Merge wizard-seeded assets without clobbering existing entries (so
+      // re-opening the wizard never blows away assets configured later).
+      const existingAssets = (Array.isArray(prev['assets']) ? prev['assets'] : []) as Array<{ id: string }>;
+      const existingIds = new Set(existingAssets.map(a => a.id));
+      const seededAssets = result.assetSeeds
+        .filter(seed => !existingIds.has(seed.id))
+        .map(seed => ({
+          id: seed.id,
+          label: seed.label,
+          meta: { assetTypeId: seed.assetTypeId },
+        }));
+
+      return {
+        ...prev,
+        title: result.calendarName,
+        setup: {
+          ...(prev['setup'] ?? {}),
+          completed: true,
+          preferredTheme: result.theme,
+        },
+        display: {
+          ...(prev['display'] ?? {}),
+          defaultView: result.defaultView,
+          enabledViews: result.enabledViews,
+        },
+        team: {
+          ...(prev['team'] ?? {}),
+          locationLabel: result.locationLabel,
+          members: [
+            ...((prev['team']?.members ?? []) as Array<{ id: unknown }>)
+              .filter(m => !result.teamMembers.some(r => String(r.id) === String(m.id))),
+            ...result.teamMembers,
+          ],
+        },
+        assetTypes: result.assetTypes,
+        assets: [...existingAssets, ...seededAssets],
+        requirementTemplates: result.requirementTemplates,
+      };
+    });
 
     // 2) Save each chosen recipe as a Smart View so it shows up in the
     //    views bar. Recipes map to real filter + groupBy state; the owner
@@ -2420,6 +2437,7 @@ export const WorksCalendar = forwardRef<CalendarApi, WorksCalendarProps>(functio
             categories={resolvedAssetRequestCategories}
             initialStart={cal.currentDate}
             initialAssetId={undefined}
+            requirementTemplates={ownerCfg.config?.['requirementTemplates'] as Record<string, { roles: { id: string; label: string }[]; requiresApproval: boolean }> | undefined}
             onSubmit={(payload: LooseValue) => {
               handleEventSave(payload);
               setAssetRequestOpen(false);

--- a/src/ui/AssetRequestForm.tsx
+++ b/src/ui/AssetRequestForm.tsx
@@ -11,13 +11,16 @@
  */
 import { useMemo, useState } from 'react';
 import type { FormEvent, ChangeEvent, MouseEvent } from 'react';
-import { X } from 'lucide-react';
+import { X, ShieldCheck } from 'lucide-react';
 import { useFocusTrap } from '../hooks/useFocusTrap';
 import { toDatetimeLocal, fromDatetimeLocal } from '../hooks/useEventDraftState';
 import styles from './EventForm.module.css';
 
 type AssetEntry = { id: string; label: string; group?: string | undefined; meta?: Record<string, unknown> | undefined };
 type CategoryEntry = { id: string; label?: string | undefined; color?: string | undefined };
+
+type RoleEntry = { id: string; label: string };
+type RequirementTemplate = { roles: RoleEntry[]; requiresApproval: boolean };
 
 type AssetRequestPayload = {
   title: string;
@@ -34,6 +37,13 @@ type AssetRequestFormProps = {
   categories: CategoryEntry[];
   initialStart?: Date | undefined;
   initialAssetId?: string | undefined;
+  /**
+   * Per-asset-type requirement templates. The form looks up the selected
+   * asset's `meta.assetTypeId` and renders a slot input per role plus an
+   * approval-required banner when requested. Optional — when absent the
+   * form behaves exactly like the pre-template version.
+   */
+  requirementTemplates?: Record<string, RequirementTemplate> | undefined;
   onSubmit: (payload: AssetRequestPayload) => void;
   onClose: () => void;
 };
@@ -43,6 +53,7 @@ export default function AssetRequestForm({
   categories,
   initialStart,
   initialAssetId,
+  requirementTemplates,
   onSubmit,
   onClose,
 }: AssetRequestFormProps) {
@@ -57,12 +68,29 @@ export default function AssetRequestForm({
   const [startStr, setStartStr] = useState(toDatetimeLocal(start));
   const [endStr,   setEndStr]   = useState(toDatetimeLocal(defaultEnd));
   const [notes,    setNotes]    = useState('');
+  const [requirements, setRequirements] = useState<Record<string, string>>({});
   const [errors,   setErrors]   = useState<Record<string, string>>({});
 
   const assetOptions = useMemo(
     () => assets.map((a) => ({ value: a.id, label: a.label || a.id })),
     [assets],
   );
+
+  const selectedAsset = useMemo(
+    () => assets.find(a => a.id === assetId),
+    [assets, assetId],
+  );
+
+  // The active template is the one keyed by the selected asset's typeId.
+  // Anonymous types (assets without `meta.assetTypeId`) get no slots.
+  const activeTemplate: RequirementTemplate | null = useMemo(() => {
+    if (!requirementTemplates) return null;
+    const typeId = typeof selectedAsset?.meta?.['assetTypeId'] === 'string'
+      ? (selectedAsset.meta['assetTypeId'] as string)
+      : null;
+    if (!typeId) return null;
+    return requirementTemplates[typeId] ?? null;
+  }, [requirementTemplates, selectedAsset]);
 
   function validate() {
     const e: Record<string, string> = {};
@@ -76,6 +104,13 @@ export default function AssetRequestForm({
       const en = fromDatetimeLocal(endStr);
       if (s && en && en <= s) e['end'] = 'End must be after start';
     }
+    if (activeTemplate) {
+      for (const role of activeTemplate.roles) {
+        if (!requirements[role.id]?.trim()) {
+          e[`req:${role.id}`] = `${role.label} is required`;
+        }
+      }
+    }
     setErrors(e);
     return Object.keys(e).length === 0;
   }
@@ -86,6 +121,18 @@ export default function AssetRequestForm({
     const s = fromDatetimeLocal(startStr);
     const en = fromDatetimeLocal(endStr);
     if (!s || !en) return;
+
+    // Trim and only emit role keys actually defined by the active template;
+    // dropping stale entries keeps the persisted payload clean if the user
+    // switched assets after typing.
+    const cleanRequirements: Record<string, string> = {};
+    if (activeTemplate) {
+      for (const role of activeTemplate.roles) {
+        const value = requirements[role.id]?.trim();
+        if (value) cleanRequirements[role.id] = value;
+      }
+    }
+
     onSubmit({
       title:    title.trim(),
       start:    s,
@@ -95,6 +142,7 @@ export default function AssetRequestForm({
       resource: assetId,
       meta: {
         ...(notes.trim() ? { notes: notes.trim() } : {}),
+        ...(Object.keys(cleanRequirements).length > 0 ? { requirements: cleanRequirements } : {}),
         approvalStage: { stage: 'requested', updatedAt: new Date().toISOString() },
       },
     });
@@ -180,6 +228,55 @@ export default function AssetRequestForm({
               {errors['end'] && <span className={styles['error']}>{errors['end']}</span>}
             </div>
           </div>
+
+          {activeTemplate && activeTemplate.roles.length > 0 && (
+            <fieldset className={styles['field']} style={{ border: 0, padding: 0, margin: 0 }}>
+              <legend className={styles['label']} style={{ padding: 0 }}>
+                Required for this {selectedAsset?.meta?.['assetTypeId'] ? 'type' : 'asset'}
+              </legend>
+              {activeTemplate.roles.map(role => {
+                const errKey = `req:${role.id}`;
+                const inputId = `ar-req-${role.id}`;
+                return (
+                  <div key={role.id} className={styles['field']} style={{ marginTop: 8 }}>
+                    <label className={styles['label']} htmlFor={inputId}>
+                      {role.label} <span className={styles['req']}>*</span>
+                    </label>
+                    <input
+                      id={inputId}
+                      className={[styles['input'], errors[errKey] && styles['inputError']].filter(Boolean).join(' ')}
+                      value={requirements[role.id] ?? ''}
+                      onChange={(e: ChangeEvent<HTMLInputElement>) =>
+                        setRequirements(prev => ({ ...prev, [role.id]: e.target.value }))
+                      }
+                      placeholder={`Who is the ${role.label.toLowerCase()}?`}
+                    />
+                    {errors[errKey] && <span className={styles['error']}>{errors[errKey]}</span>}
+                  </div>
+                );
+              })}
+            </fieldset>
+          )}
+
+          {activeTemplate?.requiresApproval && (
+            <div
+              role="status"
+              style={{
+                display: 'flex',
+                alignItems: 'center',
+                gap: 8,
+                padding: '8px 10px',
+                fontSize: 12,
+                color: 'var(--wc-text-muted, #475569)',
+                background: 'color-mix(in srgb, var(--wc-accent, #3b82f6) 8%, transparent)',
+                border: '1px dashed color-mix(in srgb, var(--wc-accent, #3b82f6) 35%, transparent)',
+                borderRadius: 8,
+              }}
+            >
+              <ShieldCheck size={14} aria-hidden="true" />
+              <span>This request needs approval before it’s confirmed.</span>
+            </div>
+          )}
 
           <div className={styles['field']}>
             <label className={styles['label']} htmlFor="ar-notes">Notes</label>

--- a/src/ui/SetupLanding.module.css
+++ b/src/ui/SetupLanding.module.css
@@ -438,6 +438,158 @@
   gap: 12px;
 }
 
+/* ── Assets & Requirements step ────────────────────────────────────────── */
+
+.assetTypeCard {
+  border: 1px solid var(--wc-border, #e2e8f0);
+  border-radius: 12px;
+  padding: 14px;
+  background: var(--wc-bg, #ffffff);
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.assetTypeHeader {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  color: var(--wc-text, #0f172a);
+}
+
+.assetTypeName {
+  flex: 1;
+  font-size: 15px;
+  font-weight: 700;
+  border: 1px solid transparent;
+  border-radius: 6px;
+  padding: 4px 6px;
+  background: transparent;
+  color: inherit;
+  outline: none;
+  transition: border-color 0.12s ease, background 0.12s ease;
+}
+
+.assetTypeName:hover,
+.assetTypeName:focus-visible {
+  border-color: var(--wc-border, #cbd5e1);
+  background: var(--wc-surface, #f8fafc);
+}
+
+.assetSubsection {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.assetSubDesc {
+  font-size: 12px;
+  color: var(--wc-text-muted, #64748b);
+  margin: 0;
+  line-height: 1.5;
+}
+
+.assetEmpty {
+  font-size: 12px;
+  color: var(--wc-text-muted, #94a3b8);
+  font-style: italic;
+  margin: 0;
+}
+
+.assetSeedList {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.assetSeedRow {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+}
+
+.rolePillRow,
+.rolePillSuggestRow {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  align-items: center;
+}
+
+.rolePillSelected {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 4px 8px 4px 10px;
+  font-size: 12px;
+  font-weight: 600;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--wc-accent, #3b82f6) 15%, transparent);
+  color: var(--wc-accent, #3b82f6);
+  border: 1px solid color-mix(in srgb, var(--wc-accent, #3b82f6) 35%, transparent);
+}
+
+.rolePillRemove {
+  background: transparent;
+  border: none;
+  color: inherit;
+  cursor: pointer;
+  font-size: 14px;
+  line-height: 1;
+  padding: 0 2px;
+  margin-left: 2px;
+  border-radius: 4px;
+}
+
+.rolePillRemove:hover {
+  background: color-mix(in srgb, var(--wc-accent, #3b82f6) 25%, transparent);
+}
+
+.rolePillSuggest {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 4px 8px;
+  font-size: 12px;
+  font-weight: 500;
+  border-radius: 999px;
+  background: var(--wc-surface, #f1f5f9);
+  color: var(--wc-text-muted, #475569);
+  border: 1px dashed var(--wc-border, #cbd5e1);
+  cursor: pointer;
+  font-family: inherit;
+}
+
+.rolePillSuggest:hover {
+  border-style: solid;
+  color: var(--wc-accent, #3b82f6);
+  border-color: var(--wc-accent, #3b82f6);
+}
+
+.approvalToggleRow {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 13px;
+  color: var(--wc-text, #0f172a);
+  cursor: pointer;
+  user-select: none;
+}
+
+.addTypeRow {
+  display: flex;
+  gap: 8px;
+  align-items: stretch;
+  margin-top: 4px;
+}
+
+.addTypeRow .input {
+  flex: 1;
+}
+
 /* ── Footer / buttons ──────────────────────────────────────────────────── */
 
 .footer {

--- a/src/ui/SetupLanding.tsx
+++ b/src/ui/SetupLanding.tsx
@@ -10,7 +10,7 @@
  * and drops the owner straight into the calendar with default config.
  */
 import { useMemo, useState } from 'react';
-import { ChevronRight, ChevronLeft, Check, Sparkles, Rocket, Users, Palette, LayoutGrid, Wand2, MapPin } from 'lucide-react';
+import { ChevronRight, ChevronLeft, Check, Sparkles, Rocket, Users, Palette, LayoutGrid, Wand2, MapPin, Plane, Plus, Trash2, ShieldCheck } from 'lucide-react';
 import { THEMES, THEME_META, normalizeTheme, resolveCssTheme } from '../styles/themes';
 import styles from './SetupLanding.module.css';
 import {
@@ -33,6 +33,25 @@ export type SetupRecipeId =
 
 export type OptionalViewId = 'day' | 'agenda' | 'schedule' | 'base' | 'assets';
 
+/** A category of bookable resource. Drives requirement templates. */
+export type AssetTypeDef = { id: string; label: string };
+
+/** A concrete asset created in the wizard. Linked to an AssetTypeDef. */
+export type AssetSeed = { id: string; label: string; assetTypeId: string };
+
+/** A required role on a request, e.g. Pilot, Medic. */
+export type RoleDef = { id: string; label: string };
+
+/**
+ * Per-type rules that asset-request flows read at submit time. The wizard
+ * captures the minimum needed for v1: required role slots and an
+ * approval-before-scheduling toggle.
+ */
+export type RequirementTemplate = {
+  roles: RoleDef[];
+  requiresApproval: boolean;
+};
+
 export type SetupLandingResult = {
   calendarName: string;
   theme: string;
@@ -41,6 +60,9 @@ export type SetupLandingResult = {
   locationLabel: 'Base' | 'Region';
   teamMembers: Array<{ id: string; name: string; color: string }>;
   recipes: SetupRecipeId[];
+  assetTypes: AssetTypeDef[];
+  assetSeeds: AssetSeed[];
+  requirementTemplates: Record<string, RequirementTemplate>;
 };
 
 export type SetupLandingProps = {
@@ -58,7 +80,24 @@ export type SetupLandingProps = {
 /*  Constants                                                                 */
 /* ────────────────────────────────────────────────────────────────────────── */
 
-const TOTAL_STEPS = 6;
+const TOTAL_STEPS = 7;
+
+const DEFAULT_ASSET_TYPES: AssetTypeDef[] = [
+  { id: 'aircraft',  label: 'Aircraft' },
+  { id: 'vehicle',   label: 'Vehicle' },
+  { id: 'equipment', label: 'Equipment' },
+  { id: 'room',      label: 'Room' },
+];
+
+/** Common role suggestions surfaced as quick-add chips. */
+const SUGGESTED_ROLES: RoleDef[] = [
+  { id: 'pilot',      label: 'Pilot' },
+  { id: 'co-pilot',   label: 'Co-pilot' },
+  { id: 'medic',      label: 'Medic' },
+  { id: 'driver',     label: 'Driver' },
+  { id: 'crew',       label: 'Crew' },
+  { id: 'technician', label: 'Technician' },
+];
 
 type ViewChoice = {
   id: SetupLandingResult['defaultView'];
@@ -142,6 +181,9 @@ export default function SetupLanding({
   const [locationLabel, setLocationLabel] = useState<'Base' | 'Region'>('Base');
   const [team, setTeam] = useState(STARTER_TEAM);
   const [recipes, setRecipes] = useState<SetupRecipeId[]>(['everything']);
+  const [assetTypes, setAssetTypes] = useState<AssetTypeDef[]>(DEFAULT_ASSET_TYPES);
+  const [assetSeeds, setAssetSeeds] = useState<AssetSeed[]>([]);
+  const [requirementTemplates, setRequirementTemplates] = useState<Record<string, RequirementTemplate>>({});
 
   const next = () => setStep(s => Math.min(TOTAL_STEPS, s + 1));
   const back = () => setStep(s => Math.max(0, s - 1));
@@ -165,6 +207,23 @@ export default function SetupLanding({
     defaultViewChoices.some(v => v.id === defaultView) ? defaultView : 'month';
 
   const handleFinish = () => {
+    // Drop empty type slots and any seed pointing at a deleted type so the
+    // host never has to defensively filter the result.
+    const cleanTypes = assetTypes.filter(t => t.label.trim());
+    const validTypeIds = new Set(cleanTypes.map(t => t.id));
+    const cleanSeeds = assetSeeds
+      .filter(a => a.label.trim() && validTypeIds.has(a.assetTypeId))
+      .map(a => ({ ...a, label: a.label.trim() }));
+    const cleanTemplates: Record<string, RequirementTemplate> = {};
+    for (const typeId of validTypeIds) {
+      const template = requirementTemplates[typeId];
+      if (!template) continue;
+      const roles = template.roles.filter(r => r.label.trim());
+      // Only emit a template entry if it actually constrains something.
+      if (roles.length === 0 && !template.requiresApproval) continue;
+      cleanTemplates[typeId] = { roles, requiresApproval: template.requiresApproval };
+    }
+
     onFinish({
       calendarName: calendarName.trim() || 'My Calendar',
       theme,
@@ -175,6 +234,9 @@ export default function SetupLanding({
         .filter(m => m.name.trim())
         .map(m => ({ id: m.id, name: m.name.trim(), color: m.color })),
       recipes,
+      assetTypes: cleanTypes,
+      assetSeeds: cleanSeeds,
+      requirementTemplates: cleanTemplates,
     });
   };
 
@@ -257,6 +319,16 @@ export default function SetupLanding({
           )}
           {step === 6 && (
             <StepRecipes selected={recipes} onToggle={toggleRecipe} />
+          )}
+          {step === 7 && (
+            <StepAssets
+              assetTypes={assetTypes}
+              onAssetTypesChange={setAssetTypes}
+              assetSeeds={assetSeeds}
+              onAssetSeedsChange={setAssetSeeds}
+              requirementTemplates={requirementTemplates}
+              onRequirementTemplatesChange={setRequirementTemplates}
+            />
           )}
         </main>
 
@@ -596,9 +668,274 @@ function StepRecipes({
   );
 }
 
+/* ── Step 7: Assets & Requirements ───────────────────────────────────────── */
+
+type StepAssetsProps = {
+  assetTypes: AssetTypeDef[];
+  onAssetTypesChange: (next: AssetTypeDef[]) => void;
+  assetSeeds: AssetSeed[];
+  onAssetSeedsChange: (next: AssetSeed[]) => void;
+  requirementTemplates: Record<string, RequirementTemplate>;
+  onRequirementTemplatesChange: (next: Record<string, RequirementTemplate>) => void;
+};
+
+function StepAssets({
+  assetTypes,
+  onAssetTypesChange,
+  assetSeeds,
+  onAssetSeedsChange,
+  requirementTemplates,
+  onRequirementTemplatesChange,
+}: StepAssetsProps) {
+  const [newTypeLabel, setNewTypeLabel] = useState('');
+
+  const addType = () => {
+    const label = newTypeLabel.trim();
+    if (!label) return;
+    const id = slugifyTypeId(label, assetTypes);
+    onAssetTypesChange([...assetTypes, { id, label }]);
+    setNewTypeLabel('');
+  };
+
+  const removeType = (typeId: string) => {
+    onAssetTypesChange(assetTypes.filter(t => t.id !== typeId));
+    onAssetSeedsChange(assetSeeds.filter(a => a.assetTypeId !== typeId));
+    const { [typeId]: _removed, ...rest } = requirementTemplates;
+    onRequirementTemplatesChange(rest);
+  };
+
+  const renameType = (typeId: string, label: string) => {
+    onAssetTypesChange(assetTypes.map(t => (t.id === typeId ? { ...t, label } : t)));
+  };
+
+  const addAsset = (typeId: string) => {
+    const seed: AssetSeed = {
+      id: `asset-${Date.now()}-${assetSeeds.length}`,
+      label: '',
+      assetTypeId: typeId,
+    };
+    onAssetSeedsChange([...assetSeeds, seed]);
+  };
+
+  const updateAsset = (id: string, label: string) => {
+    onAssetSeedsChange(assetSeeds.map(a => (a.id === id ? { ...a, label } : a)));
+  };
+
+  const removeAsset = (id: string) => {
+    onAssetSeedsChange(assetSeeds.filter(a => a.id !== id));
+  };
+
+  const getTemplate = (typeId: string): RequirementTemplate =>
+    requirementTemplates[typeId] ?? { roles: [], requiresApproval: false };
+
+  const writeTemplate = (typeId: string, patch: Partial<RequirementTemplate>) => {
+    const current = getTemplate(typeId);
+    onRequirementTemplatesChange({
+      ...requirementTemplates,
+      [typeId]: { ...current, ...patch },
+    });
+  };
+
+  const addRole = (typeId: string, role: RoleDef) => {
+    const current = getTemplate(typeId);
+    if (current.roles.some(r => r.id === role.id)) return;
+    writeTemplate(typeId, { roles: [...current.roles, role] });
+  };
+
+  const removeRole = (typeId: string, roleId: string) => {
+    const current = getTemplate(typeId);
+    writeTemplate(typeId, { roles: current.roles.filter(r => r.id !== roleId) });
+  };
+
+  return (
+    <section className={styles['step']}>
+      <h2 className={styles['stepTitle']}>What do you book, and what does each booking need?</h2>
+      <p className={styles['stepPlain']}>
+        An <em>asset</em> is anything you book — a vehicle, a room, a piece of gear.
+        Tell us what kinds you have, then say what each kind needs (a pilot, a medic,
+        approval before it’s confirmed). This is the part most calendars miss.
+      </p>
+
+      {assetTypes.length === 0 && (
+        <p className={styles['stepTip']}>
+          No types yet. Add one below to get started — or skip this step entirely
+          and come back later from the settings gear.
+        </p>
+      )}
+
+      {assetTypes.map(type => {
+        const seedsOfType = assetSeeds.filter(a => a.assetTypeId === type.id);
+        const template = getTemplate(type.id);
+        return (
+          <div key={type.id} className={styles['assetTypeCard']}>
+            <header className={styles['assetTypeHeader']}>
+              <Plane size={14} aria-hidden="true" />
+              <input
+                className={styles['assetTypeName']}
+                value={type.label}
+                onChange={e => renameType(type.id, e.target.value)}
+                aria-label={`Rename ${type.label || type.id}`}
+                placeholder="Type name"
+              />
+              <button
+                type="button"
+                className={styles['rowRemoveBtn']}
+                onClick={() => removeType(type.id)}
+                aria-label={`Remove ${type.label || type.id}`}
+              >
+                <Trash2 size={12} aria-hidden="true" /> Remove type
+              </button>
+            </header>
+
+            {/* Assets of this type */}
+            <div className={styles['assetSubsection']}>
+              <span className={styles['fieldLabel']}>Your {(type.label || 'assets').toLowerCase()}</span>
+              {seedsOfType.length === 0 && (
+                <p className={styles['assetEmpty']}>None added yet.</p>
+              )}
+              <ul className={styles['assetSeedList']}>
+                {seedsOfType.map(seed => (
+                  <li key={seed.id} className={styles['assetSeedRow']}>
+                    <input
+                      className={styles['input']}
+                      value={seed.label}
+                      placeholder={`e.g. ${exampleNameFor(type.label)}`}
+                      onChange={e => updateAsset(seed.id, e.target.value)}
+                      aria-label={`Name for asset ${seed.id}`}
+                    />
+                    <button
+                      type="button"
+                      className={styles['rowRemoveBtn']}
+                      onClick={() => removeAsset(seed.id)}
+                      aria-label={`Remove asset ${seed.label || seed.id}`}
+                    >
+                      Remove
+                    </button>
+                  </li>
+                ))}
+              </ul>
+              <button
+                type="button"
+                className={styles['secondaryBtn']}
+                onClick={() => addAsset(type.id)}
+              >
+                <Plus size={13} aria-hidden="true" /> Add {(type.label || 'asset').toLowerCase()}
+              </button>
+            </div>
+
+            {/* Required roles */}
+            <div className={styles['assetSubsection']}>
+              <span className={styles['fieldLabel']}>What does a request need?</span>
+              <p className={styles['assetSubDesc']}>
+                Pick the roles a booking must fill. The request form will show one slot
+                per role so the dispatcher fills them in before submitting.
+              </p>
+              <div className={styles['rolePillRow']}>
+                {template.roles.map(role => (
+                  <span key={role.id} className={styles['rolePillSelected']}>
+                    {role.label}
+                    <button
+                      type="button"
+                      onClick={() => removeRole(type.id, role.id)}
+                      aria-label={`Remove role ${role.label}`}
+                      className={styles['rolePillRemove']}
+                    >
+                      ×
+                    </button>
+                  </span>
+                ))}
+                {template.roles.length === 0 && (
+                  <span className={styles['assetEmpty']}>No roles required yet.</span>
+                )}
+              </div>
+              <div className={styles['rolePillSuggestRow']}>
+                {SUGGESTED_ROLES.filter(r => !template.roles.some(t => t.id === r.id)).map(role => (
+                  <button
+                    key={role.id}
+                    type="button"
+                    className={styles['rolePillSuggest']}
+                    onClick={() => addRole(type.id, role)}
+                  >
+                    <Plus size={11} aria-hidden="true" /> {role.label}
+                  </button>
+                ))}
+              </div>
+            </div>
+
+            {/* Approval rule */}
+            <div className={styles['assetSubsection']}>
+              <label className={styles['approvalToggleRow']}>
+                <input
+                  type="checkbox"
+                  checked={template.requiresApproval}
+                  onChange={e => writeTemplate(type.id, { requiresApproval: e.target.checked })}
+                />
+                <ShieldCheck size={14} aria-hidden="true" />
+                <span>Requires approval before it’s confirmed</span>
+              </label>
+            </div>
+          </div>
+        );
+      })}
+
+      {/* Add new asset type */}
+      <div className={styles['addTypeRow']}>
+        <input
+          className={styles['input']}
+          value={newTypeLabel}
+          onChange={e => setNewTypeLabel(e.target.value)}
+          onKeyDown={e => {
+            if (e.key === 'Enter') {
+              e.preventDefault();
+              addType();
+            }
+          }}
+          placeholder="Add another type — e.g. Boat, Drone, Studio…"
+          aria-label="New asset type name"
+        />
+        <button
+          type="button"
+          className={styles['secondaryBtn']}
+          onClick={addType}
+          disabled={!newTypeLabel.trim()}
+        >
+          <Plus size={13} aria-hidden="true" /> Add type
+        </button>
+      </div>
+
+      <p className={styles['stepTip']}>
+        Tip: leave anything blank to skip it. You can edit assets, roles, and approval
+        rules any time from <strong>Settings → Assets</strong>.
+      </p>
+    </section>
+  );
+}
+
 /* ────────────────────────────────────────────────────────────────────────── */
 /*  Utilities                                                                 */
 /* ────────────────────────────────────────────────────────────────────────── */
+
+/** Generate a stable id slug from a free-text type label. */
+function slugifyTypeId(label: string, existing: AssetTypeDef[]): string {
+  const base = label
+    .toLowerCase()
+    .trim()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/(^-|-$)/g, '') || 'type';
+  if (!existing.some(t => t.id === base)) return base;
+  let n = 2;
+  while (existing.some(t => t.id === `${base}-${n}`)) n++;
+  return `${base}-${n}`;
+}
+
+/** Friendly placeholder for asset name input, picked from the type label. */
+function exampleNameFor(typeLabel: string): string {
+  const lc = typeLabel.toLowerCase();
+  if (lc.includes('aircraft')) return 'N100AA';
+  if (lc.includes('vehicle'))  return 'Truck 12';
+  if (lc.includes('room'))     return 'Studio A';
+  return `${typeLabel} 1`;
+}
 
 /** Map setup view ids to illustration kinds. Base/assets reuse the schedule illustration. */
 function illustrationKindFor(id: SetupLandingResult['defaultView']): 'month' | 'week' | 'day' | 'agenda' | 'schedule' {

--- a/src/ui/__tests__/AssetRequestForm.test.tsx
+++ b/src/ui/__tests__/AssetRequestForm.test.tsx
@@ -115,3 +115,111 @@ describe('AssetRequestForm', () => {
     expect(payload.meta).not.toHaveProperty('notes');
   });
 });
+
+/**
+ * requirementTemplates wire dynamic role slots onto the form. When the
+ * selected asset's `meta.assetTypeId` matches a template entry the form
+ * must render an input per role, block submission until each is filled,
+ * and ship the values inside `meta.requirements` keyed by role id.
+ */
+describe('AssetRequestForm — requirementTemplates', () => {
+  const typedAssets = [
+    { id: 'n100aa', label: 'N100AA', meta: { assetTypeId: 'aircraft' } },
+    { id: 'truck1', label: 'Truck 1', meta: { assetTypeId: 'vehicle' } },
+    { id: 'unknown', label: 'Untyped' },
+  ];
+
+  const requirementTemplates = {
+    aircraft: {
+      roles: [
+        { id: 'pilot', label: 'Pilot' },
+        { id: 'medic', label: 'Medic' },
+      ],
+      requiresApproval: true,
+    },
+    vehicle: {
+      roles: [{ id: 'driver', label: 'Driver' }],
+      requiresApproval: false,
+    },
+  };
+
+  function renderWithTemplates(overrides: Record<string, unknown> = {}) {
+    return render(
+      <AssetRequestForm
+        assets={typedAssets}
+        categories={categories}
+        requirementTemplates={requirementTemplates}
+        onSubmit={vi.fn()}
+        onClose={vi.fn()}
+        {...overrides}
+      />,
+    );
+  }
+
+  it('renders one slot input per role for the selected asset type', () => {
+    renderWithTemplates({ initialAssetId: 'n100aa' });
+    expect(screen.getByLabelText(/Pilot/)).toBeInTheDocument();
+    expect(screen.getByLabelText(/Medic/)).toBeInTheDocument();
+    // Driver belongs to the vehicle template, not aircraft.
+    expect(screen.queryByLabelText(/Driver/)).not.toBeInTheDocument();
+  });
+
+  it('shows the approval-required notice when the template asks for it', () => {
+    renderWithTemplates({ initialAssetId: 'n100aa' });
+    expect(screen.getByText(/needs approval before it’s confirmed/i)).toBeInTheDocument();
+  });
+
+  it('hides the approval notice when the template does not require it', () => {
+    renderWithTemplates({ initialAssetId: 'truck1' });
+    expect(screen.queryByText(/needs approval before it’s confirmed/i)).not.toBeInTheDocument();
+  });
+
+  it('blocks submission until every required role is filled', () => {
+    const onSubmit = vi.fn();
+    renderWithTemplates({ initialAssetId: 'n100aa', onSubmit });
+
+    fireEvent.change(screen.getByLabelText(/Title/), { target: { value: 'EMS run' } });
+    fireEvent.change(screen.getByLabelText(/Category/), { target: { value: 'training' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Submit Request' }));
+
+    expect(onSubmit).not.toHaveBeenCalled();
+    expect(screen.getByText('Pilot is required')).toBeInTheDocument();
+    expect(screen.getByText('Medic is required')).toBeInTheDocument();
+  });
+
+  it('submits filled role values inside meta.requirements keyed by role id', () => {
+    const onSubmit = vi.fn();
+    renderWithTemplates({ initialAssetId: 'n100aa', onSubmit });
+
+    fireEvent.change(screen.getByLabelText(/Title/),    { target: { value: 'EMS run' } });
+    fireEvent.change(screen.getByLabelText(/Category/), { target: { value: 'training' } });
+    fireEvent.change(screen.getByLabelText(/Pilot/),    { target: { value: 'Alex' } });
+    fireEvent.change(screen.getByLabelText(/Medic/),    { target: { value: 'Priya' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Submit Request' }));
+
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+    const payload = onSubmit.mock.calls[0][0]!;
+    expect(payload.meta.requirements).toEqual({ pilot: 'Alex', medic: 'Priya' });
+    // approvalStage is still attached on top of the new requirements field.
+    expect(payload.meta.approvalStage.stage).toBe('requested');
+  });
+
+  it('renders no slots when the selected asset has no assetTypeId', () => {
+    renderWithTemplates({ initialAssetId: 'unknown' });
+    expect(screen.queryByLabelText(/Pilot/)).not.toBeInTheDocument();
+    expect(screen.queryByLabelText(/Driver/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/needs approval/i)).not.toBeInTheDocument();
+  });
+
+  it('omits meta.requirements entirely when no template matches the asset', () => {
+    const onSubmit = vi.fn();
+    renderWithTemplates({ initialAssetId: 'unknown', onSubmit });
+
+    fireEvent.change(screen.getByLabelText(/Title/), { target: { value: 'misc' } });
+    fireEvent.change(screen.getByLabelText(/Category/), { target: { value: 'training' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Submit Request' }));
+
+    const payload = onSubmit.mock.calls[0][0]!;
+    expect(payload.meta).not.toHaveProperty('requirements');
+  });
+});

--- a/src/ui/__tests__/SetupLanding.assetsStep.test.tsx
+++ b/src/ui/__tests__/SetupLanding.assetsStep.test.tsx
@@ -1,0 +1,135 @@
+// @vitest-environment happy-dom
+/**
+ * Step 7 of SetupLanding — "Assets & Requirements".
+ *
+ * Covers the three things the step has to do that nothing else in setup
+ * could do before:
+ *   1. let owners declare what kinds of things they book (asset types),
+ *   2. seed concrete assets under each type, and
+ *   3. capture per-type requirement templates (required roles + approval).
+ *
+ * The result payload is what WorksCalendar persists into config, so these
+ * assertions also pin the wizard → config contract.
+ */
+import { render, screen, fireEvent, within } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import '@testing-library/jest-dom';
+
+import SetupLanding from '../SetupLanding';
+import type { SetupLandingResult } from '../SetupLanding';
+
+/** Click the welcome screen "Start" button and step forward to step 7. */
+function advanceToAssetsStep() {
+  // Welcome → step 1
+  fireEvent.click(screen.getByRole('button', { name: /Start setup guide/i }));
+  // Step 1 → 7 via Next. Anchored regex avoids matching view-card descriptions
+  // that legitimately contain the word "next" ("…what is coming up next").
+  for (let i = 0; i < 6; i++) {
+    fireEvent.click(screen.getByRole('button', { name: /^Next$/ }));
+  }
+}
+
+describe('SetupLanding — Assets & Requirements step', () => {
+  it('renders the four default asset types with a per-type card each', () => {
+    render(<SetupLanding onFinish={vi.fn()} onSkip={vi.fn()} />);
+    advanceToAssetsStep();
+
+    // Default labels live in editable inputs, so query by value rather than text.
+    expect(screen.getByDisplayValue('Aircraft')).toBeInTheDocument();
+    expect(screen.getByDisplayValue('Vehicle')).toBeInTheDocument();
+    expect(screen.getByDisplayValue('Equipment')).toBeInTheDocument();
+    expect(screen.getByDisplayValue('Room')).toBeInTheDocument();
+  });
+
+  it('writes assetTypes, assetSeeds, and requirementTemplates into the finish payload', () => {
+    const onFinish = vi.fn<(r: SetupLandingResult) => void>();
+    const { container } = render(<SetupLanding onFinish={onFinish} onSkip={vi.fn()} />);
+    advanceToAssetsStep();
+
+    // Locate the Aircraft type card by walking up from its name input. Every
+    // type renders the same suggested-role chips, so we must scope the chip
+    // queries to the matching card or we'll pick the wrong card's chip.
+    const aircraftNameInput = screen.getByDisplayValue('Aircraft') as HTMLInputElement;
+    const aircraftCard = aircraftNameInput.closest(`[class*="assetTypeCard"]`) as HTMLElement;
+    expect(aircraftCard).toBeTruthy();
+    void container;
+
+    // Add an aircraft asset under that card.
+    fireEvent.click(within(aircraftCard).getByRole('button', { name: /Add aircraft/i }));
+    fireEvent.change(within(aircraftCard).getByLabelText(/Name for asset/i), {
+      target: { value: 'N100AA' },
+    });
+
+    // Add Pilot + Medic via the suggested role chips inside the card.
+    fireEvent.click(within(aircraftCard).getByRole('button', { name: /Pilot/ }));
+    fireEvent.click(within(aircraftCard).getByRole('button', { name: /Medic/ }));
+
+    // Toggle "Requires approval" on for the Aircraft card.
+    fireEvent.click(within(aircraftCard).getByRole('checkbox', {
+      name: /Requires approval before it’s confirmed/i,
+    }));
+
+    // Finish.
+    fireEvent.click(screen.getByRole('button', { name: /I’m done/i }));
+
+    expect(onFinish).toHaveBeenCalledTimes(1);
+    const result = onFinish.mock.calls[0]![0];
+
+    // Types: 4 defaults preserved.
+    expect(result.assetTypes.map(t => t.id)).toEqual([
+      'aircraft', 'vehicle', 'equipment', 'room',
+    ]);
+
+    // Seeds: only the one we added, scoped to the aircraft type id.
+    expect(result.assetSeeds).toHaveLength(1);
+    expect(result.assetSeeds[0]).toMatchObject({
+      label: 'N100AA',
+      assetTypeId: 'aircraft',
+    });
+
+    // Templates: aircraft has Pilot + Medic and requiresApproval=true.
+    // Other types contributed nothing → no entry emitted.
+    expect(Object.keys(result.requirementTemplates)).toEqual(['aircraft']);
+    const tpl = result.requirementTemplates['aircraft']!;
+    expect(tpl.roles.map(r => r.id)).toEqual(['pilot', 'medic']);
+    expect(tpl.requiresApproval).toBe(true);
+  });
+
+  it('drops empty seeds and types so the host never sees half-filled rows', () => {
+    const onFinish = vi.fn<(r: SetupLandingResult) => void>();
+    render(<SetupLanding onFinish={onFinish} onSkip={vi.fn()} />);
+    advanceToAssetsStep();
+
+    // Add an asset row but never type a name into it.
+    fireEvent.click(screen.getByRole('button', { name: /Add aircraft/i }));
+
+    // Blank out the "Vehicle" type label — the wizard should drop it.
+    fireEvent.change(screen.getByDisplayValue('Vehicle'), { target: { value: '' } });
+
+    fireEvent.click(screen.getByRole('button', { name: /I’m done/i }));
+
+    const result = onFinish.mock.calls[0]![0];
+    expect(result.assetSeeds).toEqual([]);
+    expect(result.assetTypes.map(t => t.id)).not.toContain('vehicle');
+    // The blanked type also stays out of templates — i.e. no entry under
+    // any falsy / blank key.
+    expect(Object.keys(result.requirementTemplates).every(k => k.length > 0)).toBe(true);
+  });
+
+  it('lets owners add a custom asset type from the input row', () => {
+    const onFinish = vi.fn<(r: SetupLandingResult) => void>();
+    render(<SetupLanding onFinish={onFinish} onSkip={vi.fn()} />);
+    advanceToAssetsStep();
+
+    const newTypeInput = screen.getByLabelText(/New asset type name/i);
+    fireEvent.change(newTypeInput, { target: { value: 'Drone' } });
+    fireEvent.click(screen.getByRole('button', { name: /Add type/i }));
+
+    // The new card renders with an editable name input pre-filled "Drone".
+    expect(screen.getByDisplayValue('Drone')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: /I’m done/i }));
+    const result = onFinish.mock.calls[0]![0];
+    expect(result.assetTypes.map(t => t.id)).toContain('drone');
+  });
+});


### PR DESCRIPTION
The full-page guided setup (SetupLanding) covered name, theme, tabs,
default view, team, and smart views, but never let owners declare what
they actually book or what each booking needs. As a result, calendars
could finish setup with the asset system entirely unconfigured — assets,
requirements, and approval rules all lived in the post-setup gear.

This commit adds a 7th step ("Assets & Requirements") that:
  * captures asset types (Aircraft / Vehicle / Equipment / Room by
    default, plus custom),
  * lets owners seed concrete assets under each type,
  * collects required role slots per type via suggested-role chips
    (Pilot, Medic, Driver…), and
  * toggles "requires approval before confirmed" per type.

The wizard now writes config.assetTypes, merges seeded entries into
config.assets, and persists config.requirementTemplates. AssetRequestForm
reads requirementTemplates and, for any asset whose meta.assetTypeId
matches an entry, renders one input per required role plus an
approval-required notice. Submission ships filled values inside
meta.requirements and blocks until every required slot is set.

Tests cover the new step's defaults, payload contract, blank-field
trimming, and custom-type creation, plus the form's role-slot rendering,
validation, and meta.requirements emission.