### PR TITLE
dispatch: new top-level view answering "what can launch right now?"

### DIFF
--- a/demo/App.tsx
+++ b/demo/App.tsx
@@ -24,6 +24,7 @@ import {
 } from './emsData';
 import MissionHoverCard, { allRequirementsMet } from './MissionHoverCard';
 import missionStyles from './MissionHoverCard.module.css';
+import { makeDispatchEvaluator } from './dispatchEvaluator';
 
 /* ─── Demo identity ─────────────────────────────────────────────── */
 // Air EMS demo: new calendar id so the IHC Fleet localStorage doesn't bleed
@@ -361,6 +362,38 @@ function App() {
     [],
   );
 
+  // ── Dispatch view wiring ────────────────────────────────────────
+  // The library's DispatchView is generic — it knows nothing about
+  // pilots, certs, aircraft hours, etc. Air EMS specifics live in
+  // ./dispatchEvaluator and feed in via these two props.
+  const dispatchMissions = useMemo(() => ([
+    { id: mission.id, label: mission.title, sublabel: 'Pending — needs aircraft' },
+  ]), []);
+
+  const dispatchEvaluator = useMemo(() => {
+    const missionsById = { [mission.id]: mission };
+    // isBookedAt — quick scan of the live event store. Events without a
+    // resource binding (base-wide events) don't lock individual crew.
+    const isBookedAt = (resourceId, at) => {
+      const t = at.getTime();
+      for (const ev of events) {
+        if (ev?.resource == null) continue;
+        if (String(ev.resource) !== resourceId) continue;
+        const s = new Date(ev.start).getTime();
+        const e = new Date(ev.end).getTime();
+        if (s <= t && e >= t) return true;
+      }
+      return false;
+    };
+    return makeDispatchEvaluator({
+      aircraft: EMS_ASSETS,
+      pilots: crew,
+      medicalCrew,
+      missionsById,
+      isBookedAt,
+    });
+  }, [events]);
+
   const [updateSW] = useState(() =>
     registerSW({
       onNeedRefresh()  { setNeedsRefresh(true); },
@@ -492,6 +525,8 @@ function App() {
             categoriesConfig={UNIFIED_CATEGORIES_CONFIG}
             locationProvider={assetLocationProvider}
             filterSchema={DEMO_FILTER_SCHEMA}
+            dispatchMissions={dispatchMissions}
+            dispatchEvaluator={dispatchEvaluator}
           />
         </div>
       </div>

--- a/demo/MissionHoverCard.tsx
+++ b/demo/MissionHoverCard.tsx
@@ -46,7 +46,7 @@ function aircraftById(id: string, fleet: DemoAircraft[]): DemoAircraft | undefin
   return fleet.find(a => a.id === id);
 }
 
-function meetsAircraftReqs(ac: DemoAircraft, mission: DemoMissionRequest): boolean {
+export function meetsAircraftReqs(ac: DemoAircraft, mission: DemoMissionRequest): boolean {
   if (ac.hoursRemaining < mission.requirements.aircraft.minHoursRemaining) return false;
   const caps = mission.requirements.aircraft.requiredCapabilities ?? [];
   return caps.every(c => ac.capabilities.includes(c));

--- a/demo/dispatchEvaluator.ts
+++ b/demo/dispatchEvaluator.ts
@@ -1,0 +1,101 @@
+/**
+ * Air EMS dispatch evaluator — translates the demo's `DemoMissionRequest`
+ * shape into the readiness verdict the generic DispatchView expects.
+ *
+ * Library separation: the calendar package's DispatchView knows nothing
+ * about pilots, certifications, aircraft capabilities, or hours
+ * remaining. This file owns those Air EMS specifics and exposes a
+ * `(assetId, missionId, asOf) → { crewReady, equipmentReady, missing[] }`
+ * callback the host wires into the view.
+ *
+ * The evaluator runs the same predicate `MissionHoverCard` already uses
+ * for assignment validation (`meetsAircraftReqs`) plus a "is there
+ * enough qualified, unbooked crew at this aircraft's base?" check that
+ * the modal didn't surface.
+ */
+import type { DemoAircraft, DemoEmployee, DemoMissionRequest } from './types';
+import { meetsAircraftReqs } from './MissionHoverCard';
+
+export type DispatchEvaluatorInput = {
+  /** Whole fleet — looked up by id. */
+  aircraft: DemoAircraft[];
+  /** Pilots only (for cert matching against pilot slots). */
+  pilots: DemoEmployee[];
+  /** Medical crew only (for cert matching against medical slots). */
+  medicalCrew: DemoEmployee[];
+  /** Pending missions/requests indexed by id. */
+  missionsById: Record<string, DemoMissionRequest>;
+  /** Returns true if the given resource (employee or asset) is booked at `at`. */
+  isBookedAt: (resourceId: string, at: Date) => boolean;
+};
+
+export type ReadinessVerdict = {
+  crewReady: boolean;
+  equipmentReady: boolean;
+  missing: string[];
+};
+
+/**
+ * Build the (assetId, missionId, asOf) evaluator the DispatchView wants.
+ * The `asOf` flows into `isBookedAt` so cert-qualified-but-busy crew are
+ * correctly excluded — a pilot with the right tickets who's already on
+ * a flight at the chosen moment can't fill this mission's slot.
+ */
+export function makeDispatchEvaluator(
+  inputs: DispatchEvaluatorInput,
+): (assetId: string, missionId: string, asOf: Date) => ReadinessVerdict {
+  return (assetId, missionId, asOf) => {
+    const mission = inputs.missionsById[missionId];
+    if (!mission) {
+      return { crewReady: false, equipmentReady: false, missing: ['Unknown mission'] };
+    }
+    const ac = inputs.aircraft.find(a => a.id === assetId);
+    if (!ac) {
+      return { crewReady: false, equipmentReady: false, missing: ['Not an aircraft'] };
+    }
+
+    const missing: string[] = [];
+
+    // ── Equipment / aircraft checks ──────────────────────────────────
+    const equipmentReady = meetsAircraftReqs(ac, mission);
+    if (ac.hoursRemaining < mission.requirements.aircraft.minHoursRemaining) {
+      missing.push(`Aircraft below ${mission.requirements.aircraft.minHoursRemaining}h remaining (has ${ac.hoursRemaining}h)`);
+    }
+    const reqCaps = mission.requirements.aircraft.requiredCapabilities ?? [];
+    const missingCaps = reqCaps.filter(c => !ac.capabilities.includes(c));
+    if (missingCaps.length > 0) {
+      missing.push(`Aircraft missing capability: ${missingCaps.join(', ')}`);
+    }
+
+    // ── Crew checks at this aircraft's base ──────────────────────────
+    const reqPilotCerts = mission.requirements.crew.pilots.certifications ?? [];
+    const reqPilotCount = mission.requirements.crew.pilots.count;
+    const qualifiedPilots = inputs.pilots.filter(p =>
+      p.basedAt === ac.basedAt
+      && !inputs.isBookedAt(String(p.id), asOf)
+      && reqPilotCerts.every(c => p.certifications.includes(c)),
+    );
+    if (qualifiedPilots.length < reqPilotCount) {
+      const certLabel = reqPilotCerts.length > 0 ? ` w/ ${reqPilotCerts.join('+')}` : '';
+      missing.push(
+        `Need ${reqPilotCount} pilot${reqPilotCount === 1 ? '' : 's'}${certLabel}; ${qualifiedPilots.length} ready at base`,
+      );
+    }
+
+    let crewSlotsCovered = qualifiedPilots.length >= reqPilotCount;
+    for (const slot of mission.requirements.crew.medical) {
+      const qualified = inputs.medicalCrew.filter(m =>
+        m.basedAt === ac.basedAt
+        && !inputs.isBookedAt(String(m.id), asOf)
+        && slot.certifications.every(c => m.certifications.includes(c)),
+      );
+      if (qualified.length === 0) {
+        crewSlotsCovered = false;
+        const certLabel = slot.certifications.length > 0 ? ` w/ ${slot.certifications.join('+')}` : '';
+        missing.push(`No ${slot.role}${certLabel} ready at base`);
+      }
+    }
+
+    return { crewReady: crewSlotsCovered, equipmentReady, missing };
+  };
+}

--- a/src/WorksCalendar.tsx
+++ b/src/WorksCalendar.tsx
@@ -88,6 +88,7 @@ import AgendaView             from './views/AgendaView';
 import TimelineView           from './views/TimelineView';
 import AssetsView             from './views/AssetsView';
 import BaseGanttView          from './views/BaseGanttView';
+import DispatchView           from './views/DispatchView';
 import { createManualLocationProvider } from './providers/ManualLocationProvider.ts';
 import type { AssetsZoomLevel, LocationData, LocationProvider } from './types/assets';
 import { canViewScheduleTemplate, instantiateScheduleTemplate } from './api/v1/templates.ts';
@@ -306,6 +307,7 @@ const ALL_VIEWS: readonly ViewDef[] = [
   { id: 'schedule', label: 'Schedule', alwaysOn: false, hint: 'Staffing — day/night shifts, on-call rotation, duty status' },
   { id: 'base',     label: 'Base',     alwaysOn: false, hint: 'Gantt-style — employees, aircraft, and base events side by side' },
   { id: 'assets',   label: 'Assets',   alwaysOn: false },
+  { id: 'dispatch', label: 'Dispatch', alwaysOn: false, hint: 'Fleet readiness at a moment in time — what can launch now?' },
 ];
 
 const DEFAULT_SCHEDULE_INSTANTIATION_LIMITS = {
@@ -2405,6 +2407,16 @@ export const WorksCalendar = forwardRef<CalendarApi, WorksCalendarProps>(functio
                   onRequestAsset={canRequestAsset ? () => setAssetRequestOpen(true) : undefined}
                   approvalsConfig={ownerCfg.config?.['approvals']}
                   onApprovalAction={onApprovalAction as ((event: LooseValue, action: string) => void | Promise<void>) | undefined}
+                />
+              )}
+              {cal.view === 'dispatch' && (
+                <DispatchView
+                  events={expandedEvents}
+                  employees={configuredEmployees}
+                  assets={effectiveAssets ?? []}
+                  bases={configuredBases}
+                  locationLabel={locationLabel}
+                  onEventClick={handleEventClick}
                 />
               )}
             </>

--- a/src/WorksCalendar.tsx
+++ b/src/WorksCalendar.tsx
@@ -2442,6 +2442,13 @@ export const WorksCalendar = forwardRef<CalendarApi, WorksCalendarProps>(functio
                   onEventClick={handleEventClick}
                   missions={dispatchMissions}
                   evaluateForMission={dispatchEvaluator}
+                  // Sync the calendar's currentDate with the dispatcher's chosen
+                  // as-of moment so recurring-event expansion + fetch ranges
+                  // re-anchor around it. Without this, a far-future as-of would
+                  // see no overlapping events (since they were never expanded
+                  // for the original currentDate range) and the row would be
+                  // wrongly classified Available.
+                  onAsOfChange={cal.setCurrentDate}
                 />
               )}
             </>

--- a/src/WorksCalendar.tsx
+++ b/src/WorksCalendar.tsx
@@ -89,6 +89,14 @@ import TimelineView           from './views/TimelineView';
 import AssetsView             from './views/AssetsView';
 import BaseGanttView          from './views/BaseGanttView';
 import DispatchView           from './views/DispatchView';
+import type { DispatchMissionCandidate, DispatchMissionReadiness } from './views/DispatchView';
+
+type DispatchEvaluator = (
+  assetId: string,
+  missionId: string,
+  asOf: Date,
+) => DispatchMissionReadiness;
+export type { DispatchMissionCandidate, DispatchMissionReadiness, DispatchEvaluator };
 import { createManualLocationProvider } from './providers/ManualLocationProvider.ts';
 import type { AssetsZoomLevel, LocationData, LocationProvider } from './types/assets';
 import { canViewScheduleTemplate, instantiateScheduleTemplate } from './api/v1/templates.ts';
@@ -224,6 +232,19 @@ export type WorksCalendarProps = {
    * no-op chip (harmless).
    */
   focusChips?: FocusChipDef[] | boolean;
+  /**
+   * Pending missions/requests offered as the "For mission" picker on the
+   * Dispatch view. Empty/undefined hides the picker (the view falls back
+   * to generic readiness). Pair with `dispatchEvaluator` — the picker is
+   * also hidden when no evaluator is wired.
+   */
+  dispatchMissions?: DispatchMissionCandidate[];
+  /**
+   * Per-(asset, mission) readiness evaluator for the Dispatch view. Hosts
+   * translate their domain primitives (cert matching, capability checks,
+   * hours remaining, etc.) into the readiness shape the table expects.
+   */
+  dispatchEvaluator?: DispatchEvaluator;
   emptyState?: ReactNode;
   filterSchema?: FilterField[];
   showAddButton?: boolean;
@@ -474,6 +495,8 @@ export const WorksCalendar = forwardRef<CalendarApi, WorksCalendarProps>(functio
     renderFilterBar,
     renderSavedViewsBar,
     focusChips,
+    dispatchMissions,
+    dispatchEvaluator,
     emptyState,
 
     // ── Filter schema (pass a custom FilterField[] to extend or replace defaults) ──
@@ -2417,6 +2440,8 @@ export const WorksCalendar = forwardRef<CalendarApi, WorksCalendarProps>(functio
                   bases={configuredBases}
                   locationLabel={locationLabel}
                   onEventClick={handleEventClick}
+                  missions={dispatchMissions}
+                  evaluateForMission={dispatchEvaluator}
                 />
               )}
             </>

--- a/src/core/viewScope.ts
+++ b/src/core/viewScope.ts
@@ -8,7 +8,7 @@
  */
 import { isScheduleWorkflowEvent, SCHEDULE_TAB_CATEGORY_SEEDS } from './scheduleModel';
 
-export type ViewId = 'month' | 'week' | 'day' | 'agenda' | 'schedule' | 'base' | 'assets';
+export type ViewId = 'month' | 'week' | 'day' | 'agenda' | 'schedule' | 'base' | 'assets' | 'dispatch';
 
 export type ViewScopeContext = {
   employees: Array<{ id: string; base?: string | null }>;
@@ -92,6 +92,10 @@ export const VIEW_SCOPES: Record<ViewId, ViewScope> = Object.freeze({
     includes: () => true,
     persistedFields: ['groupBy', 'sort', 'zoomLevel', 'collapsedGroups'],
   },
+  // Dispatch reads the full event pool to compute per-asset readiness at a
+  // user-chosen as-of time, so we accept everything here. Filters still
+  // apply via the host pipeline; this just makes scoping a no-op.
+  dispatch: { id: 'dispatch', includes: () => true },
 });
 
 export function getViewScope(view: string): ViewScope {

--- a/src/ui/ConfigPanel.tsx
+++ b/src/ui/ConfigPanel.tsx
@@ -414,7 +414,7 @@ function SetupTab({
   const enabledViews  = Array.isArray(display['enabledViews']) ? (display['enabledViews'] as string[]) : [];
   const baseLabel     = (team['locationLabel'] as string | undefined) ?? 'Base';
   const formatViewLabel = (id: string) => id === 'base' ? baseLabel : id.charAt(0).toUpperCase() + id.slice(1);
-  const visibleViewCount = enabledViews.length > 0 ? enabledViews.length + 2 : 7; // +2 = always-on Month/Week
+  const visibleViewCount = enabledViews.length > 0 ? enabledViews.length + 2 : 8; // +2 = always-on Month/Week; total = 8
   const baseCount     = Array.isArray(team['bases']) ? (team['bases'] as unknown[]).length : 0;
   const employeeCount = Array.isArray(team['employees']) ? (team['employees'] as unknown[]).length : 0;
 
@@ -512,7 +512,7 @@ function SetupTab({
         <button type="button" className={styles['setupHubCard']} onClick={() => goToTab('display')}>
           <span className={styles['setupHubTitle']}>Default view &amp; visible tabs</span>
           <span className={styles['setupHubMeta']}>
-            Default: {formatViewLabel(defaultView)} · {visibleViewCount} of 7 tabs shown
+            Default: {formatViewLabel(defaultView)} · {visibleViewCount} of 8 tabs shown
           </span>
         </button>
         <button type="button" className={styles['setupHubCard']} onClick={() => goToTab('team')}>
@@ -1732,7 +1732,7 @@ function DisplayTab({ config, onUpdate }: ConfigPanelSectionProps) {
       <div className={styles['formRow']}>
         <span>Default view</span>
         <select className={styles['select']} value={d.defaultView} onChange={e => set('defaultView', e.target.value)}>
-          {['month','week','day','agenda','schedule','base','assets'].map(v => (
+          {['month','week','day','agenda','schedule','base','assets','dispatch'].map(v => (
             <option key={v} value={v}>
               {v === 'base'
                 ? (config['team']?.locationLabel ?? 'Base')
@@ -1751,6 +1751,7 @@ function DisplayTab({ config, onUpdate }: ConfigPanelSectionProps) {
         { id: 'schedule', label: 'Schedule (gantt)' },
         { id: 'base',     label: `${config['team']?.locationLabel ?? 'Base'} (location-first)` },
         { id: 'assets',   label: 'Assets' },
+        { id: 'dispatch', label: 'Dispatch (readiness board)' },
       ].map(v => (
         <label key={v.id} className={styles['toggle']}>
           <span>{v.label}</span>

--- a/src/ui/ProfileBar.tsx
+++ b/src/ui/ProfileBar.tsx
@@ -13,7 +13,7 @@
 import { useMemo, useState, useRef, useEffect } from 'react';
 import {
   Plus, Bookmark, BookmarkCheck,
-  CalendarDays, Calendar, Columns3, List, CalendarRange, Boxes, MapPin,
+  CalendarDays, Calendar, Columns3, List, CalendarRange, Boxes, MapPin, Radio,
 } from 'lucide-react';
 import { DEFAULT_FILTER_SCHEMA } from '../filters/filterSchema';
 import ViewsDropdown from './ViewsDropdown';
@@ -34,10 +34,11 @@ const VIEW_ICON_MAP: Record<string, { Icon: any; label: string }> = {
   schedule: { Icon: CalendarRange, label: 'Schedule view' },
   base:     { Icon: MapPin,        label: 'Base view' },
   assets:   { Icon: Boxes,         label: 'Assets view' },
+  dispatch: { Icon: Radio,         label: 'Dispatch view' },
 };
 
 const GLOBAL_GROUP_KEY = '__global__';
-const DEFAULT_VIEW_ORDER = ['month','week','day','agenda','schedule','base','assets'];
+const DEFAULT_VIEW_ORDER = ['month','week','day','agenda','schedule','base','assets','dispatch'];
 const ALWAYS_ON_VIEWS = new Set(['month', 'week']);
 
 export default function ProfileBar({

--- a/src/ui/SetupLanding.tsx
+++ b/src/ui/SetupLanding.tsx
@@ -31,7 +31,7 @@ export type SetupRecipeId =
   | 'on-call'
   | 'this-week';
 
-export type OptionalViewId = 'day' | 'agenda' | 'schedule' | 'base' | 'assets';
+export type OptionalViewId = 'day' | 'agenda' | 'schedule' | 'base' | 'assets' | 'dispatch';
 
 /** A category of bookable resource. Drives requirement templates. */
 export type AssetTypeDef = { id: string; label: string };
@@ -55,7 +55,7 @@ export type RequirementTemplate = {
 export type SetupLandingResult = {
   calendarName: string;
   theme: string;
-  defaultView: 'month' | 'week' | 'day' | 'agenda' | 'schedule' | 'base' | 'assets';
+  defaultView: 'month' | 'week' | 'day' | 'agenda' | 'schedule' | 'base' | 'assets' | 'dispatch';
   enabledViews: OptionalViewId[];
   locationLabel: 'Base' | 'Region';
   teamMembers: Array<{ id: string; name: string; color: string }>;
@@ -128,9 +128,10 @@ const VIEW_CHOICES: ViewChoice[] = [
   { id: 'schedule', label: 'Schedule', plain: 'One row per person. Great for shifts and coverage.' },
   { id: 'base',     label: 'Base',     plain: 'One row per location. Shows the assets, people, and events at each base.' },
   { id: 'assets',   label: 'Assets',   plain: 'One row per asset — vehicles, rooms, equipment.' },
+  { id: 'dispatch', label: 'Dispatch', plain: 'A live readiness board — which assets can launch right now.' },
 ];
 
-const OPTIONAL_VIEW_IDS: OptionalViewId[] = ['day', 'agenda', 'schedule', 'base', 'assets'];
+const OPTIONAL_VIEW_IDS: OptionalViewId[] = ['day', 'agenda', 'schedule', 'base', 'assets', 'dispatch'];
 
 const RECIPE_CHOICES: Array<{
   id: SetupRecipeId;
@@ -972,9 +973,9 @@ function exampleNameFor(typeLabel: string): string {
   return `${typeLabel} 1`;
 }
 
-/** Map setup view ids to illustration kinds. Base/assets reuse the schedule illustration. */
+/** Map setup view ids to illustration kinds. Base/assets/dispatch reuse the schedule illustration. */
 function illustrationKindFor(id: SetupLandingResult['defaultView']): 'month' | 'week' | 'day' | 'agenda' | 'schedule' {
-  if (id === 'base' || id === 'assets') return 'schedule';
+  if (id === 'base' || id === 'assets' || id === 'dispatch') return 'schedule';
   return id;
 }
 

--- a/src/ui/ViewsDropdown.tsx
+++ b/src/ui/ViewsDropdown.tsx
@@ -9,7 +9,7 @@
 import { useEffect, useRef, useState } from 'react';
 import {
   BookmarkCheck, Bookmark, Eye, EyeOff, ChevronDown,
-  CalendarDays, Calendar, Columns3, List, CalendarRange, Boxes,
+  CalendarDays, Calendar, Columns3, List, CalendarRange, Boxes, Radio,
 } from 'lucide-react';
 import styles from './ProfileBar.module.css';
 
@@ -20,6 +20,7 @@ const VIEW_ICON_MAP = {
   agenda:   List,
   schedule: CalendarRange,
   assets:   Boxes,
+  dispatch: Radio,
 };
 type ViewKey = keyof typeof VIEW_ICON_MAP;
 

--- a/src/views/DispatchView.module.css
+++ b/src/views/DispatchView.module.css
@@ -1,0 +1,367 @@
+.root {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  min-height: 0;
+  background: var(--wc-bg);
+}
+
+/* ── Toolbar ─────────────────────────────────────────────────── */
+.toolbar {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  padding: 12px 16px;
+  border-bottom: 1px solid var(--wc-border);
+  background: var(--wc-surface);
+  flex-wrap: wrap;
+}
+
+.title {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+  min-width: 140px;
+}
+
+.titleLabel {
+  font-size: 14px;
+  font-weight: 700;
+  color: var(--wc-text);
+}
+
+.titleHint {
+  font-size: 11px;
+  color: var(--wc-text-muted);
+}
+
+.asOfBlock {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.asOfLabel {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--wc-text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.asOfInput {
+  height: 30px;
+  padding: 0 8px;
+  border: 1px solid var(--wc-border);
+  border-radius: var(--wc-radius-sm);
+  background: var(--wc-bg);
+  color: var(--wc-text);
+  font-size: 12px;
+  font-family: inherit;
+  outline: none;
+  transition: border-color 0.15s;
+}
+.asOfInput:focus { border-color: var(--wc-accent); }
+
+.nowBtn {
+  height: 30px;
+  padding: 0 10px;
+  border: 1px solid var(--wc-border);
+  border-radius: var(--wc-radius-sm);
+  background: transparent;
+  color: var(--wc-text-muted);
+  font-size: 12px;
+  font-weight: 500;
+  font-family: inherit;
+  cursor: pointer;
+  transition: all 0.15s;
+}
+.nowBtn:not(:disabled):hover {
+  border-color: var(--wc-accent);
+  color: var(--wc-accent);
+}
+.nowBtnActive {
+  background: var(--wc-accent-dim, color-mix(in srgb, var(--wc-accent) 12%, transparent));
+  color: var(--wc-accent);
+  border-color: var(--wc-accent);
+  cursor: default;
+}
+
+/* ── Summary pills ──────────────────────────────────────────── */
+.summary {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  margin-left: auto;
+  flex-wrap: wrap;
+}
+
+.summaryPill {
+  display: inline-flex;
+  align-items: center;
+  padding: 3px 10px;
+  border-radius: 100px;
+  border: 1px solid var(--wc-border);
+  font-size: 11px;
+  font-weight: 600;
+  background: var(--wc-bg);
+  color: var(--wc-text-muted);
+}
+
+.summaryAvailable {
+  border-color: var(--wc-success, #10b981);
+  color: var(--wc-success, #10b981);
+}
+.summaryBusy {
+  border-color: var(--wc-warning, #f59e0b);
+  color: var(--wc-warning, #f59e0b);
+}
+.summaryMaintenance {
+  border-color: var(--wc-danger, #ef4444);
+  color: var(--wc-danger, #ef4444);
+}
+
+/* ── Scroll/table ───────────────────────────────────────────── */
+.scroll {
+  flex: 1;
+  overflow: auto;
+  min-height: 0;
+}
+
+.table {
+  width: 100%;
+  border-collapse: separate;
+  border-spacing: 0;
+  font-size: 13px;
+}
+
+.table thead th {
+  position: sticky;
+  top: 0;
+  z-index: 1;
+  text-align: left;
+  font-size: 11px;
+  font-weight: 700;
+  color: var(--wc-text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  padding: 10px 12px;
+  background: var(--wc-surface);
+  border-bottom: 1px solid var(--wc-border);
+  white-space: nowrap;
+}
+
+.table tbody td {
+  padding: 10px 12px;
+  border-bottom: 1px solid var(--wc-border);
+  color: var(--wc-text);
+  vertical-align: middle;
+}
+
+.table tbody tr:hover td {
+  background: var(--wc-surface);
+}
+
+.table tbody tr[data-status="maintenance"] td:first-child {
+  border-left: 3px solid var(--wc-danger, #ef4444);
+  padding-left: 9px;
+}
+.table tbody tr[data-status="busy"] td:first-child {
+  border-left: 3px solid var(--wc-warning, #f59e0b);
+  padding-left: 9px;
+}
+.table tbody tr[data-status="available"] td:first-child {
+  border-left: 3px solid var(--wc-success, #10b981);
+  padding-left: 9px;
+}
+
+.assetCell {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+}
+
+.assetName {
+  font-weight: 600;
+  color: var(--wc-text);
+}
+
+.assetSub {
+  font-size: 11px;
+  color: var(--wc-text-muted);
+}
+
+/* ── Status pill ────────────────────────────────────────────── */
+.statusPill {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 3px 10px;
+  border-radius: 100px;
+  font-size: 11px;
+  font-weight: 600;
+  border: 1px solid var(--wc-border);
+  background: var(--wc-bg);
+  color: var(--wc-text-muted);
+  white-space: nowrap;
+}
+
+.statusDot {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: currentColor;
+  flex-shrink: 0;
+}
+
+.status_available {
+  border-color: var(--wc-success, #10b981);
+  color: var(--wc-success, #10b981);
+}
+.status_busy {
+  border-color: var(--wc-warning, #f59e0b);
+  color: var(--wc-warning, #f59e0b);
+}
+.status_maintenance {
+  border-color: var(--wc-danger, #ef4444);
+  color: var(--wc-danger, #ef4444);
+}
+
+/* ── Readiness chips ────────────────────────────────────────── */
+.readinessChip {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 2px 8px;
+  border-radius: var(--wc-radius-sm);
+  font-size: 11px;
+  font-weight: 600;
+  border: 1px solid transparent;
+}
+
+.readinessOk {
+  background: color-mix(in srgb, var(--wc-success, #10b981) 12%, transparent);
+  color: var(--wc-success, #10b981);
+}
+
+.readinessNo {
+  background: color-mix(in srgb, var(--wc-warning, #f59e0b) 12%, transparent);
+  color: var(--wc-warning, #f59e0b);
+}
+
+.naChip {
+  font-size: 12px;
+  color: var(--wc-text-muted);
+}
+
+/* ── Missing list ───────────────────────────────────────────── */
+.missingCell {
+  max-width: 280px;
+}
+
+.missingNone {
+  color: var(--wc-text-muted);
+}
+
+.missingList {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.missingList li {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  font-size: 12px;
+  color: var(--wc-text);
+}
+
+.missingList li svg {
+  flex-shrink: 0;
+  color: var(--wc-warning, #f59e0b);
+}
+
+/* ── Action column ──────────────────────────────────────────── */
+.actionCol {
+  width: 1%;
+  white-space: nowrap;
+}
+
+.actionBtn {
+  padding: 4px 12px;
+  border-radius: var(--wc-radius-sm);
+  border: 1px solid var(--wc-border);
+  background: transparent;
+  color: var(--wc-text-muted);
+  font-size: 12px;
+  font-weight: 600;
+  font-family: inherit;
+  cursor: pointer;
+  transition: all 0.15s;
+}
+.actionBtn:hover {
+  border-color: var(--wc-accent);
+  color: var(--wc-accent);
+}
+
+.actionPrimary {
+  background: var(--wc-accent);
+  border-color: var(--wc-accent);
+  color: #fff;
+}
+.actionPrimary:hover {
+  opacity: 0.85;
+  color: #fff;
+}
+
+.actionWarn {
+  border-color: var(--wc-warning, #f59e0b);
+  color: var(--wc-warning, #f59e0b);
+}
+
+.actionMuted {
+  color: var(--wc-text-muted);
+  font-size: 12px;
+}
+
+/* ── Footer ─────────────────────────────────────────────────── */
+.footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 8px 16px;
+  border-top: 1px solid var(--wc-border);
+  background: var(--wc-surface);
+  font-size: 11px;
+  color: var(--wc-text-muted);
+}
+
+.footer span {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+}
+
+/* ── Empty state ────────────────────────────────────────────── */
+.emptyState {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  padding: 48px 24px;
+  text-align: center;
+  color: var(--wc-text-muted);
+}
+
+.emptyHint {
+  font-size: 12px;
+  color: var(--wc-text-faint, var(--wc-text-muted));
+}

--- a/src/views/DispatchView.module.css
+++ b/src/views/DispatchView.module.css
@@ -90,6 +90,18 @@
   cursor: default;
 }
 
+.missionBlock {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+.missionBlock .asOfInput {
+  min-width: 200px;
+  height: 30px;
+  padding: 0 8px;
+  appearance: auto;
+}
+
 /* ── Summary pills ──────────────────────────────────────────── */
 .summary {
   display: inline-flex;

--- a/src/views/DispatchView.tsx
+++ b/src/views/DispatchView.tsx
@@ -110,7 +110,7 @@ export type DispatchViewProps = {
 
 type Status = 'available' | 'busy' | 'maintenance';
 
-type Row = {
+export type DispatchRow = {
   asset: Asset;
   baseId: string;
   baseName: string;
@@ -120,6 +120,9 @@ type Row = {
   equipmentReady: boolean;
   missing: string[];
 };
+
+// Internal alias kept short to avoid churn in the existing call sites.
+type Row = DispatchRow;
 
 function toDate(value: string | Date | undefined): Date | null {
   if (!value) return null;
@@ -256,6 +259,35 @@ export function decorateDispatchRows(
   });
 }
 
+/**
+ * Replace generic crew/equipment readiness on each row with the host
+ * evaluator's verdict for a specific mission.
+ *
+ * Status (busy / maintenance / available) is preserved verbatim — a
+ * mission-eligible aircraft that is currently in maintenance still
+ * needs to read as Maintenance, not Available. We also keep any base
+ * `missing` notes that explain a non-available status (e.g. "Busy:
+ * Trauma transport") so the dispatcher sees both the blocking
+ * calendar event AND the mission-fit gaps in one cell.
+ */
+export function applyMissionOverride(
+  rows: DispatchRow[],
+  evaluate: (assetId: string, missionId: string, asOf: Date) => DispatchMissionReadiness,
+  missionId: string,
+  asOf: Date,
+): DispatchRow[] {
+  return rows.map(row => {
+    const verdict = evaluate(String(row.asset.id), missionId, asOf);
+    const blockingNotes = row.status === 'available' ? [] : row.missing;
+    return {
+      ...row,
+      crewReady: verdict.crewReady,
+      equipmentReady: verdict.equipmentReady,
+      missing: [...blockingNotes, ...verdict.missing],
+    };
+  });
+}
+
 function formatDateTimeLocal(d: Date): string {
   // <input type="datetime-local"> wants 'YYYY-MM-DDTHH:mm' in local time.
   const pad = (n: number) => String(n).padStart(2, '0');
@@ -285,22 +317,7 @@ export default function DispatchView({
     const skel = computeDispatchRows(asOf, assets, employees, bases, locationLabel);
     const base = decorateDispatchRows(skel, asOf, events, employees);
     if (!activeMission || !evaluateForMission) return base;
-    // When a mission is selected, the host's evaluator owns crew/equipment/
-    // missing semantics. Status (busy/maintenance/available) is still driven
-    // by the calendar — a maintenance asset can't fly even if it'd otherwise
-    // fit the mission profile, and the dispatcher needs to see that fact.
-    return base.map(row => {
-      const verdict = evaluateForMission(String(row.asset.id), activeMission.id, asOf);
-      const baseMissing = row.status === 'maintenance' || row.status === 'busy'
-        ? row.missing
-        : [];
-      return {
-        ...row,
-        crewReady: verdict.crewReady,
-        equipmentReady: verdict.equipmentReady,
-        missing: [...baseMissing, ...verdict.missing],
-      };
-    });
+    return applyMissionOverride(base, evaluateForMission, activeMission.id, asOf);
   }, [asOf, assets, employees, bases, events, locationLabel, activeMission, evaluateForMission]);
 
   const summary = useMemo(() => {

--- a/src/views/DispatchView.tsx
+++ b/src/views/DispatchView.tsx
@@ -55,6 +55,30 @@ type Asset = {
 
 type Base = { id: string; name: string };
 
+/**
+ * A pending mission/request the dispatcher might launch. Hosts compute
+ * this list from their own event semantics (typically open requests with
+ * no assignment yet) and pass it in. Empty/undefined hides the picker.
+ */
+export type DispatchMissionCandidate = {
+  id: string;
+  label: string;
+  /** Optional sublabel — e.g. priority, ETA, route. */
+  sublabel?: string;
+};
+
+/**
+ * Per-asset readiness for a specific mission. Hosts return whatever their
+ * own validation primitives report (cert matches, aircraft capability
+ * checks, hours remaining, etc.) translated into the same shape the
+ * generic readiness pipeline produces.
+ */
+export type DispatchMissionReadiness = {
+  crewReady: boolean;
+  equipmentReady: boolean;
+  missing: string[];
+};
+
 export type DispatchViewProps = {
   events: LooseEvent[];
   employees: Employee[];
@@ -64,6 +88,24 @@ export type DispatchViewProps = {
   onEventClick?: (id: string | number) => void;
   /** Default as-of time. Component manages its own state from this seed. */
   initialAsOf?: Date;
+  /**
+   * Optional list of pending missions/requests. When present, the toolbar
+   * surfaces a "For mission" picker; selecting one routes each row's
+   * readiness through `evaluateForMission` instead of the generic checks.
+   */
+  missions?: DispatchMissionCandidate[] | undefined;
+  /**
+   * Per-(asset, mission) readiness evaluator. Required for the picker to
+   * do anything useful — without it the picker is hidden even when
+   * `missions` is non-empty. The view passes the chosen as-of time so the
+   * host can re-validate cert lapses, aircraft hours, etc. at that
+   * moment.
+   */
+  evaluateForMission?: ((
+    assetId: string,
+    missionId: string,
+    asOf: Date,
+  ) => DispatchMissionReadiness) | undefined;
 };
 
 type Status = 'available' | 'busy' | 'maintenance';
@@ -228,13 +270,38 @@ export default function DispatchView({
   locationLabel = 'Base',
   onEventClick,
   initialAsOf,
+  missions,
+  evaluateForMission,
 }: DispatchViewProps) {
   const [asOf, setAsOf] = useState<Date>(() => initialAsOf ?? new Date());
+  const [forMissionId, setForMissionId] = useState<string | null>(null);
+
+  const missionPickerEnabled = !!(missions && missions.length > 0 && evaluateForMission);
+  const activeMission = missionPickerEnabled && forMissionId
+    ? missions!.find(m => m.id === forMissionId) ?? null
+    : null;
 
   const rows = useMemo(() => {
     const skel = computeDispatchRows(asOf, assets, employees, bases, locationLabel);
-    return decorateDispatchRows(skel, asOf, events, employees);
-  }, [asOf, assets, employees, bases, events, locationLabel]);
+    const base = decorateDispatchRows(skel, asOf, events, employees);
+    if (!activeMission || !evaluateForMission) return base;
+    // When a mission is selected, the host's evaluator owns crew/equipment/
+    // missing semantics. Status (busy/maintenance/available) is still driven
+    // by the calendar — a maintenance asset can't fly even if it'd otherwise
+    // fit the mission profile, and the dispatcher needs to see that fact.
+    return base.map(row => {
+      const verdict = evaluateForMission(String(row.asset.id), activeMission.id, asOf);
+      const baseMissing = row.status === 'maintenance' || row.status === 'busy'
+        ? row.missing
+        : [];
+      return {
+        ...row,
+        crewReady: verdict.crewReady,
+        equipmentReady: verdict.equipmentReady,
+        missing: [...baseMissing, ...verdict.missing],
+      };
+    });
+  }, [asOf, assets, employees, bases, events, locationLabel, activeMission, evaluateForMission]);
 
   const summary = useMemo(() => {
     let available = 0, busy = 0, maintenance = 0;
@@ -280,6 +347,28 @@ export default function DispatchView({
             Now
           </button>
         </div>
+
+        {missionPickerEnabled && (
+          <div className={styles['missionBlock']}>
+            <label className={styles['asOfLabel']} htmlFor="dispatch-mission">
+              For mission
+            </label>
+            <select
+              id="dispatch-mission"
+              className={styles['asOfInput']}
+              value={forMissionId ?? ''}
+              onChange={e => setForMissionId(e.target.value || null)}
+              aria-label="Evaluate readiness against a specific mission"
+            >
+              <option value="">Generic readiness</option>
+              {missions!.map(m => (
+                <option key={m.id} value={m.id}>
+                  {m.label}{m.sublabel ? ` — ${m.sublabel}` : ''}
+                </option>
+              ))}
+            </select>
+          </div>
+        )}
 
         <div className={styles['summary']}>
           <span className={[styles['summaryPill'], styles['summaryAvailable']].join(' ')}>
@@ -362,6 +451,7 @@ export default function DispatchView({
                         row={row}
                         blockingId={blockingId != null ? String(blockingId) : null}
                         onView={onEventClick}
+                        missionLabel={activeMission?.label}
                       />
                     </td>
                   </tr>
@@ -410,10 +500,12 @@ function ActionButton({
   row,
   blockingId,
   onView,
+  missionLabel,
 }: {
   row: Row;
   blockingId: string | null;
   onView?: ((id: string | number) => void) | undefined;
+  missionLabel?: string | undefined;
 }) {
   if (row.status === 'maintenance') {
     return blockingId
@@ -428,5 +520,9 @@ function ActionButton({
   if (!row.crewReady && row.baseId) {
     return <button type="button" className={[styles['actionBtn'], styles['actionWarn']].join(' ')}>Find crew</button>;
   }
-  return <button type="button" className={[styles['actionBtn'], styles['actionPrimary']].join(' ')}>Assign</button>;
+  if (!row.equipmentReady) {
+    return <span className={styles['actionMuted']}>Not eligible</span>;
+  }
+  const assignLabel = missionLabel ? `Assign to ${missionLabel}` : 'Assign';
+  return <button type="button" className={[styles['actionBtn'], styles['actionPrimary']].join(' ')}>{assignLabel}</button>;
 }

--- a/src/views/DispatchView.tsx
+++ b/src/views/DispatchView.tsx
@@ -85,7 +85,13 @@ export type DispatchViewProps = {
   assets: Asset[];
   bases: Base[];
   locationLabel?: string;
-  onEventClick?: (id: string | number) => void;
+  /**
+   * Click handler for blocker events surfaced via "View booking" / "View
+   * work" actions. Receives the full event object (matching the contract
+   * the rest of the view-prop pipeline expects), not just an id, so the
+   * downstream HoverCard / detail panel can render `event.start` etc.
+   */
+  onEventClick?: (event: LooseEvent) => void;
   /** Default as-of time. Component manages its own state from this seed. */
   initialAsOf?: Date;
   /**
@@ -106,6 +112,16 @@ export type DispatchViewProps = {
     missionId: string,
     asOf: Date,
   ) => DispatchMissionReadiness) | undefined;
+  /**
+   * Notified when the user changes `asOf` via the picker or "Now" button.
+   * Hosts wire this to their calendar's date setter so the underlying
+   * recurring-event expansion follows — without it, an `asOf` outside
+   * the loaded range produces wrong "available" verdicts because the
+   * blocking events for that moment never made it into `events`.
+   *
+   * Not invoked on initial mount — only on user-driven changes.
+   */
+  onAsOfChange?: ((asOf: Date) => void) | undefined;
 };
 
 type Status = 'available' | 'busy' | 'maintenance';
@@ -304,9 +320,18 @@ export default function DispatchView({
   initialAsOf,
   missions,
   evaluateForMission,
+  onAsOfChange,
 }: DispatchViewProps) {
   const [asOf, setAsOf] = useState<Date>(() => initialAsOf ?? new Date());
   const [forMissionId, setForMissionId] = useState<string | null>(null);
+
+  // Single setter so every user-driven asOf change bubbles up. Initial
+  // mount uses `useState`'s lazy initializer above and intentionally
+  // does NOT notify — the host already knows its own currentDate.
+  const updateAsOf = (next: Date) => {
+    setAsOf(next);
+    onAsOfChange?.(next);
+  };
 
   const missionPickerEnabled = !!(missions && missions.length > 0 && evaluateForMission);
   const activeMission = missionPickerEnabled && forMissionId
@@ -351,13 +376,13 @@ export default function DispatchView({
             value={formatDateTimeLocal(asOf)}
             onChange={e => {
               const d = new Date(e.target.value);
-              if (isValid(d)) setAsOf(d);
+              if (isValid(d)) updateAsOf(d);
             }}
           />
           <button
             type="button"
             className={[styles['nowBtn'], isNow && styles['nowBtnActive']].filter(Boolean).join(' ')}
-            onClick={() => setAsOf(new Date())}
+            onClick={() => updateAsOf(new Date())}
             disabled={isNow}
             title={isNow ? 'Already showing live status' : 'Reset to current time'}
           >
@@ -423,7 +448,6 @@ export default function DispatchView({
               {rows.map(row => {
                 const assetLabel = row.asset.label ?? row.asset.name ?? String(row.asset.id);
                 const sublabel = typeof row.asset.meta?.sublabel === 'string' ? row.asset.meta.sublabel : null;
-                const blockingId = row.blockingEvent?.id;
                 return (
                   <tr key={String(row.asset.id)} data-status={row.status}>
                     <td>{row.baseName}</td>
@@ -466,7 +490,6 @@ export default function DispatchView({
                     <td className={styles['actionCol']}>
                       <ActionButton
                         row={row}
-                        blockingId={blockingId != null ? String(blockingId) : null}
                         onView={onEventClick}
                         missionLabel={activeMission?.label}
                       />
@@ -515,23 +538,22 @@ function ReadinessChip({
 
 function ActionButton({
   row,
-  blockingId,
   onView,
   missionLabel,
 }: {
   row: Row;
-  blockingId: string | null;
-  onView?: ((id: string | number) => void) | undefined;
+  onView?: ((event: LooseEvent) => void) | undefined;
   missionLabel?: string | undefined;
 }) {
+  const blockingEvent = row.blockingEvent;
   if (row.status === 'maintenance') {
-    return blockingId
-      ? <button type="button" className={styles['actionBtn']} onClick={() => onView?.(blockingId)}>View work</button>
+    return blockingEvent
+      ? <button type="button" className={styles['actionBtn']} onClick={() => onView?.(blockingEvent)}>View work</button>
       : <span className={styles['actionMuted']}>—</span>;
   }
   if (row.status === 'busy') {
-    return blockingId
-      ? <button type="button" className={styles['actionBtn']} onClick={() => onView?.(blockingId)}>View booking</button>
+    return blockingEvent
+      ? <button type="button" className={styles['actionBtn']} onClick={() => onView?.(blockingEvent)}>View booking</button>
       : <span className={styles['actionMuted']}>—</span>;
   }
   if (!row.crewReady && row.baseId) {

--- a/src/views/DispatchView.tsx
+++ b/src/views/DispatchView.tsx
@@ -1,0 +1,432 @@
+/**
+ * DispatchView — fleet-readiness table answering "what can I launch right now?"
+ *
+ * The mission/asset-request modal already validates per-mission fit (pilots
+ * with the right certifications, aircraft hours, maintenance status, etc.)
+ * but the inverse question — "which assets are available this minute?" —
+ * required clicking through every mission first. This view inverts that:
+ * a flat readiness table per asset, evaluated against an `asOf` time the
+ * dispatcher chooses (defaults to now, retargetable for shift-change
+ * pre-staging).
+ *
+ * Status taxonomy is intentionally generic so the same view works for any
+ * deployment, not just air EMS:
+ *   - Maintenance — an event with category 'maintenance' overlaps asOf
+ *   - Busy        — any other event overlaps asOf for this resource
+ *   - Available   — neither
+ *
+ * Crew Ready is a heuristic: at least one employee at the asset's base is
+ * not booked at asOf. Equipment Ready is true unless the asset's own
+ * `meta.status === 'maintenance'`. The table surfaces what's missing in
+ * a final column so the dispatcher's next move is visible at a glance.
+ */
+import { useMemo, useState } from 'react';
+import { format, parseISO, isValid } from 'date-fns';
+import { Wrench, Users, Plane, AlertTriangle, Clock, MapPin } from 'lucide-react';
+import styles from './DispatchView.module.css';
+
+type LooseEvent = {
+  id?: string | number;
+  start?: string | Date;
+  end?: string | Date;
+  resource?: string | number | null;
+  category?: string;
+  title?: string;
+  meta?: Record<string, unknown> | null | undefined;
+};
+
+type Employee = {
+  id: string | number;
+  name?: string;
+  base?: string | null | undefined;
+};
+
+type Asset = {
+  id: string | number;
+  label?: string;
+  name?: string;
+  meta?: {
+    base?: string | null;
+    status?: string | null;
+    sublabel?: string | null;
+    [key: string]: unknown;
+  } | null | undefined;
+};
+
+type Base = { id: string; name: string };
+
+export type DispatchViewProps = {
+  events: LooseEvent[];
+  employees: Employee[];
+  assets: Asset[];
+  bases: Base[];
+  locationLabel?: string;
+  onEventClick?: (id: string | number) => void;
+  /** Default as-of time. Component manages its own state from this seed. */
+  initialAsOf?: Date;
+};
+
+type Status = 'available' | 'busy' | 'maintenance';
+
+type Row = {
+  asset: Asset;
+  baseId: string;
+  baseName: string;
+  status: Status;
+  blockingEvent: LooseEvent | null;
+  crewReady: boolean;
+  equipmentReady: boolean;
+  missing: string[];
+};
+
+function toDate(value: string | Date | undefined): Date | null {
+  if (!value) return null;
+  if (value instanceof Date) return isValid(value) ? value : null;
+  const d = parseISO(value);
+  return isValid(d) ? d : null;
+}
+
+function eventCoversAsOf(ev: LooseEvent, asOf: Date): boolean {
+  const s = toDate(ev.start);
+  const e = toDate(ev.end);
+  if (!s || !e) return false;
+  return s.getTime() <= asOf.getTime() && e.getTime() >= asOf.getTime();
+}
+
+/**
+ * Resolve the resource(s) an event applies to. The library's event model
+ * uses `resource` (single) and an optional `meta.base` for base-wide events.
+ * For dispatch readiness we only care about events bound to a specific
+ * resource — base-wide events don't make a specific asset busy.
+ */
+function eventResourceId(ev: LooseEvent): string | null {
+  if (ev.resource == null) return null;
+  return String(ev.resource);
+}
+
+function isMaintenanceEvent(ev: LooseEvent): boolean {
+  const cat = (ev.category ?? '').toLowerCase();
+  return cat === 'maintenance' || cat.includes('maintenance');
+}
+
+export function computeDispatchRows(
+  asOf: Date,
+  assets: Asset[],
+  employees: Employee[],
+  bases: Base[],
+  locationLabel: string,
+): Row[] {
+  // Bucket events by the resource they bind to so each asset/employee
+  // lookup is O(1) rather than O(events) per row.
+  const baseNameById = new Map<string, string>();
+  for (const b of bases) baseNameById.set(String(b.id), b.name);
+
+  const rows: Row[] = [];
+  const missingFallback = `${locationLabel} unassigned`;
+
+  for (const asset of assets) {
+    const baseId = asset.meta?.base != null ? String(asset.meta.base) : '';
+    const baseName = baseId ? (baseNameById.get(baseId) ?? baseId) : missingFallback;
+    rows.push({
+      asset,
+      baseId,
+      baseName,
+      status: 'available',
+      blockingEvent: null,
+      crewReady: false,
+      equipmentReady: false,
+      missing: [],
+    });
+  }
+  return rows;
+}
+
+/**
+ * Decorate the rows produced by computeDispatchRows with status, crew, and
+ * equipment readiness derived from the full event pool. Split out so the
+ * skeleton (rows for every asset, ordered) can be unit-tested independently
+ * of the readiness pipeline.
+ */
+export function decorateDispatchRows(
+  rows: Row[],
+  asOf: Date,
+  events: LooseEvent[],
+  employees: Employee[],
+): Row[] {
+  // Index events touching `asOf` by resource for O(1) lookup per row.
+  const eventsByResource = new Map<string, LooseEvent[]>();
+  for (const ev of events) {
+    if (!eventCoversAsOf(ev, asOf)) continue;
+    const r = eventResourceId(ev);
+    if (!r) continue;
+    if (!eventsByResource.has(r)) eventsByResource.set(r, []);
+    eventsByResource.get(r)!.push(ev);
+  }
+
+  return rows.map(row => {
+    const assetId = String(row.asset.id);
+    const live = eventsByResource.get(assetId) ?? [];
+    const maintEvent = live.find(isMaintenanceEvent) ?? null;
+    const otherEvent = live.find(e => !isMaintenanceEvent(e)) ?? null;
+
+    const declaredStatus = row.asset.meta?.status;
+    const declaredMaint = typeof declaredStatus === 'string' && declaredStatus.toLowerCase() === 'maintenance';
+
+    let status: Status;
+    let blockingEvent: LooseEvent | null = null;
+    if (maintEvent || declaredMaint) {
+      status = 'maintenance';
+      blockingEvent = maintEvent;
+    } else if (otherEvent) {
+      status = 'busy';
+      blockingEvent = otherEvent;
+    } else {
+      status = 'available';
+    }
+
+    // Crew readiness: at least one employee at the asset's base is free at asOf.
+    let crewReady = false;
+    if (row.baseId) {
+      for (const emp of employees) {
+        if (String(emp.base ?? '') !== row.baseId) continue;
+        const empBookings = eventsByResource.get(String(emp.id));
+        if (!empBookings || empBookings.length === 0) {
+          crewReady = true;
+          break;
+        }
+      }
+    }
+
+    const equipmentReady = status !== 'maintenance';
+
+    const missing: string[] = [];
+    if (status === 'maintenance') missing.push('In maintenance');
+    if (status === 'busy') {
+      const t = otherEvent?.title ?? otherEvent?.category ?? 'booking';
+      missing.push(`Busy: ${t}`);
+    }
+    if (status !== 'maintenance' && !crewReady && row.baseId) {
+      missing.push('No crew available at this base');
+    }
+    if (!row.baseId) missing.push(`No ${row.baseName.toLowerCase()} assigned`);
+
+    return { ...row, status, blockingEvent, crewReady, equipmentReady, missing };
+  });
+}
+
+function formatDateTimeLocal(d: Date): string {
+  // <input type="datetime-local"> wants 'YYYY-MM-DDTHH:mm' in local time.
+  const pad = (n: number) => String(n).padStart(2, '0');
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}`;
+}
+
+export default function DispatchView({
+  events,
+  employees,
+  assets,
+  bases,
+  locationLabel = 'Base',
+  onEventClick,
+  initialAsOf,
+}: DispatchViewProps) {
+  const [asOf, setAsOf] = useState<Date>(() => initialAsOf ?? new Date());
+
+  const rows = useMemo(() => {
+    const skel = computeDispatchRows(asOf, assets, employees, bases, locationLabel);
+    return decorateDispatchRows(skel, asOf, events, employees);
+  }, [asOf, assets, employees, bases, events, locationLabel]);
+
+  const summary = useMemo(() => {
+    let available = 0, busy = 0, maintenance = 0;
+    for (const r of rows) {
+      if (r.status === 'available') available++;
+      else if (r.status === 'busy') busy++;
+      else maintenance++;
+    }
+    return { available, busy, maintenance };
+  }, [rows]);
+
+  const isNow = useMemo(() => Math.abs(Date.now() - asOf.getTime()) < 60_000, [asOf]);
+
+  return (
+    <div className={styles['root']} role="region" aria-label="Dispatch readiness">
+      <div className={styles['toolbar']}>
+        <div className={styles['title']}>
+          <span className={styles['titleLabel']}>Dispatch</span>
+          <span className={styles['titleHint']}>Who can launch right now?</span>
+        </div>
+
+        <div className={styles['asOfBlock']}>
+          <label className={styles['asOfLabel']} htmlFor="dispatch-asof">
+            <Clock size={13} aria-hidden="true" /> As of
+          </label>
+          <input
+            id="dispatch-asof"
+            type="datetime-local"
+            className={styles['asOfInput']}
+            value={formatDateTimeLocal(asOf)}
+            onChange={e => {
+              const d = new Date(e.target.value);
+              if (isValid(d)) setAsOf(d);
+            }}
+          />
+          <button
+            type="button"
+            className={[styles['nowBtn'], isNow && styles['nowBtnActive']].filter(Boolean).join(' ')}
+            onClick={() => setAsOf(new Date())}
+            disabled={isNow}
+            title={isNow ? 'Already showing live status' : 'Reset to current time'}
+          >
+            Now
+          </button>
+        </div>
+
+        <div className={styles['summary']}>
+          <span className={[styles['summaryPill'], styles['summaryAvailable']].join(' ')}>
+            {summary.available} Available
+          </span>
+          <span className={[styles['summaryPill'], styles['summaryBusy']].join(' ')}>
+            {summary.busy} Busy
+          </span>
+          <span className={[styles['summaryPill'], styles['summaryMaintenance']].join(' ')}>
+            {summary.maintenance} Maintenance
+          </span>
+        </div>
+      </div>
+
+      <div className={styles['scroll']}>
+        {rows.length === 0 ? (
+          <div className={styles['emptyState']}>
+            <p>No assets configured.</p>
+            <p className={styles['emptyHint']}>Add assets in Settings → Assets to populate this board.</p>
+          </div>
+        ) : (
+          <table className={styles['table']} role="grid" aria-label="Asset readiness">
+            <thead>
+              <tr>
+                <th scope="col">{locationLabel}</th>
+                <th scope="col">Asset</th>
+                <th scope="col">Status</th>
+                <th scope="col">Crew</th>
+                <th scope="col">Equipment</th>
+                <th scope="col">Missing / Note</th>
+                <th scope="col" className={styles['actionCol']}>Action</th>
+              </tr>
+            </thead>
+            <tbody>
+              {rows.map(row => {
+                const assetLabel = row.asset.label ?? row.asset.name ?? String(row.asset.id);
+                const sublabel = typeof row.asset.meta?.sublabel === 'string' ? row.asset.meta.sublabel : null;
+                const blockingId = row.blockingEvent?.id;
+                return (
+                  <tr key={String(row.asset.id)} data-status={row.status}>
+                    <td>{row.baseName}</td>
+                    <td>
+                      <div className={styles['assetCell']}>
+                        <span className={styles['assetName']}>{assetLabel}</span>
+                        {sublabel && <span className={styles['assetSub']}>{sublabel}</span>}
+                      </div>
+                    </td>
+                    <td>
+                      <span className={[styles['statusPill'], styles[`status_${row.status}`]].join(' ')}>
+                        <span className={styles['statusDot']} aria-hidden="true" />
+                        {row.status === 'available' ? 'Available'
+                          : row.status === 'busy' ? 'Busy'
+                          : 'Maintenance'}
+                      </span>
+                    </td>
+                    <td>
+                      <ReadinessChip ok={row.crewReady} okIcon={<Users size={12} aria-hidden="true" />} okLabel="Ready" naLabel="—" na={row.status === 'maintenance'} />
+                    </td>
+                    <td>
+                      <ReadinessChip ok={row.equipmentReady} okIcon={<Plane size={12} aria-hidden="true" />} okLabel="Ready" />
+                    </td>
+                    <td className={styles['missingCell']}>
+                      {row.missing.length === 0 ? (
+                        <span className={styles['missingNone']}>—</span>
+                      ) : (
+                        <ul className={styles['missingList']}>
+                          {row.missing.map((m, i) => (
+                            <li key={i}>
+                              {m.startsWith('In maintenance')
+                                ? <Wrench size={11} aria-hidden="true" />
+                                : <AlertTriangle size={11} aria-hidden="true" />}
+                              <span>{m}</span>
+                            </li>
+                          ))}
+                        </ul>
+                      )}
+                    </td>
+                    <td className={styles['actionCol']}>
+                      <ActionButton
+                        row={row}
+                        blockingId={blockingId != null ? String(blockingId) : null}
+                        onView={onEventClick}
+                      />
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        )}
+      </div>
+
+      <div className={styles['footer']}>
+        <span>
+          <MapPin size={11} aria-hidden="true" />
+          {' '}{bases.length} {bases.length === 1 ? locationLabel.toLowerCase() : `${locationLabel.toLowerCase()}s`}
+          {' · '}{assets.length} {assets.length === 1 ? 'asset' : 'assets'}
+        </span>
+        <span>{format(asOf, 'EEE MMM d, h:mm a')}</span>
+      </div>
+    </div>
+  );
+}
+
+function ReadinessChip({
+  ok,
+  okIcon,
+  okLabel,
+  naLabel,
+  na = false,
+}: {
+  ok: boolean;
+  okIcon?: React.ReactNode;
+  okLabel: string;
+  naLabel?: string;
+  na?: boolean;
+}) {
+  if (na) return <span className={styles['naChip']}>{naLabel ?? '—'}</span>;
+  return (
+    <span className={[styles['readinessChip'], ok ? styles['readinessOk'] : styles['readinessNo']].join(' ')}>
+      {ok ? okIcon : null}
+      <span>{ok ? okLabel : 'Missing'}</span>
+    </span>
+  );
+}
+
+function ActionButton({
+  row,
+  blockingId,
+  onView,
+}: {
+  row: Row;
+  blockingId: string | null;
+  onView?: ((id: string | number) => void) | undefined;
+}) {
+  if (row.status === 'maintenance') {
+    return blockingId
+      ? <button type="button" className={styles['actionBtn']} onClick={() => onView?.(blockingId)}>View work</button>
+      : <span className={styles['actionMuted']}>—</span>;
+  }
+  if (row.status === 'busy') {
+    return blockingId
+      ? <button type="button" className={styles['actionBtn']} onClick={() => onView?.(blockingId)}>View booking</button>
+      : <span className={styles['actionMuted']}>—</span>;
+  }
+  if (!row.crewReady && row.baseId) {
+    return <button type="button" className={[styles['actionBtn'], styles['actionWarn']].join(' ')}>Find crew</button>;
+  }
+  return <button type="button" className={[styles['actionBtn'], styles['actionPrimary']].join(' ')}>Assign</button>;
+}

--- a/src/views/__tests__/DispatchView.actions.test.tsx
+++ b/src/views/__tests__/DispatchView.actions.test.tsx
@@ -1,0 +1,128 @@
+// @vitest-environment happy-dom
+/**
+ * DispatchView — action button click contract.
+ *
+ * The `View booking` / `View work` buttons must hand the FULL blocking
+ * event object to `onEventClick`. Previously they passed the event's
+ * id (a string), and the rest of the WorksCalendar pipeline expects an
+ * event — HoverCard later crashes when it formats `event.start` /
+ * `event.end`. This test pins the post-fix contract so the regression
+ * cannot return silently.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+
+import DispatchView from '../DispatchView';
+
+const ASSETS = [
+  { id: 'a-busy',    label: 'N801', meta: { base: 'b-logan' } },
+  { id: 'a-maint',   label: 'N802', meta: { base: 'b-logan', status: 'maintenance' } },
+];
+const EMPLOYEES = [{ id: 'e1', name: 'Alex', base: 'b-logan' }];
+const BASES = [{ id: 'b-logan', name: 'Logan' }];
+
+const NOON = new Date('2026-04-26T12:00:00Z');
+
+describe('DispatchView action buttons', () => {
+  it('passes the full event object to onEventClick when "View booking" is clicked', () => {
+    const blockingEvent = {
+      id: 'mission-1',
+      title: 'Trauma transport',
+      start: '2026-04-26T08:00:00Z',
+      end:   '2026-04-26T16:00:00Z',
+      resource: 'a-busy',
+      category: 'mission-assignment',
+    };
+    const onEventClick = vi.fn();
+    render(
+      <DispatchView
+        events={[blockingEvent]}
+        employees={EMPLOYEES}
+        assets={[ASSETS[0]!]}
+        bases={BASES}
+        initialAsOf={NOON}
+        onEventClick={onEventClick}
+      />,
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'View booking' }));
+    expect(onEventClick).toHaveBeenCalledTimes(1);
+    expect(onEventClick).toHaveBeenCalledWith(blockingEvent);
+  });
+
+  it('passes the full event object to onEventClick when "View work" is clicked', () => {
+    const maintEvent = {
+      id: 'wo-1',
+      title: '50hr inspection',
+      start: '2026-04-26T08:00:00Z',
+      end:   '2026-04-26T20:00:00Z',
+      resource: 'a-maint',
+      category: 'maintenance',
+    };
+    const onEventClick = vi.fn();
+    render(
+      <DispatchView
+        events={[maintEvent]}
+        employees={EMPLOYEES}
+        assets={[ASSETS[1]!]}
+        bases={BASES}
+        initialAsOf={NOON}
+        onEventClick={onEventClick}
+      />,
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'View work' }));
+    expect(onEventClick).toHaveBeenCalledTimes(1);
+    expect(onEventClick).toHaveBeenCalledWith(maintEvent);
+  });
+});
+
+describe('DispatchView as-of navigation', () => {
+  it('does not invoke onAsOfChange on initial mount', () => {
+    const onAsOfChange = vi.fn();
+    render(
+      <DispatchView
+        events={[]}
+        employees={EMPLOYEES}
+        assets={[ASSETS[0]!]}
+        bases={BASES}
+        initialAsOf={NOON}
+        onAsOfChange={onAsOfChange}
+      />,
+    );
+    expect(onAsOfChange).not.toHaveBeenCalled();
+  });
+
+  it('invokes onAsOfChange when the user changes the as-of input', () => {
+    const onAsOfChange = vi.fn();
+    render(
+      <DispatchView
+        events={[]}
+        employees={EMPLOYEES}
+        assets={[ASSETS[0]!]}
+        bases={BASES}
+        initialAsOf={NOON}
+        onAsOfChange={onAsOfChange}
+      />,
+    );
+    const input = screen.getByLabelText('As of') as HTMLInputElement;
+    fireEvent.change(input, { target: { value: '2026-05-15T09:30' } });
+    expect(onAsOfChange).toHaveBeenCalledTimes(1);
+    expect(onAsOfChange.mock.calls[0]![0]).toBeInstanceOf(Date);
+  });
+
+  it('invokes onAsOfChange when the user clicks "Now"', () => {
+    const onAsOfChange = vi.fn();
+    render(
+      <DispatchView
+        events={[]}
+        employees={EMPLOYEES}
+        assets={[ASSETS[0]!]}
+        bases={BASES}
+        initialAsOf={NOON}
+        onAsOfChange={onAsOfChange}
+      />,
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'Now' }));
+    expect(onAsOfChange).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/views/__tests__/DispatchView.override.test.ts
+++ b/src/views/__tests__/DispatchView.override.test.ts
@@ -1,0 +1,117 @@
+/**
+ * Unit tests for `applyMissionOverride` — the pure helper that swaps
+ * generic readiness for a host-supplied per-mission verdict.
+ *
+ * Calendar-driven status is intentionally preserved across the override
+ * so a mission-fit aircraft that is currently in maintenance still
+ * reads as Maintenance (you can't fly a broken plane). These tests
+ * pin that contract.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { applyMissionOverride } from '../DispatchView';
+import type { DispatchRow } from '../DispatchView';
+
+const NOON = new Date('2026-04-26T12:00:00Z');
+
+function row(overrides: Partial<DispatchRow> = {}): DispatchRow {
+  return {
+    asset: { id: 'a1', label: 'N801AW', meta: { base: 'b-logan' } },
+    baseId: 'b-logan',
+    baseName: 'Logan',
+    status: 'available',
+    blockingEvent: null,
+    crewReady: true,
+    equipmentReady: true,
+    missing: [],
+    ...overrides,
+  };
+}
+
+describe('applyMissionOverride', () => {
+  it('replaces crew/equipment readiness with the evaluator verdict', () => {
+    const evaluator = () => ({
+      crewReady: false,
+      equipmentReady: false,
+      missing: ['Need IFR pilot', 'Aircraft missing capability: Critical Care'],
+    });
+    const out = applyMissionOverride([row()], evaluator, 'm1', NOON);
+    expect(out[0]?.crewReady).toBe(false);
+    expect(out[0]?.equipmentReady).toBe(false);
+    expect(out[0]?.missing).toContain('Need IFR pilot');
+    expect(out[0]?.missing).toContain('Aircraft missing capability: Critical Care');
+  });
+
+  it('preserves status (busy / maintenance / available)', () => {
+    const evaluator = () => ({ crewReady: true, equipmentReady: true, missing: [] });
+    const inputs: DispatchRow[] = [
+      row({ status: 'available' }),
+      row({ status: 'busy', asset: { id: 'a2', label: 'N802', meta: { base: 'b-logan' } } }),
+      row({ status: 'maintenance', asset: { id: 'a3', label: 'N803', meta: { base: 'b-logan' } } }),
+    ];
+    const out = applyMissionOverride(inputs, evaluator, 'm1', NOON);
+    expect(out.map(r => r.status)).toEqual(['available', 'busy', 'maintenance']);
+  });
+
+  it('drops generic available-row notes (they were placeholders for empty)', () => {
+    // Available rows in the base pipeline have empty `missing[]` already, but
+    // the helper should not echo any incidental notes that may exist there.
+    const evaluator = () => ({ crewReady: true, equipmentReady: true, missing: [] });
+    const out = applyMissionOverride(
+      [row({ status: 'available', missing: ['stale note'] })],
+      evaluator, 'm1', NOON,
+    );
+    expect(out[0]?.missing).toEqual([]);
+  });
+
+  it('keeps base notes for busy/maintenance rows so blockers stay visible', () => {
+    const evaluator = () => ({
+      crewReady: false,
+      equipmentReady: true,
+      missing: ['Need 4 IFR pilots; 2 ready at base'],
+    });
+    const busyRow = row({
+      status: 'busy',
+      missing: ['Busy: Trauma transport'],
+    });
+    const out = applyMissionOverride([busyRow], evaluator, 'm1', NOON);
+    expect(out[0]?.missing).toEqual([
+      'Busy: Trauma transport',
+      'Need 4 IFR pilots; 2 ready at base',
+    ]);
+  });
+
+  it('forwards (assetId, missionId, asOf) to the evaluator unchanged', () => {
+    const evaluator = vi.fn(() => ({ crewReady: true, equipmentReady: true, missing: [] }));
+    applyMissionOverride([row({ asset: { id: 42, meta: { base: 'b-logan' } } })], evaluator, 'mission-x', NOON);
+    expect(evaluator).toHaveBeenCalledWith('42', 'mission-x', NOON);
+  });
+
+  it('calls the evaluator once per row', () => {
+    const evaluator = vi.fn(() => ({ crewReady: true, equipmentReady: true, missing: [] }));
+    applyMissionOverride(
+      [row(), row({ asset: { id: 'a2', meta: { base: 'b-logan' } } })],
+      evaluator, 'm1', NOON,
+    );
+    expect(evaluator).toHaveBeenCalledTimes(2);
+  });
+
+  it('returns a fresh array — does not mutate the input rows', () => {
+    const input = [row()];
+    const evaluator = () => ({ crewReady: false, equipmentReady: true, missing: ['x'] });
+    const out = applyMissionOverride(input, evaluator, 'm1', NOON);
+    expect(out).not.toBe(input);
+    expect(input[0]?.crewReady).toBe(true); // original untouched
+    expect(out[0]?.crewReady).toBe(false);
+  });
+
+  it('coerces non-string asset ids before passing to the evaluator', () => {
+    const evaluator = vi.fn<(...args: [string, string, Date]) => { crewReady: boolean; equipmentReady: boolean; missing: string[] }>(
+      () => ({ crewReady: true, equipmentReady: true, missing: [] }),
+    );
+    applyMissionOverride(
+      [row({ asset: { id: 42, meta: { base: 'b-logan' } } })],
+      evaluator, 'm1', NOON,
+    );
+    expect(evaluator.mock.calls[0]?.[0]).toBe('42');
+  });
+});

--- a/src/views/__tests__/DispatchView.readiness.test.ts
+++ b/src/views/__tests__/DispatchView.readiness.test.ts
@@ -1,0 +1,152 @@
+/**
+ * Unit tests for the DispatchView readiness pipeline.
+ *
+ * The view itself is rendered against React, but the per-asset status /
+ * crew / equipment computation is pure: stable inputs in, deterministic
+ * row layout out. Testing it as a function keeps the table render pure
+ * styling concern and lets us catch readiness regressions cheaply.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  computeDispatchRows,
+  decorateDispatchRows,
+} from '../DispatchView';
+
+const ASSETS = [
+  { id: 'a1', label: 'N801AW', meta: { base: 'b-logan',  sublabel: 'Helicopter' } },
+  { id: 'a2', label: 'N803LJ', meta: { base: 'b-provo',  sublabel: 'Helicopter' } },
+  { id: 'a3', label: 'N804AW', meta: { base: 'b-logan',  sublabel: 'Helicopter', status: 'maintenance' } },
+];
+
+const EMPLOYEES = [
+  { id: 'e1', name: 'Alex',  base: 'b-logan' },
+  { id: 'e2', name: 'Bea',   base: 'b-provo' },
+];
+
+const BASES = [
+  { id: 'b-logan', name: 'Logan' },
+  { id: 'b-provo', name: 'Provo' },
+];
+
+const NOON = new Date('2026-04-26T12:00:00Z');
+const ONE_PM = new Date('2026-04-26T13:00:00Z');
+
+describe('computeDispatchRows', () => {
+  it('produces one row per asset preserving input order', () => {
+    const rows = computeDispatchRows(NOON, ASSETS, EMPLOYEES, BASES, 'Base');
+    expect(rows.map(r => r.asset.id)).toEqual(['a1', 'a2', 'a3']);
+  });
+
+  it('resolves base name from asset.meta.base via the bases lookup', () => {
+    const rows = computeDispatchRows(NOON, ASSETS, EMPLOYEES, BASES, 'Base');
+    expect(rows.find(r => r.asset.id === 'a1')?.baseName).toBe('Logan');
+    expect(rows.find(r => r.asset.id === 'a2')?.baseName).toBe('Provo');
+  });
+
+  it('falls back to a placeholder when no base is configured on the asset', () => {
+    const orphan = { id: 'a-orphan', label: 'Drone', meta: {} };
+    const rows = computeDispatchRows(NOON, [orphan], EMPLOYEES, BASES, 'Hub');
+    expect(rows[0]?.baseName.toLowerCase()).toContain('hub');
+    expect(rows[0]?.baseId).toBe('');
+  });
+});
+
+describe('decorateDispatchRows — status', () => {
+  const skeleton = computeDispatchRows(NOON, ASSETS, EMPLOYEES, BASES, 'Base');
+
+  it('marks assets without overlapping events Available (a3 stays maintenance via meta.status)', () => {
+    const rows = decorateDispatchRows(skeleton, NOON, [], EMPLOYEES);
+    expect(rows.find(r => r.asset.id === 'a1')?.status).toBe('available');
+    expect(rows.find(r => r.asset.id === 'a2')?.status).toBe('available');
+    expect(rows.find(r => r.asset.id === 'a3')?.status).toBe('maintenance');
+  });
+
+  it('flips an asset to Busy when a non-maintenance event overlaps as-of', () => {
+    const rows = decorateDispatchRows(skeleton, NOON, [
+      { id: 'ev1', start: '2026-04-26T11:00:00Z', end: '2026-04-26T15:00:00Z', resource: 'a1', category: 'mission-assignment', title: 'Trauma transport' },
+    ], EMPLOYEES);
+    const a1 = rows.find(r => r.asset.id === 'a1');
+    expect(a1?.status).toBe('busy');
+    expect(a1?.missing.some(m => m.includes('Trauma transport'))).toBe(true);
+  });
+
+  it('flips an asset to Maintenance when a maintenance event overlaps', () => {
+    const rows = decorateDispatchRows(skeleton, NOON, [
+      { id: 'ev2', start: '2026-04-26T08:00:00Z', end: '2026-04-26T20:00:00Z', resource: 'a1', category: 'maintenance', title: '50hr inspection' },
+    ], EMPLOYEES);
+    expect(rows.find(r => r.asset.id === 'a1')?.status).toBe('maintenance');
+  });
+
+  it('honors meta.status === "maintenance" even when no event is on file', () => {
+    const rows = decorateDispatchRows(skeleton, NOON, [], EMPLOYEES);
+    expect(rows.find(r => r.asset.id === 'a3')?.status).toBe('maintenance');
+  });
+
+  it('prefers maintenance over busy when both apply', () => {
+    const rows = decorateDispatchRows(skeleton, NOON, [
+      { id: 'm', start: '2026-04-26T08:00Z', end: '2026-04-26T20:00Z', resource: 'a1', category: 'maintenance' },
+      { id: 'b', start: '2026-04-26T08:00Z', end: '2026-04-26T20:00Z', resource: 'a1', category: 'mission-assignment' },
+    ], EMPLOYEES);
+    expect(rows.find(r => r.asset.id === 'a1')?.status).toBe('maintenance');
+  });
+
+  it('ignores events that are entirely outside the as-of moment', () => {
+    const rows = decorateDispatchRows(skeleton, NOON, [
+      { id: 'ev', start: '2026-04-27T08:00Z', end: '2026-04-27T20:00Z', resource: 'a1', category: 'mission-assignment' },
+    ], EMPLOYEES);
+    expect(rows.find(r => r.asset.id === 'a1')?.status).toBe('available');
+  });
+
+  it('ignores base-wide events with no resource binding', () => {
+    const rows = decorateDispatchRows(skeleton, NOON, [
+      { id: 'b1', start: '2026-04-26T08:00Z', end: '2026-04-26T20:00Z', meta: { base: 'b-logan' }, category: 'closure' },
+    ], EMPLOYEES);
+    expect(rows.find(r => r.asset.id === 'a1')?.status).toBe('available');
+  });
+});
+
+describe('decorateDispatchRows — crew readiness', () => {
+  const skeleton = computeDispatchRows(NOON, ASSETS, EMPLOYEES, BASES, 'Base');
+
+  it('reports crewReady=true when at least one employee at the base is unbooked', () => {
+    const rows = decorateDispatchRows(skeleton, NOON, [], EMPLOYEES);
+    expect(rows.find(r => r.asset.id === 'a1')?.crewReady).toBe(true);
+  });
+
+  it('reports crewReady=false when every employee at that base is booked', () => {
+    const rows = decorateDispatchRows(skeleton, NOON, [
+      { id: 'pe', start: '2026-04-26T08:00Z', end: '2026-04-26T20:00Z', resource: 'e1', category: 'pto' },
+    ], EMPLOYEES);
+    expect(rows.find(r => r.asset.id === 'a1')?.crewReady).toBe(false);
+    expect(rows.find(r => r.asset.id === 'a1')?.missing.some(m => m.includes('crew'))).toBe(true);
+  });
+
+  it('does not bleed across bases — Logan booking does not affect Provo readiness', () => {
+    const rows = decorateDispatchRows(skeleton, NOON, [
+      { id: 'pe', start: '2026-04-26T08:00Z', end: '2026-04-26T20:00Z', resource: 'e1', category: 'pto' },
+    ], EMPLOYEES);
+    expect(rows.find(r => r.asset.id === 'a2')?.crewReady).toBe(true);
+  });
+
+  it('a future booking does not block crew readiness now', () => {
+    const rows = decorateDispatchRows(skeleton, NOON, [
+      { id: 'pe', start: '2026-04-26T13:00Z', end: '2026-04-26T20:00Z', resource: 'e1', category: 'pto' },
+    ], EMPLOYEES);
+    expect(rows.find(r => r.asset.id === 'a1')?.crewReady).toBe(true);
+    // …but the same booking checked at 1pm does block.
+    const later = decorateDispatchRows(skeleton, ONE_PM, [
+      { id: 'pe', start: '2026-04-26T13:00Z', end: '2026-04-26T20:00Z', resource: 'e1', category: 'pto' },
+    ], EMPLOYEES);
+    expect(later.find(r => r.asset.id === 'a1')?.crewReady).toBe(false);
+  });
+});
+
+describe('decorateDispatchRows — equipment readiness', () => {
+  const skeleton = computeDispatchRows(NOON, ASSETS, EMPLOYEES, BASES, 'Base');
+
+  it('reports equipmentReady=false only when the asset is in maintenance', () => {
+    const rows = decorateDispatchRows(skeleton, NOON, [], EMPLOYEES);
+    expect(rows.find(r => r.asset.id === 'a1')?.equipmentReady).toBe(true);
+    expect(rows.find(r => r.asset.id === 'a3')?.equipmentReady).toBe(false);
+  });
+});


### PR DESCRIPTION
The mission/asset-request modal already validates per-mission fit
(pilot certs, aircraft hours, maintenance, etc.) but the inverse
question — which assets are launch-ready at this moment? — required
clicking through every mission first.

Add a flat readiness table per asset, evaluated against an as-of
time the dispatcher chooses (defaults to now, retargetable for
shift-change pre-staging).

Status taxonomy is intentionally generic so the same view works for
any deployment, not just air EMS:
- Maintenance: a maintenance event overlaps as-of, OR
  asset.meta.status === 'maintenance'
- Busy: any other event is bound to this resource at as-of
- Available: neither

Crew Ready is a heuristic (≥1 employee at the asset's base is unbooked
at as-of); Equipment Ready follows status. The table surfaces a
"Missing / Note" column so the dispatcher's next move is visible at a
glance and an Action button that routes to the blocking event when one
exists.

Wiring:
- New ViewId 'dispatch' in viewScope; VIEW_SCOPES.dispatch passes
  events through unmodified (the view filters at as-of itself).
- Registered in ALL_VIEWS, ProfileBar VIEW_ICON_MAP, ViewsDropdown,
  ConfigPanel Display tab (default-view picker + visible-tabs
  toggle), SetupLanding wizard's StepTabs choice list.
- Dispatch chips count toward visibleViewCount in the Setup hub.

Pure decorateDispatchRows / computeDispatchRows helpers are exported
so the readiness pipeline is unit-testable in isolation; 15 tests
cover status, crew, equipment, and bleed-across-bases scenarios.