### PR TITLE
docs+examples: MapView plugin guide and runnable example

### DIFF
--- a/docs/MapView.md
+++ b/docs/MapView.md
@@ -120,16 +120,19 @@ Pick one of these for live deployments:
 | **OpenFreeMap** | Free, community-funded, no API key. |
 | **Self-hosted OSM** | Full control; you operate the tile server. |
 
-Pass the chosen style URL via the `mapStyle` prop:
+Pass the chosen style URL via the `mapStyle` prop. `WorksCalendar` accepts
+it as a top-level prop and forwards it to the active map view:
 
 ```jsx
 <WorksCalendar
   events={events}
   initialView="map"
-  // WorksCalendar forwards an unknown prop to the MapView when active
   mapStyle="https://tiles.openfreemap.org/styles/liberty"
 />;
 ```
+
+The same prop is accepted by the standalone `MapView` shown above. When
+omitted, both fall back to the MapLibre demo style.
 
 ## Bundle impact
 

--- a/docs/MapView.md
+++ b/docs/MapView.md
@@ -1,0 +1,166 @@
+# MapView
+
+`MapView` is the calendar's geographic view: events that carry coordinates
+appear as markers on a MapLibre basemap. It is shipped as an **opt-in plugin**
+so the calendar's main bundle stays slim — install the peers and the view
+renders, skip them and a graceful install hint is shown instead.
+
+> Why a plugin? MapLibre + `react-map-gl` add ~200 KB gz to the runtime, plus
+> a tile provider. Most calendars don't need a map, so the cost shouldn't be
+> paid by default. Hosts that want it install two peers and pass an
+> `initialView="map"` (or render `<MapView />` directly).
+
+## Installation
+
+```bash
+npm install maplibre-gl react-map-gl
+```
+
+`react-map-gl` ships both Mapbox and MapLibre adapters; this view imports
+from the MapLibre subpath (`react-map-gl/maplibre`) so no Mapbox token is
+required.
+
+## Quick start
+
+```jsx
+import { WorksCalendar } from 'works-calendar';
+import 'works-calendar/styles';
+
+const events = [
+  {
+    id: 'phx-arrival',
+    title: 'Phoenix arrival',
+    start: new Date(),
+    meta: { coords: { lat: 33.43, lon: -112.01 } },
+  },
+  {
+    id: 'bos-departure',
+    title: 'Boston departure',
+    start: new Date(),
+    meta: { coords: { lat: 42.36, lon: -71.06 } },
+  },
+];
+
+<WorksCalendar events={events} initialView="map" />;
+```
+
+The Map tab also appears in the view picker when `'map'` is enabled in the
+view list (it follows the same opt-in pattern as `dispatch` / `assets` /
+`base`).
+
+## Where coordinates come from
+
+`MapView` plots an event when one of these is set on `event.meta`:
+
+```ts
+event.meta.coords = { lat: 33.43, lon: -112.01 };  // canonical — matches LocationData
+event.meta = { lat: 33.43, lon: -112.01 };         // loose, lat/lon top-level
+event.meta = { lat: 33.43, lng: -112.01 };         // loose, lng spelling
+```
+
+Events without coordinates are silently skipped. If **no** events have
+coordinates, the view shows a hint instead of an empty map.
+
+The `coords` shape intentionally matches
+[`LocationData.coords`](./LocationProvider.md) — if you already wire up a
+`LocationProvider` for the Assets view, the same coord pairs feed the map
+without a translation layer.
+
+## Marker color
+
+Markers resolve through the same `colorRules` as every other view, so:
+
+- `event.color` ⇒ marker fill
+- otherwise the configured `colorRules` decide
+- otherwise the theme's `--wc-accent` fallback
+
+This means the map respects the same category palette as the rest of the
+calendar without per-view configuration.
+
+## Standalone usage
+
+`MapView` is also exported directly for hosts that want to embed only the
+map (no calendar shell, no toolbar):
+
+```jsx
+import { MapView } from 'works-calendar';
+import 'works-calendar/styles';
+
+<MapView
+  events={events}
+  onEventClick={ev => openSidebar(ev)}
+  initialCenter={{ lat: 39.5, lng: -98.35 }}  // continental US center
+  initialZoom={4}
+  mapStyle="https://api.maptiler.com/maps/streets/style.json?key=YOUR_KEY"
+/>;
+```
+
+### Props
+
+| Prop            | Type                                       | Default                   | Notes |
+| --------------- | ------------------------------------------ | ------------------------- | ----- |
+| `events`        | `Array<{ id; title; start; meta?; … }>`    | required                  | Same shape as the rest of the calendar; only items with coords are plotted. |
+| `onEventClick`  | `(event) => void`                          | —                         | Fired on marker click. |
+| `initialCenter` | `{ lat: number; lng: number }`             | centroid of plotted events | Auto-fits the marker cloud when omitted. |
+| `initialZoom`   | `number`                                   | `4` (or `2` if no events) | MapLibre zoom level. |
+| `mapStyle`      | `string`                                   | demo tile server          | MapLibre style URL — see "Tile providers" below. |
+
+## Tile providers
+
+The default `mapStyle` is MapLibre's
+[free demo style](https://demotiles.maplibre.org/style.json). It's fine for
+local development but is rate-limited and not appropriate for production.
+Pick one of these for live deployments:
+
+| Provider | Notes |
+| --- | --- |
+| **MapTiler** | Free tier (100 K tile loads/mo). Style URL ends with `?key=...`. Easiest path. |
+| **Stadia Maps** | Free tier for non-commercial; commercial plans available. |
+| **Protomaps** | Self-host vector tiles from a single static `.pmtiles` file — no per-tile billing. |
+| **OpenFreeMap** | Free, community-funded, no API key. |
+| **Self-hosted OSM** | Full control; you operate the tile server. |
+
+Pass the chosen style URL via the `mapStyle` prop:
+
+```jsx
+<WorksCalendar
+  events={events}
+  initialView="map"
+  // WorksCalendar forwards an unknown prop to the MapView when active
+  mapStyle="https://tiles.openfreemap.org/styles/liberty"
+/>;
+```
+
+## Bundle impact
+
+When the peers are **not** installed, `MapView` adds nothing meaningful to
+the calendar bundle — only a small fallback component plus the dynamic-import
+boundaries. The library build externalizes `maplibre-gl`, `react-map-gl`, and
+`react-map-gl/maplibre` so they're never inlined into `dist/`.
+
+When the peers **are** installed in the host app, the host bundler resolves
+the dynamic imports into a separate chunk that loads only when the user
+switches to the map view — the rest of the calendar remains unaffected.
+
+## Custom map layers and overlays
+
+This first cut keeps the surface narrow: markers + popup + navigation
+control. If you need polylines, choropleths, clustering, or custom GL layers,
+fall back to MapLibre directly inside your own component and reuse just the
+event-iteration pattern from `MapView.tsx`. We expect to grow the prop
+surface based on real-world feedback rather than guessing at the right
+abstractions up front.
+
+## Why MapLibre over a custom map?
+
+- A from-scratch SVG/canvas marker map gets you ~2–3 days of work before you
+  hit projection, tile loading, and gesture handling.
+- A from-scratch raster-tile map (lat/lng → pixel, OSM tiles, clustering)
+  is a 1–2 week project and loses GPU-accelerated panning.
+- A vector-tile renderer with smooth interactions is a multi-month project
+  and effectively reinvents MapLibre.
+- MapLibre is BSD-3, no API key required, runs against any open-tile
+  provider, and `react-map-gl` already gives idiomatic React bindings.
+
+The "build it yourself" path was prototyped on the way to this view; the
+trade-off didn't pencil out for what users actually wanted.

--- a/docs/README.md
+++ b/docs/README.md
@@ -18,6 +18,7 @@ This index is the canonical docs entrypoint for the package.
 - [Resource scheduling and asset management](./ResourceScheduling.md)
 - [Resource pools](./ResourcePools.md)
 - [Location provider](./LocationProvider.md)
+- [Map view (optional plugin)](./MapView.md)
 
 ## Provider setup guides
 

--- a/docs/Setup.md
+++ b/docs/Setup.md
@@ -189,6 +189,7 @@ Views are the buttons across the top (Month, Week, etc.). Turn on only what you 
 | `schedule` | Team shifts / coverage (PTO → uncovered → filled) |
 | `timeline` | Rows of resources across time (Gantt-like) |
 | `assets` | Fleet / room / equipment rows (see Step 7) |
+| `map` | Geographic plot of events with coordinates — opt-in plugin, see [MapView](./MapView.md) |
 
 ### Drag & drop is already on
 

--- a/examples/11-Map.tsx
+++ b/examples/11-Map.tsx
@@ -1,0 +1,154 @@
+/**
+ * Example 11 — Map View (optional plugin)
+ *
+ * Plots events that carry coordinates on a MapLibre basemap. The map runtime
+ * is shipped as an opt-in plugin — if `react-map-gl` and `maplibre-gl` are
+ * not installed in the host app, the view renders a clear install hint
+ * instead of breaking. To run this example with a real map:
+ *
+ *   npm install maplibre-gl react-map-gl
+ *
+ * This page renders the standalone `MapView` so the tile-style picker can
+ * customise the basemap. The same data also works inside the full calendar
+ * shell — pass `initialView="map"` to `<WorksCalendar />` and switch tabs.
+ *
+ * See docs/MapView.md for the full plugin guide.
+ *
+ * Coordinate convention demonstrated:
+ *   meta.coords = { lat, lon }   // canonical (matches LocationData)
+ *   meta.lat / meta.lon          // loose convenience form
+ */
+import { useState, useCallback } from 'react';
+import { MapView } from '../src/index.ts';
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+const now = new Date();
+
+function at(offsetDays, hour = 9, min = 0) {
+  const d = new Date(now);
+  d.setDate(d.getDate() + offsetDays);
+  d.setHours(hour, min, 0, 0);
+  return d;
+}
+
+// ── Event data ────────────────────────────────────────────────────────────────
+// Air-EMS-style mission set across the continental US.
+const INITIAL_EVENTS = [
+  {
+    id: 'm-phx-1',
+    title: 'KPHX — Inter-facility transfer',
+    start: at(0, 9), end: at(0, 11),
+    color: '#ef4444',
+    meta: { coords: { lat: 33.434, lon: -112.012 } },
+  },
+  {
+    id: 'm-bos-1',
+    title: 'KBOS — Pediatric transport',
+    start: at(0, 13), end: at(0, 15),
+    color: '#ef4444',
+    meta: { coords: { lat: 42.366, lon: -71.020 } },
+  },
+  {
+    id: 'm-sea-1',
+    title: 'KSEA — Trauma response',
+    start: at(1, 6), end: at(1, 9),
+    color: '#ef4444',
+    meta: { coords: { lat: 47.450, lon: -122.309 } },
+  },
+  {
+    id: 'm-mia-1',
+    title: 'KMIA — Cardiac transfer',
+    start: at(1, 12), end: at(1, 14),
+    color: '#f97316',
+    meta: { coords: { lat: 25.795, lon: -80.290 } },
+  },
+  {
+    id: 'm-den-1',
+    title: 'KDEN — Search and rescue',
+    start: at(2, 8), end: at(2, 11),
+    color: '#0ea5e9',
+    meta: { coords: { lat: 39.861, lon: -104.673 } },
+  },
+  {
+    id: 'm-ord-1',
+    title: 'KORD — Organ transport',
+    start: at(2, 16), end: at(2, 18),
+    color: '#8b5cf6',
+    meta: { coords: { lat: 41.978, lon: -87.904 } },
+  },
+  {
+    id: 'm-aus-1',
+    title: 'KAUS — Routine repositioning',
+    start: at(3, 10), end: at(3, 12),
+    color: '#10b981',
+    // Loose form — meta.lat / meta.lon at the top level.
+    meta: { lat: 30.194, lon: -97.670 },
+  },
+];
+
+// ── Tile styles ──────────────────────────────────────────────────────────────
+// In production swap the demo style for a provider you control. The demo
+// style is rate-limited and not appropriate for live deployments.
+const STYLES = [
+  { id: 'demo',     label: 'MapLibre demo',           url: 'https://demotiles.maplibre.org/style.json' },
+  { id: 'liberty',  label: 'OpenFreeMap · Liberty',   url: 'https://tiles.openfreemap.org/styles/liberty' },
+  { id: 'positron', label: 'OpenFreeMap · Positron',  url: 'https://tiles.openfreemap.org/styles/positron' },
+];
+
+// ── Component ────────────────────────────────────────────────────────────────
+export function MapExample() {
+  const [styleId, setStyleId] = useState('demo');
+  const mapStyle = STYLES.find(s => s.id === styleId).url;
+
+  const handleEventClick = useCallback((ev) => {
+    // In a real app: open a sidebar / drawer / mission detail page.
+    // eslint-disable-next-line no-console
+    console.log('Clicked mission marker:', ev);
+  }, []);
+
+  return (
+    <div style={{ height: '100%', display: 'flex', flexDirection: 'column' }}>
+      {/* Tile-style picker — demo aid only, not part of the component. */}
+      <div style={{
+        padding: '8px 12px',
+        background: '#f8fafc',
+        borderBottom: '1px solid #e2e8f0',
+        display: 'flex', gap: 6, alignItems: 'center', flexShrink: 0,
+      }}>
+        <span style={{
+          fontSize: 11, color: '#94a3b8', fontWeight: 600,
+          textTransform: 'uppercase', letterSpacing: '0.06em',
+        }}>
+          Tile style
+        </span>
+        {STYLES.map(s => (
+          <button
+            key={s.id}
+            onClick={() => setStyleId(s.id)}
+            style={{
+              padding: '3px 10px', borderRadius: 6, border: 'none', cursor: 'pointer', fontSize: 11,
+              fontWeight: styleId === s.id ? 700 : 400,
+              background: styleId === s.id ? '#1e293b' : '#e2e8f0',
+              color:      styleId === s.id ? '#fff'    : '#64748b',
+            }}
+          >
+            {s.label}
+          </button>
+        ))}
+        <span style={{ marginLeft: 'auto', fontSize: 11, color: '#94a3b8' }}>
+          Install <code>maplibre-gl</code> + <code>react-map-gl</code> to render the map.
+        </span>
+      </div>
+
+      <div style={{ flex: 1, minHeight: 0 }}>
+        <MapView
+          events={INITIAL_EVENTS}
+          onEventClick={handleEventClick}
+          mapStyle={mapStyle}
+          initialCenter={{ lat: 39.5, lng: -98.35 }}
+          initialZoom={3}
+        />
+      </div>
+    </div>
+  );
+}

--- a/examples/App.tsx
+++ b/examples/App.tsx
@@ -20,6 +20,7 @@ import { MultiSource }             from './07-MultiSource';
 import { ShiftCoverageTracking }   from './08-ShiftCoverageTracking';
 import { GroupingExample }         from './09-Grouping';
 import { DragAndDropExample }      from './10-DragAndDrop';
+import { MapExample }              from './11-Map';
 import { BasicUsageExample }       from './basic-usage';
 import { SetupWizardExample }      from './setup-wizard';
 import { AdvancedFiltersExample }  from './advanced-filters';
@@ -141,6 +142,13 @@ const EXAMPLES = [
     desc:  'Drag an event across groups (agenda) or rows (timeline) to reassign. Patches flow through engine validation.',
     component: DragAndDropExample,
   },
+  {
+    id:    'map',
+    label: 'Map View',
+    tag:   'Optional plugin',
+    desc:  'Geographic plot of events with meta.coords. Renders an install hint until maplibre-gl + react-map-gl are installed.',
+    component: MapExample,
+  },
 ];
 
 // ── Sidebar ───────────────────────────────────────────────────────────────────
