### PR TITLE
base view: redesign for scale (searchable picker, region grouping, click-to-focus)

### DIFF
--- a/src/WorksCalendar.tsx
+++ b/src/WorksCalendar.tsx
@@ -927,8 +927,9 @@ export const WorksCalendar = forwardRef<CalendarApi, WorksCalendarProps>(functio
   );
 
   // ── Base/Region view config ───────────────────────────────────────────────
-  const configuredBases = ownerCfg.config?.['team']?.bases ?? [];
-  const locationLabel   = ownerCfg.config?.['team']?.locationLabel ?? 'Base';
+  const configuredBases   = ownerCfg.config?.['team']?.bases ?? [];
+  const configuredRegions = ownerCfg.config?.['team']?.regions ?? [];
+  const locationLabel     = ownerCfg.config?.['team']?.locationLabel ?? 'Base';
 
   // ── Visible-tabs config (Setup/ConfigPanel → Views) ──────────────────────
   const VIEWS = useMemo(() => {
@@ -2341,6 +2342,7 @@ export const WorksCalendar = forwardRef<CalendarApi, WorksCalendarProps>(functio
                   employees={configuredEmployees}
                   assets={effectiveAssets ?? []}
                   bases={configuredBases}
+                  regions={configuredRegions}
                   locationLabel={locationLabel}
                   selectedBaseIds={selectedBaseIds}
                   onBaseSelectionChange={setSelectedBaseIds}

--- a/src/views/BaseGanttView.module.css
+++ b/src/views/BaseGanttView.module.css
@@ -95,37 +95,179 @@
   color: #fff;
 }
 
-/* ── Base picker chips ── */
-.picker {
+/* ── Base picker (dropdown) ── */
+.pickerWrap {
+  position: relative;
+}
+
+.pickerTrigger {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 5px 10px;
+  border-radius: 6px;
+  border: 1px solid var(--wc-border);
+  background: var(--wc-bg);
+  color: var(--wc-text);
+  font-size: 12px;
+  font-weight: 600;
+  cursor: pointer;
+  min-width: 180px;
+  text-align: left;
+}
+
+.pickerTrigger:hover {
+  border-color: var(--wc-border-dark, var(--wc-border));
+}
+
+.pickerTriggerLabel {
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.pickerCaret {
+  font-size: 10px;
+  color: var(--wc-text-muted);
+}
+
+.pickerPopover {
+  position: absolute;
+  top: calc(100% + 4px);
+  left: 0;
+  z-index: 50;
+  width: 280px;
+  max-height: 360px;
+  display: flex;
+  flex-direction: column;
+  background: var(--wc-bg);
+  border: 1px solid var(--wc-border-dark, var(--wc-border));
+  border-radius: 8px;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.12);
+  overflow: hidden;
+}
+
+.pickerHeader {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 8px;
+  border-bottom: 1px solid var(--wc-border);
+  background: var(--wc-surface);
+}
+
+.pickerSearch {
+  width: 100%;
+  padding: 6px 8px;
+  border: 1px solid var(--wc-border);
+  border-radius: 4px;
+  font-size: 12px;
+  background: var(--wc-bg);
+  color: var(--wc-text);
+}
+
+.pickerSearch:focus {
+  outline: 2px solid var(--wc-accent, #0066cc);
+  outline-offset: -1px;
+  border-color: transparent;
+}
+
+.pickerActions {
   display: flex;
   gap: 6px;
-  flex-wrap: wrap;
 }
 
-.pickerChip {
-  padding: 4px 10px;
-  border-radius: 999px;
+.pickerActionBtn {
+  padding: 3px 8px;
   border: 1px solid var(--wc-border);
-  background: var(--wc-surface);
-  color: var(--wc-text-muted);
-  font-size: 12px;
+  border-radius: 4px;
+  background: var(--wc-bg);
+  color: var(--wc-text);
+  font-size: 11px;
+  font-weight: 600;
   cursor: pointer;
 }
 
-.pickerChipActive {
-  background: var(--wc-accent);
-  color: var(--wc-accent-contrast, #fff);
-  border-color: var(--wc-accent);
+.pickerActionBtn:hover:not(:disabled) {
+  background: color-mix(in srgb, var(--wc-text) 6%, transparent);
 }
 
-.pickerClear {
-  padding: 4px 8px;
-  border: none;
-  background: transparent;
+.pickerActionBtn:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
+.pickerList {
+  flex: 1;
+  overflow-y: auto;
+  padding: 4px 0;
+}
+
+.pickerEmpty {
+  padding: 12px;
+  text-align: center;
   color: var(--wc-text-muted);
   font-size: 12px;
+}
+
+.pickerGroup + .pickerGroup {
+  border-top: 1px solid var(--wc-border);
+  margin-top: 4px;
+  padding-top: 4px;
+}
+
+.pickerGroupLabel {
+  padding: 4px 12px;
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: var(--wc-text-muted);
+}
+
+.pickerOption {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 5px 12px;
+  font-size: 12px;
+  color: var(--wc-text);
   cursor: pointer;
-  text-decoration: underline;
+}
+
+.pickerOption:hover {
+  background: color-mix(in srgb, var(--wc-text) 5%, transparent);
+}
+
+.pickerOptionName {
+  flex: 1;
+}
+
+.pickerOptionEmpty {
+  font-size: 10px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--wc-text-muted);
+  padding: 1px 6px;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--wc-text) 6%, transparent);
+}
+
+/* ── Hide-empty toolbar toggle ── */
+.toolbarToggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 12px;
+  color: var(--wc-text);
+  cursor: pointer;
+  user-select: none;
+}
+
+.toolbarToggle input {
+  cursor: pointer;
 }
 
 /* ── Scroll wrap & inner ── */
@@ -244,6 +386,78 @@
   font-weight: 700;
   font-size: 14px;
   color: var(--wc-text);
+  background: transparent;
+  border: none;
+  padding: 0;
+  text-align: left;
+  cursor: pointer;
+  font-family: inherit;
+  width: fit-content;
+  border-radius: 3px;
+}
+
+.baseTitle:hover {
+  color: var(--wc-accent, #0066cc);
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+
+.baseTitle:focus-visible {
+  outline: 2px solid var(--wc-accent, #0066cc);
+  outline-offset: 2px;
+}
+
+/* ── Region block (collapsible) ── */
+.regionBlock {
+  display: flex;
+  flex-direction: column;
+}
+
+.regionHeader {
+  position: sticky;
+  left: 0;
+  z-index: 25;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: max-content;
+  min-width: 100%;
+  padding: 6px 12px;
+  background: var(--wc-surface);
+  border: none;
+  border-top: 1px solid var(--wc-border-dark, var(--wc-border));
+  border-bottom: 1px solid var(--wc-border);
+  font-family: inherit;
+  font-size: 12px;
+  font-weight: 700;
+  color: var(--wc-text);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  cursor: pointer;
+  text-align: left;
+}
+
+.regionHeader:hover {
+  background: color-mix(in srgb, var(--wc-text) 5%, var(--wc-surface));
+}
+
+.regionCaret {
+  display: inline-block;
+  width: 10px;
+  font-size: 10px;
+  color: var(--wc-text-muted);
+}
+
+.regionName {
+  color: var(--wc-text);
+}
+
+.regionCount {
+  color: var(--wc-text-muted);
+  font-weight: 500;
+  text-transform: none;
+  letter-spacing: 0;
+  font-size: 11px;
 }
 
 .baseCounts {

--- a/src/views/BaseGanttView.tsx
+++ b/src/views/BaseGanttView.tsx
@@ -37,7 +37,8 @@ const SPAN_OPTIONS = [
   { id: 90 as const, label: '90 days' },
 ];
 
-type BaseDef = { id: string; name: string };
+type BaseDef = { id: string; name: string; regionId?: string | null };
+type RegionDef = { id: string; name: string };
 type ManagerAssignment = { title?: string; phone?: string };
 type EmployeeDef = {
   id: string;
@@ -121,6 +122,7 @@ export default function BaseGanttView({
   employees = [],
   assets = [],
   bases = [],
+  regions = [],
   locationLabel = 'Base',
   selectedBaseIds = [],
   onBaseSelectionChange,
@@ -131,13 +133,35 @@ export default function BaseGanttView({
   employees?: EmployeeDef[]
   assets?: AssetDef[]
   bases?: BaseDef[]
+  regions?: RegionDef[]
   locationLabel?: string
   selectedBaseIds?: string[]
   onBaseSelectionChange?: (ids: string[]) => void
 }) {
   const ctx = useCalendarContext();
   const [spanDays, setSpanDays] = useState<14 | 90>(14);
+  const [pickerOpen, setPickerOpen] = useState(false);
+  const [pickerQuery, setPickerQuery] = useState('');
+  const [collapsedRegions, setCollapsedRegions] = useState<Set<string>>(() => new Set());
+  const [hideEmpty, setHideEmpty] = useState(false);
   const wrapRef = useRef<HTMLDivElement | null>(null);
+  const pickerRef = useRef<HTMLDivElement | null>(null);
+
+  // Close picker on outside click / escape.
+  useEffect(() => {
+    if (!pickerOpen) return;
+    const onDown = (e: MouseEvent) => {
+      if (!pickerRef.current) return;
+      if (!pickerRef.current.contains(e.target as Node)) setPickerOpen(false);
+    };
+    const onKey = (e: KeyboardEvent) => { if (e.key === 'Escape') setPickerOpen(false); };
+    document.addEventListener('mousedown', onDown);
+    document.addEventListener('keydown', onKey);
+    return () => {
+      document.removeEventListener('mousedown', onDown);
+      document.removeEventListener('keydown', onKey);
+    };
+  }, [pickerOpen]);
 
   const rangeStart = useMemo(() => startOfDay(currentDate), [currentDate]);
   const rangeEnd   = useMemo(() => addDays(rangeStart, spanDays - 1), [rangeStart, spanDays]);
@@ -161,7 +185,9 @@ export default function BaseGanttView({
     wrap.scrollLeft = targetLeft;
   }, [rangeStart, spanDays]);
 
-  const visibleBases = useMemo(() => {
+  // Bases passing the user's selection filter (no search, no hide-empty).
+  // Also used to drive the picker's "selected" state.
+  const selectedBases = useMemo(() => {
     if (!selectedBaseIds || selectedBaseIds.length === 0) return bases;
     const set = new Set(selectedBaseIds);
     return bases.filter(b => set.has(b.id));
@@ -226,6 +252,80 @@ export default function BaseGanttView({
     }
     return m;
   }, [events, empIndex, assetIndex]);
+
+  // Per-base "has any event in current span" — drives the hide-empty toggle
+  // and the count badge in the picker. Cheap because the maps above already
+  // bucket events; we only care about non-empty arrays.
+  const isBaseEmpty = useMemo(() => {
+    const m = new Map<string, boolean>();
+    for (const b of bases) {
+      const baseWide = baseWideEvents.get(b.id);
+      if (baseWide && baseWide.length > 0) { m.set(b.id, false); continue; }
+      let any = false;
+      for (const a of assetsByBase.get(b.id) ?? []) {
+        if ((eventsByResource.get(String(a.id))?.length ?? 0) > 0) { any = true; break; }
+      }
+      if (!any) {
+        for (const e of empsByBase.get(b.id) ?? []) {
+          if ((eventsByResource.get(String(e.id))?.length ?? 0) > 0) { any = true; break; }
+        }
+      }
+      m.set(b.id, !any);
+    }
+    return m;
+  }, [bases, baseWideEvents, assetsByBase, empsByBase, eventsByResource]);
+
+  // Final list of bases to render: selection filter → hide-empty filter.
+  const visibleBases = useMemo(() => {
+    if (!hideEmpty) return selectedBases;
+    return selectedBases.filter(b => !isBaseEmpty.get(b.id));
+  }, [selectedBases, hideEmpty, isBaseEmpty]);
+
+  // Group rendered bases by region. Bases with no regionId (or whose region
+  // is not configured) fall into a synthetic 'Unassigned' bucket. When no
+  // regions are configured at all, we still render a single flat group with
+  // no region header (the consumer hasn't opted in to the hierarchy).
+  const regionsById = useMemo(() => {
+    const m = new Map<string, RegionDef>();
+    regions.forEach(r => m.set(r.id, r));
+    return m;
+  }, [regions]);
+
+  const groupedBases = useMemo(() => {
+    if (regions.length === 0) {
+      return [{ region: null as RegionDef | null, bases: visibleBases }];
+    }
+    const buckets = new Map<string, BaseDef[]>();
+    const unassigned: BaseDef[] = [];
+    for (const b of visibleBases) {
+      const rid = b.regionId && regionsById.has(b.regionId) ? b.regionId : null;
+      if (rid == null) { unassigned.push(b); continue; }
+      if (!buckets.has(rid)) buckets.set(rid, []);
+      buckets.get(rid)!.push(b);
+    }
+    const out: { region: RegionDef | null; bases: BaseDef[] }[] = [];
+    for (const r of regions) {
+      const list = buckets.get(r.id);
+      if (list && list.length > 0) out.push({ region: r, bases: list });
+    }
+    if (unassigned.length > 0) {
+      out.push({ region: { id: '__unassigned__', name: 'Unassigned' }, bases: unassigned });
+    }
+    return out;
+  }, [regions, regionsById, visibleBases]);
+
+  const toggleRegion = (id: string) => {
+    setCollapsedRegions(prev => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id); else next.add(id);
+      return next;
+    });
+  };
+
+  const focusBase = (id: string) => {
+    if (!onBaseSelectionChange) return;
+    onBaseSelectionChange([id]);
+  };
 
   const toggleBase = (id: string) => {
     if (!onBaseSelectionChange) return;
@@ -295,32 +395,123 @@ export default function BaseGanttView({
 
         <div className={styles['toolbarGroup']}>
           <span className={styles['toolbarLabel']}>{locationLabel}s</span>
-          <div className={styles['picker']} role="group" aria-label={`Select ${locationLabel.toLowerCase()}s`}>
-            {bases.map(b => {
-              const active = selectedBaseIds.length === 0 || selectedBaseIds.includes(b.id);
+          <div ref={pickerRef} className={styles['pickerWrap']}>
+            {(() => {
+              const total = bases.length;
+              const sel = selectedBaseIds.length;
+              const summary = sel === 0
+                ? `All ${locationLabel.toLowerCase()}s (${total})`
+                : sel === 1
+                  ? (bases.find(b => b.id === selectedBaseIds[0])?.name ?? `1 ${locationLabel.toLowerCase()}`)
+                  : `${sel} of ${total} ${locationLabel.toLowerCase()}s`;
               return (
                 <button
-                  key={b.id}
                   type="button"
-                  className={[styles['pickerChip'], active && styles['pickerChipActive']].filter(Boolean).join(' ')}
-                  aria-pressed={active}
-                  onClick={() => toggleBase(b.id)}
+                  className={styles['pickerTrigger']}
+                  aria-haspopup="listbox"
+                  aria-expanded={pickerOpen}
+                  onClick={() => setPickerOpen(o => !o)}
                 >
-                  {b.name}
+                  <span className={styles['pickerTriggerLabel']}>{summary}</span>
+                  <span className={styles['pickerCaret']} aria-hidden>▾</span>
                 </button>
               );
-            })}
-            {selectedBaseIds.length > 0 && (
-              <button
-                type="button"
-                className={styles['pickerClear']}
-                onClick={() => onBaseSelectionChange?.([])}
-              >
-                Clear
-              </button>
-            )}
+            })()}
+            {pickerOpen && (() => {
+              const q = pickerQuery.trim().toLowerCase();
+              const matches = (b: BaseDef) => !q || b.name.toLowerCase().includes(q);
+              const filtered = bases.filter(matches);
+              // Group by region for the picker (independent of hide-empty / selection).
+              const buckets = new Map<string, BaseDef[]>();
+              const unassigned: BaseDef[] = [];
+              for (const b of filtered) {
+                const rid = b.regionId && regionsById.has(b.regionId) ? b.regionId : null;
+                if (rid == null) { unassigned.push(b); continue; }
+                if (!buckets.has(rid)) buckets.set(rid, []);
+                buckets.get(rid)!.push(b);
+              }
+              const pickerGroups: { region: RegionDef | null; bases: BaseDef[] }[] = [];
+              if (regions.length === 0) {
+                pickerGroups.push({ region: null, bases: filtered });
+              } else {
+                for (const r of regions) {
+                  const list = buckets.get(r.id);
+                  if (list && list.length > 0) pickerGroups.push({ region: r, bases: list });
+                }
+                if (unassigned.length > 0) {
+                  pickerGroups.push({ region: { id: '__unassigned__', name: 'Unassigned' }, bases: unassigned });
+                }
+              }
+              return (
+                <div className={styles['pickerPopover']} role="listbox" aria-label={`${locationLabel}s`}>
+                  <div className={styles['pickerHeader']}>
+                    <input
+                      autoFocus
+                      type="search"
+                      className={styles['pickerSearch']}
+                      placeholder={`Search ${locationLabel.toLowerCase()}s…`}
+                      value={pickerQuery}
+                      onChange={e => setPickerQuery(e.target.value)}
+                    />
+                    <div className={styles['pickerActions']}>
+                      <button
+                        type="button"
+                        className={styles['pickerActionBtn']}
+                        onClick={() => onBaseSelectionChange?.([])}
+                        disabled={selectedBaseIds.length === 0}
+                      >
+                        Show all
+                      </button>
+                      <button
+                        type="button"
+                        className={styles['pickerActionBtn']}
+                        onClick={() => onBaseSelectionChange?.(filtered.map(b => b.id))}
+                      >
+                        Only these
+                      </button>
+                    </div>
+                  </div>
+                  <div className={styles['pickerList']}>
+                    {filtered.length === 0 && (
+                      <div className={styles['pickerEmpty']}>No matches</div>
+                    )}
+                    {pickerGroups.map(g => (
+                      <div key={g.region?.id ?? '__none__'} className={styles['pickerGroup']}>
+                        {g.region && (
+                          <div className={styles['pickerGroupLabel']}>{g.region.name}</div>
+                        )}
+                        {g.bases.map(b => {
+                          const checked = selectedBaseIds.length === 0 || selectedBaseIds.includes(b.id);
+                          const empty = isBaseEmpty.get(b.id) === true;
+                          return (
+                            <label key={b.id} className={styles['pickerOption']}>
+                              <input
+                                type="checkbox"
+                                checked={checked}
+                                onChange={() => toggleBase(b.id)}
+                              />
+                              <span className={styles['pickerOptionName']}>{b.name}</span>
+                              {empty && <span className={styles['pickerOptionEmpty']}>empty</span>}
+                            </label>
+                          );
+                        })}
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              );
+            })()}
           </div>
         </div>
+
+        <label className={styles['toolbarToggle']}>
+          <input
+            type="checkbox"
+            checked={hideEmpty}
+            onChange={e => setHideEmpty(e.target.checked)}
+          />
+          <span>Hide empty</span>
+        </label>
 
         <div className={styles['toolbarSpacer']} />
         <div className={styles['rangeLabel']}>
@@ -352,8 +543,25 @@ export default function BaseGanttView({
             </div>
           </div>
 
-          {/* Base groups */}
-          {visibleBases.map(b => {
+          {/* Base groups, grouped by region when configured. */}
+          {groupedBases.map(group => {
+            const region = group.region;
+            const collapsed = region ? collapsedRegions.has(region.id) : false;
+            return (
+              <div key={region?.id ?? '__flat__'} className={styles['regionBlock']}>
+                {region && (
+                  <button
+                    type="button"
+                    className={styles['regionHeader']}
+                    onClick={() => toggleRegion(region.id)}
+                    aria-expanded={!collapsed}
+                  >
+                    <span className={styles['regionCaret']} aria-hidden>{collapsed ? '▸' : '▾'}</span>
+                    <span className={styles['regionName']}>{region.name}</span>
+                    <span className={styles['regionCount']}>{group.bases.length} {locationLabel.toLowerCase()}{group.bases.length === 1 ? '' : 's'}</span>
+                  </button>
+                )}
+                {!collapsed && group.bases.map(b => {
             const baseEmps   = empsByBase.get(b.id) ?? [];
             const baseAssets = assetsByBase.get(b.id) ?? [];
             const baseWide   = baseWideEvents.get(b.id) ?? [];
@@ -371,7 +579,14 @@ export default function BaseGanttView({
                 {/* Base header row */}
                 <div className={styles['baseHeaderRow']} style={{ minHeight: Math.max(baseRowH, 72) }}>
                   <div className={styles['baseHeaderName']} style={{ width: NAME_W }}>
-                    <div className={styles['baseTitle']}>{b.name}</div>
+                    <button
+                      type="button"
+                      className={styles['baseTitle']}
+                      title={`Focus ${b.name}  ·  Shift-click to toggle in selection`}
+                      onClick={(e) => { if (e.shiftKey) toggleBase(b.id); else focusBase(b.id); }}
+                    >
+                      {b.name}
+                    </button>
                     <div className={styles['baseCounts']}>
                       {baseAssets.length} assets · {baseEmps.length} people
                     </div>
@@ -503,6 +718,9 @@ export default function BaseGanttView({
                     <div className={styles['timelineCell']} style={{ width: timelineW, height: 32 }} />
                   </div>
                 )}
+              </div>
+            );
+                })}
               </div>
             );
           })}

--- a/src/views/__tests__/BaseGanttView.test.tsx
+++ b/src/views/__tests__/BaseGanttView.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, within } from '@testing-library/react';
 import React from 'react';
 import BaseGanttView from '../BaseGanttView';
 import { CalendarContext } from '../../core/CalendarContext';
@@ -68,43 +68,205 @@ describe('BaseGanttView — span toggle', () => {
   });
 });
 
-// ─── Base picker ──────────────────────────────────────────────────────────────
+// ─── Base picker dropdown ─────────────────────────────────────────────────────
 
-describe('BaseGanttView — base picker chips', () => {
+describe('BaseGanttView — base picker dropdown', () => {
   const bases = [
     { id: 'b1', name: 'Alpha Base' },
     { id: 'b2', name: 'Bravo Base' },
   ];
 
-  it('renders a chip for each base', () => {
-    wrap({ bases });
-    expect(screen.getByRole('button', { name: 'Alpha Base' })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'Bravo Base' })).toBeInTheDocument();
+  function openPicker() {
+    fireEvent.click(screen.getByRole('button', { expanded: false }));
+  }
+
+  it('shows an "All bases (N)" summary on the trigger when nothing is selected', () => {
+    wrap({ bases, selectedBaseIds: [] });
+    expect(screen.getByRole('button', { name: /All bases \(2\)/i })).toBeInTheDocument();
   });
 
-  it('calls onBaseSelectionChange when a chip is clicked', () => {
+  it('shows the single base name on the trigger when one base is selected', () => {
+    wrap({ bases, selectedBaseIds: ['b1'] });
+    // Trigger is the listbox-haspopup button.
+    const trigger = screen.getByRole('button', { expanded: false });
+    expect(within(trigger).getByText('Alpha Base')).toBeInTheDocument();
+  });
+
+  it('shows "N of M" on the trigger when multiple bases are selected', () => {
+    wrap({ bases, selectedBaseIds: ['b1', 'b2'] });
+    expect(screen.getByRole('button', { name: /2 of 2 bases/i })).toBeInTheDocument();
+  });
+
+  it('opens the popover when the trigger is clicked', () => {
+    wrap({ bases });
+    expect(screen.queryByRole('listbox')).toBeNull();
+    openPicker();
+    expect(screen.getByRole('listbox')).toBeInTheDocument();
+  });
+
+  it('renders a checkbox option for each base inside the popover', () => {
+    wrap({ bases });
+    openPicker();
+    const lb = screen.getByRole('listbox');
+    expect(within(lb).getByText('Alpha Base')).toBeInTheDocument();
+    expect(within(lb).getByText('Bravo Base')).toBeInTheDocument();
+    // Two checkboxes inside the popover (one per base).
+    expect(within(lb).getAllByRole('checkbox')).toHaveLength(2);
+  });
+
+  it('toggles selection when an option is clicked', () => {
     const onBaseSelectionChange = vi.fn();
     wrap({ bases, selectedBaseIds: [], onBaseSelectionChange });
-    fireEvent.click(screen.getByRole('button', { name: 'Alpha Base' }));
-    expect(onBaseSelectionChange).toHaveBeenCalledOnce();
+    openPicker();
+    const lb = screen.getByRole('listbox');
+    fireEvent.click(within(lb).getByText('Alpha Base'));
     expect(onBaseSelectionChange).toHaveBeenCalledWith(['b1']);
   });
 
-  it('shows a Clear button when selectedBaseIds is non-empty', () => {
-    wrap({ bases, selectedBaseIds: ['b1'] });
-    expect(screen.getByRole('button', { name: /Clear/i })).toBeInTheDocument();
+  it('filters options by the search query', () => {
+    wrap({ bases });
+    openPicker();
+    const lb = screen.getByRole('listbox');
+    const search = within(lb).getByPlaceholderText(/Search bases/i);
+    fireEvent.change(search, { target: { value: 'alph' } });
+    expect(within(lb).getByText('Alpha Base')).toBeInTheDocument();
+    expect(within(lb).queryByText('Bravo Base')).toBeNull();
   });
 
-  it('does not show a Clear button when selectedBaseIds is empty', () => {
-    wrap({ bases, selectedBaseIds: [] });
-    expect(screen.queryByRole('button', { name: /Clear/i })).toBeNull();
+  it('shows "No matches" when the search query matches nothing', () => {
+    wrap({ bases });
+    openPicker();
+    const lb = screen.getByRole('listbox');
+    fireEvent.change(within(lb).getByPlaceholderText(/Search bases/i), { target: { value: 'zzzz' } });
+    expect(within(lb).getByText(/No matches/i)).toBeInTheDocument();
   });
 
-  it('calls onBaseSelectionChange([]) when Clear is clicked', () => {
+  it('"Show all" clears selectedBaseIds', () => {
     const onBaseSelectionChange = vi.fn();
     wrap({ bases, selectedBaseIds: ['b1'], onBaseSelectionChange });
-    fireEvent.click(screen.getByRole('button', { name: /Clear/i }));
+    openPicker();
+    const lb = screen.getByRole('listbox');
+    fireEvent.click(within(lb).getByRole('button', { name: /Show all/i }));
     expect(onBaseSelectionChange).toHaveBeenCalledWith([]);
+  });
+
+  it('"Show all" is disabled when nothing is selected', () => {
+    wrap({ bases, selectedBaseIds: [] });
+    openPicker();
+    const lb = screen.getByRole('listbox');
+    expect(within(lb).getByRole('button', { name: /Show all/i })).toBeDisabled();
+  });
+
+  it('"Only these" sets selection to the currently filtered bases', () => {
+    const onBaseSelectionChange = vi.fn();
+    wrap({ bases, selectedBaseIds: [], onBaseSelectionChange });
+    openPicker();
+    const lb = screen.getByRole('listbox');
+    fireEvent.change(within(lb).getByPlaceholderText(/Search bases/i), { target: { value: 'brav' } });
+    fireEvent.click(within(lb).getByRole('button', { name: /Only these/i }));
+    expect(onBaseSelectionChange).toHaveBeenCalledWith(['b2']);
+  });
+});
+
+// ─── Region grouping ──────────────────────────────────────────────────────────
+
+describe('BaseGanttView — region grouping', () => {
+  const regions = [
+    { id: 'r-north', name: 'Northern' },
+    { id: 'r-south', name: 'Southern' },
+  ];
+  const bases = [
+    { id: 'b1', name: 'Alpha Base', regionId: 'r-north' },
+    { id: 'b2', name: 'Bravo Base', regionId: 'r-south' },
+    { id: 'b3', name: 'Charlie Base' }, // no region → Unassigned
+  ];
+
+  it('renders a region header per region with at least one visible base', () => {
+    wrap({ bases, regions });
+    expect(screen.getByRole('button', { name: /Northern/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Southern/i })).toBeInTheDocument();
+  });
+
+  it('groups bases without a configured region under "Unassigned"', () => {
+    wrap({ bases, regions });
+    expect(screen.getByRole('button', { name: /Unassigned/i })).toBeInTheDocument();
+  });
+
+  it('does not render region headers when no regions are configured', () => {
+    wrap({ bases: [{ id: 'b1', name: 'Alpha Base' }] });
+    expect(screen.queryByRole('button', { name: /Northern/i })).toBeNull();
+  });
+
+  it('hides bases under a region when its header is clicked (collapse)', () => {
+    wrap({ bases, regions });
+    // Northern region contains Alpha Base.
+    expect(screen.getByText('Alpha Base')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: /Northern/i }));
+    expect(screen.queryByText('Alpha Base')).toBeNull();
+    // Other regions still visible.
+    expect(screen.getByText('Bravo Base')).toBeInTheDocument();
+  });
+
+  it('groups picker options by region inside the popover', () => {
+    wrap({ bases, regions });
+    fireEvent.click(screen.getByRole('button', { expanded: false }));
+    const lb = screen.getByRole('listbox');
+    expect(within(lb).getByText('Northern')).toBeInTheDocument();
+    expect(within(lb).getByText('Southern')).toBeInTheDocument();
+    expect(within(lb).getByText('Unassigned')).toBeInTheDocument();
+  });
+});
+
+// ─── Click-to-focus on base header ────────────────────────────────────────────
+
+describe('BaseGanttView — click-to-focus base header', () => {
+  const bases = [
+    { id: 'b1', name: 'Alpha Base' },
+    { id: 'b2', name: 'Bravo Base' },
+  ];
+
+  it('clicking a base header focuses just that base (selectedBaseIds = [id])', () => {
+    const onBaseSelectionChange = vi.fn();
+    wrap({ bases, selectedBaseIds: [], onBaseSelectionChange });
+    // Both base headers exist as buttons; pick Alpha Base.
+    fireEvent.click(screen.getByRole('button', { name: 'Alpha Base' }));
+    expect(onBaseSelectionChange).toHaveBeenCalledWith(['b1']);
+  });
+
+  it('shift-clicking a base header toggles it in the existing selection', () => {
+    const onBaseSelectionChange = vi.fn();
+    // Start with both selected so both headers render and shift-click can remove.
+    wrap({ bases, selectedBaseIds: ['b1', 'b2'], onBaseSelectionChange });
+    // The trigger summary also reads "Alpha Base" sometimes; pick the header
+    // by selecting the second matching button (the rendered base header).
+    const headers = screen.getAllByRole('button', { name: 'Alpha Base' });
+    fireEvent.click(headers[headers.length - 1]!, { shiftKey: true });
+    expect(onBaseSelectionChange).toHaveBeenCalledWith(['b2']);
+  });
+});
+
+// ─── Hide-empty toggle ────────────────────────────────────────────────────────
+
+describe('BaseGanttView — hide empty toggle', () => {
+  const bases = [
+    { id: 'b1', name: 'Alpha Base' },
+    { id: 'b2', name: 'Bravo Base' },
+  ];
+  const employees = [{ id: 'e1', name: 'Alice', base: 'b1' }];
+  const events = [
+    { id: 'ev1', title: 'Shift', resource: 'e1',
+      start: d(2026, 4, 21), end: d(2026, 4, 22) },
+  ];
+
+  it('hides bases with no events when "Hide empty" is checked', () => {
+    wrap({ bases, employees, events }, minCtx);
+    // Both visible by default.
+    expect(screen.getByRole('button', { name: 'Alpha Base' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Bravo Base' })).toBeInTheDocument();
+    // Toggle on.
+    fireEvent.click(screen.getByLabelText(/Hide empty/i));
+    expect(screen.getByRole('button', { name: 'Alpha Base' })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Bravo Base' })).toBeNull();
   });
 });
 
@@ -115,8 +277,8 @@ describe('BaseGanttView — base groups', () => {
 
   it('renders the base name in the header', () => {
     wrap({ bases });
-    // 'Alpha Base' appears in both the picker chip and the base header title.
-    expect(screen.getAllByText('Alpha Base').length).toBeGreaterThanOrEqual(2);
+    // Base name appears as a clickable header button (Click-to-focus).
+    expect(screen.getByRole('button', { name: 'Alpha Base' })).toBeInTheDocument();
   });
 
   it('shows asset and people counts in the base header', () => {
@@ -182,15 +344,12 @@ describe('BaseGanttView — person rows', () => {
       accountableManagers: [{ title: 'Site Manager' }],
     }];
     wrap({ bases, employees });
-    // Title renders in both the base header manager list and the person row badge.
     expect(screen.getAllByText('Site Manager').length).toBeGreaterThanOrEqual(1);
   });
 
   it('renders a tel: link for an employee phone number', () => {
     const employees = [{ id: 'e1', name: 'Carol', base: 'b1', phone: '5550001234' }];
     wrap({ bases, employees });
-    // Accessible name comes from visible text "(555) 000-1234"; title="Call Carol"
-    // is advisory only. Query by the formatted number text content.
     const link = screen.getByRole('link', { name: /555.*000.*1234/ });
     expect(link).toHaveAttribute('href', 'tel:5550001234');
   });
@@ -232,7 +391,6 @@ describe('BaseGanttView — event bars', () => {
     wrap({ bases, employees, events, onEventClick }, minCtx);
     fireEvent.click(screen.getByRole('button', { name: /Scheduled Shift/i }));
     expect(onEventClick).toHaveBeenCalledOnce();
-    // assignLanes enriches the event with _lane/_dayStart/_dayEnd; use objectContaining.
     expect(onEventClick).toHaveBeenCalledWith(
       expect.objectContaining({ id: 'ev1', title: 'Scheduled Shift', resource: 'e1' }),
     );
@@ -258,16 +416,15 @@ describe('BaseGanttView — selectedBaseIds filtering', () => {
 
   it('shows all bases when selectedBaseIds is empty', () => {
     wrap({ bases, selectedBaseIds: [] });
-    // Each name appears in both the picker chip and the base group header.
-    expect(screen.getAllByText('Alpha Base').length).toBeGreaterThanOrEqual(2);
-    expect(screen.getAllByText('Bravo Base').length).toBeGreaterThanOrEqual(2);
+    expect(screen.getByRole('button', { name: 'Alpha Base' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Bravo Base' })).toBeInTheDocument();
   });
 
   it('shows only selected bases when selectedBaseIds is set', () => {
     wrap({ bases, selectedBaseIds: ['b1'] });
-    // Alpha Base: picker chip + group header (selected → group rendered).
-    expect(screen.getAllByText('Alpha Base').length).toBeGreaterThanOrEqual(2);
-    // Bravo Base: picker chip only — group body is filtered out.
-    expect(screen.getAllByText('Bravo Base')).toHaveLength(1);
+    // Alpha Base appears twice: once in the trigger summary (single-base label),
+    // once as the rendered base header. Bravo Base appears nowhere.
+    expect(screen.getAllByRole('button', { name: 'Alpha Base' })).toHaveLength(2);
+    expect(screen.queryByRole('button', { name: 'Bravo Base' })).toBeNull();
   });
 });


### PR DESCRIPTION
The chip-strip picker wraps unmanageably past ~10 bases and offers no way to
answer "who's at base X" quickly when the list grows to 30. Replace the chips
with a searchable dropdown grouped by region, render bases under collapsible
region headers, make the base header itself clickable to focus a single base
(shift-click multi-toggle), and add a "Hide empty" toolbar toggle to trim
zero-event bases from view.

Adds an optional `regions` prop and `regionId` on bases; falls back to a flat
flat layout when no regions are configured. Wires `team.regions` through from
`WorksCalendar.tsx`.

https://claude.ai/code/session_01WtSwxfdaT6VMUaciniXLp9