### PR TITLE
test(e2e): catch saved-view-chip + theme-button selectors up to curre…

### DIFF
--- a/tests-e2e/calendar.assets-grouping.spec.ts
+++ b/tests-e2e/calendar.assets-grouping.spec.ts
@@ -63,6 +63,11 @@ test.describe('WorksCalendar Assets view', () => {
     await page.reload();
     await expect(page.getByTestId('works-calendar')).toBeVisible();
 
+    // The compact ProfileBar scopes saved-view chips to the current view (plus
+    // globally-pinned ones), so a chip with view='assets' only appears once
+    // the user is on the Assets tab. Switch first, then look for the chip.
+    await page.getByRole('button', { name: /^Assets$/ }).click();
+
     // ProfileBar chip for our seeded view should be visible. The chip's
     // accessible name is just the view.name — the view-type icon next to
     // it carries an aria-label but isn't part of the chip's button name.

--- a/tests-e2e/calendar.happy-paths.spec.ts
+++ b/tests-e2e/calendar.happy-paths.spec.ts
@@ -114,10 +114,14 @@ test.describe('WorksCalendar happy paths', () => {
     // Dialog auto-opens on successful auth (SHA-256 check is async, give it time).
     await expect(page.getByRole('dialog', { name: /Calendar settings/i })).toBeVisible({ timeout: 10000 });
 
-    // The Setup tab should be active by default, click the Corporate Dark
-    // theme (after issue #268 the theme list is family × mode; corporate-dark
-    // resolves to the historical 'ocean' CSS selector via resolveCssTheme).
-    await page.getByRole('button', { name: /Corporate Dark/i }).click();
+    // The Setup tab should be active by default. After issue #268 + the
+    // family-card refactor, themes are rendered as family cards (e.g.
+    // "Corporate") with separate Light / Dark mode toggle buttons. The mode
+    // buttons carry the full theme label as their `title` attribute, which
+    // is the stable accessible hook for "Corporate Dark" specifically.
+    // corporate-dark resolves to the historical 'ocean' CSS selector via
+    // resolveCssTheme — verified below.
+    await page.getByTitle('Corporate Dark', { exact: true }).click();
 
     // Close the settings panel
     await page.getByLabel('Close settings').click();


### PR DESCRIPTION
…nt UI

Two test-only fixes for failures the re-enabled E2E job surfaced on real CI. Both are stale selectors that drifted away from production UI; no product behavior changed.

calendar.assets-grouping.spec.ts:40
  The compact ProfileBar (c1789d3 + the layout-collapse PRs around it)
  scopes saved-view chips to the current view, plus globally-pinned
  ones. The seeded view targets view='assets' but the demo defaults to
  month, so the "Assets Day Zoom" chip wasn't in the strip on initial
  load. Switch to the Assets tab before locating the chip — the other
  two tests in the same file already do this.

calendar.happy-paths.spec.ts:106
  The Setup tab now renders themes as family cards (Corporate, Industrial,
  …) with separate Light / Dark mode toggle buttons. Each mode button
  carries `title={meta.label}` (e.g. "Corporate Dark") as the stable
  accessible hook, not the visible button text ("Dark"). Switch to
  getByTitle('Corporate Dark') so the locator survives future label
  text changes.

Verified locally: both tests pass; full suite 88/92 (the 4 remaining failures are sandbox-only cert errors in calendar.demo.spec.ts that do not reproduce on the real CI runner — confirmed by the 90/92 split on the CI re-enable PR).

## Summary
Describe exactly what this PR changes.

## Scope
- Stage: 
- Planned PR number in sprint: 
- Target files/directories: 
- Why this slice is isolated: 

## Lessons Learned Check (REQUIRED)
Confirm these were actively used while building this PR:

- [ ] PR is intentionally small and isolated
- [ ] Boundary typing was prioritized over internal perfection
- [ ] No silent spread of `any`
- [ ] Advisory root `tsc` was used to catch integration issues
- [ ] I did not assume “looks typed” means “safe”
- [ ] I stopped and isolated typing cascades instead of expanding scope

## Definition of Done (ALL REQUIRED)
This PR is not done unless every box is checked.

- [ ] `npm run type-check:strict` passes
- [ ] Root advisory `tsc --noEmit` passes
- [ ] Tests pass for touched scope at minimum
- [ ] No uncontrolled increase in `any`
- [ ] All new types are intentional and named
- [ ] Public interfaces and exported functions are explicitly typed
- [ ] PR scope matches the sprint plan with no scope creep
- [ ] Any new `any` has an adjacent justification comment
- [ ] No file-wide `: any`
- [ ] No implicit `any` in exported functions

## What Was Typed
List exactly what was typed in this PR.

- 
- 
- 

## What Was Intentionally Left Loose
List anything intentionally not tightened yet.

- 
- 
- 

## `any` Ledger (REQUIRED)
- New `any` added: 
- Existing `any` removed: 
- Net change: 

For every new `any`, explain why it is required and why a safer type was not used yet.

1. 
2. 
3. 

## Boundary Notes
Document any public seams, caller-protection choices, or compatibility decisions.

- 
- 
- 

## Risk Level
- [ ] Low
- [ ] Medium
- [ ] High

Why:

## Validation Evidence
Paste the exact commands run and a short result summary.

```bash
npm run type-check:strict
npx tsc --noEmit -p tsconfig.json
```

Test commands run:

```bash
# paste commands here
```

## Stop Conditions Check
If any item below happened, explain how scope was reduced before merge.

- [ ] `any` started spreading across files
- [ ] Root `tsc` broke repeatedly
- [ ] Types required cross-module rewrites
- [ ] Scope was reduced to keep the PR reviewable

Notes:

## Reviewer Focus
What should reviewers look at first?

- 
- 
- 