@@ -229,6 +237,7 @@ function SourceHint({ id }) {
     'shift-coverage':       '08-ShiftCoverageTracking.jsx',
     'grouping':             '09-Grouping.jsx',
     'drag-and-drop':        '10-DragAndDrop.jsx',
+    'map':                  '11-Map.jsx',
     'basic-usage-modern':   'basic-usage.jsx',
     'setup-wizard':         'setup-wizard.jsx',
     'advanced-filters-new': 'advanced-filters.jsx',

--- a/examples/App.tsx
+++ b/examples/App.tsx
@@ -149,6 +149,8 @@ const EXAMPLES = [
     tag:   'Optional plugin',
     desc:  'Geographic plot of events with meta.coords. Renders an install hint until maplibre-gl + react-map-gl are installed.',
     component: MapExample,
+  },
+  {
     id:    'maintenance-invoicing',
     label: 'Maintenance & Invoicing',
     tag:   'Asset health · CSV export',

--- a/examples/README.md
+++ b/examples/README.md
@@ -18,6 +18,9 @@ npm run examples
 - `06-TeamCalendar.jsx` — multi-resource team scheduling
 - `07-MultiSource.jsx` — merged multi-source data views
 - `08-ShiftCoverageTracking.jsx` — PTO + coverage workflow
+- `09-Grouping.jsx` — 1-, 2-, 3-level grouping presets
+- `10-DragAndDrop.jsx` — drag events across groups / rows
+- `11-Map.jsx` — geographic plot via the optional MapView plugin (see [docs/MapView.md](../docs/MapView.md))
 
 ## Focused examples
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -21,8 +21,6 @@ npm run examples
 - `09-Grouping.jsx` — 1-, 2-, 3-level grouping presets
 - `10-DragAndDrop.jsx` — drag events across groups / rows
 - `11-Map.jsx` — geographic plot via the optional MapView plugin (see [docs/MapView.md](../docs/MapView.md))
-- `09-Grouping.jsx` — single / nested groupBy + saved views
-- `10-DragAndDrop.jsx` — drag events across groups and rows
 - `11-MaintenanceAndInvoicing.jsx` — asset-health badges, in-form maintenance completion, CSV export for invoicing + maintenance log
 
 ## Focused examples

--- a/examples/WORKFLOWS.md
+++ b/examples/WORKFLOWS.md
@@ -59,6 +59,21 @@ What it shows:
 
 ---
 
+## Geographic / Map view (optional plugin)
+
+Use this example:
+- `11-Map.jsx`
+
+What it shows:
+- standalone `MapView` import alongside the calendar shell
+- `meta.coords = { lat, lon }` data convention (matches `LocationData`)
+- swappable basemap via `mapStyle` (MapLibre demo, OpenFreeMap)
+- graceful install hint when `maplibre-gl` + `react-map-gl` aren't installed
+
+See [docs/MapView.md](../docs/MapView.md) for the full plugin guide.
+
+---
+
 ## Demo entry flow
 
 Use this example:

--- a/src/WorksCalendar.tsx
+++ b/src/WorksCalendar.tsx
@@ -217,6 +217,12 @@ export type WorksCalendarProps = {
   blockedWindows?: UnknownRecord[];
   theme?: string;
   colorRules?: UnknownRecord[];
+  /**
+   * Forwarded to the optional Map view (`initialView="map"`) as its
+   * MapLibre style URL. Ignored when the map view isn't active or when the
+   * `react-map-gl` / `maplibre-gl` peers aren't installed.
+   */
+  mapStyle?: string;
   businessHours?: UnknownRecord;
   renderEvent?: (event: WorksCalendarEvent, context?: UnknownRecord) => ReactNode;
   renderHoverCard?: (event: WorksCalendarEvent, onClose: () => void) => ReactNode;
@@ -546,6 +552,9 @@ export const WorksCalendar = forwardRef<CalendarApi, WorksCalendarProps>(functio
     logoSrc,
     logoAlt,
     backgroundImage,
+
+    // ── Map view (optional plugin) ──
+    mapStyle,
   }: WorksCalendarProps,
   ref: ForwardedRef<CalendarApi>,
 ) {
@@ -2474,7 +2483,11 @@ export const WorksCalendar = forwardRef<CalendarApi, WorksCalendarProps>(functio
                 />
               )}
               {cal.view === 'map' && (
-                <MapView events={visibleEvents as any} onEventClick={handleEventClick} />
+                <MapView
+                  events={visibleEvents as any}
+                  onEventClick={handleEventClick}
+                  {...(mapStyle ? { mapStyle } : {})}
+                />
               )}
             </>
           )}


