### PR TITLE
csv-import: typed billing + maintenance fields, tighter header matching

### DIFF
--- a/docs/MaintenanceAndInvoicing.md
+++ b/docs/MaintenanceAndInvoicing.md
@@ -1,0 +1,257 @@
+# Maintenance & Invoicing Integration
+
+WorksCalendar plugs into your existing accounting and maintenance
+systems instead of trying to replace them. You get:
+
+- **Typed metadata** that hangs off your existing events
+  (`event.meta.billing` / `event.meta.maintenance`).
+- **Pure helpers** that compute due-status and project next-due
+  values — no event storage, no async, easy to unit-test.
+- **UI components** for asset-row badges and an in-form maintenance
+  section so service work is logged in the same place as everything else.
+- **Export helpers** that emit clean CSVs for QuickBooks, Stripe,
+  Excel, or fleet tools.
+
+The library does not produce invoices and does not store meter readings
+— those live wherever you want. WorksCalendar surfaces, schedules, and
+exports.
+
+## Use cases
+
+Built with these operators in mind:
+
+- Small trucking companies (mileage-driven service intervals)
+- Flight schools (Hobbs / tach-time intervals + annual inspections)
+- Equipment / porta-potty rental shops (date-based service rotations)
+- Anyone running scheduling in WorksCalendar and invoicing somewhere else
+
+## Data shapes
+
+Billing meta lives on the event:
+
+```ts
+import type { BillableMeta } from 'works-calendar';
+
+const event = {
+  title: 'ABC Logistics — transit',
+  start: new Date(...),
+  end:   new Date(...),
+  resource: 'truck-12',
+  meta: {
+    billing: {
+      billable: true,
+      customer: 'ABC Logistics',
+      rate: 120,            // numeric; units are your call (per hour, per job, …)
+      quantity: 5,          // optional — defaults to event duration
+      currency: 'USD',
+      invoiceStatus: 'unbilled',  // 'unbilled' | 'invoiced' | 'paid' | 'void'
+      description: 'Transit',
+    },
+  },
+};
+```
+
+Maintenance rules are owned by the consumer:
+
+```ts
+import type { MaintenanceRule } from 'works-calendar';
+
+const oilChange: MaintenanceRule = {
+  id: 'oil-10k',
+  assetType: 'truck',
+  title: 'Oil change',
+  interval:      { miles: 10_000 },
+  warningWindow: { miles: 1_500  },
+};
+```
+
+Maintenance work events carry their own meta:
+
+```ts
+event.meta.maintenance = {
+  ruleId: 'oil-10k',
+  lifecycle: 'scheduled',  // 'due' | 'scheduled' | 'in-progress' | 'complete' | 'skipped'
+  meterAtService: 110_500,
+  // After completion, the form auto-stamps:
+  nextDueMiles: 120_500,
+  nextDueDate:  '2027-04-10T00:00:00.000Z',
+};
+```
+
+## Pure helpers
+
+All in `import { computeDueStatus, projectNextDue, completeMaintenance } from 'works-calendar'`.
+
+```ts
+const due = computeDueStatus(
+  oilChange,
+  { meter: { type: 'miles', value: 109_200 } },
+  { meterAtService: 100_000, completedAt: '2025-12-01T00:00:00Z' },
+);
+// due.status: 'overdue' | 'due-soon' | 'ok' | 'unknown'
+// due.miles?: { remaining: number }   // negative when overdue
+// due.days?:  { remaining: number }
+```
+
+The most-urgent dimension drives `status` (miles ok + days overdue ⇒
+`overdue`). Returns `unknown` when there isn't enough data to compute,
+rather than lying with `ok`.
+
+```ts
+const projection = projectNextDue(oilChange, { meterAtService: 110_500 });
+// projection.nextDueMiles → 120_500
+```
+
+```ts
+const { event: stamped, reading } = completeMaintenance(
+  workEvent,
+  oilChange,
+  { assetId: 'truck-12', type: 'miles', value: 110_500 },
+);
+// stamped.meta.maintenance.lifecycle      → 'complete'
+// stamped.meta.maintenance.meterAtService → 110_500
+// stamped.meta.maintenance.nextDueMiles   → 120_500
+// reading is a MeterReading{ assetId, type, value, asOf } you append to your log
+```
+
+## Asset-row badges
+
+The library exposes a `renderAssetBadges` slot on `WorksCalendar` /
+`AssetsView`. Pair it with the bundled `<AssetMaintenanceBadges>`:
+
+```tsx
+import {
+  WorksCalendar,
+  AssetMaintenanceBadges,
+} from 'works-calendar';
+
+<WorksCalendar
+  events={events}
+  assets={assets}
+  renderAssetBadges={(asset) => (
+    <AssetMaintenanceBadges
+      rules={rulesByAsset[asset.id] ?? []}
+      currentMeter={meters[asset.id]}
+      lastServiceByRule={lastServiceByAssetRule[asset.id]}
+      max={3}
+      // hideHealthy        // optional — only show overdue / due-soon
+    />
+  )}
+/>
+```
+
+Status colors come from theme tokens (`--wc-danger`, `--wc-warning`,
+`--wc-success`, muted) so badges adapt to the active theme.
+
+## In-form maintenance completion
+
+Pass `maintenanceRules` to `WorksCalendar` (or directly to `EventForm`
+in custom integrations). The form gains a Maintenance section:
+
+```tsx
+<WorksCalendar
+  events={events}
+  maintenanceRules={RULES}
+  // …
+/>
+```
+
+When the user marks the lifecycle `complete` and enters a meter reading
+(or selects a date-only rule), the form internally calls
+`completeMaintenance()` so projected `nextDueMiles` / `nextDueHours` /
+`nextDueCycles` / `nextDueDate` land on the saved event automatically.
+The asset-row badges update on the next render — no extra wiring.
+
+The section is **opt-in**: omit `maintenanceRules` (or pass `[]`) and the
+form behaves exactly as before, with zero overhead.
+
+## CSV import
+
+The existing CSV import dialog (`CSVImportDialog`) renders mappable
+fields dynamically from `EVENT_FIELDS`, so once you have billing /
+maintenance columns in your sheet you can map them through the same
+flow operators already use:
+
+| Sheet column (examples)     | Maps to                  |
+|------------------------------|--------------------------|
+| Customer / Client / Account  | `meta.billing.customer`  |
+| Rate / Hourly Rate           | `meta.billing.rate`      |
+| Hours / Qty                  | `meta.billing.quantity`  |
+| Invoice Status               | `meta.billing.invoiceStatus` |
+| Truck / Tail # / Aircraft    | `resource` (asset id)    |
+| Hobbs / Mileage / Odometer   | `meta.meter.value`       |
+| Service / Maintenance Rule   | `meta.maintenance.ruleId` |
+
+Numeric cells tolerate `$`, `,`, and whitespace. Symbol-only cells
+(`"$"`, `","`) are reported as per-row errors instead of silently
+importing as 0.
+
+## CSV export
+
+Three layers of access — pick whichever fits:
+
+```ts
+import {
+  toInvoiceLineItems,
+  invoiceLineItemsToCSV,
+  downloadInvoicesCSV,
+  toMaintenanceLog,
+  maintenanceLogToCSV,
+  downloadMaintenanceLogCSV,
+} from 'works-calendar';
+
+// 1. Pure transform — for sending to a webhook, a custom backend, etc.
+const items = toInvoiceLineItems(events, { onlyBillable: true });
+
+// 2. CSV string — paste into anything, log it, sign it, ship it.
+const csv = invoiceLineItemsToCSV(items);
+
+// 3. One-shot browser download.
+downloadInvoicesCSV(events, { statuses: ['unbilled'] }, 'april-invoices');
+
+// Maintenance log mirror image:
+downloadMaintenanceLogCSV(events, {
+  rules: RULES,
+  lifecycles: ['complete'],   // service-history report
+}, 'service-history');
+```
+
+Both CSVs emit headers even for empty input — most accounting-tool
+imports treat that as "no rows" rather than erroring on a truly empty
+file.
+
+### Quantity defaults
+
+`toInvoiceLineItems` derives `quantity` from event duration when
+`meta.billing.quantity` is absent:
+
+| `quantityFrom`     | Behavior                               |
+|---------------------|----------------------------------------|
+| `'duration-hours'` (default) | end − start, in hours, 2-decimal |
+| `'duration-days'`   | end − start, in days, 2-decimal       |
+| `'none'`            | `0` when not explicitly set           |
+
+`total = rate × quantity` when both present, else `null`.
+
+## Round-trip with the user's spreadsheet
+
+The realistic adoption story is *"keep your sheet, we plug in"*. The
+typical loop:
+
+1. Operator imports their working sheet through the CSV dialog. Domain
+   columns (`Truck`, `Hobbs`, `Customer`, `Rate`) auto-map; everything
+   else they map manually once.
+2. Calendar shows their schedule, asset health badges light up where
+   service is due.
+3. Operator runs jobs and logs maintenance through the form. The form
+   auto-stamps next-due fields.
+4. Operator exports invoice CSV → drops into QuickBooks. Exports
+   maintenance log → emails to the fleet owner.
+
+No accounting / fleet replacement required.
+
+## Related
+
+- [Example: 11-MaintenanceAndInvoicing.jsx](../examples/11-MaintenanceAndInvoicing.tsx)
+- [Examples index](../examples/README.md)
+- [Resource scheduling](./ResourceScheduling.md) — asset registry basics

--- a/docs/README.md
+++ b/docs/README.md
@@ -18,6 +18,7 @@ This index is the canonical docs entrypoint for the package.
 - [Resource scheduling and asset management](./ResourceScheduling.md)
 - [Resource pools](./ResourcePools.md)
 - [Location provider](./LocationProvider.md)
+- [Maintenance & invoicing integration](./MaintenanceAndInvoicing.md)
 
 ## Provider setup guides
 

--- a/examples/11-MaintenanceAndInvoicing.tsx
+++ b/examples/11-MaintenanceAndInvoicing.tsx
@@ -1,0 +1,222 @@
+/**
+ * Example 11 — Maintenance & Invoicing Integration
+ *
+ * Small ops shops (trucking, flight schools, equipment rental) typically run
+ * scheduling separately from their accounting + maintenance systems. This
+ * example shows how WorksCalendar plugs into both without owning either:
+ *
+ *   • Per-asset maintenance rules with automatic due-status computation
+ *   • Asset-row badges that surface "due soon" / "overdue" at a glance
+ *   • EventForm gains a Maintenance section — completing a service auto-
+ *     stamps next-due fields onto the event so the badges update.
+ *   • One-click CSV export for invoices and maintenance log, ready to
+ *     drop into QuickBooks, Excel, or a fleet management tool.
+ *
+ * The library does not produce invoices and does not store readings —
+ * those live wherever the consumer wants. This example uses simple in-
+ * memory state to keep the wiring honest.
+ */
+import { useState, useCallback, useMemo } from 'react';
+import {
+  WorksCalendar,
+  AssetMaintenanceBadges,
+  toInvoiceLineItems,
+  invoiceLineItemsToCSV,
+  downloadInvoicesCSV,
+  downloadMaintenanceLogCSV,
+} from '../src/index.ts';
+import type {
+  WorksCalendarEvent,
+  MaintenanceRule,
+  MeterType,
+  LastService,
+} from '../src/index.ts';
+
+// ── Asset registry ───────────────────────────────────────────────────────────
+const ASSETS = [
+  { id: 'truck-12', label: 'Truck 12', meta: { sublabel: 'Box truck · F-450' } },
+  { id: 'truck-13', label: 'Truck 13', meta: { sublabel: 'Box truck · F-550' } },
+  { id: 'truck-14', label: 'Truck 14', meta: { sublabel: 'Reefer · M2-106'   } },
+];
+
+// ── Maintenance rules (per-asset or per-asset-type) ──────────────────────────
+const RULES: MaintenanceRule[] = [
+  {
+    id: 'oil-10k',
+    assetType: 'truck',
+    title: 'Oil change',
+    interval:      { miles: 10_000 },
+    warningWindow: { miles: 1_500 },
+  },
+  {
+    id: 'dot-annual',
+    assetType: 'truck',
+    title: 'DOT inspection',
+    interval:      { days: 365 },
+    warningWindow: { days: 30 },
+  },
+  {
+    id: 'brake-30k',
+    assetType: 'truck',
+    title: 'Brake service',
+    interval:      { miles: 30_000 },
+    warningWindow: { miles: 5_000 },
+  },
+];
+
+// In a real app these come from a backend. Here, simulated last-service state.
+const LAST_SERVICE_BY_ASSET: Record<string, Record<string, LastService>> = {
+  'truck-12': {
+    'oil-10k':    { meterAtService: 100_000, completedAt: '2025-12-01T00:00:00Z' },
+    'dot-annual': { completedAt: '2025-04-15T00:00:00Z' }, // due soon
+    'brake-30k':  { meterAtService:  90_000, completedAt: '2025-08-01T00:00:00Z' },
+  },
+  'truck-13': {
+    'oil-10k':    { meterAtService: 200_000, completedAt: '2026-03-20T00:00:00Z' },
+    'dot-annual': { completedAt: '2025-10-01T00:00:00Z' },
+  },
+  // truck-14 has no history yet — badges render as "unknown".
+};
+
+const CURRENT_METER: Record<string, { type: MeterType; value: number }> = {
+  'truck-12': { type: 'miles', value: 109_200 }, // oil due soon (800 mi away)
+  'truck-13': { type: 'miles', value: 201_400 },
+  'truck-14': { type: 'miles', value:  35_000 },
+};
+
+// ── Seed events: a mix of billable jobs and maintenance work ─────────────────
+function seedEvents(): WorksCalendarEvent[] {
+  const today = new Date();
+  const day   = (offset: number, hour = 9) => {
+    const d = new Date(today);
+    d.setDate(today.getDate() + offset);
+    d.setHours(hour, 0, 0, 0);
+    return d;
+  };
+  return [
+    {
+      id: 'job-1', title: 'ABC Logistics — transit', resource: 'truck-12',
+      start: day(-1, 8), end: day(-1, 16),
+      meta: { billing: { billable: true, customer: 'ABC Logistics', rate: 120, currency: 'USD', invoiceStatus: 'invoiced' } },
+    },
+    {
+      id: 'job-2', title: 'XYZ Freight — delivery', resource: 'truck-13',
+      start: day(0, 7), end: day(0, 12),
+      meta: { billing: { billable: true, customer: 'XYZ Freight', rate: 145, currency: 'USD', invoiceStatus: 'unbilled' } },
+    },
+    {
+      id: 'svc-1', title: 'Oil change — Truck 12', resource: 'truck-12',
+      start: day(1, 10), end: day(1, 11),
+      category: 'Maintenance',
+      meta: { maintenance: { ruleId: 'oil-10k', lifecycle: 'scheduled' } },
+    },
+    {
+      id: 'job-3', title: 'Acme — last-mile run', resource: 'truck-14',
+      start: day(2, 8), end: day(2, 14),
+      meta: { billing: { billable: true, customer: 'Acme', rate: 95, currency: 'USD', invoiceStatus: 'paid' } },
+    },
+  ];
+}
+
+// ── Component ────────────────────────────────────────────────────────────────
+export function MaintenanceAndInvoicingExample() {
+  const [events, setEvents] = useState<WorksCalendarEvent[]>(seedEvents);
+
+  const handleSave = useCallback((ev: WorksCalendarEvent) => {
+    setEvents(prev => {
+      const idx = prev.findIndex(e => e.id === ev.id);
+      if (idx >= 0) { const next = [...prev]; next[idx] = ev; return next; }
+      return [...prev, { ...ev, id: ev.id ?? `evt-${Date.now()}` }];
+    });
+  }, []);
+
+  // Renders the maintenance status chips inside each asset row.
+  // The library passes us the asset id; we look up rules + state and let
+  // <AssetMaintenanceBadges /> compute due-status and render chips.
+  const renderAssetBadges = useCallback((asset: { id: string }) => (
+    <AssetMaintenanceBadges
+      rules={RULES}
+      currentMeter={CURRENT_METER[asset.id]}
+      lastServiceByRule={LAST_SERVICE_BY_ASSET[asset.id]}
+      max={3}
+    />
+  ), []);
+
+  // Pre-compute invoice totals so the toolbar can show a quick summary.
+  const invoiceSummary = useMemo(() => {
+    const items = toInvoiceLineItems(
+      // The export helpers want NormalizedEvent[] — for in-memory examples
+      // we cast through unknown since our raw events are close enough in shape.
+      events as unknown as Parameters<typeof toInvoiceLineItems>[0],
+    );
+    const total = items.reduce((acc, i) => acc + (i.total ?? 0), 0);
+    return { count: items.length, total };
+  }, [events]);
+
+  function handleExportInvoices() {
+    downloadInvoicesCSV(events as unknown as Parameters<typeof downloadInvoicesCSV>[0], {}, 'invoices');
+  }
+
+  function handleExportMaintenance() {
+    downloadMaintenanceLogCSV(
+      events as unknown as Parameters<typeof downloadMaintenanceLogCSV>[0],
+      { rules: RULES },
+      'maintenance-log',
+    );
+  }
+
+  function handleCopyInvoiceCSV() {
+    const csv = invoiceLineItemsToCSV(toInvoiceLineItems(
+      events as unknown as Parameters<typeof toInvoiceLineItems>[0],
+    ));
+    if (navigator.clipboard) navigator.clipboard.writeText(csv);
+  }
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', height: '100%' }}>
+      {/* Lightweight toolbar above the calendar — invoicing / export actions. */}
+      <div style={{
+        display: 'flex', alignItems: 'center', gap: 12,
+        padding: '10px 14px', borderBottom: '1px solid var(--wc-border)',
+        background: 'var(--wc-surface)',
+      }}>
+        <strong style={{ fontSize: 13 }}>Invoices:</strong>
+        <span style={{ fontSize: 13, color: 'var(--wc-text-muted)' }}>
+          {invoiceSummary.count} item{invoiceSummary.count === 1 ? '' : 's'}
+          {' · '}
+          ${invoiceSummary.total.toFixed(2)}
+        </span>
+        <div style={{ flex: 1 }} />
+        <button onClick={handleCopyInvoiceCSV}    style={btn}>Copy CSV</button>
+        <button onClick={handleExportInvoices}    style={btn}>Export invoices</button>
+        <button onClick={handleExportMaintenance} style={btn}>Export maintenance log</button>
+      </div>
+
+      <div style={{ flex: 1, minHeight: 0 }}>
+        <WorksCalendar
+          devMode
+          calendarId="maintenance-invoicing"
+          initialView="assets"
+          events={events}
+          assets={ASSETS}
+          renderAssetBadges={renderAssetBadges}
+          maintenanceRules={RULES}
+          showAddButton
+          onEventSave={handleSave}
+          onEventDelete={(id) => setEvents(prev => prev.filter(e => e.id !== id))}
+        />
+      </div>
+    </div>
+  );
+}
+
+const btn: React.CSSProperties = {
+  padding: '6px 10px',
+  fontSize: 12,
+  fontWeight: 500,
+  background: 'var(--wc-bg)',
+  color: 'var(--wc-text)',
+  border: '1px solid var(--wc-border)',
+  borderRadius: 6,
+  cursor: 'pointer',
+};

