### PR TITLE
base view: address P2 review feedback on hide-empty + Only these

### DIFF
--- a/src/views/BaseGanttView.tsx
+++ b/src/views/BaseGanttView.tsx
@@ -254,26 +254,32 @@ export default function BaseGanttView({
   }, [events, empIndex, assetIndex]);
 
   // Per-base "has any event in current span" — drives the hide-empty toggle
-  // and the count badge in the picker. Cheap because the maps above already
-  // bucket events; we only care about non-empty arrays.
+  // and the count badge in the picker. Events are clipped to [rangeStart,
+  // rangeEnd]; a base whose only events fall outside the visible window is
+  // treated as empty so the toggle actually hides it.
   const isBaseEmpty = useMemo(() => {
+    const overlapsRange = (e: BaseGanttEvent) => {
+      const s = startOfDay(e.start);
+      const en = startOfDay(e.end);
+      return s <= rangeEnd && en >= rangeStart;
+    };
     const m = new Map<string, boolean>();
     for (const b of bases) {
       const baseWide = baseWideEvents.get(b.id);
-      if (baseWide && baseWide.length > 0) { m.set(b.id, false); continue; }
+      if (baseWide && baseWide.some(overlapsRange)) { m.set(b.id, false); continue; }
       let any = false;
       for (const a of assetsByBase.get(b.id) ?? []) {
-        if ((eventsByResource.get(String(a.id))?.length ?? 0) > 0) { any = true; break; }
+        if ((eventsByResource.get(String(a.id)) ?? []).some(overlapsRange)) { any = true; break; }
       }
       if (!any) {
         for (const e of empsByBase.get(b.id) ?? []) {
-          if ((eventsByResource.get(String(e.id))?.length ?? 0) > 0) { any = true; break; }
+          if ((eventsByResource.get(String(e.id)) ?? []).some(overlapsRange)) { any = true; break; }
         }
       }
       m.set(b.id, !any);
     }
     return m;
-  }, [bases, baseWideEvents, assetsByBase, empsByBase, eventsByResource]);
+  }, [bases, baseWideEvents, assetsByBase, empsByBase, eventsByResource, rangeStart, rangeEnd]);
 
   // Final list of bases to render: selection filter → hide-empty filter.
   const visibleBases = useMemo(() => {
@@ -465,7 +471,12 @@ export default function BaseGanttView({
                       <button
                         type="button"
                         className={styles['pickerActionBtn']}
-                        onClick={() => onBaseSelectionChange?.(filtered.map(b => b.id))}
+                        onClick={() => {
+                          if (filtered.length === 0) return;
+                          onBaseSelectionChange?.(filtered.map(b => b.id));
+                        }}
+                        disabled={filtered.length === 0}
+                        title={filtered.length === 0 ? 'No matches to apply' : `Show only the ${filtered.length} matching ${locationLabel.toLowerCase()}s`}
                       >
                         Only these
                       </button>


### PR DESCRIPTION
Two fixes for issues raised on PR #394:

- isBaseEmpty was checking whether a base had any attached events, period. A base with only out-of-range events (e.g. next month) was therefore treated as non-empty and survived the "Hide empty" toggle even though no bars rendered in the current 14/90-day span. The lookup now clips every event list to [rangeStart, rangeEnd] before deciding empty.

- "Only these" passed the live filtered.map(...) array to the selection callback. With zero search matches that becomes [], which the picker reads as "show all bases" — the opposite of what the button promises. The handler now no-ops on empty filtered, and the button is disabled with a "No matches to apply" tooltip in that state.

## Summary
Describe exactly what this PR changes.

## Scope
- Stage: 
- Planned PR number in sprint: 
- Target files/directories: 
- Why this slice is isolated: 

## Lessons Learned Check (REQUIRED)
Confirm these were actively used while building this PR:

- [ ] PR is intentionally small and isolated
- [ ] Boundary typing was prioritized over internal perfection
- [ ] No silent spread of `any`
- [ ] Advisory root `tsc` was used to catch integration issues
- [ ] I did not assume “looks typed” means “safe”
- [ ] I stopped and isolated typing cascades instead of expanding scope

## Definition of Done (ALL REQUIRED)
This PR is not done unless every box is checked.

- [ ] `npm run type-check:strict` passes
- [ ] Root advisory `tsc --noEmit` passes
- [ ] Tests pass for touched scope at minimum
- [ ] No uncontrolled increase in `any`
- [ ] All new types are intentional and named
- [ ] Public interfaces and exported functions are explicitly typed
- [ ] PR scope matches the sprint plan with no scope creep
- [ ] Any new `any` has an adjacent justification comment
- [ ] No file-wide `: any`
- [ ] No implicit `any` in exported functions

## What Was Typed
List exactly what was typed in this PR.

- 
- 
- 

## What Was Intentionally Left Loose
List anything intentionally not tightened yet.

- 
- 
- 

## `any` Ledger (REQUIRED)
- New `any` added: 
- Existing `any` removed: 
- Net change: 

For every new `any`, explain why it is required and why a safer type was not used yet.

1. 
2. 
3. 

## Boundary Notes
Document any public seams, caller-protection choices, or compatibility decisions.

- 
- 
- 

## Risk Level
- [ ] Low
- [ ] Medium
- [ ] High

Why:

## Validation Evidence
Paste the exact commands run and a short result summary.

```bash
npm run type-check:strict
npx tsc --noEmit -p tsconfig.json
```

Test commands run:

```bash
# paste commands here
```

## Stop Conditions Check
If any item below happened, explain how scope was reduced before merge.

- [ ] `any` started spreading across files
- [ ] Root `tsc` broke repeatedly
- [ ] Types required cross-module rewrites
- [ ] Scope was reduced to keep the PR reviewable

Notes:

## Reviewer Focus
What should reviewers look at first?

- 
- 
- 