### PR DESCRIPTION
- docs/MapView.md: full plugin guide — install, meta.coords data shape, props table, tile-provider options (MapTiler / Stadia / Protomaps / OpenFreeMap / self-hosted), bundle-impact notes, and the "why MapLibre over a custom map" trade-off.
- docs/README.md, docs/Setup.md: link to the new guide; add 'map' row to the views table.
- examples/11-Map.tsx: runnable mission-set example using the standalone MapView import with a tile-style picker (MapLibre demo / OpenFreeMap Liberty / Positron). Demonstrates both meta.coords and the loose meta.lat/meta.lon convenience form.
- examples/App.tsx, examples/README.md: register the example.
- examples/WORKFLOWS.md: add a "Geographic / Map view" section.

Verified: examples build code-splits maplibre-gl into its own ~218 KB gz chunk that only loads when the map example is opened — confirming the static-specifier dynamic import works correctly through the host bundler.

## Summary
Describe exactly what this PR changes.

## Scope
- Stage: 
- Planned PR number in sprint: 
- Target files/directories: 
- Why this slice is isolated: 

## Lessons Learned Check (REQUIRED)
Confirm these were actively used while building this PR:

- [ ] PR is intentionally small and isolated
- [ ] Boundary typing was prioritized over internal perfection
- [ ] No silent spread of `any`
- [ ] Advisory root `tsc` was used to catch integration issues
- [ ] I did not assume “looks typed” means “safe”
- [ ] I stopped and isolated typing cascades instead of expanding scope

