### PR TITLE
ci: re-enable browser E2E job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,6 @@ jobs:
 
   browser-e2e:
     name: Browser E2E Tests
-    if: false
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -74,11 +73,4 @@ jobs:
           VITE_BASE: /
 
       - name: Run E2E tests
-        run: |
-          if [ "$SKIP_E2E" = "true" ]; then
-            echo "Skipping E2E tests during strict-null migration"
-          else
-            npm run test:browser
-          fi
-        env:
-          SKIP_E2E: true
+        run: npm run test:browser


### PR DESCRIPTION
Removes the two pauses left over from the strict-null migration:

- Job-level `if: false` on `browser-e2e` (the real kill switch).
- Step-level `SKIP_E2E: true` env + bash guard around `npm run test:browser` (the older, now-redundant soft kill switch).

Local run reports 86 passed / 6 failed. The 6 failures collapse to 3 distinct issues, none in code newer than the maintenance/invoicing work:
  1. calendar.demo.spec.ts × 4 viewports — strict console-error assertion trips on net::ERR_CERT_AUTHORITY_INVALID, which only reproduces in sandboxed environments. Likely clean on the real runner.
  2. calendar.assets-grouping saved-view-with-legacy-zoomLevel — "Assets Day Zoom" chip not rendered.
  3. calendar.happy-paths theme-via-Settings — "Corporate Dark" button never appears (theme list is family×mode per #268).

Real CI run will confirm whether (1) reproduces; (2) and (3) need follow-up fixes in the saved-views / Settings surfaces.

## Summary
Describe exactly what this PR changes.

## Scope
- Stage: 
- Planned PR number in sprint: 
- Target files/directories: 
- Why this slice is isolated: 

## Lessons Learned Check (REQUIRED)
Confirm these were actively used while building this PR:

- [ ] PR is intentionally small and isolated
- [ ] Boundary typing was prioritized over internal perfection
- [ ] No silent spread of `any`
- [ ] Advisory root `tsc` was used to catch integration issues
- [ ] I did not assume “looks typed” means “safe”
- [ ] I stopped and isolated typing cascades instead of expanding scope

## Definition of Done (ALL REQUIRED)
This PR is not done unless every box is checked.

- [ ] `npm run type-check:strict` passes
- [ ] Root advisory `tsc --noEmit` passes
- [ ] Tests pass for touched scope at minimum
- [ ] No uncontrolled increase in `any`
- [ ] All new types are intentional and named
- [ ] Public interfaces and exported functions are explicitly typed
- [ ] PR scope matches the sprint plan with no scope creep
- [ ] Any new `any` has an adjacent justification comment
- [ ] No file-wide `: any`
- [ ] No implicit `any` in exported functions

## What Was Typed
List exactly what was typed in this PR.

- 
- 
- 

## What Was Intentionally Left Loose
List anything intentionally not tightened yet.

- 
- 
- 

## `any` Ledger (REQUIRED)
- New `any` added: 
- Existing `any` removed: 
- Net change: 

For every new `any`, explain why it is required and why a safer type was not used yet.

1. 
2. 
3. 

## Boundary Notes
Document any public seams, caller-protection choices, or compatibility decisions.

- 
- 
- 

## Risk Level
- [ ] Low
- [ ] Medium
- [ ] High

Why:

## Validation Evidence
Paste the exact commands run and a short result summary.

```bash
npm run type-check:strict
npx tsc --noEmit -p tsconfig.json
```

Test commands run:

```bash
# paste commands here
```

## Stop Conditions Check
If any item below happened, explain how scope was reduced before merge.

- [ ] `any` started spreading across files
- [ ] Root `tsc` broke repeatedly
- [ ] Types required cross-module rewrites
- [ ] Scope was reduced to keep the PR reviewable

Notes:

## Reviewer Focus
What should reviewers look at first?

- 
- 
- 
