### PR TITLE
demo: default to industrial-light theme for a warmer first impression

### DIFF
--- a/demo/App.tsx
+++ b/demo/App.tsx
@@ -73,7 +73,7 @@ const DEMO_BASES = bases.map(b => ({ id: b.id, name: b.name }));
 //   2. Default view returns to Month. The seed previously hard-coded
 //      `defaultView: 'base'`; only the carried-over 'base' choice is reset
 //      so any user-picked view is respected.
-const DEMO_SEED_VERSION = 5;
+const DEMO_SEED_VERSION = 6;
 const SEED_VER_KEY      = `wc-demo-seed-v-${DEMO_CALENDAR_ID}`;
 const storedCfg         = localStorage.getItem(`wc-config-${DEMO_CALENDAR_ID}`);
 const storedSeedVer     = Number(localStorage.getItem(SEED_VER_KEY) ?? 0);
@@ -82,7 +82,7 @@ if (!storedCfg) {
   saveConfig(DEMO_CALENDAR_ID, {
     ...DEFAULT_CONFIG,
     title: 'Air EMS Operations',
-    setup: { completed: true, preferredTheme: 'ops-dark' },
+    setup: { completed: true, preferredTheme: 'industrial-light' },
     team: { ...DEFAULT_CONFIG.team, bases: DEMO_BASES },
     approvals: { ...DEFAULT_CONFIG.approvals, enabled: true },
   });
@@ -91,10 +91,15 @@ if (!storedCfg) {
   const existing = loadConfig(DEMO_CALENDAR_ID);
   const carriedDefaultView = existing.display?.defaultView;
   const nextDefaultView = carriedDefaultView === 'base' ? 'month' : carriedDefaultView;
+  // Theme migration: pre-v6 demos defaulted to 'ops-dark'. The new default
+  // is 'industrial-light' (warmer, friendlier first impression). Replace the
+  // old default in place; preserve any other theme the user actively chose.
+  const carriedTheme = existing.setup?.preferredTheme;
+  const nextTheme = carriedTheme && carriedTheme !== 'ops-dark' ? carriedTheme : 'industrial-light';
   saveConfig(DEMO_CALENDAR_ID, {
     ...existing,
     title:     existing.title ?? 'Air EMS Operations',
-    setup:     { ...existing.setup, preferredTheme: existing.setup?.preferredTheme ?? 'ops-dark' },
+    setup:     { ...existing.setup, preferredTheme: nextTheme },
     display:   { ...existing.display, defaultView: nextDefaultView ?? 'month' },
     team:      { ...existing.team, bases: DEMO_BASES },
     approvals: { ...existing.approvals, enabled: true },
@@ -103,7 +108,7 @@ if (!storedCfg) {
 }
 
 const _seedConfig  = loadConfig(DEMO_CALENDAR_ID);
-const INITIAL_THEME = _seedConfig.setup?.preferredTheme ?? 'ops-dark';
+const INITIAL_THEME = _seedConfig.setup?.preferredTheme ?? 'industrial-light';
 
 /* ─── Employees ────────────────────────────────────────────────── */
 // Pilots + medical crew + mechanics rendered as the people roster. Each

--- a/demo/index.html
+++ b/demo/index.html
@@ -6,7 +6,7 @@
   <title>WorksCalendar — Air EMS Operations Demo</title>
 
   <!-- PWA / theme metadata -->
-  <meta name="theme-color" content="#00d4ff" />
+  <meta name="theme-color" content="#c2410c" />
   <meta name="description" content="WorksCalendar Air EMS Operations Demo — flight coordination, medical staffing, and maintenance coverage in one view" />
   <meta name="mobile-web-app-capable" content="yes" />
   <meta name="apple-mobile-web-app-capable" content="yes" />
@@ -26,10 +26,10 @@
     body {
       margin: 0;
       font-family: 'Inter', system-ui, sans-serif;
-      /* Match the default ops-dark theme so the initial paint doesn't
-         flash light before React mounts. */
-      background: #060d1a;
-      color: #c8e8f0;
+      /* Match the default industrial-light theme so the initial paint
+         doesn't flash a different color before React mounts. */
+      background: #fffbf7;
+      color: #2d1f0e;
     }
     /* Let the calendar sit flush with the viewport edges in the demo. */
     #root > div > [data-testid="works-calendar"] {


### PR DESCRIPTION
The ops-dark default leaves the demo feeling heavy and a little dated out of the box. industrial-light (warm cream + burnt orange accent, already shipping in the theme registry) lands much closer to the "professional ops dashboard" look — same product, much better first paint.

Changes:
- demo/App.tsx — fresh-load preferredTheme + INITIAL_THEME fallback flipped to 'industrial-light'.
- demo/App.tsx — DEMO_SEED_VERSION 5 → 6 with a one-shot migration: if the user's saved theme is still 'ops-dark' (i.e. the old default they never customized), upgrade to 'industrial-light'. Any other theme is left alone.
- demo/index.html — early-paint <body> background / color and the theme-color <meta> updated so the pre-React flash matches the new default.

No layout, no behavior, no public-API changes. Owners who picked a specific theme keep theirs.

## Summary
Describe exactly what this PR changes.

## Scope
- Stage: 
- Planned PR number in sprint: 
- Target files/directories: 
- Why this slice is isolated: 

## Lessons Learned Check (REQUIRED)
Confirm these were actively used while building this PR:

- [ ] PR is intentionally small and isolated
- [ ] Boundary typing was prioritized over internal perfection
- [ ] No silent spread of `any`
- [ ] Advisory root `tsc` was used to catch integration issues
- [ ] I did not assume “looks typed” means “safe”
- [ ] I stopped and isolated typing cascades instead of expanding scope

## Definition of Done (ALL REQUIRED)
This PR is not done unless every box is checked.

- [ ] `npm run type-check:strict` passes
- [ ] Root advisory `tsc --noEmit` passes
- [ ] Tests pass for touched scope at minimum
- [ ] No uncontrolled increase in `any`
- [ ] All new types are intentional and named
- [ ] Public interfaces and exported functions are explicitly typed
- [ ] PR scope matches the sprint plan with no scope creep
- [ ] Any new `any` has an adjacent justification comment
- [ ] No file-wide `: any`
- [ ] No implicit `any` in exported functions

## What Was Typed
List exactly what was typed in this PR.

- 
- 
- 

## What Was Intentionally Left Loose
List anything intentionally not tightened yet.

- 
- 
- 

## `any` Ledger (REQUIRED)
- New `any` added: 
- Existing `any` removed: 
- Net change: 

For every new `any`, explain why it is required and why a safer type was not used yet.

1. 
2. 
3. 

## Boundary Notes
Document any public seams, caller-protection choices, or compatibility decisions.

- 
- 
- 

## Risk Level
- [ ] Low
- [ ] Medium
- [ ] High

Why:

## Validation Evidence
Paste the exact commands run and a short result summary.

```bash
npm run type-check:strict
npx tsc --noEmit -p tsconfig.json
```

Test commands run:

```bash
# paste commands here
```

## Stop Conditions Check
If any item below happened, explain how scope was reduced before merge.

- [ ] `any` started spreading across files
- [ ] Root `tsc` broke repeatedly
- [ ] Types required cross-module rewrites
- [ ] Scope was reduced to keep the PR reviewable

Notes:

## Reviewer Focus
What should reviewers look at first?

- 
- 
- 