## Definition of Done (ALL REQUIRED)
This PR is not done unless every box is checked.

- [ ] `npm run type-check:strict` passes
- [ ] Root advisory `tsc --noEmit` passes
- [ ] Tests pass for touched scope at minimum
- [ ] No uncontrolled increase in `any`
- [ ] All new types are intentional and named
- [ ] Public interfaces and exported functions are explicitly typed
- [ ] PR scope matches the sprint plan with no scope creep
- [ ] Any new `any` has an adjacent justification comment
- [ ] No file-wide `: any`
- [ ] No implicit `any` in exported functions

## What Was Typed
List exactly what was typed in this PR.

- 
- 
- 

## What Was Intentionally Left Loose
List anything intentionally not tightened yet.

- 
- 
- 

## `any` Ledger (REQUIRED)
- New `any` added: 
- Existing `any` removed: 
- Net change: 

For every new `any`, explain why it is required and why a safer type was not used yet.

1. 
2. 
3. 

## Boundary Notes
Document any public seams, caller-protection choices, or compatibility decisions.

- 
- 
- 

## Risk Level
- [ ] Low
- [ ] Medium
- [ ] High

Why:

## Validation Evidence
Paste the exact commands run and a short result summary.

```bash
npm run type-check:strict
npx tsc --noEmit -p tsconfig.json
```

Test commands run:

```bash
# paste commands here
```

## Stop Conditions Check
If any item below happened, explain how scope was reduced before merge.

- [ ] `any` started spreading across files
- [ ] Root `tsc` broke repeatedly
- [ ] Types required cross-module rewrites
- [ ] Scope was reduced to keep the PR reviewable

Notes:

## Reviewer Focus
What should reviewers look at first?

- 
- 
- 