--- a/examples/App.tsx
+++ b/examples/App.tsx
@@ -20,6 +20,7 @@ import { MultiSource }             from './07-MultiSource';
 import { ShiftCoverageTracking }   from './08-ShiftCoverageTracking';
 import { GroupingExample }         from './09-Grouping';
 import { DragAndDropExample }      from './10-DragAndDrop';
+import { MaintenanceAndInvoicingExample } from './11-MaintenanceAndInvoicing';
 import { BasicUsageExample }       from './basic-usage';
 import { SetupWizardExample }      from './setup-wizard';
 import { AdvancedFiltersExample }  from './advanced-filters';
@@ -141,6 +142,13 @@ const EXAMPLES = [
     desc:  'Drag an event across groups (agenda) or rows (timeline) to reassign. Patches flow through engine validation.',
     component: DragAndDropExample,
   },
+  {
+    id:    'maintenance-invoicing',
+    label: 'Maintenance & Invoicing',
+    tag:   'Asset health · CSV export',
+    desc:  'Asset-row badges show due/overdue maintenance; completing service in the form auto-stamps next-due. One-click CSV export for invoices and maintenance log.',
+    component: MaintenanceAndInvoicingExample,
+  },
 ];
 
 // ── Sidebar ───────────────────────────────────────────────────────────────────
