### PR TITLE
shell: &lt;AppHeader&gt; with three-zone layout + hamburger dropdown (PR 3)

### DIFF
--- a/src/WorksCalendar.module.css
+++ b/src/WorksCalendar.module.css
@@ -490,6 +490,29 @@
   flex-direction: column;
 }
 
+/* Main pane: padded shell holding the bordered calendar card. */
+.mainPane {
+  flex: 1;
+  min-height: 0;
+  display: flex;
+  padding: calc(12px * var(--wc-density, 1));
+}
+
+/* Calendar card: bordered, rounded, shadowed surface that wraps the
+ * sub-toolbar and the view grid. Tokens-only so per-theme overrides
+ * (radius, shadow, border) apply automatically. */
+.calendarCard {
+  flex: 1;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  background: var(--wc-surface);
+  border: var(--wc-border-width, 1px) solid var(--wc-border);
+  border-radius: var(--wc-radius);
+  box-shadow: var(--wc-shadow);
+  overflow: hidden;
+}
+
 .emptyStateWrap {
   flex: 1;
   display: flex;

--- a/src/WorksCalendar.tsx
+++ b/src/WorksCalendar.tsx
@@ -46,6 +46,7 @@ import { useTabScopedEvents } from './hooks/useTabScopedEvents';
 import { captureSavedViewFields, type ViewId } from './core/viewScope';
 import { buildActiveFilterPills, buildFilterSummary, hasActiveFilters } from './filters/filterState';
 import { AppShell }           from './ui/AppShell';
+import { SubToolbar }         from './ui/SubToolbar';
 import FilterBar              from './ui/FilterBar';
 import ProfileBar             from './ui/ProfileBar';
 import FilterGroupSidebar, { SidebarToggleButton } from './ui/FilterGroupSidebar';
@@ -2212,12 +2213,6 @@ export const WorksCalendar = forwardRef<CalendarApi, WorksCalendarProps>(functio
             </div>
 
             <div className={styles['actions']}>
-              <SidebarToggleButton
-                isOpen={sidebarOpen}
-                onClick={() => setSidebarOpen(v => !v)}
-                filterCount={hasActiveFilters(cal.filters, schema) ? 1 : 0}
-                groupCount={sidebarGroupLevels.length}
-              />
               {devMode && <span className={styles['devBadge']}>Dev</span>}
               {(ownerCfg.isOwner || devMode) && (
                 <button
@@ -2230,33 +2225,6 @@ export const WorksCalendar = forwardRef<CalendarApi, WorksCalendarProps>(functio
                   {editMode && <span className={styles['wandBtnLabel']}>Done</span>}
                 </button>
               )}
-              {hasAddButton && cal.view !== 'schedule' && (
-                <button className={styles['addBtn']} onClick={() => setFormEvent({})} aria-label="Add new event">
-                  <Plus size={14} aria-hidden="true" /><span className={styles['addBtnLabel']}> Add Event</span>
-                </button>
-              )}
-              {hasAddButton && hasScheduleTemplates && (
-                <button
-                  className={styles['addBtn']}
-                  onClick={() => {
-                    setScheduleOpen(true);
-                    trackScheduleTemplateAnalytics('schedule_dialog_opened', {
-                      templateCount: visibleScheduleTemplates.length,
-                    });
-                  }}
-                  aria-label="Add schedule from template"
-                >
-                  <Plus size={14} aria-hidden="true" /><span className={styles['addBtnLabel']}> Add Schedule</span>
-                </button>
-              )}
-              {hasImport && (
-                <button className={styles['exportBtn']} onClick={() => setImportOpen(true)} aria-label="Import .ics calendar">
-                  <Upload size={15} aria-hidden="true" />
-                </button>
-              )}
-              <button className={styles['exportBtn']} onClick={() => exportVisibleEvents(visibleEvents)} aria-label="Export to Excel">
-                <Download size={15} aria-hidden="true" />
-              </button>
               {ownerPassword && (
                 <OwnerLock
                   isOwner={ownerCfg.isOwner}
@@ -2357,7 +2325,48 @@ export const WorksCalendar = forwardRef<CalendarApi, WorksCalendarProps>(functio
           items:         scopedEvents,
         })}
           </>}
-          main={<>
+          main={
+        <div className={styles['mainPane']}>
+          <div className={styles['calendarCard']}>
+            <SubToolbar
+              leftSlot={<>
+                <SidebarToggleButton
+                  isOpen={sidebarOpen}
+                  onClick={() => setSidebarOpen(v => !v)}
+                  filterCount={hasActiveFilters(cal.filters, schema) ? 1 : 0}
+                  groupCount={sidebarGroupLevels.length}
+                />
+                {hasAddButton && cal.view !== 'schedule' && (
+                  <button className={styles['addBtn']} onClick={() => setFormEvent({})} aria-label="Add new event">
+                    <Plus size={14} aria-hidden="true" /><span className={styles['addBtnLabel']}> Add Event</span>
+                  </button>
+                )}
+                {hasAddButton && hasScheduleTemplates && (
+                  <button
+                    className={styles['addBtn']}
+                    onClick={() => {
+                      setScheduleOpen(true);
+                      trackScheduleTemplateAnalytics('schedule_dialog_opened', {
+                        templateCount: visibleScheduleTemplates.length,
+                      });
+                    }}
+                    aria-label="Add schedule from template"
+                  >
+                    <Plus size={14} aria-hidden="true" /><span className={styles['addBtnLabel']}> Add Schedule</span>
+                  </button>
+                )}
+              </>}
+              rightSlot={<>
+                {hasImport && (
+                  <button className={styles['exportBtn']} onClick={() => setImportOpen(true)} aria-label="Import .ics calendar">
+                    <Upload size={15} aria-hidden="true" />
+                  </button>
+                )}
+                <button className={styles['exportBtn']} onClick={() => exportVisibleEvents(visibleEvents)} aria-label="Export to Excel">
+                  <Download size={15} aria-hidden="true" />
+                </button>
+              </>}
+            />
         {/* ── View area ── */}
         <div
           ref={swipeAreaRef}
@@ -2466,7 +2475,9 @@ export const WorksCalendar = forwardRef<CalendarApi, WorksCalendarProps>(functio
             </>
           )}
         </div>
-          </>}
+          </div>
+        </div>
+          }
         />
 
         {/* ── Filter / Groups / Views overlay drawer ── */}

--- a/src/WorksCalendar.tsx
+++ b/src/WorksCalendar.tsx
@@ -46,6 +46,7 @@ import { useTabScopedEvents } from './hooks/useTabScopedEvents';
 import { captureSavedViewFields, type ViewId } from './core/viewScope';
 import { buildActiveFilterPills, buildFilterSummary, hasActiveFilters } from './filters/filterState';
 import { AppShell }           from './ui/AppShell';
+import { AppHeader }          from './ui/AppHeader';
 import { SubToolbar }         from './ui/SubToolbar';
 import FilterBar              from './ui/FilterBar';
 import ProfileBar             from './ui/ProfileBar';
@@ -2166,76 +2167,90 @@ export const WorksCalendar = forwardRef<CalendarApi, WorksCalendarProps>(functio
         {renderToolbar ? (
           <div className={styles['customToolbar']}>{renderToolbar(api)}</div>
         ) : (
-          <div className={styles['toolbar']} role="toolbar" aria-label="Calendar navigation">
-            <div className={styles['navGroup']}>
-              {logoSrc && (
-                <img
-                  src={logoSrc}
-                  alt={logoAlt ?? ''}
-                  className={styles['logo']}
-                  aria-hidden={!logoAlt ? 'true' : undefined}
-                />
-              )}
-              <button
-                className={styles['navBtn']}
-                onClick={() => cal.navigate(-1)}
-                aria-label="Previous"
-                title={`Previous ${cal.view}`}
-              >
-                <ChevronLeft size={18} aria-hidden="true" />
-              </button>
-              <button className={styles['todayBtn']} onClick={cal.goToToday}>Today</button>
-              <button
-                className={styles['navBtn']}
-                onClick={() => cal.navigate(1)}
-                aria-label="Next"
-                title={`Next ${cal.view}`}
-              >
-                <ChevronRight size={18} aria-hidden="true" />
-              </button>
-              <span className={styles['dateLabel']} aria-live="polite" aria-atomic="true">{getDateLabel()}</span>
-              <span className={styles['calendarTitle']}>{calendarTitle}</span>
-              {fetchLoading && <span className={styles['loadingDot']} title="Loading…" aria-label="Loading events" role="status" />}
-            </div>
-
-            <div className={styles['viewGroup']} role="group" aria-label="Calendar view">
-              {VIEWS.map(v => (
+          <AppHeader
+            leftSlot={
+              <div className={styles['navGroup']}>
+                {logoSrc && (
+                  <img
+                    src={logoSrc}
+                    alt={logoAlt ?? ''}
+                    className={styles['logo']}
+                    aria-hidden={!logoAlt ? 'true' : undefined}
+                  />
+                )}
                 <button
-                  key={v.id}
-                  className={[styles['viewBtn'], cal.view === v.id && styles['activeView']].filter(Boolean).join(' ')}
-                  onClick={() => cal.setView(v.id)}
-                  aria-pressed={cal.view === v.id}
-                  title={v.hint}
+                  className={styles['navBtn']}
+                  onClick={() => cal.navigate(-1)}
+                  aria-label="Previous"
+                  title={`Previous ${cal.view}`}
                 >
-                  {v.label}
+                  <ChevronLeft size={18} aria-hidden="true" />
                 </button>
-              ))}
-            </div>
-
-            <div className={styles['actions']}>
-              {devMode && <span className={styles['devBadge']}>Dev</span>}
-              {(ownerCfg.isOwner || devMode) && (
+                <button className={styles['todayBtn']} onClick={cal.goToToday}>Today</button>
                 <button
-                  className={[styles['wandBtn'], editMode && styles['wandBtnActive']].filter(Boolean).join(' ')}
-                  onClick={() => { setEditMode(v => !v); setInlineEditTarget(null); }}
-                  aria-label={editMode ? 'Exit edit mode' : 'Enter edit mode — click events to customize them'}
-                  title={editMode ? 'Exit edit mode' : 'Customize events'}
+                  className={styles['navBtn']}
+                  onClick={() => cal.navigate(1)}
+                  aria-label="Next"
+                  title={`Next ${cal.view}`}
                 >
-                  <Sparkles size={15} aria-hidden="true" />
-                  {editMode && <span className={styles['wandBtnLabel']}>Done</span>}
+                  <ChevronRight size={18} aria-hidden="true" />
                 </button>
-              )}
-              {ownerPassword && (
-                <OwnerLock
-                  isOwner={ownerCfg.isOwner}
-                  authError={ownerCfg.authError}
-                  isAuthLoading={ownerCfg.isAuthLoading}
-                  onAuthenticate={ownerCfg.authenticate}
-                  onOpen={() => ownerCfg.setConfigOpen(true)}
-                />
-              )}
-            </div>
-          </div>
+                <span className={styles['dateLabel']} aria-live="polite" aria-atomic="true">{getDateLabel()}</span>
+                <span className={styles['calendarTitle']}>{calendarTitle}</span>
+                {fetchLoading && <span className={styles['loadingDot']} title="Loading…" aria-label="Loading events" role="status" />}
+              </div>
+            }
+            centerSlot={
+              <div className={styles['viewGroup']} role="group" aria-label="Calendar view">
+                {VIEWS.map(v => (
+                  <button
+                    key={v.id}
+                    className={[styles['viewBtn'], cal.view === v.id && styles['activeView']].filter(Boolean).join(' ')}
+                    onClick={() => cal.setView(v.id)}
+                    aria-pressed={cal.view === v.id}
+                    title={v.hint}
+                  >
+                    {v.label}
+                  </button>
+                ))}
+              </div>
+            }
+            rightSlot={
+              <div className={styles['actions']}>
+                {devMode && <span className={styles['devBadge']}>Dev</span>}
+                {(ownerCfg.isOwner || devMode) && (
+                  <button
+                    className={[styles['wandBtn'], editMode && styles['wandBtnActive']].filter(Boolean).join(' ')}
+                    onClick={() => { setEditMode(v => !v); setInlineEditTarget(null); }}
+                    aria-label={editMode ? 'Exit edit mode' : 'Enter edit mode — click events to customize them'}
+                    title={editMode ? 'Exit edit mode' : 'Customize events'}
+                  >
+                    <Sparkles size={15} aria-hidden="true" />
+                    {editMode && <span className={styles['wandBtnLabel']}>Done</span>}
+                  </button>
+                )}
+                {ownerPassword && (
+                  <OwnerLock
+                    isOwner={ownerCfg.isOwner}
+                    authError={ownerCfg.authError}
+                    isAuthLoading={ownerCfg.isAuthLoading}
+                    onAuthenticate={ownerCfg.authenticate}
+                    onOpen={() => ownerCfg.setConfigOpen(true)}
+                  />
+                )}
+              </div>
+            }
+            menuItems={[
+              ...(ownerCfg.isOwner ? [
+                { label: 'Settings',          sub: 'Calendar config, integrations', onClick: () => ownerCfg.setConfigOpen(true) },
+                { label: 'Themes',            sub: 'Switch palette / appearance',   onClick: () => ownerCfg.openConfigToTab('theme') },
+                { label: 'Advanced settings', sub: 'Smart views, fields, approvals', onClick: () => ownerCfg.openConfigToTab('smartViews') },
+              ] : []),
+              { label: 'Saved views',         sub: 'Manage your view library',      onClick: () => { setSidebarInitialTab('saved'); setSidebarOpen(true); } },
+              { label: 'Keyboard shortcuts',  sub: 'Quick reference',               onClick: () => setHelpOpen(true) },
+              { label: 'Help & feedback',                                          onClick: () => window.open('https://github.com/WorksCalendar/CalendarThatWorks/issues', '_blank', 'noopener') },
+            ]}
+          />
         )}
 
         {/* ── Profile / Saved-views Bar ── */}

--- a/src/WorksCalendar.tsx
+++ b/src/WorksCalendar.tsx
@@ -45,6 +45,7 @@ import { SCHEDULE_WORKFLOW_CATEGORIES } from './core/scheduleModel';
 import { useTabScopedEvents } from './hooks/useTabScopedEvents';
 import { captureSavedViewFields, type ViewId } from './core/viewScope';
 import { buildActiveFilterPills, buildFilterSummary, hasActiveFilters } from './filters/filterState';
+import { AppShell }           from './ui/AppShell';
 import FilterBar              from './ui/FilterBar';
 import ProfileBar             from './ui/ProfileBar';
 import FilterGroupSidebar, { SidebarToggleButton } from './ui/FilterGroupSidebar';
@@ -2158,6 +2159,8 @@ export const WorksCalendar = forwardRef<CalendarApi, WorksCalendarProps>(functio
       <CalendarContext.Provider value={ctxValue}>
         <div className={styles['root']} data-wc-theme={effectiveTheme} data-wc-theme-family={themeFamily} data-wc-theme-mode={themeMode} data-testid="works-calendar" data-wc-edit-mode={editMode ? '' : undefined} style={rootStyle}>
 
+        <AppShell
+          header={<>
         {/* ── Toolbar ── */}
         {renderToolbar ? (
           <div className={styles['customToolbar']}>{renderToolbar(api)}</div>
@@ -2353,37 +2356,8 @@ export const WorksCalendar = forwardRef<CalendarApi, WorksCalendarProps>(functio
           activePills:   buildActiveFilterPills(cal.filters, filterBarSchema),
           items:         scopedEvents,
         })}
-
-        {/* ── View area (with sidebar overlay) ── */}
-        <FilterGroupSidebar
-          open={sidebarOpen}
-          initialTab={sidebarInitialTab}
-          onClose={() => setSidebarOpen(false)}
-          // Groups tab
-          groupLevels={sidebarGroupLevels}
-          onGroupLevelsChange={handleSidebarGroupLevelsChange}
-          sort={activeSort ?? []}
-          onSortChange={(next) => setActiveSort(next.length > 0 ? next : null)}
-          showAllGroups={activeShowAllGroups}
-          onShowAllGroupsChange={setActiveShowAllGroups}
-          // Filters tab
-          schema={filterBarSchema}
-          items={scopedEvents}
-          onFiltersChange={handleSidebarFiltersChange}
-          // Views tab
-          views={savedViews.views}
-          activeViewId={savedViewActiveId}
-          isViewDirty={savedViewDirty}
-          onApplyView={handleApplyView}
-          onSaveView={handleSidebarSaveView}
-          onResaveView={(id) => savedViews.resaveView(id, cal.filters, cal.view, activeGroupBy, captureSavedViewFields(cal.view, savedViewCaptureCtx))}
-          onUpdateView={savedViews.updateView}
-          onDeleteView={handleDeleteView}
-          onToggleViewVisibility={savedViews.toggleStripVisibility}
-          locationLabel={locationLabel}
-          assetsLabel={assetsLabel}
-        />
-
+          </>}
+          main={<>
         {/* ── View area ── */}
         <div
           ref={swipeAreaRef}
@@ -2492,6 +2466,38 @@ export const WorksCalendar = forwardRef<CalendarApi, WorksCalendarProps>(functio
             </>
           )}
         </div>
+          </>}
+        />
+
+        {/* ── Filter / Groups / Views overlay drawer ── */}
+        <FilterGroupSidebar
+          open={sidebarOpen}
+          initialTab={sidebarInitialTab}
+          onClose={() => setSidebarOpen(false)}
+          // Groups tab
+          groupLevels={sidebarGroupLevels}
+          onGroupLevelsChange={handleSidebarGroupLevelsChange}
+          sort={activeSort ?? []}
+          onSortChange={(next) => setActiveSort(next.length > 0 ? next : null)}
+          showAllGroups={activeShowAllGroups}
+          onShowAllGroupsChange={setActiveShowAllGroups}
+          // Filters tab
+          schema={filterBarSchema}
+          items={scopedEvents}
+          onFiltersChange={handleSidebarFiltersChange}
+          // Views tab
+          views={savedViews.views}
+          activeViewId={savedViewActiveId}
+          isViewDirty={savedViewDirty}
+          onApplyView={handleApplyView}
+          onSaveView={handleSidebarSaveView}
+          onResaveView={(id) => savedViews.resaveView(id, cal.filters, cal.view, activeGroupBy, captureSavedViewFields(cal.view, savedViewCaptureCtx))}
+          onUpdateView={savedViews.updateView}
+          onDeleteView={handleDeleteView}
+          onToggleViewVisibility={savedViews.toggleStripVisibility}
+          locationLabel={locationLabel}
+          assetsLabel={assetsLabel}
+        />
 
         {/* ── Hover card ── */}
         {selectedEvent && (

--- a/src/ui/AppHeader.module.css
+++ b/src/ui/AppHeader.module.css
@@ -1,0 +1,122 @@
+/*
+ * AppHeader — three-zone top bar with optional hamburger dropdown.
+ * Token-driven; the bar inherits its surface from the active theme so the
+ * existing 12 themes restyle automatically.
+ */
+
+.root {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 0 calc(12px * var(--wc-density, 1));
+  height: calc(56px * var(--wc-density, 1));
+  border-bottom: var(--wc-border-width, 1px) solid var(--wc-border);
+  background: var(--wc-surface);
+  flex-shrink: 0;
+  position: relative;
+}
+
+.left {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex: 0 0 auto;
+  min-width: 0;
+}
+
+.center {
+  flex: 1;
+  display: flex;
+  justify-content: center;
+  min-width: 0;
+}
+
+.right {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex: 0 0 auto;
+  margin-left: auto;
+}
+
+/* ── Hamburger ────────────────────────────────────────────────────────── */
+
+.menuWrap {
+  position: relative;
+  display: flex;
+}
+
+.menuBtn {
+  width: 32px;
+  height: 32px;
+  border: none;
+  background: transparent;
+  color: var(--wc-text-muted);
+  border-radius: var(--wc-radius-sm);
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.menuBtn:hover,
+.menuBtn:focus-visible {
+  background: var(--wc-surface-2);
+  color: var(--wc-text);
+}
+
+.menuBtn:focus-visible {
+  outline: 2px solid var(--wc-accent);
+  outline-offset: 2px;
+}
+
+.dropdown {
+  position: absolute;
+  top: calc(100% + 4px);
+  left: 0;
+  min-width: 240px;
+  background: var(--wc-surface);
+  border: var(--wc-border-width, 1px) solid var(--wc-border);
+  border-radius: var(--wc-radius);
+  box-shadow: var(--wc-shadow);
+  padding: 4px;
+  z-index: 100;
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+}
+
+.dropdownItem {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 1px;
+  padding: 8px 10px;
+  border: none;
+  background: transparent;
+  color: var(--wc-text);
+  border-radius: var(--wc-radius-sm);
+  cursor: pointer;
+  text-align: left;
+  font: inherit;
+}
+
+.dropdownItem:hover,
+.dropdownItem:focus-visible {
+  background: var(--wc-surface-2);
+}
+
+.dropdownItem:focus-visible {
+  outline: 2px solid var(--wc-accent);
+  outline-offset: -2px;
+}
+
+.dropdownLabel {
+  font-size: 13px;
+  color: var(--wc-text);
+}
+
+.dropdownSub {
+  font-size: 11px;
+  color: var(--wc-text-muted);
+}

--- a/src/ui/AppHeader.tsx
+++ b/src/ui/AppHeader.tsx
@@ -1,0 +1,104 @@
+import { useEffect, useRef, useState } from 'react';
+import type { ReactNode } from 'react';
+import { Menu } from 'lucide-react';
+import cls from './AppHeader.module.css';
+
+export type AppHeaderMenuItem = {
+  /** Visible label (top line). */
+  label: string;
+  /** Optional sub-label (smaller, second line). */
+  sub?: string;
+  /** Click handler. AppHeader closes the dropdown before invoking. */
+  onClick: () => void;
+};
+
+export type AppHeaderProps = {
+  /** Left zone — branding + nav cluster. */
+  leftSlot?: ReactNode;
+  /** Center zone — view-tab pills. */
+  centerSlot?: ReactNode;
+  /** Right zone — system actions. */
+  rightSlot?: ReactNode;
+  /** Hamburger menu items. Empty / omitted hides the hamburger entirely. */
+  menuItems?: AppHeaderMenuItem[];
+};
+
+/**
+ * Top header band. Three layout zones (left / center / right) plus an
+ * optional hamburger dropdown anchored at the very start of the left zone.
+ * Slots are layout-only; the consumer owns content + state.
+ *
+ * role="toolbar" + aria-label="Calendar navigation" is preserved on the
+ * root so existing a11y queries keep working.
+ */
+export function AppHeader({ leftSlot, centerSlot, rightSlot, menuItems }: AppHeaderProps) {
+  const [menuOpen, setMenuOpen] = useState(false);
+  const menuWrapRef = useRef<HTMLDivElement>(null);
+
+  // Close on outside click
+  useEffect(() => {
+    if (!menuOpen) return;
+    const onDocClick = (e: MouseEvent) => {
+      if (menuWrapRef.current && !menuWrapRef.current.contains(e.target as Node)) {
+        setMenuOpen(false);
+      }
+    };
+    document.addEventListener('mousedown', onDocClick);
+    return () => document.removeEventListener('mousedown', onDocClick);
+  }, [menuOpen]);
+
+  // Close on Escape
+  useEffect(() => {
+    if (!menuOpen) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setMenuOpen(false);
+    };
+    document.addEventListener('keydown', onKey);
+    return () => document.removeEventListener('keydown', onKey);
+  }, [menuOpen]);
+
+  const hasMenu = !!menuItems && menuItems.length > 0;
+
+  return (
+    <div className={cls['root']} role="toolbar" aria-label="Calendar navigation">
+      <div className={cls['left']}>
+        {hasMenu && (
+          <div ref={menuWrapRef} className={cls['menuWrap']}>
+            <button
+              type="button"
+              className={cls['menuBtn']}
+              aria-label={menuOpen ? 'Close main menu' : 'Open main menu'}
+              aria-haspopup="menu"
+              aria-expanded={menuOpen}
+              onClick={() => setMenuOpen(v => !v)}
+            >
+              <Menu size={18} aria-hidden="true" />
+            </button>
+            {menuOpen && (
+              <div className={cls['dropdown']} role="menu">
+                {menuItems!.map(item => (
+                  <button
+                    key={item.label}
+                    type="button"
+                    role="menuitem"
+                    className={cls['dropdownItem']}
+                    onClick={() => {
+                      setMenuOpen(false);
+                      item.onClick();
+                    }}
+                  >
+                    <span className={cls['dropdownLabel']}>{item.label}</span>
+                    {item.sub && <span className={cls['dropdownSub']}>{item.sub}</span>}
+                  </button>
+                ))}
+              </div>
+            )}
+          </div>
+        )}
+        {leftSlot}
+      </div>
+      <div className={cls['center']}>{centerSlot}</div>
+      <div className={cls['right']}>{rightSlot}</div>
+    </div>
+  );
+}

--- a/src/ui/AppShell.module.css
+++ b/src/ui/AppShell.module.css
@@ -1,0 +1,43 @@
+/*
+ * AppShell — three-column shell scaffold.
+ *
+ * PR 1 foundation only. Header sits above a body row; left rail and right
+ * panel are slot-optional and render nothing (zero width) when their props
+ * are undefined. With only header + main the visual layout collapses to the
+ * same vertical stack the calendar used pre-AppShell — no surrounding
+ * styling changes for this PR.
+ */
+
+.shell {
+  flex: 1;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+}
+
+.headerBand {
+  flex-shrink: 0;
+  display: flex;
+  flex-direction: column;
+}
+
+.body {
+  flex: 1;
+  min-height: 0;
+  display: flex;
+}
+
+.leftRail {
+  flex-shrink: 0;
+}
+
+.main {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+}
+
+.rightPanel {
+  flex-shrink: 0;
+}

--- a/src/ui/AppShell.tsx
+++ b/src/ui/AppShell.tsx
@@ -1,0 +1,34 @@
+import type { ReactNode } from 'react';
+import cls from './AppShell.module.css';
+
+export type AppShellProps = {
+  /** Top header band, full-width above the body. */
+  header: ReactNode;
+  /** Main content column between the optional left rail and right panel. */
+  main: ReactNode;
+  /** Optional fixed-width left icon rail. Omit to render no rail. */
+  leftRail?: ReactNode;
+  /** Optional fixed-width right panel. Omit to render no panel. */
+  rightPanel?: ReactNode;
+};
+
+/**
+ * Three-column dashboard shell scaffold.
+ *
+ * Header is always rendered above a body row that holds main and (optionally)
+ * a left rail / right panel. Slots that are not provided take no space, so a
+ * shell with only `header` + `main` lays out identically to a plain stacked
+ * column.
+ */
+export function AppShell({ header, main, leftRail, rightPanel }: AppShellProps) {
+  return (
+    <div className={cls['shell']}>
+      <div className={cls['headerBand']}>{header}</div>
+      <div className={cls['body']}>
+        {leftRail !== undefined && <aside className={cls['leftRail']}>{leftRail}</aside>}
+        <div className={cls['main']}>{main}</div>
+        {rightPanel !== undefined && <aside className={cls['rightPanel']}>{rightPanel}</aside>}
+      </div>
+    </div>
+  );
+}

--- a/src/ui/SubToolbar.module.css
+++ b/src/ui/SubToolbar.module.css
@@ -1,0 +1,39 @@
+/*
+ * SubToolbar — three-zone bar inside the calendar card.
+ *
+ * Tokens-only styling so the bar inherits whatever theme is active. The
+ * 8px gap between zones matches the existing main-toolbar spacing in
+ * WorksCalendar.module.css.
+ */
+
+.root {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: calc(8px * var(--wc-density, 1)) calc(12px * var(--wc-density, 1));
+  border-bottom: var(--wc-border-width, 1px) solid var(--wc-border);
+  background: var(--wc-bg);
+  flex-shrink: 0;
+  flex-wrap: wrap;
+}
+
+.left {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.center {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 0;
+}
+
+.right {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin-left: auto;
+}

--- a/src/ui/SubToolbar.tsx
+++ b/src/ui/SubToolbar.tsx
@@ -1,0 +1,28 @@
+import type { ReactNode } from 'react';
+import cls from './SubToolbar.module.css';
+
+export type SubToolbarProps = {
+  /** Left zone — primary data actions (e.g. Add, Filter trigger). */
+  leftSlot?: ReactNode;
+  /** Center zone — view-scoped controls (e.g. day-window pill set). */
+  centerSlot?: ReactNode;
+  /** Right zone — secondary actions (e.g. Import, Export, Save view). */
+  rightSlot?: ReactNode;
+};
+
+/**
+ * Sub-toolbar that lives inside the calendar card, above the view grid.
+ *
+ * Three layout-only zones — content is provided by the consumer so the
+ * shell stays agnostic to which buttons exist in each surface (calendar
+ * top-level vs. embedder-supplied custom toolbars).
+ */
+export function SubToolbar({ leftSlot, centerSlot, rightSlot }: SubToolbarProps) {
+  return (
+    <div className={cls['root']} role="toolbar" aria-label="Calendar actions">
+      <div className={cls['left']}>{leftSlot}</div>
+      <div className={cls['center']}>{centerSlot}</div>
+      <div className={cls['right']}>{rightSlot}</div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

PR 3 of the three-column layout series. Replaces the in-place `.toolbar` JSX with a dedicated `<AppHeader>` component — three-zone layout (left / center / right) plus the consolidated hamburger dropdown the mock asks for.

**Stacks on PR 2 (#405), which stacks on PR 1 (#404).** When the parents land, this rebases onto `main` and the diff narrows to just the PR 3 changes.

## What's in this PR

- **`src/ui/AppHeader.tsx` + `AppHeader.module.css`** — new component:
  - Three layout zones: `left` (logo + nav cluster), `center` (view-tab pills), `right` (actions). The center slot's `flex: 1; justify-content: center` naturally centers the view tabs.
  - Built-in hamburger button + dropdown (consumer passes `menuItems`). Outside-click and Escape close it. Token-driven dropdown styling.
  - `role="toolbar"` + `aria-label="Calendar navigation"` preserved on the root.
- **`src/WorksCalendar.tsx`** — the default `.toolbar` JSX is now an `<AppHeader>` invocation. The custom `renderToolbar` override path is untouched.

## Hamburger menu items

| Item | Visibility | Action |
|---|---|---|
| Settings | owner only | `ownerCfg.setConfigOpen(true)` |
| Themes | owner only | `ownerCfg.openConfigToTab('theme')` |
| Advanced settings | owner only | `ownerCfg.openConfigToTab('smartViews')` |
| Saved views | always | opens `FilterGroupSidebar` on the Saved tab |
| Keyboard shortcuts | always | opens `KeyboardHelpOverlay` |
| Help & feedback | always | opens repo issues in a new tab |

OwnerLock remains in the right zone as the auth gateway — non-owners can still authenticate, and the owner-only menu items appear on the next render.

## Why no Search / Bell / Base Selector yet

The mock shows them in the right zone but they have no backing functionality (search what? notifications from where? bases configured how?). Shipping them now would land dead UI. Real wiring is a follow-up.

## Test plan

- [x] `npm run type-check` clean
- [x] `npm run test` — 2096/2096 pass
- [x] `npm run build` clean (lib gz delta ~+0.4 KB for AppHeader + dropdown styles)
- [ ] Smoke test on the Vercel preview: hamburger opens, items dispatch correctly, view tabs still center when window is wide / narrow
- [ ] Sanity-check the dropdown over both light themes (industrial-light, corporate-light) and dark themes (ops-dark, neon-dark) — the dropdown surface should visibly contrast against the header

## Followups

- PR 4 — `dayWindow` state + 7/14/30/90 pills in SubToolbar center zone
- PR 5 — `LeftRail`
- PR 6 — `RightPanel`
- PR 7 — Theme sweep
- PR 8 — Catch e2e selectors up to the new shell DOM (single sweep at the end)

---
_Generated by [Claude Code](https://claude.ai/code/session_0129D5oFDywjK6gwjRU9dWLF)_