### PR TITLE
setup: hydrate wizard from existing config so re-run is non-destructive

### DIFF
--- a/src/WorksCalendar.tsx
+++ b/src/WorksCalendar.tsx
@@ -2081,6 +2081,8 @@ export const WorksCalendar = forwardRef<CalendarApi, WorksCalendarProps>(functio
             onFinish={handleSetupFinish}
             initialName={ownerCfg.config?.['title']}
             initialTheme={ownerCfg.config?.['setup']?.preferredTheme ?? rawTheme}
+            initialAssetTypes={ownerCfg.config?.['assetTypes']}
+            initialRequirementTemplates={ownerCfg.config?.['requirementTemplates']}
           />
         </div>
       </CalendarErrorBoundary>

--- a/src/ui/SetupLanding.tsx
+++ b/src/ui/SetupLanding.tsx
@@ -74,6 +74,20 @@ export type SetupLandingProps = {
   initialName?: string;
   /** Initial theme (from config.setup.preferredTheme). */
   initialTheme?: string;
+  /**
+   * Initial asset types. When omitted, the wizard seeds a sensible default
+   * list. Pass `config.assetTypes` so re-running setup on an already-
+   * configured calendar shows the existing types (and the finish-write
+   * doesn't silently destroy them).
+   */
+  initialAssetTypes?: AssetTypeDef[];
+  /**
+   * Initial requirement templates, keyed by asset type id. Pass
+   * `config.requirementTemplates` so re-running setup preserves the
+   * owner's existing role/approval rules instead of overwriting them
+   * with empty defaults.
+   */
+  initialRequirementTemplates?: Record<string, RequirementTemplate>;
 };
 
 /* ────────────────────────────────────────────────────────────────────────── */
@@ -171,6 +185,8 @@ export default function SetupLanding({
   onSkip,
   initialName = 'My Calendar',
   initialTheme = 'corporate',
+  initialAssetTypes,
+  initialRequirementTemplates,
 }: SetupLandingProps) {
   // Step 0 is the welcome screen. Steps 1..TOTAL_STEPS are the form.
   const [step, setStep] = useState(0);
@@ -181,9 +197,22 @@ export default function SetupLanding({
   const [locationLabel, setLocationLabel] = useState<'Base' | 'Region'>('Base');
   const [team, setTeam] = useState(STARTER_TEAM);
   const [recipes, setRecipes] = useState<SetupRecipeId[]>(['everything']);
-  const [assetTypes, setAssetTypes] = useState<AssetTypeDef[]>(DEFAULT_ASSET_TYPES);
+  // Hydrate from existing config when re-running setup so the finish-write
+  // does not destroy previously-configured types or templates. An owner who
+  // already set up Aircraft + Pilot + approval should see those in the
+  // wizard, not the hardcoded defaults. Falsy / empty inputs fall back to
+  // the defaults so the first-run experience is unchanged.
+  const [assetTypes, setAssetTypes] = useState<AssetTypeDef[]>(() =>
+    Array.isArray(initialAssetTypes) && initialAssetTypes.length > 0
+      ? initialAssetTypes
+      : DEFAULT_ASSET_TYPES,
+  );
   const [assetSeeds, setAssetSeeds] = useState<AssetSeed[]>([]);
-  const [requirementTemplates, setRequirementTemplates] = useState<Record<string, RequirementTemplate>>({});
+  const [requirementTemplates, setRequirementTemplates] = useState<Record<string, RequirementTemplate>>(() =>
+    initialRequirementTemplates && typeof initialRequirementTemplates === 'object'
+      ? initialRequirementTemplates
+      : {},
+  );
 
   const next = () => setStep(s => Math.min(TOTAL_STEPS, s + 1));
   const back = () => setStep(s => Math.max(0, s - 1));

--- a/src/ui/__tests__/SetupLanding.assetsStep.test.tsx
+++ b/src/ui/__tests__/SetupLanding.assetsStep.test.tsx
@@ -116,6 +116,74 @@ describe('SetupLanding — Assets & Requirements step', () => {
     expect(Object.keys(result.requirementTemplates).every(k => k.length > 0)).toBe(true);
   });
 
+  it('hydrates types and templates from existing config so re-running setup is non-destructive', () => {
+    const onFinish = vi.fn<(r: SetupLandingResult) => void>();
+    const existingTypes = [
+      { id: 'aircraft', label: 'Aircraft' },
+      { id: 'drone',    label: 'Drone' },
+    ];
+    const existingTemplates = {
+      aircraft: {
+        roles: [{ id: 'pilot', label: 'Pilot' }, { id: 'medic', label: 'Medic' }],
+        requiresApproval: true,
+      },
+      drone: {
+        roles: [{ id: 'operator', label: 'Operator' }],
+        requiresApproval: false,
+      },
+    };
+
+    render(
+      <SetupLanding
+        onFinish={onFinish}
+        onSkip={vi.fn()}
+        initialAssetTypes={existingTypes}
+        initialRequirementTemplates={existingTemplates}
+      />,
+    );
+    advanceToAssetsStep();
+
+    // The hydrated types render as editable inputs — the wizard does not
+    // fall back to its hardcoded defaults when initial config is supplied.
+    expect(screen.getByDisplayValue('Aircraft')).toBeInTheDocument();
+    expect(screen.getByDisplayValue('Drone')).toBeInTheDocument();
+    expect(screen.queryByDisplayValue('Vehicle')).not.toBeInTheDocument();
+    expect(screen.queryByDisplayValue('Equipment')).not.toBeInTheDocument();
+
+    // Existing role pills appear inside the matching card. Querying scoped
+    // to each card, since "Pilot" / "Operator" also exist as suggestion
+    // chips on other cards.
+    const aircraftCard = (screen.getByDisplayValue('Aircraft') as HTMLInputElement)
+      .closest(`[class*="assetTypeCard"]`) as HTMLElement;
+    const droneCard = (screen.getByDisplayValue('Drone') as HTMLInputElement)
+      .closest(`[class*="assetTypeCard"]`) as HTMLElement;
+
+    // Selected role pills carry the rolePillSelected class; suggestion
+    // chips carry rolePillSuggest. Match the persisted-pill class so we
+    // don't accept the "+ Pilot" add-button as proof of hydration.
+    const aircraftSelectedPills = aircraftCard.querySelectorAll(`[class*="rolePillSelected"]`);
+    const droneSelectedPills    = droneCard.querySelectorAll(`[class*="rolePillSelected"]`);
+    expect(Array.from(aircraftSelectedPills).map(n => n.textContent)).toEqual(
+      expect.arrayContaining([expect.stringContaining('Pilot'), expect.stringContaining('Medic')]),
+    );
+    expect(Array.from(droneSelectedPills).map(n => n.textContent)).toEqual(
+      expect.arrayContaining([expect.stringContaining('Operator')]),
+    );
+
+    // The aircraft "Requires approval" checkbox is pre-checked from config.
+    const aircraftApproval = within(aircraftCard).getByRole('checkbox', {
+      name: /Requires approval before it’s confirmed/i,
+    }) as HTMLInputElement;
+    expect(aircraftApproval.checked).toBe(true);
+
+    // Finishing without touching anything must echo the hydrated state back,
+    // so handleSetupFinish persists exactly what was already in config.
+    fireEvent.click(screen.getByRole('button', { name: /I’m done/i }));
+    const result = onFinish.mock.calls[0]![0];
+    expect(result.assetTypes).toEqual(existingTypes);
+    expect(result.requirementTemplates).toEqual(existingTemplates);
+  });
+
   it('lets owners add a custom asset type from the input row', () => {
     const onFinish = vi.fn<(r: SetupLandingResult) => void>();
     render(<SetupLanding onFinish={onFinish} onSkip={vi.fn()} />);


### PR DESCRIPTION
The previous handleSetupFinish unconditionally overwrote config.assetTypes and config.requirementTemplates with the wizard's output, but SetupLanding initialized those from hardcoded defaults (DEFAULT_ASSET_TYPES) and an empty templates record. Re-opening setup on a calendar that already had per-type roles or approval rules would silently erase them, changing request validation and approval behavior for existing assets.

Fix follows the existing initialName / initialTheme pattern: SetupLanding now accepts initialAssetTypes and initialRequirementTemplates, hydrates its state from them when present, and falls back to defaults otherwise. WorksCalendar threads config.assetTypes and config.requirementTemplates in. The destructive write is now safe because the wizard's payload already mirrors what was in config; finishing without changes round-trips the existing rules unchanged.

A new regression test renders the wizard with non-default types and templates and asserts the hydrated state shows up in the UI and round- trips back through onFinish.

## Summary
Describe exactly what this PR changes.

## Scope
- Stage: 
- Planned PR number in sprint: 
- Target files/directories: 
- Why this slice is isolated: 

## Lessons Learned Check (REQUIRED)
Confirm these were actively used while building this PR:

- [ ] PR is intentionally small and isolated
- [ ] Boundary typing was prioritized over internal perfection
- [ ] No silent spread of `any`
- [ ] Advisory root `tsc` was used to catch integration issues
- [ ] I did not assume “looks typed” means “safe”
- [ ] I stopped and isolated typing cascades instead of expanding scope

## Definition of Done (ALL REQUIRED)
This PR is not done unless every box is checked.

- [ ] `npm run type-check:strict` passes
- [ ] Root advisory `tsc --noEmit` passes
- [ ] Tests pass for touched scope at minimum
- [ ] No uncontrolled increase in `any`
- [ ] All new types are intentional and named
- [ ] Public interfaces and exported functions are explicitly typed
- [ ] PR scope matches the sprint plan with no scope creep
- [ ] Any new `any` has an adjacent justification comment
- [ ] No file-wide `: any`
- [ ] No implicit `any` in exported functions

## What Was Typed
List exactly what was typed in this PR.

- 
- 
- 

## What Was Intentionally Left Loose
List anything intentionally not tightened yet.

- 
- 
- 

## `any` Ledger (REQUIRED)
- New `any` added: 
- Existing `any` removed: 
- Net change: 

For every new `any`, explain why it is required and why a safer type was not used yet.

1. 
2. 
3. 

## Boundary Notes
Document any public seams, caller-protection choices, or compatibility decisions.

- 
- 
- 

## Risk Level
- [ ] Low
- [ ] Medium
- [ ] High

Why:

## Validation Evidence
Paste the exact commands run and a short result summary.

```bash
npm run type-check:strict
npx tsc --noEmit -p tsconfig.json
```

Test commands run:

```bash
# paste commands here
```

## Stop Conditions Check
If any item below happened, explain how scope was reduced before merge.

- [ ] `any` started spreading across files
- [ ] Root `tsc` broke repeatedly
- [ ] Types required cross-module rewrites
- [ ] Scope was reduced to keep the PR reviewable

Notes:

## Reviewer Focus
What should reviewers look at first?

- 
- 
- 