@@ -229,6 +237,7 @@ function SourceHint({ id }) {
     'shift-coverage':       '08-ShiftCoverageTracking.jsx',
     'grouping':             '09-Grouping.jsx',
     'drag-and-drop':        '10-DragAndDrop.jsx',
+    'maintenance-invoicing': '11-MaintenanceAndInvoicing.jsx',
     'basic-usage-modern':   'basic-usage.jsx',
     'setup-wizard':         'setup-wizard.jsx',
     'advanced-filters-new': 'advanced-filters.jsx',

--- a/examples/README.md
+++ b/examples/README.md
@@ -18,6 +18,9 @@ npm run examples
 - `06-TeamCalendar.jsx` — multi-resource team scheduling
 - `07-MultiSource.jsx` — merged multi-source data views
 - `08-ShiftCoverageTracking.jsx` — PTO + coverage workflow
+- `09-Grouping.jsx` — single / nested groupBy + saved views
+- `10-DragAndDrop.jsx` — drag events across groups and rows
+- `11-MaintenanceAndInvoicing.jsx` — asset-health badges, in-form maintenance completion, CSV export for invoicing + maintenance log
 
 ## Focused examples
 
@@ -39,4 +42,5 @@ npm run examples
 - [Workflow map](./WORKFLOWS.md)
 - [Documentation index](../docs/README.md)
 - [Resource pools](../docs/ResourcePools.md)
+- [Maintenance & invoicing integration](../docs/MaintenanceAndInvoicing.md)
 - [Microsoft 365 adapter notes](./microsoft-365/README.md)

--- a/examples/WORKFLOWS.md
+++ b/examples/WORKFLOWS.md
@@ -69,3 +69,19 @@ What it shows:
 - filter demo path
 - saved views demo path
 - docs/examples handoff links for first-time visitors
+
+---
+
+## Maintenance & Invoicing Integration
+
+Use this example:
+- `11-MaintenanceAndInvoicing.jsx`
+
+What it shows:
+- per-asset maintenance rules (intervals + warning windows)
+- asset-row badges driven by `computeDueStatus`
+- EventForm Maintenance section with auto-projection on `complete`
+- one-click CSV export (`downloadInvoicesCSV`, `downloadMaintenanceLogCSV`)
+- pure transforms (`toInvoiceLineItems`) for custom backends
+
+See also: [docs/MaintenanceAndInvoicing.md](../docs/MaintenanceAndInvoicing.md).

--- a/src/WorksCalendar.tsx
+++ b/src/WorksCalendar.tsx
@@ -273,6 +273,7 @@ export type WorksCalendarProps = {
   onConflictCheck?: (event: WorksCalendarEvent, candidate: WorksCalendarEvent) => Promise<unknown>;
   onApprovalAction?: (event: WorksCalendarEvent, action: string) => void | Promise<void>;
   renderAssetLocation?: (locationData: AssetLocationData, asset: { id: string }) => ReactNode;
+  renderAssetBadges?: (asset: { id: string }) => ReactNode;
   renderConflictBody?: (args: UnknownRecord) => ReactNode;
 
   /**
@@ -526,6 +527,7 @@ export const WorksCalendar = forwardRef<CalendarApi, WorksCalendarProps>(functio
     onConflictCheck,
     onApprovalAction,
     renderAssetLocation,
+    renderAssetBadges,
     renderConflictBody,
 
     // ── Resource pools (#212) ──
@@ -2426,6 +2428,7 @@ export const WorksCalendar = forwardRef<CalendarApi, WorksCalendarProps>(functio
                   onCollapsedGroupsChange={setActiveAssetsCollapsed}
                   locationProvider={effectiveLocationProvider}
                   renderAssetLocation={renderAssetLocation}
+                  renderAssetBadges={renderAssetBadges}
                   onEditAssets={ownerCfg.isOwner ? () => ownerCfg.openConfigToTab('assets') : undefined}
                   onRequestAsset={canRequestAsset ? () => setAssetRequestOpen(true) : undefined}
                   approvalsConfig={ownerCfg.config?.['approvals']}

--- a/src/WorksCalendar.tsx
+++ b/src/WorksCalendar.tsx
@@ -274,6 +274,11 @@ export type WorksCalendarProps = {
   onApprovalAction?: (event: WorksCalendarEvent, action: string) => void | Promise<void>;
   renderAssetLocation?: (locationData: AssetLocationData, asset: { id: string }) => ReactNode;
   renderAssetBadges?: (asset: { id: string }) => ReactNode;
+  /** Maintenance rules offered in the EventForm. When non-empty, the form
+   *  shows a Maintenance section; lifecycle='complete' triggers a built-in
+   *  call to completeMaintenance() so projected nextDue* fields land on
+   *  event.meta.maintenance automatically. */
+  maintenanceRules?: readonly import('./types/maintenance').MaintenanceRule[];
   renderConflictBody?: (args: UnknownRecord) => ReactNode;
 
   /**
@@ -528,6 +533,7 @@ export const WorksCalendar = forwardRef<CalendarApi, WorksCalendarProps>(functio
     onApprovalAction,
     renderAssetLocation,
     renderAssetBadges,
+    maintenanceRules,
     renderConflictBody,
 
     // ── Resource pools (#212) ──
@@ -2492,6 +2498,7 @@ export const WorksCalendar = forwardRef<CalendarApi, WorksCalendarProps>(functio
             onClose={() => setFormEvent(null)}
             permissions={perms}
             onAddCategory={perms.canManageOptions ? eventOptions.addCategory : undefined}
+            maintenanceRules={maintenanceRules}
           />
         )}
 

--- a/src/core/__tests__/csvParser.test.ts
+++ b/src/core/__tests__/csvParser.test.ts
@@ -211,6 +211,125 @@ describe('mapToEvents', () => {
   });
 });
 
+// ── Billing + maintenance metadata ────────────────────────────────────────────
+
+describe('mapToEvents — billing fields', () => {
+  it('attaches billing meta when billing columns are mapped', () => {
+    const { events, errors } = mapToEvents(
+      [{ T: 'Job 12', S: '2026-04-10', Bill: 'true', Cust: 'ABC Logistics', Rate: '120', Qty: '5', Inv: 'Unbilled' }],
+      { title: 'T', start: 'S', billable: 'Bill', customer: 'Cust', rate: 'Rate', quantity: 'Qty', invoiceStatus: 'Inv' },
+      'iso',
+    );
+    expect(errors).toHaveLength(0);
+    const billing = (events[0]!.meta as any).billing;
+    expect(billing).toEqual({
+      billable: true,
+      customer: 'ABC Logistics',
+      rate: 120,
+      quantity: 5,
+      invoiceStatus: 'unbilled',
+    });
+  });
+
+  it('tolerates currency symbols and thousand separators in rate', () => {
+    const { events } = mapToEvents(
+      [{ T: 'Job', S: '2026-04-10', Rate: '$1,250.50' }],
+      { title: 'T', start: 'S', rate: 'Rate' },
+      'iso',
+    );
+    expect((events[0]!.meta as any).billing.rate).toBe(1250.5);
+  });
+
+  it('reports a per-row error when rate is non-numeric', () => {
+    const { events, errors } = mapToEvents(
+      [{ T: 'Job', S: '2026-04-10', Rate: 'cheap' }],
+      { title: 'T', start: 'S', rate: 'Rate' },
+      'iso',
+    );
+    expect(events).toHaveLength(0);
+    expect(errors[0]!.message).toMatch(/rate/i);
+  });
+
+  it('does not attach meta when no billing columns map and values exist', () => {
+    const { events } = mapToEvents(
+      [{ T: 'Plain', S: '2026-04-10' }],
+      { title: 'T', start: 'S' },
+      'iso',
+    );
+    expect(events[0]!.meta).toBeUndefined();
+  });
+
+  it('skips billable when value is unrecognised (not true/false-like)', () => {
+    const { events } = mapToEvents(
+      [{ T: 'Job', S: '2026-04-10', Bill: 'maybe' }],
+      { title: 'T', start: 'S', billable: 'Bill' },
+      'iso',
+    );
+    expect(events[0]!.meta).toBeUndefined();
+  });
+});
+
+describe('mapToEvents — maintenance fields', () => {
+  it('attaches maintenance + meter meta when maintenance columns are mapped', () => {
+    const { events, errors } = mapToEvents(
+      [{ T: 'Oil change', S: '2026-04-10', Rule: 'oil-10k', LC: 'Scheduled', M: '120000', MT: 'Miles' }],
+      { title: 'T', start: 'S', maintenanceRule: 'Rule', lifecycle: 'LC', meterValue: 'M', meterType: 'MT' },
+      'iso',
+    );
+    expect(errors).toHaveLength(0);
+    const meta = events[0]!.meta as any;
+    expect(meta.maintenance).toEqual({
+      ruleId: 'oil-10k',
+      lifecycle: 'scheduled',
+      meterAtService: 120000,
+    });
+    expect(meta.meter).toEqual({ value: 120000, type: 'miles' });
+  });
+
+  it('omits meter block when only meter type is present (no reading)', () => {
+    const { events } = mapToEvents(
+      [{ T: 'Service', S: '2026-04-10', MT: 'hours' }],
+      { title: 'T', start: 'S', meterType: 'MT' },
+      'iso',
+    );
+    expect((events[0]!.meta as any).meter).toEqual({ type: 'hours' });
+  });
+
+  it('produces independent billing and maintenance blocks for the same event', () => {
+    const { events } = mapToEvents(
+      [{ T: 'Service', S: '2026-04-10', Cust: 'Internal', Rule: 'inspection-50h' }],
+      { title: 'T', start: 'S', customer: 'Cust', maintenanceRule: 'Rule' },
+      'iso',
+    );
+    const meta = events[0]!.meta as any;
+    expect(meta.billing.customer).toBe('Internal');
+    expect(meta.maintenance.ruleId).toBe('inspection-50h');
+    expect(meta.meter).toBeUndefined();
+  });
+});
+
+describe('suggestMapping — domain vocabulary', () => {
+  it('maps "Truck" to resource', () => {
+    expect(suggestMapping(['Title', 'Date', 'Truck'])['resource']).toBe('Truck');
+  });
+
+  it('maps "Tail Number" to resource (aviation)', () => {
+    expect(suggestMapping(['Subject', 'Date', 'Tail Number'])['resource']).toBe('Tail Number');
+  });
+
+  it('maps "Customer" to customer billing field', () => {
+    expect(suggestMapping(['Title', 'Date', 'Customer'])['customer']).toBe('Customer');
+  });
+
+  it('maps "Hobbs" to meterValue (aviation)', () => {
+    expect(suggestMapping(['Title', 'Date', 'Hobbs'])['meterValue']).toBe('Hobbs');
+  });
+
+  it('maps "Odometer" to meterValue (trucking)', () => {
+    expect(suggestMapping(['Title', 'Date', 'Odometer'])['meterValue']).toBe('Odometer');
+  });
+});
+
 // ── Preset storage ────────────────────────────────────────────────────────────
 
 describe('presets', () => {

--- a/src/core/__tests__/csvParser.test.ts
+++ b/src/core/__tests__/csvParser.test.ts
@@ -250,6 +250,26 @@ describe('mapToEvents — billing fields', () => {
     expect(errors[0]!.message).toMatch(/rate/i);
   });
 
+  it('rejects symbol-only rate ("$") instead of importing it as 0', () => {
+    const { events, errors } = mapToEvents(
+      [{ T: 'Job', S: '2026-04-10', Rate: '$' }],
+      { title: 'T', start: 'S', rate: 'Rate' },
+      'iso',
+    );
+    expect(events).toHaveLength(0);
+    expect(errors[0]!.message).toMatch(/rate/i);
+  });
+
+  it('rejects comma-only quantity (",") instead of importing it as 0', () => {
+    const { events, errors } = mapToEvents(
+      [{ T: 'Job', S: '2026-04-10', Q: ',' }],
+      { title: 'T', start: 'S', quantity: 'Q' },
+      'iso',
+    );
+    expect(events).toHaveLength(0);
+    expect(errors[0]!.message).toMatch(/quantity/i);
+  });
+
   it('does not attach meta when no billing columns map and values exist', () => {
     const { events } = mapToEvents(
       [{ T: 'Plain', S: '2026-04-10' }],

--- a/src/core/__tests__/maintenance.test.ts
+++ b/src/core/__tests__/maintenance.test.ts
@@ -210,6 +210,21 @@ describe('completeMaintenance', () => {
     expect(JSON.stringify(baseEvent)).toBe(before);
   });
 
+  it('writes nextDueCycles for cycle-based rules', () => {
+    const cycleRule: MaintenanceRule = {
+      id: 'engine-overhaul',
+      assetType: 'engine',
+      title: 'Overhaul',
+      interval: { cycles: 2_000 },
+    };
+    const { event } = completeMaintenance(
+      { id: 'evt', title: 'Overhaul', start: '2026-04-10', meta: { maintenance: { ruleId: 'engine-overhaul' } } },
+      cycleRule,
+      { assetId: 'eng-3', type: 'cycles', value: 5_400 },
+    );
+    expect((event.meta as any).maintenance.nextDueCycles).toBe(7_400);
+  });
+
   it('preserves unrelated meta keys on the event', () => {
     const eventWithExtra: WorksCalendarEvent = {
       ...baseEvent,

--- a/src/core/__tests__/maintenance.test.ts
+++ b/src/core/__tests__/maintenance.test.ts
@@ -1,0 +1,223 @@
+/**
+ * maintenance helpers — computeDueStatus / projectNextDue / completeMaintenance.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  computeDueStatus,
+  projectNextDue,
+  completeMaintenance,
+} from '../maintenance';
+import type { MaintenanceRule } from '../../types/maintenance';
+import type { WorksCalendarEvent } from '../../types/events';
+
+const oilChange: MaintenanceRule = {
+  id: 'oil-10k',
+  assetType: 'truck',
+  title: 'Oil change',
+  interval:      { miles: 10_000 },
+  warningWindow: { miles: 2_000  },
+};
+
+const dotInspection: MaintenanceRule = {
+  id: 'dot-annual',
+  assetType: 'truck',
+  title: 'DOT inspection',
+  interval:      { days: 365 },
+  warningWindow: { days: 30  },
+};
+
+const combined: MaintenanceRule = {
+  id: 'major',
+  assetType: 'truck',
+  title: 'Major service',
+  interval:      { miles: 30_000, days: 365 },
+  warningWindow: { miles: 1_500,  days: 14  },
+};
+
+// ── computeDueStatus ─────────────────────────────────────────────────────────
+
+describe('computeDueStatus', () => {
+  it('returns unknown when the rule has no interval', () => {
+    const rule: MaintenanceRule = { id: 'x', assetType: 't', title: '?' };
+    expect(computeDueStatus(rule, { meter: { type: 'miles', value: 100 } }).status).toBe('unknown');
+  });
+
+  it('returns unknown when a meter-based rule has no current reading', () => {
+    expect(computeDueStatus(oilChange, {}, { meterAtService: 100_000 }).status).toBe('unknown');
+  });
+
+  it('returns unknown when a meter-based rule has no last service', () => {
+    expect(computeDueStatus(oilChange, { meter: { type: 'miles', value: 100_000 } }).status).toBe('unknown');
+  });
+
+  it('returns ok when remaining miles exceed the warning window', () => {
+    const r = computeDueStatus(
+      oilChange,
+      { meter: { type: 'miles', value: 102_000 } },
+      { meterAtService: 100_000 },
+    );
+    expect(r.status).toBe('ok');
+    expect(r.miles).toEqual({ remaining: 8_000 }); // 100k + 10k - 102k
+  });
+
+  it('returns due-soon when remaining miles are within the warning window', () => {
+    const r = computeDueStatus(
+      oilChange,
+      { meter: { type: 'miles', value: 109_000 } },
+      { meterAtService: 100_000 },
+    );
+    expect(r.status).toBe('due-soon');
+    expect(r.miles!.remaining).toBe(1_000);
+  });
+
+  it('returns overdue with negative remaining when the meter has passed the next-due', () => {
+    const r = computeDueStatus(
+      oilChange,
+      { meter: { type: 'miles', value: 111_500 } },
+      { meterAtService: 100_000 },
+    );
+    expect(r.status).toBe('overdue');
+    expect(r.miles!.remaining).toBe(-1_500);
+  });
+
+  it('ignores meter readings of the wrong type', () => {
+    const r = computeDueStatus(
+      oilChange,
+      { meter: { type: 'hours', value: 9_000 } }, // wrong unit
+      { meterAtService: 100_000 },
+    );
+    expect(r.status).toBe('unknown');
+  });
+
+  it('handles days-only rules using lastService.completedAt', () => {
+    const completedAt = '2026-01-01T00:00:00Z';
+    const now         = new Date('2026-04-01T00:00:00Z');
+    const r = computeDueStatus(dotInspection, {}, { completedAt }, now);
+    expect(r.status).toBe('ok');
+    expect(r.days!.remaining).toBeGreaterThan(30);
+  });
+
+  it('flags days as due-soon inside the warning window', () => {
+    const completedAt = '2026-01-01T00:00:00Z';
+    const now         = new Date('2026-12-15T00:00:00Z'); // ~17 days before due
+    const r = computeDueStatus(dotInspection, {}, { completedAt }, now);
+    expect(r.status).toBe('due-soon');
+  });
+
+  it('flags days as overdue past the next-due date', () => {
+    const completedAt = '2025-01-01T00:00:00Z';
+    const now         = new Date('2026-03-01T00:00:00Z'); // ~59 days late
+    const r = computeDueStatus(dotInspection, {}, { completedAt }, now);
+    expect(r.status).toBe('overdue');
+    expect(r.days!.remaining).toBeLessThan(0);
+  });
+
+  it('promotes status to the worst dimension (miles ok + days overdue → overdue)', () => {
+    const completedAt = '2024-01-01T00:00:00Z';
+    const now         = new Date('2026-01-15T00:00:00Z'); // >365 days late
+    const r = computeDueStatus(
+      combined,
+      { meter: { type: 'miles', value: 105_000 } },
+      { meterAtService: 100_000, completedAt },
+      now,
+    );
+    expect(r.miles!.remaining).toBe(25_000); // ok in miles
+    expect(r.days!.remaining).toBeLessThan(0);
+    expect(r.status).toBe('overdue');
+  });
+});
+
+// ── projectNextDue ───────────────────────────────────────────────────────────
+
+describe('projectNextDue', () => {
+  it('projects miles from last service meter', () => {
+    expect(projectNextDue(oilChange, { meterAtService: 100_000 })).toEqual({ nextDueMiles: 110_000 });
+  });
+
+  it('projects date from last service completedAt', () => {
+    const out = projectNextDue(dotInspection, { completedAt: '2026-01-01T00:00:00Z' });
+    expect(out.nextDueDate).toBe('2027-01-01T00:00:00.000Z');
+  });
+
+  it('returns empty when interval has nothing to project against', () => {
+    expect(projectNextDue(oilChange, { completedAt: '2026-01-01' })).toEqual({});
+  });
+
+  it('returns empty when rule has no interval', () => {
+    const rule: MaintenanceRule = { id: 'x', assetType: 't', title: '?' };
+    expect(projectNextDue(rule, { meterAtService: 100, completedAt: '2026-01-01' })).toEqual({});
+  });
+
+  it('handles combined miles + days rules', () => {
+    const out = projectNextDue(combined, { meterAtService: 200_000, completedAt: '2026-01-01T00:00:00Z' });
+    expect(out.nextDueMiles).toBe(230_000);
+    expect(out.nextDueDate).toBe('2027-01-01T00:00:00.000Z');
+  });
+});
+
+// ── completeMaintenance ──────────────────────────────────────────────────────
+
+describe('completeMaintenance', () => {
+  const baseEvent: WorksCalendarEvent = {
+    id: 'evt-1',
+    title: 'Oil change',
+    start: '2026-04-10T09:00',
+    meta: { maintenance: { ruleId: 'oil-10k', lifecycle: 'in-progress' } },
+  };
+
+  it('stamps lifecycle complete, meter at service, and next-due', () => {
+    const { event } = completeMaintenance(baseEvent, oilChange, {
+      assetId: 'truck-12',
+      type:    'miles',
+      value:   110_500,
+      asOf:    '2026-04-10T11:00:00Z',
+    });
+    const maint = (event.meta as any).maintenance;
+    expect(maint.lifecycle).toBe('complete');
+    expect(maint.meterAtService).toBe(110_500);
+    expect(maint.nextDueMiles).toBe(120_500);
+    expect(maint.ruleId).toBe('oil-10k'); // preserved
+  });
+
+  it('produces a MeterReading from the supplied values', () => {
+    const { reading } = completeMaintenance(baseEvent, oilChange, {
+      assetId:    'truck-12',
+      type:       'miles',
+      value:      110_500,
+      asOf:       '2026-04-10T11:00:00Z',
+      reportedBy: 'driver-7',
+    });
+    expect(reading).toEqual({
+      assetId:    'truck-12',
+      type:       'miles',
+      value:      110_500,
+      asOf:       '2026-04-10T11:00:00Z',
+      reportedBy: 'driver-7',
+    });
+  });
+
+  it('falls back to ruleId from the rule when the event meta lacks it', () => {
+    const noRuleIdEvent: WorksCalendarEvent = { ...baseEvent, meta: { maintenance: {} } };
+    const { event } = completeMaintenance(noRuleIdEvent, oilChange, {
+      assetId: 'truck-12', type: 'miles', value: 100,
+    });
+    expect((event.meta as any).maintenance.ruleId).toBe('oil-10k');
+  });
+
+  it('does not mutate the input event', () => {
+    const before = JSON.stringify(baseEvent);
+    completeMaintenance(baseEvent, oilChange, { assetId: 'a', type: 'miles', value: 1 });
+    expect(JSON.stringify(baseEvent)).toBe(before);
+  });
+
+  it('preserves unrelated meta keys on the event', () => {
+    const eventWithExtra: WorksCalendarEvent = {
+      ...baseEvent,
+      meta: { ...baseEvent.meta, billing: { customer: 'Internal' } },
+    };
+    const { event } = completeMaintenance(eventWithExtra, oilChange, {
+      assetId: 'truck-12', type: 'miles', value: 100_000,
+    });
+    expect((event.meta as any).billing).toEqual({ customer: 'Internal' });
+  });
+});

--- a/src/core/csvParser.ts
+++ b/src/core/csvParser.ts
@@ -256,6 +256,11 @@ function _parseNum(raw: string, fieldLabel: string): number | null {
   if (!v) return null;
   // Tolerate currency symbols, thousand separators.
   const cleaned = v.replace(/[$,\s]/g, '');
+  if (!cleaned) {
+    // Original cell had content (e.g. "$" or ",") but stripping left nothing.
+    // Treat as a non-numeric value rather than silently returning 0.
+    throw new Error(`Cannot parse ${fieldLabel}: "${raw}"`);
+  }
   const n = Number(cleaned);
   if (!Number.isFinite(n)) {
     throw new Error(`Cannot parse ${fieldLabel}: "${raw}"`);

--- a/src/core/csvParser.ts
+++ b/src/core/csvParser.ts
@@ -16,15 +16,26 @@
 // ── Event fields ──────────────────────────────────────────────────────────────
 
 export const EVENT_FIELDS = [
-  { key: 'title',    label: 'Title',          required: true,  hint: 'Event name / summary'        },
-  { key: 'start',    label: 'Start',          required: true,  hint: 'Start date or date + time'   },
-  { key: 'end',      label: 'End',            required: false, hint: 'End date or date + time'     },
-  { key: 'allDay',   label: 'All-day',        required: false, hint: '"true" / "false" / "1" / "0"' },
-  { key: 'category', label: 'Category',       required: false, hint: 'Meeting, Incident, PTO, …'   },
-  { key: 'resource', label: 'Resource',       required: false, hint: 'Person, room, or team'        },
-  { key: 'status',   label: 'Status',         required: false, hint: 'confirmed / tentative / cancelled' },
-  { key: 'color',    label: 'Color',          required: false, hint: 'Hex color (#3b82f6)'          },
-  { key: 'id',       label: 'ID',             required: false, hint: 'Unique identifier'            },
+  { key: 'title',          label: 'Title',          required: true,  hint: 'Event name / summary'        },
+  { key: 'start',          label: 'Start',          required: true,  hint: 'Start date or date + time'   },
+  { key: 'end',            label: 'End',            required: false, hint: 'End date or date + time'     },
+  { key: 'allDay',         label: 'All-day',        required: false, hint: '"true" / "false" / "1" / "0"' },
+  { key: 'category',       label: 'Category',       required: false, hint: 'Meeting, Incident, PTO, …'   },
+  { key: 'resource',       label: 'Resource',       required: false, hint: 'Person, room, or team'        },
+  { key: 'status',         label: 'Status',         required: false, hint: 'confirmed / tentative / cancelled' },
+  { key: 'color',          label: 'Color',          required: false, hint: 'Hex color (#3b82f6)'          },
+  { key: 'id',             label: 'ID',             required: false, hint: 'Unique identifier'            },
+  // Billing fields → event.meta.billing
+  { key: 'billable',       label: 'Billable',       required: false, hint: '"true" / "false" / "1" / "0"' },
+  { key: 'customer',       label: 'Customer',       required: false, hint: 'Customer name or account ID'  },
+  { key: 'rate',           label: 'Rate',           required: false, hint: 'Numeric rate (per hour/job)'  },
+  { key: 'quantity',       label: 'Quantity',       required: false, hint: 'Hours, units, or jobs'        },
+  { key: 'invoiceStatus',  label: 'Invoice status', required: false, hint: 'unbilled / invoiced / paid / void' },
+  // Maintenance fields → event.meta.maintenance + event.meta.meter
+  { key: 'maintenanceRule', label: 'Maint. rule',   required: false, hint: 'Rule ID (e.g. "oil-change-10k")' },
+  { key: 'lifecycle',       label: 'Lifecycle',     required: false, hint: 'due / scheduled / in-progress / complete / skipped' },
+  { key: 'meterValue',      label: 'Meter reading', required: false, hint: 'Numeric meter value at service' },
+  { key: 'meterType',       label: 'Meter type',    required: false, hint: 'miles / hours / cycles / kilometers' },
 ];
 
 // ── Date formats ──────────────────────────────────────────────────────────────
@@ -97,10 +108,21 @@ const FIELD_HINTS: Record<string, string[]> = {
   end:      ['end', 'finish', 'to', 'enddate', 'endtime', 'until', 'thru', 'through'],
   allDay:   ['allday', 'allday', 'wholeday', 'fullday'],
   category: ['category', 'type', 'kind', 'tag', 'label', 'group', 'class'],
-  resource: ['resource', 'person', 'owner', 'assignee', 'employee', 'user', 'room', 'location'],
+  resource: ['resource', 'person', 'owner', 'assignee', 'employee', 'user', 'room', 'location', 'truck', 'asset', 'aircraft', 'tail', 'unit', 'vehicle'],
   status:   ['status', 'state', 'confirmed', 'tentative'],
   color:    ['color', 'colour'],
   id:       ['id', 'uid', 'identifier', 'key', 'ref'],
+  // Billing
+  billable:       ['billable', 'bill', 'chargeable'],
+  customer:       ['customer', 'client', 'account', 'company', 'payer'],
+  rate:           ['rate', 'price', 'cost', 'hourlyrate', 'rateperhour'],
+  quantity:       ['quantity', 'qty', 'hours', 'units', 'count'],
+  invoiceStatus:  ['invoicestatus', 'invoice', 'invoiced', 'paid', 'billingstatus'],
+  // Maintenance
+  maintenanceRule: ['maintenancerule', 'rule', 'service', 'servicetype', 'maintenance'],
+  lifecycle:       ['lifecycle', 'workstatus', 'progress', 'phase'],
+  meterValue:      ['meter', 'mileage', 'odometer', 'hobbs', 'tach', 'engine', 'cycles'],
+  meterType:       ['metertype', 'meterunit', 'unit', 'meterkind'],
 };
 
 /**
@@ -110,12 +132,21 @@ const FIELD_HINTS: Record<string, string[]> = {
 export function suggestMapping(headers: string[]): Record<string, string> {
   const mapping: Record<string, string> = {};
   const used = new Set<string>();
+  // Short hints (e.g. "to", "id", "tag") must match exactly — otherwise
+  // they'd grab unrelated headers via substring overlap (e.g. "Customer"
+  // contains "to").
+  const PARTIAL_MIN = 4;
 
   for (const [field, hints] of Object.entries(FIELD_HINTS)) {
     for (const header of headers) {
       if (used.has(header)) continue;
       const norm = header.toLowerCase().replace(/[\s_\-\.]/g, '');
-      if (hints.some(h => norm === h || norm.includes(h) || h.includes(norm))) {
+      const match = hints.some(h =>
+        norm === h ||
+        (h.length    >= PARTIAL_MIN && norm.includes(h)) ||
+        (norm.length >= PARTIAL_MIN && h.includes(norm)),
+      );
+      if (match) {
         mapping[field] = header;
         used.add(header);
         break;
@@ -146,6 +177,7 @@ type EventShape = {
   status?: string;
   color?: string;
   id: string;
+  meta?: Record<string, unknown>;
 };
 
 export function mapToEvents(
@@ -178,6 +210,8 @@ export function mapToEvents(
         ? ['true', '1', 'yes', 'y'].includes(allDayRaw.toLowerCase())
         : (!endRaw && !startRaw.includes(':') && !startRaw.includes('T'));
 
+      const meta = _buildMeta(row, mapping);
+
       const event = {
         title: title.trim(),
         start,
@@ -188,6 +222,7 @@ export function mapToEvents(
         ...(_field(row, mapping['status'])   && { status:    _field(row, mapping['status']) }),
         ...(_field(row, mapping['color'])    && { color:     _field(row, mapping['color']) }),
         id: _field(row, mapping['id']) || `csv-${Date.now()}-${autoId++}`,
+        ...(meta && { meta }),
       };
 
       events.push(event);
@@ -202,6 +237,74 @@ export function mapToEvents(
 
 function _field(row: CsvRow, header: string | undefined): string {
   return header ? (row[header] ?? '') : '';
+}
+
+// ── Meta assembly (billing + maintenance) ────────────────────────────────────
+
+const TRUTHY = new Set(['true', '1', 'yes', 'y', 't']);
+const FALSY  = new Set(['false', '0', 'no', 'n', 'f']);
+
+function _parseBool(raw: string): boolean | null {
+  const v = raw.trim().toLowerCase();
+  if (TRUTHY.has(v)) return true;
+  if (FALSY.has(v))  return false;
+  return null;
+}
+
+function _parseNum(raw: string, fieldLabel: string): number | null {
+  const v = raw.trim();
+  if (!v) return null;
+  // Tolerate currency symbols, thousand separators.
+  const cleaned = v.replace(/[$,\s]/g, '');
+  const n = Number(cleaned);
+  if (!Number.isFinite(n)) {
+    throw new Error(`Cannot parse ${fieldLabel}: "${raw}"`);
+  }
+  return n;
+}
+
+/**
+ * Build the optional `meta` object holding billing + maintenance + meter data.
+ * Returns `undefined` when no relevant columns are mapped or all values are blank,
+ * so events without these fields don't carry a meta stub.
+ */
+function _buildMeta(
+  row: CsvRow,
+  mapping: Record<string, string>,
+): Record<string, unknown> | undefined {
+  const billing: Record<string, unknown> = {};
+  const billableRaw = _field(row, mapping['billable']);
+  if (billableRaw) {
+    const b = _parseBool(billableRaw);
+    if (b !== null) billing['billable'] = b;
+  }
+  const customer = _field(row, mapping['customer']);
+  if (customer) billing['customer'] = customer;
+  const rate = _parseNum(_field(row, mapping['rate']), 'rate');
+  if (rate !== null) billing['rate'] = rate;
+  const quantity = _parseNum(_field(row, mapping['quantity']), 'quantity');
+  if (quantity !== null) billing['quantity'] = quantity;
+  const invoiceStatus = _field(row, mapping['invoiceStatus']).toLowerCase();
+  if (invoiceStatus) billing['invoiceStatus'] = invoiceStatus;
+
+  const maintenance: Record<string, unknown> = {};
+  const ruleId = _field(row, mapping['maintenanceRule']);
+  if (ruleId) maintenance['ruleId'] = ruleId;
+  const lifecycle = _field(row, mapping['lifecycle']).toLowerCase();
+  if (lifecycle) maintenance['lifecycle'] = lifecycle;
+  const meterAtService = _parseNum(_field(row, mapping['meterValue']), 'meter reading');
+  if (meterAtService !== null) maintenance['meterAtService'] = meterAtService;
+
+  const meter: Record<string, unknown> = {};
+  if (meterAtService !== null) meter['value'] = meterAtService;
+  const meterType = _field(row, mapping['meterType']).toLowerCase();
+  if (meterType) meter['type'] = meterType;
+
+  const out: Record<string, unknown> = {};
+  if (Object.keys(billing).length)     out['billing']     = billing;
+  if (Object.keys(maintenance).length) out['maintenance'] = maintenance;
+  if (Object.keys(meter).length)       out['meter']       = meter;
+  return Object.keys(out).length ? out : undefined;
 }
 
 // ── Date parsing ──────────────────────────────────────────────────────────────

--- a/src/core/maintenance.ts
+++ b/src/core/maintenance.ts
@@ -1,0 +1,197 @@
+/**
+ * Maintenance helpers — pure functions over the types in `src/types/maintenance.ts`.
+ *
+ * computeDueStatus(rule, current, lastService?, now?)  → DueResult
+ * projectNextDue(rule, lastService)                    → next-due projection
+ * completeMaintenance(event, rule, reading)            → updated event + reading
+ *
+ * No event storage, no async, no side effects. Callers feed in the relevant
+ * pieces (typically derived from prior calendar events + asset state) and get
+ * data back to display, persist, or discard.
+ */
+
+import type {
+  MaintenanceRule,
+  MaintenanceMeta,
+  MeterReading,
+  MeterType,
+} from '../types/maintenance';
+import type { WorksCalendarEvent } from '../types/events';
+
+// ── Types ────────────────────────────────────────────────────────────────────
+
+export type DueStatus = 'unknown' | 'ok' | 'due-soon' | 'overdue';
+
+export interface DueResult {
+  status: DueStatus;
+  /** Per-dimension projection. Negative `remaining` = overdue by that amount. */
+  miles?:  { remaining: number };
+  hours?:  { remaining: number };
+  days?:   { remaining: number };
+  cycles?: { remaining: number };
+}
+
+export interface CurrentState {
+  /** Most recent meter reading for the asset, if any. */
+  meter?: { type: MeterType; value: number };
+}
+
+export interface LastService {
+  /** Meter value at the moment the last service completed. */
+  meterAtService?: number;
+  /** ISO-8601 timestamp the last service completed. */
+  completedAt?: string;
+}
+
+export interface NextDueProjection {
+  nextDueMiles?: number;
+  nextDueHours?: number;
+  nextDueCycles?: number;
+  /** ISO-8601 date string. */
+  nextDueDate?: string;
+}
+
+// ── computeDueStatus ─────────────────────────────────────────────────────────
+
+const MS_PER_DAY = 86_400_000;
+/** Worst dimension drives the overall status. */
+const SEVERITY: Record<DueStatus, number> = { unknown: 0, ok: 1, 'due-soon': 2, overdue: 3 };
+
+export function computeDueStatus(
+  rule: MaintenanceRule,
+  current: CurrentState,
+  lastService: LastService = {},
+  now: Date = new Date(),
+): DueResult {
+  const interval = rule.interval;
+  const warning  = rule.warningWindow ?? {};
+
+  if (!interval) return { status: 'unknown' };
+
+  const result: DueResult = { status: 'unknown' };
+  let worst: DueStatus = 'unknown';
+  const promote = (s: DueStatus) => { if (SEVERITY[s] > SEVERITY[worst]) worst = s; };
+
+  // Meter-based dimensions. Each requires both the rule interval AND a current
+  // reading whose meter type matches the dimension we're evaluating.
+  const meterValue = current.meter?.value;
+  const meterType  = current.meter?.type;
+
+  const meterDim = (
+    key: 'miles' | 'hours' | 'cycles',
+    matchType: MeterType,
+  ) => {
+    const intervalAmt = interval[key];
+    if (intervalAmt == null) return;
+    if (meterValue == null || meterType !== matchType || lastService.meterAtService == null) {
+      promote('unknown');
+      return;
+    }
+    const nextDue   = lastService.meterAtService + intervalAmt;
+    const remaining = nextDue - meterValue;
+    result[key] = { remaining };
+    if (remaining < 0) promote('overdue');
+    else if (warning[key] != null && remaining <= warning[key]!) promote('due-soon');
+    else promote('ok');
+  };
+
+  meterDim('miles',  'miles');
+  meterDim('hours',  'hours');
+  meterDim('cycles', 'cycles');
+
+  // Days dimension — relative to lastService.completedAt.
+  if (interval.days != null) {
+    if (!lastService.completedAt) {
+      promote('unknown');
+    } else {
+      const completed = new Date(lastService.completedAt);
+      if (isNaN(completed.getTime())) {
+        promote('unknown');
+      } else {
+        const dueAt     = completed.getTime() + interval.days * MS_PER_DAY;
+        const remaining = Math.floor((dueAt - now.getTime()) / MS_PER_DAY);
+        result.days = { remaining };
+        if (remaining < 0) promote('overdue');
+        else if (warning.days != null && remaining <= warning.days) promote('due-soon');
+        else promote('ok');
+      }
+    }
+  }
+
+  result.status = worst;
+  return result;
+}
+
+// ── projectNextDue ───────────────────────────────────────────────────────────
+
+export function projectNextDue(
+  rule: MaintenanceRule,
+  lastService: LastService,
+): NextDueProjection {
+  const out: NextDueProjection = {};
+  const interval = rule.interval;
+  if (!interval) return out;
+
+  if (interval.miles  != null && lastService.meterAtService != null) out.nextDueMiles  = lastService.meterAtService + interval.miles;
+  if (interval.hours  != null && lastService.meterAtService != null) out.nextDueHours  = lastService.meterAtService + interval.hours;
+  if (interval.cycles != null && lastService.meterAtService != null) out.nextDueCycles = lastService.meterAtService + interval.cycles;
+
+  if (interval.days != null && lastService.completedAt) {
+    const completed = new Date(lastService.completedAt);
+    if (!isNaN(completed.getTime())) {
+      const due = new Date(completed.getTime() + interval.days * MS_PER_DAY);
+      out.nextDueDate = due.toISOString();
+    }
+  }
+
+  return out;
+}
+
+// ── completeMaintenance ──────────────────────────────────────────────────────
+
+/**
+ * Mark a maintenance event complete: stamps lifecycle, meter, and projected
+ * next-due fields on `event.meta.maintenance`, and produces a `MeterReading`
+ * the caller can append to its history. Pure — does not mutate inputs.
+ */
+export function completeMaintenance(
+  event: WorksCalendarEvent,
+  rule: MaintenanceRule,
+  reading: { assetId: string; type: MeterType; value: number; asOf?: string; reportedBy?: string },
+): { event: WorksCalendarEvent; reading: MeterReading } {
+  const asOf = reading.asOf ?? new Date().toISOString();
+
+  const projection = projectNextDue(rule, {
+    meterAtService: reading.value,
+    completedAt:    asOf,
+  });
+
+  const prior = (event.meta?.['maintenance'] as MaintenanceMeta | undefined) ?? {};
+  const maintenance: MaintenanceMeta = {
+    ...prior,
+    ruleId: prior.ruleId ?? rule.id,
+    lifecycle: 'complete',
+    meterAtService: reading.value,
+    ...(projection.nextDueMiles != null && { nextDueMiles: projection.nextDueMiles }),
+    ...(projection.nextDueHours != null && { nextDueHours: projection.nextDueHours }),
+    ...(projection.nextDueDate           && { nextDueDate: projection.nextDueDate }),
+  };
+
+  const nextEvent: WorksCalendarEvent = {
+    ...event,
+    meta: {
+      ...(event.meta ?? {}),
+      maintenance,
+    },
+  };
+
+  const meterReading: MeterReading = {
+    assetId: reading.assetId,
+    type:    reading.type,
+    value:   reading.value,
+    asOf,
+    ...(reading.reportedBy && { reportedBy: reading.reportedBy }),
+  };
+
+  return { event: nextEvent, reading: meterReading };
+}

--- a/src/core/maintenance.ts
+++ b/src/core/maintenance.ts
@@ -172,9 +172,10 @@ export function completeMaintenance(
     ruleId: prior.ruleId ?? rule.id,
     lifecycle: 'complete',
     meterAtService: reading.value,
-    ...(projection.nextDueMiles != null && { nextDueMiles: projection.nextDueMiles }),
-    ...(projection.nextDueHours != null && { nextDueHours: projection.nextDueHours }),
-    ...(projection.nextDueDate           && { nextDueDate: projection.nextDueDate }),
+    ...(projection.nextDueMiles  != null && { nextDueMiles:  projection.nextDueMiles }),
+    ...(projection.nextDueHours  != null && { nextDueHours:  projection.nextDueHours }),
+    ...(projection.nextDueCycles != null && { nextDueCycles: projection.nextDueCycles }),
+    ...(projection.nextDueDate            && { nextDueDate:  projection.nextDueDate }),
   };
 
   const nextEvent: WorksCalendarEvent = {

--- a/src/export/__tests__/invoiceExport.test.ts
+++ b/src/export/__tests__/invoiceExport.test.ts
@@ -1,0 +1,159 @@
+/**
+ * invoiceExport — pure transform + CSV serialization.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  toInvoiceLineItems,
+  invoiceLineItemsToCSV,
+} from '../invoiceExport';
+import type { NormalizedEvent } from '../../types/events';
+
+function makeEvent(overrides: Partial<NormalizedEvent> = {}): NormalizedEvent {
+  return {
+    id:    'evt-1',
+    title: 'Job',
+    start: new Date('2026-04-10T09:00:00Z'),
+    end:   new Date('2026-04-10T11:00:00Z'),
+    allDay: false,
+    category: null,
+    color:    '#3b82f6',
+    resource: 'truck-12',
+    status:   'confirmed',
+    meta:     {},
+    rrule:    null,
+    exdates:  [],
+    _raw:     {} as any,
+    ...overrides,
+  };
+}
+
+// ── toInvoiceLineItems ───────────────────────────────────────────────────────
+
+describe('toInvoiceLineItems', () => {
+  it('skips events with no meta.billing', () => {
+    expect(toInvoiceLineItems([makeEvent()])).toEqual([]);
+  });
+
+  it('emits a line item with all fields populated when billing is set', () => {
+    const ev = makeEvent({
+      meta: { billing: {
+        billable: true, customer: 'ABC Logistics', rate: 120, quantity: 2,
+        currency: 'USD', invoiceStatus: 'unbilled', description: 'Transit',
+      } },
+    });
+    const [item] = toInvoiceLineItems([ev]);
+    expect(item).toEqual({
+      eventId:     'evt-1',
+      date:        ev.start,
+      customer:    'ABC Logistics',
+      description: 'Transit',
+      quantity:    2,
+      rate:        120,
+      total:       240,
+      currency:    'USD',
+      status:      'unbilled',
+    });
+  });
+
+  it('falls back to event title when description is absent', () => {
+    const ev = makeEvent({ title: 'Box truck run', meta: { billing: { rate: 50 } } });
+    expect(toInvoiceLineItems([ev])[0]!.description).toBe('Box truck run');
+  });
+
+  it('derives quantity from event duration in hours by default (2-hour event → 2)', () => {
+    const ev = makeEvent({ meta: { billing: { rate: 100 } } });
+    const [item] = toInvoiceLineItems([ev]);
+    expect(item!.quantity).toBe(2);
+    expect(item!.total).toBe(200);
+  });
+
+  it('derives quantity in days when quantityFrom: duration-days', () => {
+    const ev = makeEvent({
+      start: new Date('2026-04-10T00:00:00Z'),
+      end:   new Date('2026-04-12T12:00:00Z'),
+      meta:  { billing: { rate: 250 } },
+    });
+    const [item] = toInvoiceLineItems([ev], { quantityFrom: 'duration-days' });
+    expect(item!.quantity).toBe(2.5);
+    expect(item!.total).toBe(625);
+  });
+
+  it('leaves quantity at 0 when quantityFrom: none and no explicit quantity', () => {
+    const ev = makeEvent({ meta: { billing: { rate: 100 } } });
+    const [item] = toInvoiceLineItems([ev], { quantityFrom: 'none' });
+    expect(item!.quantity).toBe(0);
+    expect(item!.total).toBe(0);
+  });
+
+  it('leaves total null when rate is absent', () => {
+    const ev = makeEvent({ meta: { billing: { quantity: 3 } } });
+    expect(toInvoiceLineItems([ev])[0]!.total).toBeNull();
+    expect(toInvoiceLineItems([ev])[0]!.rate).toBeNull();
+  });
+
+  it('defaults status to "unbilled" when invoiceStatus is absent', () => {
+    const ev = makeEvent({ meta: { billing: { rate: 50 } } });
+    expect(toInvoiceLineItems([ev])[0]!.status).toBe('unbilled');
+  });
+
+  it('honors onlyBillable: true to drop billable=false events', () => {
+    const billable    = makeEvent({ id: 'a', meta: { billing: { billable: true,  rate: 50 } } });
+    const nonBillable = makeEvent({ id: 'b', meta: { billing: { billable: false, rate: 50 } } });
+    const unspecified = makeEvent({ id: 'c', meta: { billing: { rate: 50 } } });
+    const ids = toInvoiceLineItems([billable, nonBillable, unspecified], { onlyBillable: true })
+      .map(i => i.eventId);
+    expect(ids).toEqual(['a', 'c']); // unspecified absence is included
+  });
+
+  it('filters by status when provided', () => {
+    const a = makeEvent({ id: 'a', meta: { billing: { rate: 1, invoiceStatus: 'unbilled' } } });
+    const b = makeEvent({ id: 'b', meta: { billing: { rate: 1, invoiceStatus: 'invoiced' } } });
+    const c = makeEvent({ id: 'c', meta: { billing: { rate: 1, invoiceStatus: 'paid' } } });
+    const ids = toInvoiceLineItems([a, b, c], { statuses: ['invoiced', 'paid'] }).map(i => i.eventId);
+    expect(ids).toEqual(['b', 'c']);
+  });
+
+  it('rounds derived quantity to 2 decimal places', () => {
+    const ev = makeEvent({
+      start: new Date('2026-04-10T09:00:00Z'),
+      end:   new Date('2026-04-10T09:20:00Z'), // 0.333… hours
+      meta:  { billing: { rate: 60 } },
+    });
+    const [item] = toInvoiceLineItems([ev]);
+    expect(item!.quantity).toBe(0.33);
+    expect(item!.total).toBe(19.8); // 0.33 * 60
+  });
+
+  it('treats malformed meta.billing (non-object) as absent', () => {
+    const ev = makeEvent({ meta: { billing: 'oops' as unknown as object } });
+    expect(toInvoiceLineItems([ev])).toEqual([]);
+  });
+});
+
+// ── invoiceLineItemsToCSV ────────────────────────────────────────────────────
+
+describe('invoiceLineItemsToCSV', () => {
+  it('emits headers + a row, ISO-formatted date, blank for nulls', () => {
+    const ev = makeEvent({
+      meta: { billing: { customer: 'ABC', rate: 100, invoiceStatus: 'paid' } },
+    });
+    const csv = invoiceLineItemsToCSV(toInvoiceLineItems([ev]));
+    const [header, row] = csv.split('\n');
+    expect(header).toBe('"Event ID","Date","Customer","Description","Quantity","Rate","Total","Currency","Status"');
+    expect(row).toBe('"evt-1","2026-04-10","ABC","Job","2","100","200","","paid"');
+  });
+
+  it('escapes embedded quotes in description', () => {
+    const ev = makeEvent({
+      title: 'She said "hi"',
+      meta:  { billing: { rate: 50 } },
+    });
+    const csv = invoiceLineItemsToCSV(toInvoiceLineItems([ev]));
+    expect(csv.split('\n')[1]).toContain('"She said ""hi"""');
+  });
+
+  it('emits a header-only CSV for empty input (accounting tools import cleanly)', () => {
+    const csv = invoiceLineItemsToCSV([]);
+    expect(csv).toBe('"Event ID","Date","Customer","Description","Quantity","Rate","Total","Currency","Status"');
+  });
+});

--- a/src/export/__tests__/maintenanceExport.test.ts
+++ b/src/export/__tests__/maintenanceExport.test.ts
@@ -1,0 +1,133 @@
+/**
+ * maintenanceExport — pure transform + CSV serialization.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  toMaintenanceLog,
+  maintenanceLogToCSV,
+} from '../maintenanceExport';
+import type { NormalizedEvent } from '../../types/events';
+import type { MaintenanceRule } from '../../types/maintenance';
+
+function makeEvent(overrides: Partial<NormalizedEvent> = {}): NormalizedEvent {
+  return {
+    id: 'evt-1',
+    title: 'Service work',
+    start: new Date('2026-04-10T09:00:00Z'),
+    end:   new Date('2026-04-10T11:00:00Z'),
+    allDay: false,
+    category: null,
+    color: '#3b82f6',
+    resource: 'truck-12',
+    status: 'confirmed',
+    meta: {},
+    rrule: null,
+    exdates: [],
+    _raw: {} as any,
+    ...overrides,
+  };
+}
+
+const oilChange: MaintenanceRule = {
+  id: 'oil-10k',
+  assetType: 'truck',
+  title: 'Oil change',
+  interval: { miles: 10_000 },
+};
+
+// ── toMaintenanceLog ─────────────────────────────────────────────────────────
+
+describe('toMaintenanceLog', () => {
+  it('skips events with no meta.maintenance', () => {
+    expect(toMaintenanceLog([makeEvent()])).toEqual([]);
+  });
+
+  it('emits an entry with all fields populated when maintenance meta is set', () => {
+    const ev = makeEvent({
+      meta: { maintenance: {
+        ruleId: 'oil-10k', lifecycle: 'complete',
+        meterAtService: 110_500, nextDueMiles: 120_500,
+        notes: 'Filter changed too',
+      } },
+    });
+    const [entry] = toMaintenanceLog([ev], { rules: [oilChange] });
+    expect(entry).toEqual({
+      eventId:        'evt-1',
+      date:           ev.start,
+      asset:          'truck-12',
+      rule:           'Oil change',
+      ruleId:         'oil-10k',
+      lifecycle:      'complete',
+      meterAtService: 110_500,
+      nextDueMiles:   120_500,
+      nextDueHours:   null,
+      nextDueCycles:  null,
+      nextDueDate:    null,
+      notes:          'Filter changed too',
+    });
+  });
+
+  it('falls back to ruleId for rule label when rules registry is omitted', () => {
+    const ev = makeEvent({ meta: { maintenance: { ruleId: 'unknown-rule', lifecycle: 'scheduled' } } });
+    const [entry] = toMaintenanceLog([ev]);
+    expect(entry!.rule).toBe('unknown-rule');
+  });
+
+  it('null-fills missing numeric fields rather than omitting the column', () => {
+    const ev = makeEvent({ meta: { maintenance: { ruleId: 'oil-10k', lifecycle: 'due' } } });
+    const [entry] = toMaintenanceLog([ev]);
+    expect(entry!.meterAtService).toBeNull();
+    expect(entry!.nextDueMiles).toBeNull();
+    expect(entry!.nextDueDate).toBeNull();
+    expect(entry!.notes).toBe(''); // notes default to '' not null
+  });
+
+  it('filters by lifecycle when provided', () => {
+    const a = makeEvent({ id: 'a', meta: { maintenance: { ruleId: 'r', lifecycle: 'scheduled' } } });
+    const b = makeEvent({ id: 'b', meta: { maintenance: { ruleId: 'r', lifecycle: 'complete'  } } });
+    const c = makeEvent({ id: 'c', meta: { maintenance: { ruleId: 'r' } } }); // no lifecycle
+    const ids = toMaintenanceLog([a, b, c], { lifecycles: ['complete'] }).map(e => e.eventId);
+    expect(ids).toEqual(['b']);
+  });
+
+  it('rule field is null when meta has no ruleId', () => {
+    const ev = makeEvent({ meta: { maintenance: { lifecycle: 'due' } } });
+    const [entry] = toMaintenanceLog([ev]);
+    expect(entry!.rule).toBeNull();
+    expect(entry!.ruleId).toBeNull();
+  });
+
+  it('treats malformed meta.maintenance (non-object) as absent', () => {
+    const ev = makeEvent({ meta: { maintenance: 'oops' as unknown as object } });
+    expect(toMaintenanceLog([ev])).toEqual([]);
+  });
+});
+
+// ── maintenanceLogToCSV ──────────────────────────────────────────────────────
+
+describe('maintenanceLogToCSV', () => {
+  it('emits headers + a row with ISO date and slice of nextDueDate', () => {
+    const ev = makeEvent({
+      meta: { maintenance: {
+        ruleId: 'oil-10k', lifecycle: 'complete',
+        meterAtService: 110_500, nextDueMiles: 120_500,
+        nextDueDate: '2027-04-10T00:00:00.000Z',
+      } },
+    });
+    const csv = maintenanceLogToCSV(toMaintenanceLog([ev], { rules: [oilChange] }));
+    const [header, row] = csv.split('\n');
+    expect(header).toBe(
+      '"Event ID","Date","Asset","Rule","Rule ID","Lifecycle","Meter at service","Next due (miles)","Next due (hours)","Next due (cycles)","Next due (date)","Notes"',
+    );
+    expect(row).toBe(
+      '"evt-1","2026-04-10","truck-12","Oil change","oil-10k","complete","110500","120500","","","2027-04-10",""',
+    );
+  });
+
+  it('emits a header-only CSV for empty input', () => {
+    const csv = maintenanceLogToCSV([]);
+    expect(csv).toBe(
+      '"Event ID","Date","Asset","Rule","Rule ID","Lifecycle","Meter at service","Next due (miles)","Next due (hours)","Next due (cycles)","Next due (date)","Notes"',
+    );
+  });
+});

--- a/src/export/invoiceExport.ts
+++ b/src/export/invoiceExport.ts
@@ -1,0 +1,162 @@
+/**
+ * invoiceExport — pluggable export for billable events.
+ *
+ * Three layers:
+ *   1. toInvoiceLineItems(events, options?)   — pure data transform
+ *   2. invoiceLineItemsToCSV(items)           — pure CSV string
+ *   3. downloadInvoicesCSV(events, …)         — browser download convenience
+ *
+ * The library does not produce invoices; it produces the structured line-item
+ * data a downstream system (QuickBooks, Stripe, your accountant's CSV import)
+ * can consume. Source data lives on `event.meta.billing` (BillableMeta).
+ */
+import type { NormalizedEvent } from '../types/events';
+import type { BillableMeta, InvoiceLineItem, InvoiceStatus } from '../types/billing';
+
+const MS_PER_HOUR = 3_600_000;
+const MS_PER_DAY  = 86_400_000;
+
+export type InvoiceQuantitySource = 'duration-hours' | 'duration-days' | 'none';
+
+export interface InvoiceLineItemsOptions {
+  /** Exclude events where `meta.billing.billable === false`. Events with the
+   *  flag absent are still included by default — absence means "not specified",
+   *  not "non-billable". Set this to `true` only when you trust the flag. */
+  onlyBillable?: boolean;
+  /** Restrict output to line items with one of these statuses. Default: all. */
+  statuses?: readonly InvoiceStatus[];
+  /** How to compute `quantity` when meta.billing.quantity is absent.
+   *  - 'duration-hours' (default): event duration in hours, rounded to 2 dec.
+   *  - 'duration-days':  event duration in days, rounded to 2 dec.
+   *  - 'none':           leave quantity at 0 when not explicitly set. */
+  quantityFrom?: InvoiceQuantitySource;
+}
+
+/**
+ * Transform NormalizedEvents into a flat InvoiceLineItem[] ready for
+ * downstream invoicing tools. Events without `meta.billing` are skipped.
+ */
+export function toInvoiceLineItems(
+  events: readonly NormalizedEvent[],
+  options: InvoiceLineItemsOptions = {},
+): InvoiceLineItem[] {
+  const onlyBillable = options.onlyBillable ?? false;
+  const statuses     = options.statuses;
+  const quantityFrom = options.quantityFrom ?? 'duration-hours';
+
+  const out: InvoiceLineItem[] = [];
+
+  for (const ev of events) {
+    const billing = readBilling(ev);
+    if (!billing) continue;
+    if (onlyBillable && billing.billable === false) continue;
+
+    const status: InvoiceStatus = billing.invoiceStatus ?? 'unbilled';
+    if (statuses && !statuses.includes(status)) continue;
+
+    const quantity = billing.quantity ?? deriveQuantity(ev, quantityFrom);
+    const rate     = billing.rate     ?? null;
+    const total    = rate != null ? round2(rate * quantity) : null;
+
+    out.push({
+      eventId:     ev.id,
+      date:        ev.start,
+      customer:    billing.customer ?? null,
+      description: billing.description ?? ev.title,
+      quantity,
+      rate,
+      total,
+      currency:    billing.currency ?? null,
+      status,
+    });
+  }
+
+  return out;
+}
+
+// ── CSV serialization ────────────────────────────────────────────────────────
+
+const INVOICE_HEADERS = [
+  'Event ID',
+  'Date',
+  'Customer',
+  'Description',
+  'Quantity',
+  'Rate',
+  'Total',
+  'Currency',
+  'Status',
+] as const;
+
+export function invoiceLineItemsToCSV(items: readonly InvoiceLineItem[]): string {
+  const rows = items.map(it => [
+    it.eventId,
+    formatDate(it.date),
+    it.customer ?? '',
+    it.description,
+    String(it.quantity),
+    it.rate  != null ? String(it.rate)  : '',
+    it.total != null ? String(it.total) : '',
+    it.currency ?? '',
+    it.status,
+  ]);
+  return toCSV([INVOICE_HEADERS as readonly string[], ...rows]);
+}
+
+// ── Browser download ─────────────────────────────────────────────────────────
+
+/**
+ * Convenience: transform → CSV → trigger a browser download. Skipped silently
+ * when called outside the browser (no `document`).
+ */
+export function downloadInvoicesCSV(
+  events: readonly NormalizedEvent[],
+  options: InvoiceLineItemsOptions = {},
+  filename = 'invoices',
+): void {
+  const items = toInvoiceLineItems(events, options);
+  const csv   = invoiceLineItemsToCSV(items);
+  downloadCSV(csv, `${filename}.csv`);
+}
+
+// ── helpers ──────────────────────────────────────────────────────────────────
+
+function readBilling(ev: NormalizedEvent): BillableMeta | null {
+  const candidate = ev.meta?.['billing'];
+  return candidate && typeof candidate === 'object' ? (candidate as BillableMeta) : null;
+}
+
+function deriveQuantity(ev: NormalizedEvent, mode: InvoiceQuantitySource): number {
+  if (mode === 'none') return 0;
+  const ms = ev.end.getTime() - ev.start.getTime();
+  if (!Number.isFinite(ms) || ms <= 0) return 0;
+  if (mode === 'duration-days') return round2(ms / MS_PER_DAY);
+  return round2(ms / MS_PER_HOUR);
+}
+
+function round2(n: number): number {
+  return Math.round(n * 100) / 100;
+}
+
+function formatDate(d: Date): string {
+  // ISO date (yyyy-mm-dd) — matches what most accounting tools want.
+  if (!(d instanceof Date) || isNaN(d.getTime())) return '';
+  return d.toISOString().slice(0, 10);
+}
+
+function toCSV(rows: readonly (readonly string[])[]): string {
+  if (rows.length === 0) return '';
+  const escape = (v: string) => `"${v.replace(/"/g, '""')}"`;
+  return rows.map(r => r.map(escape).join(',')).join('\n');
+}
+
+function downloadCSV(content: string, filename: string): void {
+  if (typeof document === 'undefined') return;
+  const blob = new Blob([content], { type: 'text/csv;charset=utf-8;' });
+  const url  = URL.createObjectURL(blob);
+  const a    = Object.assign(document.createElement('a'), { href: url, download: filename });
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
+  URL.revokeObjectURL(url);
+}

--- a/src/export/maintenanceExport.ts
+++ b/src/export/maintenanceExport.ts
@@ -1,0 +1,168 @@
+/**
+ * maintenanceExport — pluggable export for maintenance work events.
+ *
+ * Three layers:
+ *   1. toMaintenanceLog(events, options?)     — pure data transform
+ *   2. maintenanceLogToCSV(entries)           — pure CSV string
+ *   3. downloadMaintenanceLogCSV(events, …)   — browser download convenience
+ *
+ * Source data lives on `event.meta.maintenance` (MaintenanceMeta). Pass the
+ * rules array via options to get human-readable rule titles in the output.
+ */
+import type { NormalizedEvent } from '../types/events';
+import type {
+  MaintenanceMeta,
+  MaintenanceLifecycle,
+  MaintenanceRule,
+} from '../types/maintenance';
+
+export interface MaintenanceLogEntry {
+  eventId: string;
+  date: Date;
+  /** Asset id from `event.resource`. May be null when the event has none. */
+  asset: string | null;
+  /** Human-readable rule title from the supplied rules array. Falls back to ruleId. */
+  rule: string | null;
+  ruleId: string | null;
+  lifecycle: MaintenanceLifecycle | null;
+  meterAtService: number | null;
+  nextDueMiles: number | null;
+  nextDueHours: number | null;
+  nextDueCycles: number | null;
+  /** ISO-8601 date string from MaintenanceMeta.nextDueDate. */
+  nextDueDate: string | null;
+  notes: string;
+}
+
+export interface MaintenanceLogOptions {
+  /** Filter to entries with one of these lifecycles. Default: all maintenance events. */
+  lifecycles?: readonly MaintenanceLifecycle[];
+  /** Rules registry — used to resolve `ruleId` → human-readable `rule`. */
+  rules?: readonly MaintenanceRule[];
+}
+
+/**
+ * Transform NormalizedEvents into a flat MaintenanceLogEntry[] for downstream
+ * reporting. Events without `meta.maintenance` are skipped.
+ */
+export function toMaintenanceLog(
+  events: readonly NormalizedEvent[],
+  options: MaintenanceLogOptions = {},
+): MaintenanceLogEntry[] {
+  const lifecycles = options.lifecycles;
+  const rulesById  = indexRules(options.rules);
+
+  const out: MaintenanceLogEntry[] = [];
+
+  for (const ev of events) {
+    const m = readMaintenance(ev);
+    if (!m) continue;
+    const lifecycle = m.lifecycle ?? null;
+    if (lifecycles && (lifecycle == null || !lifecycles.includes(lifecycle))) continue;
+
+    const ruleId = m.ruleId ?? null;
+    const rule   = ruleId
+      ? (rulesById?.get(ruleId)?.title ?? ruleId)
+      : null;
+
+    out.push({
+      eventId:        ev.id,
+      date:           ev.start,
+      asset:          ev.resource,
+      rule,
+      ruleId,
+      lifecycle,
+      meterAtService: m.meterAtService ?? null,
+      nextDueMiles:   m.nextDueMiles   ?? null,
+      nextDueHours:   m.nextDueHours   ?? null,
+      nextDueCycles:  m.nextDueCycles  ?? null,
+      nextDueDate:    m.nextDueDate    ?? null,
+      notes:          m.notes ?? '',
+    });
+  }
+
+  return out;
+}
+
+// ── CSV serialization ────────────────────────────────────────────────────────
+
+const MAINTENANCE_HEADERS = [
+  'Event ID',
+  'Date',
+  'Asset',
+  'Rule',
+  'Rule ID',
+  'Lifecycle',
+  'Meter at service',
+  'Next due (miles)',
+  'Next due (hours)',
+  'Next due (cycles)',
+  'Next due (date)',
+  'Notes',
+] as const;
+
+export function maintenanceLogToCSV(entries: readonly MaintenanceLogEntry[]): string {
+  const rows = entries.map(e => [
+    e.eventId,
+    formatDate(e.date),
+    e.asset ?? '',
+    e.rule  ?? '',
+    e.ruleId ?? '',
+    e.lifecycle ?? '',
+    e.meterAtService != null ? String(e.meterAtService) : '',
+    e.nextDueMiles   != null ? String(e.nextDueMiles)   : '',
+    e.nextDueHours   != null ? String(e.nextDueHours)   : '',
+    e.nextDueCycles  != null ? String(e.nextDueCycles)  : '',
+    e.nextDueDate ? e.nextDueDate.slice(0, 10) : '',
+    e.notes,
+  ]);
+  return toCSV([MAINTENANCE_HEADERS as readonly string[], ...rows]);
+}
+
+// ── Browser download ─────────────────────────────────────────────────────────
+
+export function downloadMaintenanceLogCSV(
+  events: readonly NormalizedEvent[],
+  options: MaintenanceLogOptions = {},
+  filename = 'maintenance-log',
+): void {
+  const entries = toMaintenanceLog(events, options);
+  const csv     = maintenanceLogToCSV(entries);
+  downloadCSV(csv, `${filename}.csv`);
+}
+
+// ── helpers ──────────────────────────────────────────────────────────────────
+
+function readMaintenance(ev: NormalizedEvent): MaintenanceMeta | null {
+  const candidate = ev.meta?.['maintenance'];
+  return candidate && typeof candidate === 'object' ? (candidate as MaintenanceMeta) : null;
+}
+
+function indexRules(rules: readonly MaintenanceRule[] | undefined): Map<string, MaintenanceRule> | null {
+  if (!rules || !rules.length) return null;
+  const m = new Map<string, MaintenanceRule>();
+  for (const r of rules) m.set(r.id, r);
+  return m;
+}
+
+function formatDate(d: Date): string {
+  if (!(d instanceof Date) || isNaN(d.getTime())) return '';
+  return d.toISOString().slice(0, 10);
+}
+
+function toCSV(rows: readonly (readonly string[])[]): string {
+  if (rows.length === 0) return '';
+  const escape = (v: string) => `"${v.replace(/"/g, '""')}"`;
+  return rows.map(r => r.map(escape).join(',')).join('\n');
+}
+
+function downloadCSV(content: string, filename: string): void {
+  if (typeof document === 'undefined') return;
+  const blob = new Blob([content], { type: 'text/csv;charset=utf-8;' });
+  const url  = URL.createObjectURL(blob);
+  const a    = Object.assign(document.createElement('a'), { href: url, download: filename });
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
+  URL.revokeObjectURL(url);
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,6 +18,18 @@ export type {
   MeterReading,
   MeterType,
 } from './types/maintenance';
+export {
+  computeDueStatus,
+  projectNextDue,
+  completeMaintenance,
+} from './core/maintenance';
+export type {
+  DueStatus,
+  DueResult,
+  CurrentState,
+  LastService,
+  NextDueProjection,
+} from './core/maintenance';
 export type {
   ConfigPanelProps,
   ConfigPanelTabId,

--- a/src/index.ts
+++ b/src/index.ts
@@ -55,6 +55,24 @@ export { normalizeEvent, normalizeEvents } from './core/eventModel';
 export { loadConfig, saveConfig, DEFAULT_CONFIG, FIELD_TYPES } from './core/configSchema';
 export { applyFilters, getCategories, getResources } from './filters/filterEngine';
 export { exportToExcel }                  from './export/exportToExcelLazy';
+export {
+  toInvoiceLineItems,
+  invoiceLineItemsToCSV,
+  downloadInvoicesCSV,
+} from './export/invoiceExport';
+export type {
+  InvoiceLineItemsOptions,
+  InvoiceQuantitySource,
+} from './export/invoiceExport';
+export {
+  toMaintenanceLog,
+  maintenanceLogToCSV,
+  downloadMaintenanceLogCSV,
+} from './export/maintenanceExport';
+export type {
+  MaintenanceLogEntry,
+  MaintenanceLogOptions,
+} from './export/maintenanceExport';
 export { useCalendar }                    from './hooks/useCalendar';
 export { useOwnerConfig }                 from './hooks/useOwnerConfig';
 export { useRealtimeEvents }              from './hooks/useRealtimeEvents';

--- a/src/index.ts
+++ b/src/index.ts
@@ -34,6 +34,8 @@ export { MaintenanceBadge }       from './ui/MaintenanceBadge';
 export type { MaintenanceBadgeProps } from './ui/MaintenanceBadge';
 export { AssetMaintenanceBadges } from './ui/AssetMaintenanceBadges';
 export type { AssetMaintenanceBadgesProps } from './ui/AssetMaintenanceBadges';
+export { MaintenanceSection }     from './ui/EventFormSections/MaintenanceSection';
+export type { MaintenanceSectionProps } from './ui/EventFormSections/MaintenanceSection';
 export type {
   ConfigPanelProps,
   ConfigPanelTabId,

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,6 +30,10 @@ export type {
   LastService,
   NextDueProjection,
 } from './core/maintenance';
+export { MaintenanceBadge }       from './ui/MaintenanceBadge';
+export type { MaintenanceBadgeProps } from './ui/MaintenanceBadge';
+export { AssetMaintenanceBadges } from './ui/AssetMaintenanceBadges';
+export type { AssetMaintenanceBadgesProps } from './ui/AssetMaintenanceBadges';
 export type {
   ConfigPanelProps,
   ConfigPanelTabId,

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,17 @@ export * from './api/v1/index';
 
 export type { WorksCalendarEvent, NormalizedEvent, EventStatus, EventVisualPriority } from './types/events';
 export { isVisualPriority } from './types/events';
+export type { BillableMeta, InvoiceLineItem, InvoiceStatus } from './types/billing';
+export type {
+  AssetHealth,
+  AssetHealthStatus,
+  MaintenanceMeta,
+  MaintenanceRule,
+  MaintenanceInterval,
+  MaintenanceLifecycle,
+  MeterReading,
+  MeterType,
+} from './types/maintenance';
 export type {
   ConfigPanelProps,
   ConfigPanelTabId,

--- a/src/types/billing.ts
+++ b/src/types/billing.ts
@@ -1,0 +1,46 @@
+/**
+ * Billing types — typed metadata that hangs off `WorksCalendarEvent.meta.billing`.
+ *
+ * Kept intentionally minimal: this is the import/export contract for plugging
+ * WorksCalendar into a downstream invoicing system (QuickBooks, Stripe, a CSV
+ * import in the user's accounting tool, etc.). The library does not produce
+ * invoices itself.
+ */
+
+export type InvoiceStatus = 'unbilled' | 'invoiced' | 'paid' | 'void';
+
+export interface BillableMeta {
+  /** Whether this event represents billable work. Absence == unknown. */
+  billable?: boolean;
+  /** Free-form customer identifier (name, ID, account number — consumer's choice). */
+  customer?: string;
+  /** Numeric rate. Units are consumer-defined (per hour, per job, per mile). */
+  rate?: number;
+  /** Optional explicit quantity. If absent, downstream may derive from event duration. */
+  quantity?: number;
+  /** Currency code (ISO 4217) when known. */
+  currency?: string;
+  /** Lifecycle for downstream sync. */
+  invoiceStatus?: InvoiceStatus;
+  /** Opaque ID from the downstream invoicing system once exported. */
+  externalInvoiceId?: string;
+  /** Free-text description that downstream invoicing tools can use as the line label. */
+  description?: string;
+}
+
+/**
+ * Flat shape consumers (or our own export helpers) can produce from a
+ * NormalizedEvent + BillableMeta. Kept structural so any invoicing backend
+ * can map it.
+ */
+export interface InvoiceLineItem {
+  eventId: string;
+  date: Date;
+  customer: string | null;
+  description: string;
+  quantity: number;
+  rate: number | null;
+  total: number | null;
+  currency: string | null;
+  status: InvoiceStatus;
+}

--- a/src/types/maintenance.ts
+++ b/src/types/maintenance.ts
@@ -76,6 +76,7 @@ export interface MaintenanceMeta {
   /** Computed next-due meter value after this service completes. */
   nextDueMiles?: number;
   nextDueHours?: number;
+  nextDueCycles?: number;
   nextDueDate?: string;
   /** Free-text technician notes. */
   notes?: string;

--- a/src/types/maintenance.ts
+++ b/src/types/maintenance.ts
@@ -1,0 +1,82 @@
+/**
+ * Maintenance + asset-health types.
+ *
+ * These are pure data shapes. Logic for "is this overdue?" / "when is the next
+ * service due?" lives elsewhere (a future helpers module). The library does
+ * not enforce a maintenance workflow — it gives consumers typed metadata they
+ * can attach to events and assets and surface in their own UI.
+ *
+ * AssetHealth attaches to an asset record (consumer-owned).
+ * MaintenanceMeta attaches to `WorksCalendarEvent.meta.maintenance`.
+ * MeterReading is a time-series entry; consumers store the log themselves.
+ */
+
+export type MeterType = 'miles' | 'hours' | 'cycles' | 'kilometers';
+
+export type AssetHealthStatus =
+  | 'available'
+  | 'limited'
+  | 'down'
+  | 'maintenance';
+
+export type MaintenanceLifecycle =
+  | 'due'
+  | 'scheduled'
+  | 'in-progress'
+  | 'complete'
+  | 'skipped';
+
+export interface MeterReading {
+  assetId: string;
+  type: MeterType;
+  value: number;
+  /** ISO-8601 timestamp string. */
+  asOf: string;
+  /** Optional: who reported it (driver, mechanic, system). */
+  reportedBy?: string;
+}
+
+export interface AssetHealth {
+  assetId: string;
+  status: AssetHealthStatus;
+  /** Most recent meter reading, denormalized for quick display. */
+  meter?: MeterReading;
+  /** Free-text warnings surfaced in the asset view. */
+  warnings?: string[];
+}
+
+export interface MaintenanceInterval {
+  miles?: number;
+  hours?: number;
+  days?: number;
+  cycles?: number;
+}
+
+export interface MaintenanceRule {
+  id: string;
+  /** Apply to a specific asset, or to all assets of a type. One of these is required. */
+  assetId?: string;
+  assetType?: string;
+  title: string;
+  /** How often the work repeats. */
+  interval?: MaintenanceInterval;
+  /** How far ahead to start surfacing "due soon" warnings. */
+  warningWindow?: MaintenanceInterval;
+}
+
+/**
+ * Metadata attached to a calendar event when that event represents
+ * maintenance work (oil change, inspection, etc.).
+ */
+export interface MaintenanceMeta {
+  ruleId?: string;
+  lifecycle?: MaintenanceLifecycle;
+  /** Meter reading at the moment of service. */
+  meterAtService?: number;
+  /** Computed next-due meter value after this service completes. */
+  nextDueMiles?: number;
+  nextDueHours?: number;
+  nextDueDate?: string;
+  /** Free-text technician notes. */
+  notes?: string;
+}

--- a/src/ui/AssetMaintenanceBadges.tsx
+++ b/src/ui/AssetMaintenanceBadges.tsx
@@ -1,0 +1,113 @@
+/**
+ * AssetMaintenanceBadges — given an asset's rules + current state, computes
+ * due status for each rule and renders a row of `<MaintenanceBadge>` chips.
+ *
+ * Sort order: overdue → due-soon → ok → unknown, then by smallest remaining.
+ * `max` truncates the visible list with a "+N" overflow chip.
+ */
+import { useMemo } from 'react';
+import type { CSSProperties } from 'react';
+import type {
+  MaintenanceRule,
+  MeterType,
+} from '../types/maintenance';
+import {
+  computeDueStatus,
+  type CurrentState,
+  type DueResult,
+  type DueStatus,
+  type LastService,
+} from '../core/maintenance';
+import { MaintenanceBadge } from './MaintenanceBadge';
+
+const STATUS_RANK: Record<DueStatus, number> = { overdue: 0, 'due-soon': 1, ok: 2, unknown: 3 };
+
+export interface AssetMaintenanceBadgesProps {
+  rules: readonly MaintenanceRule[];
+  /** Most recent meter reading for the asset. Optional — meter-based rules
+   *  without a reading render as `unknown`. */
+  currentMeter?: { type: MeterType; value: number };
+  /** Per-rule last-service info, keyed by `rule.id`. */
+  lastServiceByRule?: Record<string, LastService>;
+  /** Override "now" for date-based rules. Defaults to `new Date()`. */
+  now?: Date;
+  /** Cap on visible chips. Extras collapse into a "+N" overflow chip. */
+  max?: number;
+  /** Hide chips with status `ok` or `unknown` (typical for compact rows). */
+  hideHealthy?: boolean;
+  style?: CSSProperties;
+  className?: string;
+}
+
+export function AssetMaintenanceBadges({
+  rules,
+  currentMeter,
+  lastServiceByRule,
+  now,
+  max,
+  hideHealthy = false,
+  style,
+  className,
+}: AssetMaintenanceBadgesProps) {
+  const entries = useMemo(() => {
+    const current: CurrentState = currentMeter ? { meter: currentMeter } : {};
+    const computed = rules.map(rule => {
+      const last = lastServiceByRule?.[rule.id] ?? {};
+      const due = computeDueStatus(rule, current, last, now);
+      return { rule, due };
+    });
+    const filtered = hideHealthy
+      ? computed.filter(e => e.due.status === 'overdue' || e.due.status === 'due-soon')
+      : computed;
+    filtered.sort((a, b) => {
+      const r = STATUS_RANK[a.due.status] - STATUS_RANK[b.due.status];
+      if (r !== 0) return r;
+      return smallestRemaining(a.due) - smallestRemaining(b.due);
+    });
+    return filtered;
+  }, [rules, currentMeter, lastServiceByRule, now, hideHealthy]);
+
+  if (!entries.length) return null;
+
+  const visible  = max != null ? entries.slice(0, max) : entries;
+  const overflow = max != null ? entries.length - visible.length : 0;
+
+  return (
+    <div
+      className={className}
+      role="group"
+      aria-label="Maintenance status"
+      style={{ display: 'inline-flex', flexWrap: 'wrap', gap: 4, ...style }}
+    >
+      {visible.map(({ rule, due }) => (
+        <MaintenanceBadge key={rule.id} rule={rule} due={due} />
+      ))}
+      {overflow > 0 && (
+        <span
+          aria-label={`${overflow} more maintenance items`}
+          title={`${overflow} more`}
+          style={{
+            display: 'inline-flex',
+            alignItems: 'center',
+            padding: '1px 6px',
+            fontSize: 10,
+            lineHeight: '14px',
+            fontWeight: 500,
+            color: 'var(--wc-text-muted)',
+            border: '1px solid var(--wc-border)',
+            borderRadius: 'var(--wc-radius-sm, 4px)',
+          }}
+        >+{overflow}</span>
+      )}
+    </div>
+  );
+}
+
+function smallestRemaining(due: DueResult): number {
+  const xs: number[] = [];
+  if (due.miles)  xs.push(due.miles.remaining);
+  if (due.hours)  xs.push(due.hours.remaining);
+  if (due.cycles) xs.push(due.cycles.remaining);
+  if (due.days)   xs.push(due.days.remaining);
+  return xs.length ? Math.min(...xs) : Number.POSITIVE_INFINITY;
+}

--- a/src/ui/EventForm.tsx
+++ b/src/ui/EventForm.tsx
@@ -12,10 +12,17 @@ import { BUILT_IN_EVENT_TEMPLATES } from '../core/engine/recurrence/templates.ts
 import { RecurrenceSection } from './EventFormSections/RecurrenceSection';
 import { CategorySection } from './EventFormSections/CategorySection';
 import { CustomFieldsSection } from './EventFormSections/CustomFieldsSection';
+import { MaintenanceSection } from './EventFormSections/MaintenanceSection';
+import { completeMaintenance } from '../core/maintenance';
+import type { MaintenanceMeta, MaintenanceRule, MeterType } from '../types/maintenance';
+import type { WorksCalendarEvent } from '../types/events';
 import ConfirmDialog from './ConfirmDialog';
 import styles from './EventForm.module.css';
 
-export default function EventForm({ event, config, categories, onSave, onDelete, onClose, permissions, onAddCategory }: any) {
+export default function EventForm({
+  event, config, categories, onSave, onDelete, onClose, permissions, onAddCategory,
+  maintenanceRules,
+}: any) {
   const isNew   = !event?.id || event.id.startsWith('wc-');
   const trapRef = useFocusTrap<HTMLDivElement>(onClose);
   const draft   = useEventDraftState(event, categories, config);
@@ -25,19 +32,60 @@ export default function EventForm({ event, config, categories, onSave, onDelete,
     e.preventDefault();
     if (!draft.validate()) return;
     const normalizedResource = draft.values.resource == null ? '' : String(draft.values.resource);
+    const resource = normalizedResource.trim() || null;
+    const start    = fromDatetimeLocal(draft.values.start);
+    const end      = fromDatetimeLocal(draft.values.end);
+
+    let meta = draft.values.meta;
+
+    // When the user marks a maintenance event complete, run completeMaintenance
+    // so the projected nextDue* fields land on event.meta.maintenance without
+    // the consumer having to wire it themselves. No-op when the form had no
+    // rules supplied or the section wasn't used.
+    const maintMeta = meta?.['maintenance'] as MaintenanceMeta | undefined;
+    if (maintMeta?.lifecycle === 'complete' && maintMeta.ruleId && Array.isArray(maintenanceRules)) {
+      const rule = (maintenanceRules as readonly MaintenanceRule[]).find(r => r.id === maintMeta.ruleId);
+      const meterType = inferMeterType(rule);
+      if (rule && (meterType ? maintMeta.meterAtService != null : true)) {
+        const partialEvent: WorksCalendarEvent = {
+          id:    event?.id,
+          title: draft.values.title.trim(),
+          start: start as Date,
+          ...(end && { end }),
+          meta,
+        };
+        const { event: completed } = completeMaintenance(partialEvent, rule, {
+          assetId: resource ?? '',
+          type:    meterType ?? 'miles', // arbitrary placeholder for date-only rules
+          value:   maintMeta.meterAtService ?? 0,
+          asOf:    (end ?? start ?? new Date()).toISOString(),
+        });
+        meta = completed.meta as Record<string, unknown>;
+      }
+    }
+
     onSave({
       ...(event || {}),
       title:    draft.values.title.trim(),
-      start:    fromDatetimeLocal(draft.values.start),
-      end:      fromDatetimeLocal(draft.values.end),
+      start,
+      end,
       allDay:   draft.values.allDay,
       category: draft.values.category || null,
-      resource: normalizedResource.trim() || null,
+      resource,
       color:    draft.values.color || undefined,
-      meta:     draft.values.meta,
+      meta,
       rrule:    draft.buildRRule(),
       exdates:  event?.exdates ?? [],
     });
+  }
+
+  function inferMeterType(rule: MaintenanceRule | undefined): MeterType | null {
+    const i = rule?.interval;
+    if (!i) return null;
+    if (i.miles  != null) return 'miles';
+    if (i.hours  != null) return 'hours';
+    if (i.cycles != null) return 'cycles';
+    return null;
   }
 
   const d = draft; // short alias for JSX readability
@@ -118,6 +166,18 @@ export default function EventForm({ event, config, categories, onSave, onDelete,
                 )}
               </div>
             </div>
+            {Array.isArray(maintenanceRules) && maintenanceRules.length > 0 && (() => {
+              const completedAt = fromDatetimeLocal(d.values.end)?.toISOString()
+                ?? fromDatetimeLocal(d.values.start)?.toISOString();
+              return (
+                <MaintenanceSection
+                  value={d.values.meta?.['maintenance'] as MaintenanceMeta | undefined}
+                  rules={maintenanceRules}
+                  {...(completedAt && { completedAt })}
+                  onChange={(next) => d.setMeta('maintenance', next)}
+                />
+              );
+            })()}
             <CustomFieldsSection category={d.values.category} customFields={d.customFields}
               metaValues={d.values.meta} errors={d.errors} onMetaChange={d.setMeta} />
             <div className={styles['actions']}>

--- a/src/ui/EventFormSections/MaintenanceSection.tsx
+++ b/src/ui/EventFormSections/MaintenanceSection.tsx
@@ -1,0 +1,181 @@
+/**
+ * MaintenanceSection — opt-in section of the EventForm for maintenance-typed
+ * events. Lets the user select a rule, set lifecycle, record a meter reading,
+ * and add notes. Renders a live "next due" preview when lifecycle is
+ * `complete` and the inputs are sufficient to project.
+ *
+ * Controlled. Reads `value: MaintenanceMeta | undefined` and emits the full
+ * next meta (or `undefined` when the rule is cleared) via `onChange`. The
+ * EventForm wires this into setMeta('maintenance', ...).
+ */
+import { useMemo } from 'react';
+import type { ChangeEvent } from 'react';
+import styles from '../EventForm.module.css';
+import type { MaintenanceMeta, MaintenanceRule, MaintenanceLifecycle, MeterType } from '../../types/maintenance';
+import { projectNextDue } from '../../core/maintenance';
+
+const LIFECYCLE_OPTIONS: { id: MaintenanceLifecycle; label: string }[] = [
+  { id: 'due',         label: 'Due'         },
+  { id: 'scheduled',   label: 'Scheduled'   },
+  { id: 'in-progress', label: 'In progress' },
+  { id: 'complete',    label: 'Complete'    },
+  { id: 'skipped',     label: 'Skipped'     },
+];
+
+export interface MaintenanceSectionProps {
+  value: MaintenanceMeta | undefined;
+  rules: readonly MaintenanceRule[];
+  /** ISO timestamp used as `completedAt` when projecting the next-due preview.
+   *  Typically `event.start` or now. */
+  completedAt?: string;
+  onChange: (next: MaintenanceMeta | undefined) => void;
+}
+
+export function MaintenanceSection({ value, rules, completedAt, onChange }: MaintenanceSectionProps) {
+  const current   = value ?? {};
+  const ruleId    = current.ruleId ?? '';
+  const lifecycle = current.lifecycle ?? '';
+  const meter     = current.meterAtService;
+  const notes     = current.notes ?? '';
+
+  const selectedRule = useMemo(() => rules.find(r => r.id === ruleId), [rules, ruleId]);
+  const meterDim     = inferMeterDim(selectedRule);
+  const showsMeter   = !!meterDim;
+
+  const preview = useMemo(() => {
+    if (!selectedRule || lifecycle !== 'complete') return null;
+    if (showsMeter && meter == null) return null;
+    return projectNextDue(selectedRule, {
+      ...(meter != null && { meterAtService: meter }),
+      ...(completedAt && { completedAt }),
+    });
+  }, [selectedRule, lifecycle, meter, completedAt, showsMeter]);
+
+  function emit(patch: Partial<MaintenanceMeta>) {
+    const next: MaintenanceMeta = { ...current, ...patch };
+    onChange(next);
+  }
+
+  function handleRuleChange(e: ChangeEvent<HTMLSelectElement>) {
+    const id = e.target.value;
+    if (!id) {
+      onChange(undefined); // clearing the rule clears the whole section
+      return;
+    }
+    // Default lifecycle to 'scheduled' when picking a rule for the first time.
+    onChange({ ...current, ruleId: id, lifecycle: current.lifecycle ?? 'scheduled' });
+  }
+
+  function handleLifecycleChange(e: ChangeEvent<HTMLSelectElement>) {
+    const v = e.target.value as MaintenanceLifecycle | '';
+    if (!v) { const { lifecycle: _drop, ...rest } = current; onChange(rest); return; }
+    emit({ lifecycle: v });
+  }
+
+  function handleMeterChange(e: ChangeEvent<HTMLInputElement>) {
+    const raw = e.target.value;
+    if (raw === '') {
+      const { meterAtService: _drop, ...rest } = current;
+      onChange(rest);
+      return;
+    }
+    const n = Number(raw);
+    if (Number.isFinite(n)) emit({ meterAtService: n });
+  }
+
+  return (
+    <fieldset className={styles['field']} style={{ border: '1px solid var(--wc-border)', borderRadius: 6, padding: 10 }}>
+      <legend style={{ padding: '0 6px', fontSize: 12, fontWeight: 600, color: 'var(--wc-text-muted)', textTransform: 'uppercase', letterSpacing: '0.05em' }}>
+        Maintenance
+      </legend>
+
+      <div className={styles['field']}>
+        <label className={styles['label']} htmlFor="ef-maint-rule">Rule</label>
+        <select id="ef-maint-rule" className={styles['select']} value={ruleId} onChange={handleRuleChange}>
+          <option value="">— None —</option>
+          {rules.map(r => <option key={r.id} value={r.id}>{r.title}</option>)}
+        </select>
+      </div>
+
+      {ruleId && (
+        <>
+          <div className={styles['field']}>
+            <label className={styles['label']} htmlFor="ef-maint-lifecycle">Status</label>
+            <select id="ef-maint-lifecycle" className={styles['select']} value={lifecycle} onChange={handleLifecycleChange}>
+              <option value="">— Not set —</option>
+              {LIFECYCLE_OPTIONS.map(o => <option key={o.id} value={o.id}>{o.label}</option>)}
+            </select>
+          </div>
+
+          {showsMeter && (
+            <div className={styles['field']}>
+              <label className={styles['label']} htmlFor="ef-maint-meter">Meter at service ({meterDim})</label>
+              <input
+                id="ef-maint-meter"
+                type="number"
+                inputMode="decimal"
+                className={styles['input']}
+                value={meter ?? ''}
+                onChange={handleMeterChange}
+                placeholder={`e.g. 110000`}
+              />
+            </div>
+          )}
+
+          <div className={styles['field']}>
+            <label className={styles['label']} htmlFor="ef-maint-notes">Notes</label>
+            <textarea
+              id="ef-maint-notes"
+              className={styles['input']}
+              rows={2}
+              value={notes}
+              onChange={e => emit({ notes: e.target.value })}
+              placeholder="Technician notes…"
+            />
+          </div>
+
+          {preview && hasAnyProjection(preview) && (
+            <div
+              data-testid="maint-next-due-preview"
+              style={{
+                fontSize: 11, color: 'var(--wc-text-muted)',
+                background: 'color-mix(in srgb, var(--wc-accent) 6%, transparent)',
+                border: '1px solid color-mix(in srgb, var(--wc-accent) 25%, transparent)',
+                borderRadius: 4, padding: '4px 8px', marginTop: 4,
+              }}
+            >
+              <strong style={{ color: 'var(--wc-text)' }}>Next due:</strong>{' '}
+              {formatProjection(preview)}
+            </div>
+          )}
+        </>
+      )}
+    </fieldset>
+  );
+}
+
+// ── helpers ──────────────────────────────────────────────────────────────────
+
+function inferMeterDim(rule: MaintenanceRule | undefined): MeterType | null {
+  const i = rule?.interval;
+  if (!i) return null;
+  if (i.miles  != null) return 'miles';
+  if (i.hours  != null) return 'hours';
+  if (i.cycles != null) return 'cycles';
+  return null; // days-only rule — no meter input needed
+}
+
+type Projection = ReturnType<typeof projectNextDue>;
+
+function hasAnyProjection(p: Projection): boolean {
+  return p.nextDueMiles != null || p.nextDueHours != null || p.nextDueCycles != null || !!p.nextDueDate;
+}
+
+function formatProjection(p: Projection): string {
+  const parts: string[] = [];
+  if (p.nextDueMiles  != null) parts.push(`${p.nextDueMiles.toLocaleString()} mi`);
+  if (p.nextDueHours  != null) parts.push(`${p.nextDueHours.toLocaleString()} hr`);
+  if (p.nextDueCycles != null) parts.push(`${p.nextDueCycles.toLocaleString()} cycles`);
+  if (p.nextDueDate)           parts.push(p.nextDueDate.slice(0, 10));
+  return parts.join(' · ');
+}

--- a/src/ui/MaintenanceBadge.tsx
+++ b/src/ui/MaintenanceBadge.tsx
@@ -1,0 +1,101 @@
+/**
+ * MaintenanceBadge — read-only chip showing the due status for a single
+ * maintenance rule. Pairs with `<AssetMaintenanceBadges>` for the multi-rule
+ * case, but is exported standalone for consumers building their own layouts.
+ *
+ * Pure presentation. Status colors come from the WorksCalendar theme tokens
+ * (--wc-danger / --wc-warning / --wc-success / --wc-text-muted).
+ */
+import type { CSSProperties } from 'react';
+import type { MaintenanceRule } from '../types/maintenance';
+import type { DueResult, DueStatus } from '../core/maintenance';
+
+const PALETTE: Record<DueStatus, { bg: string; fg: string; border: string }> = {
+  overdue:    { bg: 'color-mix(in srgb, var(--wc-danger) 14%, transparent)',  fg: 'var(--wc-danger)',      border: 'color-mix(in srgb, var(--wc-danger) 40%, transparent)' },
+  'due-soon': { bg: 'color-mix(in srgb, var(--wc-warning) 14%, transparent)', fg: 'var(--wc-warning)',     border: 'color-mix(in srgb, var(--wc-warning) 40%, transparent)' },
+  ok:         { bg: 'transparent',                                            fg: 'var(--wc-text-muted)',  border: 'var(--wc-border)' },
+  unknown:    { bg: 'transparent',                                            fg: 'var(--wc-text-faint)',  border: 'var(--wc-border)' },
+};
+
+const STATUS_LABEL: Record<DueStatus, string> = {
+  overdue:    'overdue',
+  'due-soon': 'due soon',
+  ok:         'ok',
+  unknown:    'unknown',
+};
+
+export interface MaintenanceBadgeProps {
+  rule: MaintenanceRule;
+  due: DueResult;
+  /** Override the default short label ("oil change · 1.2k mi"). */
+  label?: string;
+  style?: CSSProperties;
+  className?: string;
+}
+
+export function MaintenanceBadge({
+  rule,
+  due,
+  label,
+  style,
+  className,
+}: MaintenanceBadgeProps) {
+  const colors = PALETTE[due.status];
+  const detail = label ?? buildDetail(due);
+  const aria = `${rule.title}: ${STATUS_LABEL[due.status]}${detail ? ` (${detail})` : ''}`;
+
+  return (
+    <span
+      role="status"
+      aria-label={aria}
+      title={aria}
+      data-status={due.status}
+      className={className}
+      style={{
+        display: 'inline-flex',
+        alignItems: 'center',
+        gap: 4,
+        padding: '1px 6px',
+        fontSize: 10,
+        lineHeight: '14px',
+        fontWeight: 500,
+        background: colors.bg,
+        color: colors.fg,
+        border: `1px solid ${colors.border}`,
+        borderRadius: 'var(--wc-radius-sm, 4px)',
+        whiteSpace: 'nowrap',
+        ...style,
+      }}
+    >
+      <span style={{ opacity: 0.85 }}>{rule.title}</span>
+      {detail && <span style={{ opacity: 0.65 }}>· {detail}</span>}
+    </span>
+  );
+}
+
+/**
+ * Pick the most-actionable single-line summary from a DueResult. Prefers
+ * the dimension that drives the overall status (overdue first, then
+ * due-soon), then falls back to whichever dimension has the smallest
+ * `remaining`.
+ */
+function buildDetail(due: DueResult): string {
+  const dims: Array<{ key: 'miles' | 'hours' | 'days' | 'cycles'; remaining: number; unit: string }> = [];
+  if (due.miles)  dims.push({ key: 'miles',  remaining: due.miles.remaining,  unit: 'mi'    });
+  if (due.hours)  dims.push({ key: 'hours',  remaining: due.hours.remaining,  unit: 'hr'    });
+  if (due.cycles) dims.push({ key: 'cycles', remaining: due.cycles.remaining, unit: 'cycles'});
+  if (due.days)   dims.push({ key: 'days',   remaining: due.days.remaining,   unit: 'd'     });
+  if (!dims.length) return '';
+
+  // Worst dimension first.
+  dims.sort((a, b) => a.remaining - b.remaining);
+  const worst = dims[0]!;
+  if (worst.remaining < 0) return `${formatNum(-worst.remaining)} ${worst.unit} late`;
+  return `${formatNum(worst.remaining)} ${worst.unit}`;
+}
+
+function formatNum(n: number): string {
+  if (n >= 10_000) return `${Math.round(n / 1_000)}k`;
+  if (n >= 1_000)  return `${(n / 1_000).toFixed(1)}k`;
+  return String(n);
+}

--- a/src/ui/__tests__/EventForm.maintenance.test.tsx
+++ b/src/ui/__tests__/EventForm.maintenance.test.tsx
@@ -1,0 +1,141 @@
+// @vitest-environment happy-dom
+/**
+ * EventForm — maintenance section wiring.
+ *
+ * Verifies the section is opt-in via the `maintenanceRules` prop, that field
+ * changes flow into event.meta.maintenance, and that lifecycle='complete'
+ * triggers the built-in completeMaintenance() call so projected nextDue*
+ * fields land on the saved event without consumer plumbing.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import EventForm from '../EventForm';
+import type { MaintenanceRule } from '../../types/maintenance';
+
+const oilChange: MaintenanceRule = {
+  id: 'oil-10k',
+  assetType: 'truck',
+  title: 'Oil change',
+  interval:      { miles: 10_000 },
+  warningWindow: { miles: 2_000  },
+};
+
+const dotInspection: MaintenanceRule = {
+  id: 'dot-annual',
+  assetType: 'truck',
+  title: 'DOT inspection',
+  interval: { days: 365 },
+};
+
+function renderForm(props: any = {}) {
+  const onSave = vi.fn();
+  const { event: eventOverrides, ...rest } = props;
+  render(
+    <EventForm
+      event={{
+        id: 'evt-1',
+        title: 'Service work',
+        start: new Date('2026-04-10T09:00:00.000Z'),
+        end:   new Date('2026-04-10T11:00:00.000Z'),
+        resource: 'truck-12',
+        ...eventOverrides,
+      }}
+      config={{ eventFields: {} }}
+      categories={['Maintenance']}
+      onSave={onSave}
+      onDelete={null}
+      onClose={() => {}}
+      permissions={{}}
+      {...rest}
+    />,
+  );
+  return { onSave };
+}
+
+describe('EventForm — MaintenanceSection wiring', () => {
+  it('does not render the section when maintenanceRules is omitted', () => {
+    renderForm();
+    expect(screen.queryByLabelText('Rule')).toBeNull();
+  });
+
+  it('does not render the section when maintenanceRules is empty', () => {
+    renderForm({ maintenanceRules: [] });
+    expect(screen.queryByLabelText('Rule')).toBeNull();
+  });
+
+  it('renders the rule picker when maintenanceRules is non-empty', () => {
+    renderForm({ maintenanceRules: [oilChange, dotInspection] });
+    const ruleSelect = screen.getByLabelText('Rule') as HTMLSelectElement;
+    const optionTexts = Array.from(ruleSelect.options).map(o => o.textContent);
+    expect(optionTexts).toEqual(['— None —', 'Oil change', 'DOT inspection']);
+  });
+
+  it('writes ruleId + default lifecycle into event.meta.maintenance on save', () => {
+    const { onSave } = renderForm({ maintenanceRules: [oilChange] });
+    fireEvent.change(screen.getByLabelText('Rule'), { target: { value: 'oil-10k' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Save Changes' }));
+
+    const saved = onSave.mock.calls[0][0];
+    expect(saved.meta.maintenance).toMatchObject({
+      ruleId: 'oil-10k',
+      lifecycle: 'scheduled', // auto-default when picking a rule
+    });
+    // No projection yet — lifecycle isn't 'complete'.
+    expect(saved.meta.maintenance.nextDueMiles).toBeUndefined();
+  });
+
+  it('runs completeMaintenance on save when lifecycle is complete + meter present', () => {
+    const { onSave } = renderForm({ maintenanceRules: [oilChange] });
+    fireEvent.change(screen.getByLabelText('Rule'),                { target: { value: 'oil-10k' } });
+    fireEvent.change(screen.getByLabelText('Status'),              { target: { value: 'complete' } });
+    fireEvent.change(screen.getByLabelText(/Meter at service/),    { target: { value: '110500'  } });
+    fireEvent.click(screen.getByRole('button', { name: 'Save Changes' }));
+
+    const saved = onSave.mock.calls[0][0];
+    expect(saved.meta.maintenance).toMatchObject({
+      ruleId: 'oil-10k',
+      lifecycle: 'complete',
+      meterAtService: 110_500,
+      nextDueMiles: 120_500, // 110500 + 10000
+    });
+  });
+
+  it('shows a live "next due" preview when lifecycle is complete', () => {
+    renderForm({ maintenanceRules: [oilChange] });
+    fireEvent.change(screen.getByLabelText('Rule'),             { target: { value: 'oil-10k' } });
+    fireEvent.change(screen.getByLabelText('Status'),           { target: { value: 'complete' } });
+    fireEvent.change(screen.getByLabelText(/Meter at service/), { target: { value: '110500'  } });
+    expect(screen.getByTestId('maint-next-due-preview').textContent).toContain('120,500 mi');
+  });
+
+  it('does not show the meter input for date-only rules', () => {
+    renderForm({ maintenanceRules: [dotInspection] });
+    fireEvent.change(screen.getByLabelText('Rule'), { target: { value: 'dot-annual' } });
+    expect(screen.queryByLabelText(/Meter at service/)).toBeNull();
+  });
+
+  it('clearing the rule wipes the maintenance meta', () => {
+    const { onSave } = renderForm({ maintenanceRules: [oilChange] });
+    fireEvent.change(screen.getByLabelText('Rule'), { target: { value: 'oil-10k' } });
+    fireEvent.change(screen.getByLabelText('Rule'), { target: { value: '' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Save Changes' }));
+
+    const saved = onSave.mock.calls[0][0];
+    expect(saved.meta.maintenance).toBeUndefined();
+  });
+
+  it('does not project on save when lifecycle is not complete', () => {
+    const { onSave } = renderForm({ maintenanceRules: [oilChange] });
+    fireEvent.change(screen.getByLabelText('Rule'),             { target: { value: 'oil-10k' } });
+    fireEvent.change(screen.getByLabelText('Status'),           { target: { value: 'in-progress' } });
+    fireEvent.change(screen.getByLabelText(/Meter at service/), { target: { value: '110500' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Save Changes' }));
+
+    const saved = onSave.mock.calls[0][0];
+    expect(saved.meta.maintenance.lifecycle).toBe('in-progress');
+    expect(saved.meta.maintenance.meterAtService).toBe(110_500);
+    // No projection — only complete lifecycle triggers it.
+    expect(saved.meta.maintenance.nextDueMiles).toBeUndefined();
+  });
+});

--- a/src/ui/__tests__/MaintenanceBadge.test.tsx
+++ b/src/ui/__tests__/MaintenanceBadge.test.tsx
@@ -1,0 +1,131 @@
+// @vitest-environment happy-dom
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import '@testing-library/jest-dom';
+import { MaintenanceBadge } from '../MaintenanceBadge';
+import { AssetMaintenanceBadges } from '../AssetMaintenanceBadges';
+import type { MaintenanceRule } from '../../types/maintenance';
+
+const oilChange: MaintenanceRule = {
+  id: 'oil-10k',
+  assetType: 'truck',
+  title: 'Oil change',
+  interval:      { miles: 10_000 },
+  warningWindow: { miles: 2_000  },
+};
+
+const dot: MaintenanceRule = {
+  id: 'dot-annual',
+  assetType: 'truck',
+  title: 'DOT',
+  interval:      { days: 365 },
+  warningWindow: { days: 30  },
+};
+
+describe('MaintenanceBadge', () => {
+  it('renders rule title and a positive remaining for ok status', () => {
+    render(<MaintenanceBadge rule={oilChange} due={{ status: 'ok', miles: { remaining: 5_500 } }} />);
+    const el = screen.getByRole('status');
+    expect(el).toHaveAttribute('data-status', 'ok');
+    expect(el.getAttribute('aria-label')).toMatch(/Oil change/);
+    expect(el.textContent).toContain('Oil change');
+    expect(el.textContent).toContain('5.5k mi');
+  });
+
+  it('renders "X late" when overdue', () => {
+    render(<MaintenanceBadge rule={oilChange} due={{ status: 'overdue', miles: { remaining: -1_500 } }} />);
+    const el = screen.getByRole('status');
+    expect(el).toHaveAttribute('data-status', 'overdue');
+    expect(el.textContent).toContain('1.5k mi late');
+    expect(el.getAttribute('aria-label')).toMatch(/overdue/);
+  });
+
+  it('falls back to no detail when DueResult has no dimensions', () => {
+    render(<MaintenanceBadge rule={oilChange} due={{ status: 'unknown' }} />);
+    const el = screen.getByRole('status');
+    expect(el).toHaveAttribute('data-status', 'unknown');
+    expect(el.textContent).toBe('Oil change');
+  });
+
+  it('uses the worst dimension when multiple are present', () => {
+    render(
+      <MaintenanceBadge
+        rule={dot}
+        due={{ status: 'overdue', miles: { remaining: 5_000 }, days: { remaining: -10 } }}
+      />,
+    );
+    expect(screen.getByRole('status').textContent).toContain('10 d late');
+  });
+
+  it('honors a custom label override', () => {
+    render(<MaintenanceBadge rule={oilChange} due={{ status: 'ok' }} label="custom" />);
+    expect(screen.getByRole('status').textContent).toContain('custom');
+  });
+});
+
+describe('AssetMaintenanceBadges', () => {
+  it('renders nothing when there are no rules', () => {
+    const { container } = render(<AssetMaintenanceBadges rules={[]} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('computes a chip per rule using current meter and last service', () => {
+    render(
+      <AssetMaintenanceBadges
+        rules={[oilChange]}
+        currentMeter={{ type: 'miles', value: 109_000 }}
+        lastServiceByRule={{ 'oil-10k': { meterAtService: 100_000 } }}
+      />,
+    );
+    const el = screen.getByRole('status');
+    expect(el).toHaveAttribute('data-status', 'due-soon');
+  });
+
+  it('sorts overdue first, then due-soon, then ok', () => {
+    const r1: MaintenanceRule = { id: 'r1', assetType: 't', title: 'A-ok',     interval: { miles: 10_000 }, warningWindow: { miles: 1_000 } };
+    const r2: MaintenanceRule = { id: 'r2', assetType: 't', title: 'B-soon',   interval: { miles: 10_000 }, warningWindow: { miles: 5_000 } };
+    const r3: MaintenanceRule = { id: 'r3', assetType: 't', title: 'C-overdue',interval: { miles: 10_000 }, warningWindow: { miles: 1_000 } };
+    render(
+      <AssetMaintenanceBadges
+        rules={[r1, r2, r3]}
+        currentMeter={{ type: 'miles', value: 100_500 }}
+        lastServiceByRule={{
+          r1: { meterAtService: 95_000 },  // 4500 remaining → ok
+          r2: { meterAtService: 95_000 },  // 4500 remaining → due-soon (window 5000)
+          r3: { meterAtService: 90_000 },  // -500 remaining → overdue
+        }}
+      />,
+    );
+    const statuses = screen.getAllByRole('status').map(el => el.getAttribute('data-status'));
+    expect(statuses).toEqual(['overdue', 'due-soon', 'ok']);
+  });
+
+  it('truncates with a "+N" overflow chip when max is set', () => {
+    const rules: MaintenanceRule[] = Array.from({ length: 5 }, (_, i) => ({
+      id: `r${i}`, assetType: 't', title: `R${i}`, interval: { miles: 10_000 },
+    }));
+    render(<AssetMaintenanceBadges rules={rules} max={2} />);
+    const statuses = screen.getAllByRole('status');
+    expect(statuses).toHaveLength(2);
+    expect(screen.getByLabelText(/3 more/)).toBeInTheDocument();
+  });
+
+  it('hides healthy chips when hideHealthy is true', () => {
+    const ok:  MaintenanceRule = { id: 'ok',  assetType: 't', title: 'OK',  interval: { miles: 10_000 } };
+    const bad: MaintenanceRule = { id: 'bad', assetType: 't', title: 'BAD', interval: { miles: 10_000 } };
+    render(
+      <AssetMaintenanceBadges
+        rules={[ok, bad]}
+        currentMeter={{ type: 'miles', value: 100_500 }}
+        lastServiceByRule={{
+          ok:  { meterAtService: 95_000 },  // 4500 remaining → ok
+          bad: { meterAtService: 90_000 },  // -500 remaining → overdue
+        }}
+        hideHealthy
+      />,
+    );
+    const statuses = screen.getAllByRole('status');
+    expect(statuses).toHaveLength(1);
+    expect(statuses[0]!).toHaveAttribute('data-status', 'overdue');
+  });
+});

--- a/src/views/AssetsView.tsx
+++ b/src/views/AssetsView.tsx
@@ -91,6 +91,7 @@ interface AssetsViewProps {
   categoriesConfig?: { categories?: Array<{ id?: string; color?: string }>; pillStyle?: string } | undefined;
   locationProvider?: LocationProvider | null | undefined;
   renderAssetLocation?: ((locationData: LocationData | null, asset: { id: string }) => ReactNode) | undefined;
+  renderAssetBadges?: ((asset: { id: string }) => ReactNode) | undefined;
   collapsedGroups?: Set<string> | string[] | undefined;
   onCollapsedGroupsChange?: ((next: Set<string>) => void) | undefined;
   assets?: AssetRowDef[] | undefined;
@@ -297,6 +298,7 @@ export default function AssetsView({
   categoriesConfig,
   locationProvider,
   renderAssetLocation,
+  renderAssetBadges,
   collapsedGroups: collapsedGroupsProp,
   onCollapsedGroupsChange,
   assets,
@@ -1119,6 +1121,11 @@ export default function AssetsView({
                     </span>
                     {sublabel && (
                       <span className={styles['assetSublabel']}>{sublabel}</span>
+                    )}
+                    {!isPool && renderAssetBadges && (
+                      <div data-testid="asset-badges" style={{ marginTop: 2 }}>
+                        {renderAssetBadges({ id: resource })}
+                      </div>
                     )}
                   </div>
                   {!isPool && (

--- a/src/views/__tests__/AssetsView.maintenanceBadges.test.tsx
+++ b/src/views/__tests__/AssetsView.maintenanceBadges.test.tsx
@@ -1,0 +1,70 @@
+// @vitest-environment happy-dom
+/**
+ * AssetsView — `renderAssetBadges` slot. Mirrors the `renderAssetLocation`
+ * slot pattern: per-asset, render-prop-controlled, scoped to the sticky
+ * asset cell, only invoked for non-pool rows.
+ */
+import { render, screen, within } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import '@testing-library/jest-dom';
+import React from 'react';
+
+import AssetsView from '../AssetsView';
+import { CalendarContext } from '../../core/CalendarContext';
+
+const currentDate = new Date(2026, 3, 1);
+
+function renderView(props: Record<string, unknown> = {}) {
+  return render(
+    <CalendarContext.Provider value={null}>
+      <AssetsView
+        currentDate={currentDate}
+        events={[]}
+        onEventClick={vi.fn()}
+        {...props}
+      />
+    </CalendarContext.Provider>,
+  );
+}
+
+describe('AssetsView — renderAssetBadges', () => {
+  it('renders the slot output inside each asset row', () => {
+    renderView({
+      assets: [
+        { id: 'truck-12', label: 'Truck 12' },
+        { id: 'truck-13', label: 'Truck 13' },
+      ],
+      renderAssetBadges: (asset: { id: string }) => (
+        <span data-testid={`badge-${asset.id}`}>BADGES:{asset.id}</span>
+      ),
+    });
+    expect(screen.getByTestId('badge-truck-12').textContent).toBe('BADGES:truck-12');
+    expect(screen.getByTestId('badge-truck-13').textContent).toBe('BADGES:truck-13');
+  });
+
+  it('does not call the slot when the prop is omitted', () => {
+    renderView({ assets: [{ id: 'truck-12', label: 'Truck 12' }] });
+    expect(screen.queryByTestId('asset-badges')).toBeNull();
+  });
+
+  it('passes the asset id through to the slot', () => {
+    const seen = new Set<string>();
+    renderView({
+      assets: [{ id: 'unit-7', label: 'Unit 7' }, { id: 'unit-8', label: 'Unit 8' }],
+      renderAssetBadges: (asset: { id: string }) => {
+        seen.add(asset.id);
+        return null;
+      },
+    });
+    expect(seen).toEqual(new Set(['unit-7', 'unit-8']));
+  });
+
+  it('renders the slot inside the sticky asset rowheader, not the event zone', () => {
+    renderView({
+      assets: [{ id: 'truck-12', label: 'Truck 12' }],
+      renderAssetBadges: (asset: { id: string }) => <span data-testid="b">x</span>,
+    });
+    const header = screen.getByRole('rowheader', { name: 'Truck 12' });
+    expect(within(header).getByTestId('b')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
Add BillableMeta / MaintenanceMeta / AssetHealth / MeterReading types and
extend the CSV import surface so consumers can map sheet columns onto
event.meta.billing and event.meta.maintenance without changing the core
event shape. EVENT_FIELDS drives the dialog dynamically, so the existing
import UI picks up the new fields automatically.

Also tightens suggestMapping: short hints (<4 chars, e.g. "to", "id")
must match exactly. Without this, "Customer" matched the "end" field via
its "to" hint before the new customer hint had a chance.

Tests: 41/41 csvParser, 1993/1993 suite, typecheck clean.