### PR TITLE
shell: introduce &lt;AppShell&gt; scaffold (PR 1, no visual change)

### DIFF
--- a/src/WorksCalendar.tsx
+++ b/src/WorksCalendar.tsx
@@ -45,6 +45,7 @@ import { SCHEDULE_WORKFLOW_CATEGORIES } from './core/scheduleModel';
 import { useTabScopedEvents } from './hooks/useTabScopedEvents';
 import { captureSavedViewFields, type ViewId } from './core/viewScope';
 import { buildActiveFilterPills, buildFilterSummary, hasActiveFilters } from './filters/filterState';
+import { AppShell }           from './ui/AppShell';
 import FilterBar              from './ui/FilterBar';
 import ProfileBar             from './ui/ProfileBar';
 import FilterGroupSidebar, { SidebarToggleButton } from './ui/FilterGroupSidebar';
@@ -2158,6 +2159,8 @@ export const WorksCalendar = forwardRef<CalendarApi, WorksCalendarProps>(functio
       <CalendarContext.Provider value={ctxValue}>
         <div className={styles['root']} data-wc-theme={effectiveTheme} data-wc-theme-family={themeFamily} data-wc-theme-mode={themeMode} data-testid="works-calendar" data-wc-edit-mode={editMode ? '' : undefined} style={rootStyle}>
 
+        <AppShell
+          header={<>
         {/* ── Toolbar ── */}
         {renderToolbar ? (
           <div className={styles['customToolbar']}>{renderToolbar(api)}</div>
@@ -2353,37 +2356,8 @@ export const WorksCalendar = forwardRef<CalendarApi, WorksCalendarProps>(functio
           activePills:   buildActiveFilterPills(cal.filters, filterBarSchema),
           items:         scopedEvents,
         })}
-
-        {/* ── View area (with sidebar overlay) ── */}
-        <FilterGroupSidebar
-          open={sidebarOpen}
-          initialTab={sidebarInitialTab}
-          onClose={() => setSidebarOpen(false)}
-          // Groups tab
-          groupLevels={sidebarGroupLevels}
-          onGroupLevelsChange={handleSidebarGroupLevelsChange}
-          sort={activeSort ?? []}
-          onSortChange={(next) => setActiveSort(next.length > 0 ? next : null)}
-          showAllGroups={activeShowAllGroups}
-          onShowAllGroupsChange={setActiveShowAllGroups}
-          // Filters tab
-          schema={filterBarSchema}
-          items={scopedEvents}
-          onFiltersChange={handleSidebarFiltersChange}
-          // Views tab
-          views={savedViews.views}
-          activeViewId={savedViewActiveId}
-          isViewDirty={savedViewDirty}
-          onApplyView={handleApplyView}
-          onSaveView={handleSidebarSaveView}
-          onResaveView={(id) => savedViews.resaveView(id, cal.filters, cal.view, activeGroupBy, captureSavedViewFields(cal.view, savedViewCaptureCtx))}
-          onUpdateView={savedViews.updateView}
-          onDeleteView={handleDeleteView}
-          onToggleViewVisibility={savedViews.toggleStripVisibility}
-          locationLabel={locationLabel}
-          assetsLabel={assetsLabel}
-        />
-
+          </>}
+          main={<>
         {/* ── View area ── */}
         <div
           ref={swipeAreaRef}
@@ -2492,6 +2466,38 @@ export const WorksCalendar = forwardRef<CalendarApi, WorksCalendarProps>(functio
             </>
           )}
         </div>
+          </>}
+        />
+
+        {/* ── Filter / Groups / Views overlay drawer ── */}
+        <FilterGroupSidebar
+          open={sidebarOpen}
+          initialTab={sidebarInitialTab}
+          onClose={() => setSidebarOpen(false)}
+          // Groups tab
+          groupLevels={sidebarGroupLevels}
+          onGroupLevelsChange={handleSidebarGroupLevelsChange}
+          sort={activeSort ?? []}
+          onSortChange={(next) => setActiveSort(next.length > 0 ? next : null)}
+          showAllGroups={activeShowAllGroups}
+          onShowAllGroupsChange={setActiveShowAllGroups}
+          // Filters tab
+          schema={filterBarSchema}
+          items={scopedEvents}
+          onFiltersChange={handleSidebarFiltersChange}
+          // Views tab
+          views={savedViews.views}
+          activeViewId={savedViewActiveId}
+          isViewDirty={savedViewDirty}
+          onApplyView={handleApplyView}
+          onSaveView={handleSidebarSaveView}
+          onResaveView={(id) => savedViews.resaveView(id, cal.filters, cal.view, activeGroupBy, captureSavedViewFields(cal.view, savedViewCaptureCtx))}
+          onUpdateView={savedViews.updateView}
+          onDeleteView={handleDeleteView}
+          onToggleViewVisibility={savedViews.toggleStripVisibility}
+          locationLabel={locationLabel}
+          assetsLabel={assetsLabel}
+        />
 
         {/* ── Hover card ── */}
         {selectedEvent && (

--- a/src/ui/AppShell.module.css
+++ b/src/ui/AppShell.module.css
@@ -1,0 +1,43 @@
+/*
+ * AppShell — three-column shell scaffold.
+ *
+ * PR 1 foundation only. Header sits above a body row; left rail and right
+ * panel are slot-optional and render nothing (zero width) when their props
+ * are undefined. With only header + main the visual layout collapses to the
+ * same vertical stack the calendar used pre-AppShell — no surrounding
+ * styling changes for this PR.
+ */
+
+.shell {
+  flex: 1;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+}
+
+.headerBand {
+  flex-shrink: 0;
+  display: flex;
+  flex-direction: column;
+}
+
+.body {
+  flex: 1;
+  min-height: 0;
+  display: flex;
+}
+
+.leftRail {
+  flex-shrink: 0;
+}
+
+.main {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+}
+
+.rightPanel {
+  flex-shrink: 0;
+}

--- a/src/ui/AppShell.tsx
+++ b/src/ui/AppShell.tsx
@@ -1,0 +1,34 @@
+import type { ReactNode } from 'react';
+import cls from './AppShell.module.css';
+
+export type AppShellProps = {
+  /** Top header band, full-width above the body. */
+  header: ReactNode;
+  /** Main content column between the optional left rail and right panel. */
+  main: ReactNode;
+  /** Optional fixed-width left icon rail. Omit to render no rail. */
+  leftRail?: ReactNode;
+  /** Optional fixed-width right panel. Omit to render no panel. */
+  rightPanel?: ReactNode;
+};
+
+/**
+ * Three-column dashboard shell scaffold.
+ *
+ * Header is always rendered above a body row that holds main and (optionally)
+ * a left rail / right panel. Slots that are not provided take no space, so a
+ * shell with only `header` + `main` lays out identically to a plain stacked
+ * column.
+ */
+export function AppShell({ header, main, leftRail, rightPanel }: AppShellProps) {
+  return (
+    <div className={cls['shell']}>
+      <div className={cls['headerBand']}>{header}</div>
+      <div className={cls['body']}>
+        {leftRail !== undefined && <aside className={cls['leftRail']}>{leftRail}</aside>}
+        <div className={cls['main']}>{main}</div>
+        {rightPanel !== undefined && <aside className={cls['rightPanel']}>{rightPanel}</aside>}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

PR 1 of the three-column layout series. Pure refactor — establishes the `<AppShell>` scaffold the next 6 PRs will plug into. **Zero visual change** vs. `main`.

The mock the series is targeting: https://workscalendar.github.io/CalendarThatWorks/shell-mock.html (branch `claude/shell-mock-three-column`).

## What's in this PR

- **`src/ui/AppShell.tsx`** — four-prop slot API: `header` (always above body row), `main` (flex:1 column), optional `leftRail` / `rightPanel` (zero-width when omitted).
- **`src/ui/AppShell.module.css`** — bare flex scaffold. No colors, no borders, no padding. Keeps theme tokens out of the structural layer so per-piece styling lives in per-piece PRs.
- **`src/WorksCalendar.tsx`** — wraps existing `toolbar` / `ProfileBar` / optional `renderFilterBar` block in the `header` slot, `viewArea` in the `main` slot. `FilterGroupSidebar` (off-canvas drawer) is moved out to sit as a sibling of `AppShell` so it isn't constrained by the body-row layout. Modals, hover card, and screen-reader announcer remain siblings as before.

## Why no visual change

`AppShell` with only `header` + `main` (no rail, no panel) collapses to vertical column of `header` → `main`. That matches the prior `.root` flex-column layout exactly — same flex children, same flex sizing, same DOM order in the body. Confirmed locally:

- `npm run type-check` — clean
- `npm run test` — 2096/2096 passing
- `npm run build` — library bundle size unchanged (`works-calendar.es.js` 2.50 KB gz)

## Followups (not in this PR)

- PR 2 — sub-toolbar split + bordered card around `main`
- PR 3 — header rebuild (hamburger / wordmark / view tabs / actions)
- PR 4 — `dayWindow` state + 7/14/30/90 pills in sub-toolbar
- PR 5 — `LeftRail`
- PR 6 — `RightPanel` (region map + crew-on-shift)
- PR 7 — theme sweep across all 12 themes

## Test plan

- [x] Typecheck clean
- [x] Full vitest suite passes
- [x] Library build size unchanged
- [ ] Smoke test the demo locally / on a preview deploy — confirm the calendar looks identical
- [ ] Sanity-check `FilterGroupSidebar` still opens correctly (it's the only DOM node that moved position relative to `viewArea`)

---
_Generated by [Claude Code](https://claude.ai/code/session_0129D5oFDywjK6gwjRU9dWLF)_