### PR TITLE
shell: &lt;LeftRail&gt; wired to cal.view + extract VIEW_ICON_MAP (PR 5)

### DIFF
--- a/src/WorksCalendar.module.css
+++ b/src/WorksCalendar.module.css
@@ -490,6 +490,29 @@
   flex-direction: column;
 }
 
+/* Main pane: padded shell holding the bordered calendar card. */
+.mainPane {
+  flex: 1;
+  min-height: 0;
+  display: flex;
+  padding: calc(12px * var(--wc-density, 1));
+}
+
+/* Calendar card: bordered, rounded, shadowed surface that wraps the
+ * sub-toolbar and the view grid. Tokens-only so per-theme overrides
+ * (radius, shadow, border) apply automatically. */
+.calendarCard {
+  flex: 1;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  background: var(--wc-surface);
+  border: var(--wc-border-width, 1px) solid var(--wc-border);
+  border-radius: var(--wc-radius);
+  box-shadow: var(--wc-shadow);
+  overflow: hidden;
+}
+
 .emptyStateWrap {
   flex: 1;
   display: flex;

--- a/src/WorksCalendar.tsx
+++ b/src/WorksCalendar.tsx
@@ -47,6 +47,7 @@ import { captureSavedViewFields, type ViewId } from './core/viewScope';
 import { buildActiveFilterPills, buildFilterSummary, hasActiveFilters } from './filters/filterState';
 import { AppShell }           from './ui/AppShell';
 import { AppHeader }          from './ui/AppHeader';
+import { LeftRail }           from './ui/LeftRail';
 import { SubToolbar }         from './ui/SubToolbar';
 import { DayWindowPills }     from './ui/DayWindowPills';
 import FilterBar              from './ui/FilterBar';
@@ -2163,6 +2164,7 @@ export const WorksCalendar = forwardRef<CalendarApi, WorksCalendarProps>(functio
         <div className={styles['root']} data-wc-theme={effectiveTheme} data-wc-theme-family={themeFamily} data-wc-theme-mode={themeMode} data-testid="works-calendar" data-wc-edit-mode={editMode ? '' : undefined} style={rootStyle}>
 
         <AppShell
+          leftRail={<LeftRail items={VIEWS} activeId={cal.view} onSelect={cal.setView} />}
           header={<>
         {/* ── Toolbar ── */}
         {renderToolbar ? (

--- a/src/WorksCalendar.tsx
+++ b/src/WorksCalendar.tsx
@@ -46,6 +46,7 @@ import { useTabScopedEvents } from './hooks/useTabScopedEvents';
 import { captureSavedViewFields, type ViewId } from './core/viewScope';
 import { buildActiveFilterPills, buildFilterSummary, hasActiveFilters } from './filters/filterState';
 import { AppShell }           from './ui/AppShell';
+import { SubToolbar }         from './ui/SubToolbar';
 import FilterBar              from './ui/FilterBar';
 import ProfileBar             from './ui/ProfileBar';
 import FilterGroupSidebar, { SidebarToggleButton } from './ui/FilterGroupSidebar';
@@ -2212,12 +2213,6 @@ export const WorksCalendar = forwardRef<CalendarApi, WorksCalendarProps>(functio
             </div>
 
             <div className={styles['actions']}>
-              <SidebarToggleButton
-                isOpen={sidebarOpen}
-                onClick={() => setSidebarOpen(v => !v)}
-                filterCount={hasActiveFilters(cal.filters, schema) ? 1 : 0}
-                groupCount={sidebarGroupLevels.length}
-              />
               {devMode && <span className={styles['devBadge']}>Dev</span>}
               {(ownerCfg.isOwner || devMode) && (
                 <button
@@ -2230,33 +2225,6 @@ export const WorksCalendar = forwardRef<CalendarApi, WorksCalendarProps>(functio
                   {editMode && <span className={styles['wandBtnLabel']}>Done</span>}
                 </button>
               )}
-              {hasAddButton && cal.view !== 'schedule' && (
-                <button className={styles['addBtn']} onClick={() => setFormEvent({})} aria-label="Add new event">
-                  <Plus size={14} aria-hidden="true" /><span className={styles['addBtnLabel']}> Add Event</span>
-                </button>
-              )}
-              {hasAddButton && hasScheduleTemplates && (
-                <button
-                  className={styles['addBtn']}
-                  onClick={() => {
-                    setScheduleOpen(true);
-                    trackScheduleTemplateAnalytics('schedule_dialog_opened', {
-                      templateCount: visibleScheduleTemplates.length,
-                    });
-                  }}
-                  aria-label="Add schedule from template"
-                >
-                  <Plus size={14} aria-hidden="true" /><span className={styles['addBtnLabel']}> Add Schedule</span>
-                </button>
-              )}
-              {hasImport && (
-                <button className={styles['exportBtn']} onClick={() => setImportOpen(true)} aria-label="Import .ics calendar">
-                  <Upload size={15} aria-hidden="true" />
-                </button>
-              )}
-              <button className={styles['exportBtn']} onClick={() => exportVisibleEvents(visibleEvents)} aria-label="Export to Excel">
-                <Download size={15} aria-hidden="true" />
-              </button>
               {ownerPassword && (
                 <OwnerLock
                   isOwner={ownerCfg.isOwner}
@@ -2357,7 +2325,48 @@ export const WorksCalendar = forwardRef<CalendarApi, WorksCalendarProps>(functio
           items:         scopedEvents,
         })}
           </>}
-          main={<>
+          main={
+        <div className={styles['mainPane']}>
+          <div className={styles['calendarCard']}>
+            <SubToolbar
+              leftSlot={<>
+                <SidebarToggleButton
+                  isOpen={sidebarOpen}
+                  onClick={() => setSidebarOpen(v => !v)}
+                  filterCount={hasActiveFilters(cal.filters, schema) ? 1 : 0}
+                  groupCount={sidebarGroupLevels.length}
+                />
+                {hasAddButton && cal.view !== 'schedule' && (
+                  <button className={styles['addBtn']} onClick={() => setFormEvent({})} aria-label="Add new event">
+                    <Plus size={14} aria-hidden="true" /><span className={styles['addBtnLabel']}> Add Event</span>
+                  </button>
+                )}
+                {hasAddButton && hasScheduleTemplates && (
+                  <button
+                    className={styles['addBtn']}
+                    onClick={() => {
+                      setScheduleOpen(true);
+                      trackScheduleTemplateAnalytics('schedule_dialog_opened', {
+                        templateCount: visibleScheduleTemplates.length,
+                      });
+                    }}
+                    aria-label="Add schedule from template"
+                  >
+                    <Plus size={14} aria-hidden="true" /><span className={styles['addBtnLabel']}> Add Schedule</span>
+                  </button>
+                )}
+              </>}
+              rightSlot={<>
+                {hasImport && (
+                  <button className={styles['exportBtn']} onClick={() => setImportOpen(true)} aria-label="Import .ics calendar">
+                    <Upload size={15} aria-hidden="true" />
+                  </button>
+                )}
+                <button className={styles['exportBtn']} onClick={() => exportVisibleEvents(visibleEvents)} aria-label="Export to Excel">
+                  <Download size={15} aria-hidden="true" />
+                </button>
+              </>}
+            />
         {/* ── View area ── */}
         <div
           ref={swipeAreaRef}
@@ -2466,7 +2475,9 @@ export const WorksCalendar = forwardRef<CalendarApi, WorksCalendarProps>(functio
             </>
           )}
         </div>
-          </>}
+          </div>
+        </div>
+          }
         />
 
         {/* ── Filter / Groups / Views overlay drawer ── */}

--- a/src/WorksCalendar.tsx
+++ b/src/WorksCalendar.tsx
@@ -46,6 +46,7 @@ import { useTabScopedEvents } from './hooks/useTabScopedEvents';
 import { captureSavedViewFields, type ViewId } from './core/viewScope';
 import { buildActiveFilterPills, buildFilterSummary, hasActiveFilters } from './filters/filterState';
 import { AppShell }           from './ui/AppShell';
+import { AppHeader }          from './ui/AppHeader';
 import { SubToolbar }         from './ui/SubToolbar';
 import FilterBar              from './ui/FilterBar';
 import ProfileBar             from './ui/ProfileBar';
@@ -2166,76 +2167,90 @@ export const WorksCalendar = forwardRef<CalendarApi, WorksCalendarProps>(functio
         {renderToolbar ? (
           <div className={styles['customToolbar']}>{renderToolbar(api)}</div>
         ) : (
-          <div className={styles['toolbar']} role="toolbar" aria-label="Calendar navigation">
-            <div className={styles['navGroup']}>
-              {logoSrc && (
-                <img
-                  src={logoSrc}
-                  alt={logoAlt ?? ''}
-                  className={styles['logo']}
-                  aria-hidden={!logoAlt ? 'true' : undefined}
-                />
-              )}
-              <button
-                className={styles['navBtn']}
-                onClick={() => cal.navigate(-1)}
-                aria-label="Previous"
-                title={`Previous ${cal.view}`}
-              >
-                <ChevronLeft size={18} aria-hidden="true" />
-              </button>
-              <button className={styles['todayBtn']} onClick={cal.goToToday}>Today</button>
-              <button
-                className={styles['navBtn']}
-                onClick={() => cal.navigate(1)}
-                aria-label="Next"
-                title={`Next ${cal.view}`}
-              >
-                <ChevronRight size={18} aria-hidden="true" />
-              </button>
-              <span className={styles['dateLabel']} aria-live="polite" aria-atomic="true">{getDateLabel()}</span>
-              <span className={styles['calendarTitle']}>{calendarTitle}</span>
-              {fetchLoading && <span className={styles['loadingDot']} title="Loading…" aria-label="Loading events" role="status" />}
-            </div>
-
-            <div className={styles['viewGroup']} role="group" aria-label="Calendar view">
-              {VIEWS.map(v => (
+          <AppHeader
+            leftSlot={
+              <div className={styles['navGroup']}>
+                {logoSrc && (
+                  <img
+                    src={logoSrc}
+                    alt={logoAlt ?? ''}
+                    className={styles['logo']}
+                    aria-hidden={!logoAlt ? 'true' : undefined}
+                  />
+                )}
                 <button
-                  key={v.id}
-                  className={[styles['viewBtn'], cal.view === v.id && styles['activeView']].filter(Boolean).join(' ')}
-                  onClick={() => cal.setView(v.id)}
-                  aria-pressed={cal.view === v.id}
-                  title={v.hint}
+                  className={styles['navBtn']}
+                  onClick={() => cal.navigate(-1)}
+                  aria-label="Previous"
+                  title={`Previous ${cal.view}`}
                 >
-                  {v.label}
+                  <ChevronLeft size={18} aria-hidden="true" />
                 </button>
-              ))}
-            </div>
-
-            <div className={styles['actions']}>
-              {devMode && <span className={styles['devBadge']}>Dev</span>}
-              {(ownerCfg.isOwner || devMode) && (
+                <button className={styles['todayBtn']} onClick={cal.goToToday}>Today</button>
                 <button
-                  className={[styles['wandBtn'], editMode && styles['wandBtnActive']].filter(Boolean).join(' ')}
-                  onClick={() => { setEditMode(v => !v); setInlineEditTarget(null); }}
-                  aria-label={editMode ? 'Exit edit mode' : 'Enter edit mode — click events to customize them'}
-                  title={editMode ? 'Exit edit mode' : 'Customize events'}
+                  className={styles['navBtn']}
+                  onClick={() => cal.navigate(1)}
+                  aria-label="Next"
+                  title={`Next ${cal.view}`}
                 >
-                  <Sparkles size={15} aria-hidden="true" />
-                  {editMode && <span className={styles['wandBtnLabel']}>Done</span>}
+                  <ChevronRight size={18} aria-hidden="true" />
                 </button>
-              )}
-              {ownerPassword && (
-                <OwnerLock
-                  isOwner={ownerCfg.isOwner}
-                  authError={ownerCfg.authError}
-                  isAuthLoading={ownerCfg.isAuthLoading}
-                  onAuthenticate={ownerCfg.authenticate}
-                  onOpen={() => ownerCfg.setConfigOpen(true)}
-                />
-              )}
-            </div>
-          </div>
+                <span className={styles['dateLabel']} aria-live="polite" aria-atomic="true">{getDateLabel()}</span>
+                <span className={styles['calendarTitle']}>{calendarTitle}</span>
+                {fetchLoading && <span className={styles['loadingDot']} title="Loading…" aria-label="Loading events" role="status" />}
+              </div>
+            }
+            centerSlot={
+              <div className={styles['viewGroup']} role="group" aria-label="Calendar view">
+                {VIEWS.map(v => (
+                  <button
+                    key={v.id}
+                    className={[styles['viewBtn'], cal.view === v.id && styles['activeView']].filter(Boolean).join(' ')}
+                    onClick={() => cal.setView(v.id)}
+                    aria-pressed={cal.view === v.id}
+                    title={v.hint}
+                  >
+                    {v.label}
+                  </button>
+                ))}
+              </div>
+            }
+            rightSlot={
+              <div className={styles['actions']}>
+                {devMode && <span className={styles['devBadge']}>Dev</span>}
+                {(ownerCfg.isOwner || devMode) && (
+                  <button
+                    className={[styles['wandBtn'], editMode && styles['wandBtnActive']].filter(Boolean).join(' ')}
+                    onClick={() => { setEditMode(v => !v); setInlineEditTarget(null); }}
+                    aria-label={editMode ? 'Exit edit mode' : 'Enter edit mode — click events to customize them'}
+                    title={editMode ? 'Exit edit mode' : 'Customize events'}
+                  >
+                    <Sparkles size={15} aria-hidden="true" />
+                    {editMode && <span className={styles['wandBtnLabel']}>Done</span>}
+                  </button>
+                )}
+                {ownerPassword && (
+                  <OwnerLock
+                    isOwner={ownerCfg.isOwner}
+                    authError={ownerCfg.authError}
+                    isAuthLoading={ownerCfg.isAuthLoading}
+                    onAuthenticate={ownerCfg.authenticate}
+                    onOpen={() => ownerCfg.setConfigOpen(true)}
+                  />
+                )}
+              </div>
+            }
+            menuItems={[
+              ...(ownerCfg.isOwner ? [
+                { label: 'Settings',          sub: 'Calendar config, integrations', onClick: () => ownerCfg.setConfigOpen(true) },
+                { label: 'Themes',            sub: 'Switch palette / appearance',   onClick: () => ownerCfg.openConfigToTab('theme') },
+                { label: 'Advanced settings', sub: 'Smart views, fields, approvals', onClick: () => ownerCfg.openConfigToTab('smartViews') },
+              ] : []),
+              { label: 'Saved views',         sub: 'Manage your view library',      onClick: () => { setSidebarInitialTab('saved'); setSidebarOpen(true); } },
+              { label: 'Keyboard shortcuts',  sub: 'Quick reference',               onClick: () => setHelpOpen(true) },
+              { label: 'Help & feedback',                                          onClick: () => window.open('https://github.com/WorksCalendar/CalendarThatWorks/issues', '_blank', 'noopener') },
+            ]}
+          />
         )}
 
         {/* ── Profile / Saved-views Bar ── */}

--- a/src/WorksCalendar.tsx
+++ b/src/WorksCalendar.tsx
@@ -45,6 +45,7 @@ import { SCHEDULE_WORKFLOW_CATEGORIES } from './core/scheduleModel';
 import { useTabScopedEvents } from './hooks/useTabScopedEvents';
 import { captureSavedViewFields, type ViewId } from './core/viewScope';
 import { buildActiveFilterPills, buildFilterSummary, hasActiveFilters } from './filters/filterState';
+import { AppShell }           from './ui/AppShell';
 import FilterBar              from './ui/FilterBar';
 import ProfileBar             from './ui/ProfileBar';
 import FilterGroupSidebar, { SidebarToggleButton } from './ui/FilterGroupSidebar';
@@ -2158,6 +2159,8 @@ export const WorksCalendar = forwardRef<CalendarApi, WorksCalendarProps>(functio
       <CalendarContext.Provider value={ctxValue}>
         <div className={styles['root']} data-wc-theme={effectiveTheme} data-wc-theme-family={themeFamily} data-wc-theme-mode={themeMode} data-testid="works-calendar" data-wc-edit-mode={editMode ? '' : undefined} style={rootStyle}>
 
+        <AppShell
+          header={<>
         {/* ── Toolbar ── */}
         {renderToolbar ? (
           <div className={styles['customToolbar']}>{renderToolbar(api)}</div>
@@ -2353,37 +2356,8 @@ export const WorksCalendar = forwardRef<CalendarApi, WorksCalendarProps>(functio
           activePills:   buildActiveFilterPills(cal.filters, filterBarSchema),
           items:         scopedEvents,
         })}
-
-        {/* ── View area (with sidebar overlay) ── */}
-        <FilterGroupSidebar
-          open={sidebarOpen}
-          initialTab={sidebarInitialTab}
-          onClose={() => setSidebarOpen(false)}
-          // Groups tab
-          groupLevels={sidebarGroupLevels}
-          onGroupLevelsChange={handleSidebarGroupLevelsChange}
-          sort={activeSort ?? []}
-          onSortChange={(next) => setActiveSort(next.length > 0 ? next : null)}
-          showAllGroups={activeShowAllGroups}
-          onShowAllGroupsChange={setActiveShowAllGroups}
-          // Filters tab
-          schema={filterBarSchema}
-          items={scopedEvents}
-          onFiltersChange={handleSidebarFiltersChange}
-          // Views tab
-          views={savedViews.views}
-          activeViewId={savedViewActiveId}
-          isViewDirty={savedViewDirty}
-          onApplyView={handleApplyView}
-          onSaveView={handleSidebarSaveView}
-          onResaveView={(id) => savedViews.resaveView(id, cal.filters, cal.view, activeGroupBy, captureSavedViewFields(cal.view, savedViewCaptureCtx))}
-          onUpdateView={savedViews.updateView}
-          onDeleteView={handleDeleteView}
-          onToggleViewVisibility={savedViews.toggleStripVisibility}
-          locationLabel={locationLabel}
-          assetsLabel={assetsLabel}
-        />
-
+          </>}
+          main={<>
         {/* ── View area ── */}
         <div
           ref={swipeAreaRef}
@@ -2492,6 +2466,38 @@ export const WorksCalendar = forwardRef<CalendarApi, WorksCalendarProps>(functio
             </>
           )}
         </div>
+          </>}
+        />
+
+        {/* ── Filter / Groups / Views overlay drawer ── */}
+        <FilterGroupSidebar
+          open={sidebarOpen}
+          initialTab={sidebarInitialTab}
+          onClose={() => setSidebarOpen(false)}
+          // Groups tab
+          groupLevels={sidebarGroupLevels}
+          onGroupLevelsChange={handleSidebarGroupLevelsChange}
+          sort={activeSort ?? []}
+          onSortChange={(next) => setActiveSort(next.length > 0 ? next : null)}
+          showAllGroups={activeShowAllGroups}
+          onShowAllGroupsChange={setActiveShowAllGroups}
+          // Filters tab
+          schema={filterBarSchema}
+          items={scopedEvents}
+          onFiltersChange={handleSidebarFiltersChange}
+          // Views tab
+          views={savedViews.views}
+          activeViewId={savedViewActiveId}
+          isViewDirty={savedViewDirty}
+          onApplyView={handleApplyView}
+          onSaveView={handleSidebarSaveView}
+          onResaveView={(id) => savedViews.resaveView(id, cal.filters, cal.view, activeGroupBy, captureSavedViewFields(cal.view, savedViewCaptureCtx))}
+          onUpdateView={savedViews.updateView}
+          onDeleteView={handleDeleteView}
+          onToggleViewVisibility={savedViews.toggleStripVisibility}
+          locationLabel={locationLabel}
+          assetsLabel={assetsLabel}
+        />
 
         {/* ── Hover card ── */}
         {selectedEvent && (

--- a/src/WorksCalendar.tsx
+++ b/src/WorksCalendar.tsx
@@ -48,6 +48,7 @@ import { buildActiveFilterPills, buildFilterSummary, hasActiveFilters } from './
 import { AppShell }           from './ui/AppShell';
 import { AppHeader }          from './ui/AppHeader';
 import { SubToolbar }         from './ui/SubToolbar';
+import { DayWindowPills }     from './ui/DayWindowPills';
 import FilterBar              from './ui/FilterBar';
 import ProfileBar             from './ui/ProfileBar';
 import FilterGroupSidebar, { SidebarToggleButton } from './ui/FilterGroupSidebar';
@@ -2371,6 +2372,7 @@ export const WorksCalendar = forwardRef<CalendarApi, WorksCalendarProps>(functio
                   </button>
                 )}
               </>}
+              centerSlot={<DayWindowPills value={cal.dayWindow} onChange={cal.setDayWindow} />}
               rightSlot={<>
                 {hasImport && (
                   <button className={styles['exportBtn']} onClick={() => setImportOpen(true)} aria-label="Import .ics calendar">

--- a/src/hooks/useCalendar.ts
+++ b/src/hooks/useCalendar.ts
@@ -19,6 +19,13 @@ type CalendarState = {
   setView: (value: CalendarView) => void;
   currentDate: Date;
   setCurrentDate: (value: Date) => void;
+  /**
+   * User-controlled day-span window (in days) for the timeline-style views.
+   * Bound to the 7/14/30/90 pills in the sub-toolbar. Views that don't have
+   * a configurable day span (e.g. month, week) ignore this value.
+   */
+  dayWindow: number;
+  setDayWindow: (value: number) => void;
   events: any[];
   visibleEvents: any[];
   categories: string[];
@@ -42,10 +49,12 @@ export function useCalendar(
   rawEvents: any[],
   initialView: CalendarView = 'month',
   filterSchema: any[] = DEFAULT_FILTER_SCHEMA,
+  initialDayWindow: number = 30,
 ): CalendarState {
   const [view,        setView]        = useState(initialView);
   const [currentDate, setCurrentDate] = useState(() => new Date());
   const [filters,     setFilters]     = useState(() => createInitialFilters(filterSchema));
+  const [dayWindow,   setDayWindow]   = useState(initialDayWindow);
 
   const events = useMemo(() => normalizeEvents(rawEvents), [rawEvents]);
 
@@ -139,6 +148,7 @@ export function useCalendar(
   return {
     view, setView,
     currentDate, setCurrentDate,
+    dayWindow, setDayWindow,
     events, visibleEvents,
     categories, resources,
     filters,

--- a/src/hooks/useCalendar.ts
+++ b/src/hooks/useCalendar.ts
@@ -21,8 +21,17 @@ type CalendarState = {
   setCurrentDate: (value: Date) => void;
   /**
    * User-controlled day-span window (in days) for the timeline-style views.
-   * Bound to the 7/14/30/90 pills in the sub-toolbar. Views that don't have
-   * a configurable day span (e.g. month, week) ignore this value.
+   * Bound to the 7/14/30/90 pills in the sub-toolbar.
+   *
+   * TODO(shell-rework reflow): no view currently observes this value, so
+   * picking a pill only shifts the active swatch. Wiring up the views is
+   * a separate per-view refactor — TimelineView, BaseGanttView, and
+   * AssetsView all hardcode month-spanning math around `currentDate` and
+   * need their own props + range derivation to honour an arbitrary
+   * dayWindow. Tracked as a followup to the shell-rework PR series.
+   *
+   * Views that have an intrinsic span (month, week, day) are expected to
+   * keep ignoring this value.
    */
   dayWindow: number;
   setDayWindow: (value: number) => void;

--- a/src/ui/AppHeader.module.css
+++ b/src/ui/AppHeader.module.css
@@ -1,0 +1,122 @@
+/*
+ * AppHeader — three-zone top bar with optional hamburger dropdown.
+ * Token-driven; the bar inherits its surface from the active theme so the
+ * existing 12 themes restyle automatically.
+ */
+
+.root {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 0 calc(12px * var(--wc-density, 1));
+  height: calc(56px * var(--wc-density, 1));
+  border-bottom: var(--wc-border-width, 1px) solid var(--wc-border);
+  background: var(--wc-surface);
+  flex-shrink: 0;
+  position: relative;
+}
+
+.left {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex: 0 0 auto;
+  min-width: 0;
+}
+
+.center {
+  flex: 1;
+  display: flex;
+  justify-content: center;
+  min-width: 0;
+}
+
+.right {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex: 0 0 auto;
+  margin-left: auto;
+}
+
+/* ── Hamburger ────────────────────────────────────────────────────────── */
+
+.menuWrap {
+  position: relative;
+  display: flex;
+}
+
+.menuBtn {
+  width: 32px;
+  height: 32px;
+  border: none;
+  background: transparent;
+  color: var(--wc-text-muted);
+  border-radius: var(--wc-radius-sm);
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.menuBtn:hover,
+.menuBtn:focus-visible {
+  background: var(--wc-surface-2);
+  color: var(--wc-text);
+}
+
+.menuBtn:focus-visible {
+  outline: 2px solid var(--wc-accent);
+  outline-offset: 2px;
+}
+
+.dropdown {
+  position: absolute;
+  top: calc(100% + 4px);
+  left: 0;
+  min-width: 240px;
+  background: var(--wc-surface);
+  border: var(--wc-border-width, 1px) solid var(--wc-border);
+  border-radius: var(--wc-radius);
+  box-shadow: var(--wc-shadow);
+  padding: 4px;
+  z-index: 100;
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+}
+
+.dropdownItem {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 1px;
+  padding: 8px 10px;
+  border: none;
+  background: transparent;
+  color: var(--wc-text);
+  border-radius: var(--wc-radius-sm);
+  cursor: pointer;
+  text-align: left;
+  font: inherit;
+}
+
+.dropdownItem:hover,
+.dropdownItem:focus-visible {
+  background: var(--wc-surface-2);
+}
+
+.dropdownItem:focus-visible {
+  outline: 2px solid var(--wc-accent);
+  outline-offset: -2px;
+}
+
+.dropdownLabel {
+  font-size: 13px;
+  color: var(--wc-text);
+}
+
+.dropdownSub {
+  font-size: 11px;
+  color: var(--wc-text-muted);
+}

--- a/src/ui/AppHeader.tsx
+++ b/src/ui/AppHeader.tsx
@@ -1,0 +1,104 @@
+import { useEffect, useRef, useState } from 'react';
+import type { ReactNode } from 'react';
+import { Menu } from 'lucide-react';
+import cls from './AppHeader.module.css';
+
+export type AppHeaderMenuItem = {
+  /** Visible label (top line). */
+  label: string;
+  /** Optional sub-label (smaller, second line). */
+  sub?: string;
+  /** Click handler. AppHeader closes the dropdown before invoking. */
+  onClick: () => void;
+};
+
+export type AppHeaderProps = {
+  /** Left zone — branding + nav cluster. */
+  leftSlot?: ReactNode;
+  /** Center zone — view-tab pills. */
+  centerSlot?: ReactNode;
+  /** Right zone — system actions. */
+  rightSlot?: ReactNode;
+  /** Hamburger menu items. Empty / omitted hides the hamburger entirely. */
+  menuItems?: AppHeaderMenuItem[];
+};
+
+/**
+ * Top header band. Three layout zones (left / center / right) plus an
+ * optional hamburger dropdown anchored at the very start of the left zone.
+ * Slots are layout-only; the consumer owns content + state.
+ *
+ * role="toolbar" + aria-label="Calendar navigation" is preserved on the
+ * root so existing a11y queries keep working.
+ */
+export function AppHeader({ leftSlot, centerSlot, rightSlot, menuItems }: AppHeaderProps) {
+  const [menuOpen, setMenuOpen] = useState(false);
+  const menuWrapRef = useRef<HTMLDivElement>(null);
+
+  // Close on outside click
+  useEffect(() => {
+    if (!menuOpen) return;
+    const onDocClick = (e: MouseEvent) => {
+      if (menuWrapRef.current && !menuWrapRef.current.contains(e.target as Node)) {
+        setMenuOpen(false);
+      }
+    };
+    document.addEventListener('mousedown', onDocClick);
+    return () => document.removeEventListener('mousedown', onDocClick);
+  }, [menuOpen]);
+
+  // Close on Escape
+  useEffect(() => {
+    if (!menuOpen) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setMenuOpen(false);
+    };
+    document.addEventListener('keydown', onKey);
+    return () => document.removeEventListener('keydown', onKey);
+  }, [menuOpen]);
+
+  const hasMenu = !!menuItems && menuItems.length > 0;
+
+  return (
+    <div className={cls['root']} role="toolbar" aria-label="Calendar navigation">
+      <div className={cls['left']}>
+        {hasMenu && (
+          <div ref={menuWrapRef} className={cls['menuWrap']}>
+            <button
+              type="button"
+              className={cls['menuBtn']}
+              aria-label={menuOpen ? 'Close main menu' : 'Open main menu'}
+              aria-haspopup="menu"
+              aria-expanded={menuOpen}
+              onClick={() => setMenuOpen(v => !v)}
+            >
+              <Menu size={18} aria-hidden="true" />
+            </button>
+            {menuOpen && (
+              <div className={cls['dropdown']} role="menu">
+                {menuItems!.map(item => (
+                  <button
+                    key={item.label}
+                    type="button"
+                    role="menuitem"
+                    className={cls['dropdownItem']}
+                    onClick={() => {
+                      setMenuOpen(false);
+                      item.onClick();
+                    }}
+                  >
+                    <span className={cls['dropdownLabel']}>{item.label}</span>
+                    {item.sub && <span className={cls['dropdownSub']}>{item.sub}</span>}
+                  </button>
+                ))}
+              </div>
+            )}
+          </div>
+        )}
+        {leftSlot}
+      </div>
+      <div className={cls['center']}>{centerSlot}</div>
+      <div className={cls['right']}>{rightSlot}</div>
+    </div>
+  );
+}

--- a/src/ui/AppShell.module.css
+++ b/src/ui/AppShell.module.css
@@ -1,0 +1,43 @@
+/*
+ * AppShell — three-column shell scaffold.
+ *
+ * PR 1 foundation only. Header sits above a body row; left rail and right
+ * panel are slot-optional and render nothing (zero width) when their props
+ * are undefined. With only header + main the visual layout collapses to the
+ * same vertical stack the calendar used pre-AppShell — no surrounding
+ * styling changes for this PR.
+ */
+
+.shell {
+  flex: 1;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+}
+
+.headerBand {
+  flex-shrink: 0;
+  display: flex;
+  flex-direction: column;
+}
+
+.body {
+  flex: 1;
+  min-height: 0;
+  display: flex;
+}
+
+.leftRail {
+  flex-shrink: 0;
+}
+
+.main {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+}
+
+.rightPanel {
+  flex-shrink: 0;
+}

--- a/src/ui/AppShell.tsx
+++ b/src/ui/AppShell.tsx
@@ -1,0 +1,34 @@
+import type { ReactNode } from 'react';
+import cls from './AppShell.module.css';
+
+export type AppShellProps = {
+  /** Top header band, full-width above the body. */
+  header: ReactNode;
+  /** Main content column between the optional left rail and right panel. */
+  main: ReactNode;
+  /** Optional fixed-width left icon rail. Omit to render no rail. */
+  leftRail?: ReactNode;
+  /** Optional fixed-width right panel. Omit to render no panel. */
+  rightPanel?: ReactNode;
+};
+
+/**
+ * Three-column dashboard shell scaffold.
+ *
+ * Header is always rendered above a body row that holds main and (optionally)
+ * a left rail / right panel. Slots that are not provided take no space, so a
+ * shell with only `header` + `main` lays out identically to a plain stacked
+ * column.
+ */
+export function AppShell({ header, main, leftRail, rightPanel }: AppShellProps) {
+  return (
+    <div className={cls['shell']}>
+      <div className={cls['headerBand']}>{header}</div>
+      <div className={cls['body']}>
+        {leftRail !== undefined && <aside className={cls['leftRail']}>{leftRail}</aside>}
+        <div className={cls['main']}>{main}</div>
+        {rightPanel !== undefined && <aside className={cls['rightPanel']}>{rightPanel}</aside>}
+      </div>
+    </div>
+  );
+}

--- a/src/ui/DayWindowPills.module.css
+++ b/src/ui/DayWindowPills.module.css
@@ -1,0 +1,42 @@
+/*
+ * DayWindowPills — segmented day-window selector for the sub-toolbar.
+ * Token-driven; the active pill picks up var(--wc-surface-2) so the
+ * contrast follows the active theme.
+ */
+
+.root {
+  display: inline-flex;
+  background: var(--wc-bg);
+  border: var(--wc-border-width, 1px) solid var(--wc-border);
+  border-radius: var(--wc-radius-sm);
+  padding: 2px;
+  gap: 0;
+}
+
+.pill {
+  border: none;
+  background: transparent;
+  color: var(--wc-text-muted);
+  padding: 4px 10px;
+  font-size: 12px;
+  font-weight: 500;
+  border-radius: calc(var(--wc-radius-sm) - 2px);
+  cursor: pointer;
+  white-space: nowrap;
+  transition: background 120ms ease, color 120ms ease;
+}
+
+.pill:hover {
+  color: var(--wc-text);
+}
+
+.pill:focus-visible {
+  outline: 2px solid var(--wc-accent);
+  outline-offset: -1px;
+}
+
+.pill.active {
+  background: var(--wc-surface-2);
+  color: var(--wc-text);
+  font-weight: 600;
+}

--- a/src/ui/DayWindowPills.tsx
+++ b/src/ui/DayWindowPills.tsx
@@ -1,0 +1,47 @@
+import cls from './DayWindowPills.module.css';
+
+const DEFAULT_OPTIONS = [7, 14, 30, 90] as const;
+
+export type DayWindowPillsProps = {
+  /** Currently selected day window (in days). */
+  value: number;
+  /** Called when the user picks a different window. */
+  onChange: (next: number) => void;
+  /**
+   * Pill options to render. Defaults to [7, 14, 30, 90]. Order is preserved.
+   */
+  options?: readonly number[];
+};
+
+/**
+ * Day-window pill set. A segmented selector that picks how many days the
+ * timeline-style views (Schedule / Base / Assets) span at once.
+ *
+ * Layout-only — the consuming hook owns the underlying state. Styling uses
+ * theme tokens so all 12 themes restyle automatically.
+ */
+export function DayWindowPills({
+  value,
+  onChange,
+  options = DEFAULT_OPTIONS,
+}: DayWindowPillsProps) {
+  return (
+    <div className={cls['root']} role="group" aria-label="Day window">
+      {options.map(n => {
+        const active = n === value;
+        return (
+          <button
+            key={n}
+            type="button"
+            className={[cls['pill'], active && cls['active']].filter(Boolean).join(' ')}
+            aria-pressed={active}
+            onClick={() => onChange(n)}
+            title={`Show ${n} day${n === 1 ? '' : 's'}`}
+          >
+            {n} day
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/ui/LeftRail.module.css
+++ b/src/ui/LeftRail.module.css
@@ -1,0 +1,50 @@
+/*
+ * LeftRail — fixed-width icon column. Token-driven so all 12 themes
+ * restyle the rail automatically. Active view picks up the accent
+ * border + surface-2 background (matches the AppHeader hamburger
+ * dropdown active treatment).
+ */
+
+.root {
+  width: 56px;
+  flex-shrink: 0;
+  background: var(--wc-surface);
+  border-right: var(--wc-border-width, 1px) solid var(--wc-border);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding-top: 8px;
+  gap: 2px;
+}
+
+.btn {
+  width: 40px;
+  height: 40px;
+  border: none;
+  background: transparent;
+  color: var(--wc-text-muted);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  border-left: 2px solid transparent;
+  margin-left: -2px;
+  padding: 0;
+  transition: background 120ms ease, color 120ms ease;
+}
+
+.btn:hover {
+  color: var(--wc-text);
+  background: var(--wc-surface-2);
+}
+
+.btn:focus-visible {
+  outline: 2px solid var(--wc-accent);
+  outline-offset: -2px;
+}
+
+.btn.active {
+  color: var(--wc-accent);
+  background: var(--wc-surface-2);
+  border-left-color: var(--wc-accent);
+}

--- a/src/ui/LeftRail.tsx
+++ b/src/ui/LeftRail.tsx
@@ -1,0 +1,54 @@
+import { VIEW_ICON_MAP } from './viewIcons';
+import cls from './LeftRail.module.css';
+
+export type LeftRailItem = {
+  /** View id; must match a key in VIEW_ICON_MAP (otherwise the row is skipped). */
+  id: string;
+  /** Optional richer tooltip; falls back to the icon's accessible label. */
+  hint?: string;
+};
+
+export type LeftRailProps = {
+  /** Ordered list of views to render. */
+  items: LeftRailItem[];
+  /** Currently active view id. Marked aria-pressed=true. */
+  activeId: string;
+  /** Called when the user picks a view. */
+  onSelect: (id: string) => void;
+};
+
+/**
+ * LeftRail — fixed-width icon column rendered in <AppShell>'s leftRail slot.
+ * Each button maps a view id to its lucide icon via VIEW_ICON_MAP. Layout-
+ * only — the consumer owns the items list and the active selection.
+ *
+ * Buttons are intentionally aria-labelled with the descriptive form from
+ * VIEW_ICON_MAP (e.g. "Schedule view") rather than the bare label
+ * ("Schedule"), so they don't collide with the AppHeader view-tab pills
+ * in role/name accessibility queries.
+ */
+export function LeftRail({ items, activeId, onSelect }: LeftRailProps) {
+  return (
+    <nav className={cls['root']} aria-label="Calendar views">
+      {items.map(item => {
+        const entry = VIEW_ICON_MAP[item.id];
+        if (!entry) return null;
+        const Icon = entry.Icon;
+        const active = item.id === activeId;
+        return (
+          <button
+            key={item.id}
+            type="button"
+            className={[cls['btn'], active && cls['active']].filter(Boolean).join(' ')}
+            onClick={() => onSelect(item.id)}
+            aria-pressed={active}
+            aria-label={entry.label}
+            title={item.hint ?? entry.label}
+          >
+            <Icon size={18} aria-hidden="true" />
+          </button>
+        );
+      })}
+    </nav>
+  );
+}

--- a/src/ui/ProfileBar.tsx
+++ b/src/ui/ProfileBar.tsx
@@ -13,30 +13,18 @@
 import { useMemo, useState, useRef, useEffect } from 'react';
 import {
   Plus, Bookmark, BookmarkCheck,
-  CalendarDays, Calendar, Columns3, List, CalendarRange, Boxes, MapPin, Radio, Map as MapIcon,
 } from 'lucide-react';
 import { DEFAULT_FILTER_SCHEMA } from '../filters/filterSchema';
 import ViewsDropdown from './ViewsDropdown';
 import CustomizeQuickViewsPanel from './CustomizeQuickViewsPanel';
 import ClearFiltersButton from './ClearFiltersButton';
+import { VIEW_ICON_MAP } from './viewIcons';
 import styles from './ProfileBar.module.css';
 
 const PROFILE_COLORS = [
   '#3b82f6', '#10b981', '#f59e0b', '#ef4444',
   '#8b5cf6', '#ec4899', '#06b6d4', '#f97316',
 ];
-
-const VIEW_ICON_MAP: Record<string, { Icon: any; label: string }> = {
-  month:    { Icon: CalendarDays,  label: 'Month view' },
-  week:     { Icon: Columns3,      label: 'Week view' },
-  day:      { Icon: Calendar,      label: 'Day view' },
-  agenda:   { Icon: List,          label: 'Agenda view' },
-  schedule: { Icon: CalendarRange, label: 'Schedule view' },
-  base:     { Icon: MapPin,        label: 'Base view' },
-  assets:   { Icon: Boxes,         label: 'Assets view' },
-  dispatch: { Icon: Radio,         label: 'Dispatch view' },
-  map:      { Icon: MapIcon,       label: 'Map view' },
-};
 
 const GLOBAL_GROUP_KEY = '__global__';
 const DEFAULT_VIEW_ORDER = ['month','week','day','agenda','schedule','base','assets','dispatch','map'];

--- a/src/ui/SubToolbar.module.css
+++ b/src/ui/SubToolbar.module.css
@@ -1,0 +1,39 @@
+/*
+ * SubToolbar — three-zone bar inside the calendar card.
+ *
+ * Tokens-only styling so the bar inherits whatever theme is active. The
+ * 8px gap between zones matches the existing main-toolbar spacing in
+ * WorksCalendar.module.css.
+ */
+
+.root {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: calc(8px * var(--wc-density, 1)) calc(12px * var(--wc-density, 1));
+  border-bottom: var(--wc-border-width, 1px) solid var(--wc-border);
+  background: var(--wc-bg);
+  flex-shrink: 0;
+  flex-wrap: wrap;
+}
+
+.left {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.center {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 0;
+}
+
+.right {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin-left: auto;
+}

--- a/src/ui/SubToolbar.tsx
+++ b/src/ui/SubToolbar.tsx
@@ -1,0 +1,28 @@
+import type { ReactNode } from 'react';
+import cls from './SubToolbar.module.css';
+
+export type SubToolbarProps = {
+  /** Left zone — primary data actions (e.g. Add, Filter trigger). */
+  leftSlot?: ReactNode;
+  /** Center zone — view-scoped controls (e.g. day-window pill set). */
+  centerSlot?: ReactNode;
+  /** Right zone — secondary actions (e.g. Import, Export, Save view). */
+  rightSlot?: ReactNode;
+};
+
+/**
+ * Sub-toolbar that lives inside the calendar card, above the view grid.
+ *
+ * Three layout-only zones — content is provided by the consumer so the
+ * shell stays agnostic to which buttons exist in each surface (calendar
+ * top-level vs. embedder-supplied custom toolbars).
+ */
+export function SubToolbar({ leftSlot, centerSlot, rightSlot }: SubToolbarProps) {
+  return (
+    <div className={cls['root']} role="toolbar" aria-label="Calendar actions">
+      <div className={cls['left']}>{leftSlot}</div>
+      <div className={cls['center']}>{centerSlot}</div>
+      <div className={cls['right']}>{rightSlot}</div>
+    </div>
+  );
+}

--- a/src/ui/__tests__/DayWindowPills.test.tsx
+++ b/src/ui/__tests__/DayWindowPills.test.tsx
@@ -1,0 +1,51 @@
+// @vitest-environment happy-dom
+/**
+ * DayWindowPills — segmented day-window selector.
+ *
+ * Pins the rendering / selection / a11y contract so the sub-toolbar
+ * integration is safe to refactor.
+ */
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import '@testing-library/jest-dom';
+
+import { DayWindowPills } from '../DayWindowPills';
+
+describe('DayWindowPills', () => {
+  it('renders the default 7 / 14 / 30 / 90 options', () => {
+    render(<DayWindowPills value={30} onChange={() => {}} />);
+    expect(screen.getByRole('button', { name: '7 day' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: '14 day' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: '30 day' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: '90 day' })).toBeInTheDocument();
+  });
+
+  it('marks the active pill via aria-pressed', () => {
+    render(<DayWindowPills value={30} onChange={() => {}} />);
+    expect(screen.getByRole('button', { name: '30 day' })).toHaveAttribute('aria-pressed', 'true');
+    expect(screen.getByRole('button', { name: '7 day' })).toHaveAttribute('aria-pressed', 'false');
+    expect(screen.getByRole('button', { name: '14 day' })).toHaveAttribute('aria-pressed', 'false');
+    expect(screen.getByRole('button', { name: '90 day' })).toHaveAttribute('aria-pressed', 'false');
+  });
+
+  it('invokes onChange with the picked window', () => {
+    const onChange = vi.fn();
+    render(<DayWindowPills value={30} onChange={onChange} />);
+    fireEvent.click(screen.getByRole('button', { name: '14 day' }));
+    expect(onChange).toHaveBeenCalledWith(14);
+  });
+
+  it('exposes a labelled group for a11y trees', () => {
+    render(<DayWindowPills value={30} onChange={() => {}} />);
+    expect(screen.getByRole('group', { name: /day window/i })).toBeInTheDocument();
+  });
+
+  it('honours custom options', () => {
+    render(<DayWindowPills value={3} onChange={() => {}} options={[1, 3, 5]} />);
+    expect(screen.getByRole('button', { name: '1 day' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: '3 day' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: '5 day' })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: '7 day' })).toBeNull();
+    expect(screen.getByRole('button', { name: '3 day' })).toHaveAttribute('aria-pressed', 'true');
+  });
+});

--- a/src/ui/__tests__/LeftRail.test.tsx
+++ b/src/ui/__tests__/LeftRail.test.tsx
@@ -1,0 +1,62 @@
+// @vitest-environment happy-dom
+/**
+ * LeftRail — fixed-width icon column in the AppShell leftRail slot.
+ *
+ * Pins render / active-state / dispatch / unknown-id-skip / a11y so the
+ * AppShell wiring is safe to refactor.
+ */
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import '@testing-library/jest-dom';
+
+import { LeftRail } from '../LeftRail';
+
+const ITEMS = [
+  { id: 'month' },
+  { id: 'week' },
+  { id: 'schedule', hint: 'Staffing rotation' },
+];
+
+describe('LeftRail', () => {
+  it('renders one button per known view item', () => {
+    render(<LeftRail items={ITEMS} activeId="month" onSelect={() => {}} />);
+    expect(screen.getByRole('button', { name: 'Month view' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Week view' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Schedule view' })).toBeInTheDocument();
+  });
+
+  it('marks the active button via aria-pressed', () => {
+    render(<LeftRail items={ITEMS} activeId="schedule" onSelect={() => {}} />);
+    expect(screen.getByRole('button', { name: 'Schedule view' })).toHaveAttribute('aria-pressed', 'true');
+    expect(screen.getByRole('button', { name: 'Month view' })).toHaveAttribute('aria-pressed', 'false');
+  });
+
+  it('calls onSelect with the picked id', () => {
+    const onSelect = vi.fn();
+    render(<LeftRail items={ITEMS} activeId="month" onSelect={onSelect} />);
+    fireEvent.click(screen.getByRole('button', { name: 'Schedule view' }));
+    expect(onSelect).toHaveBeenCalledWith('schedule');
+  });
+
+  it('skips items whose id has no entry in VIEW_ICON_MAP', () => {
+    const items = [
+      ...ITEMS,
+      { id: 'no-such-view' },
+    ];
+    render(<LeftRail items={items} activeId="month" onSelect={() => {}} />);
+    expect(screen.queryByRole('button', { name: /no-such-view/i })).toBeNull();
+    // The known items still render.
+    expect(screen.getByRole('button', { name: 'Month view' })).toBeInTheDocument();
+  });
+
+  it('uses the hint as the tooltip when provided, otherwise the icon label', () => {
+    render(<LeftRail items={ITEMS} activeId="month" onSelect={() => {}} />);
+    expect(screen.getByRole('button', { name: 'Schedule view' })).toHaveAttribute('title', 'Staffing rotation');
+    expect(screen.getByRole('button', { name: 'Month view' })).toHaveAttribute('title', 'Month view');
+  });
+
+  it('exposes a labelled navigation landmark', () => {
+    render(<LeftRail items={ITEMS} activeId="month" onSelect={() => {}} />);
+    expect(screen.getByRole('navigation', { name: /calendar views/i })).toBeInTheDocument();
+  });
+});

--- a/src/ui/viewIcons.ts
+++ b/src/ui/viewIcons.ts
@@ -1,0 +1,34 @@
+/**
+ * viewIcons.ts — Single source of truth for the lucide icon + accessible
+ * label paired with each calendar view id.
+ *
+ * Used by:
+ *   - ProfileBar (saved-view chip strip, where chips group under their view)
+ *   - LeftRail   (icon rail in the AppShell — tap to switch view)
+ *
+ * Keep the keyset aligned with `ALL_VIEWS` in `WorksCalendar.tsx`. New
+ * view ids should land here too so every surface that renders a view
+ * picker gets the icon for free.
+ */
+import type { ComponentType, SVGProps } from 'react';
+import {
+  CalendarDays, Calendar, Columns3, List, CalendarRange,
+  Boxes, MapPin, Radio, Map as MapIcon,
+} from 'lucide-react';
+
+export type ViewIconEntry = {
+  Icon: ComponentType<SVGProps<SVGSVGElement> & { size?: number | string }>;
+  label: string;
+};
+
+export const VIEW_ICON_MAP: Record<string, ViewIconEntry> = {
+  month:    { Icon: CalendarDays,  label: 'Month view' },
+  week:     { Icon: Columns3,      label: 'Week view' },
+  day:      { Icon: Calendar,      label: 'Day view' },
+  agenda:   { Icon: List,          label: 'Agenda view' },
+  schedule: { Icon: CalendarRange, label: 'Schedule view' },
+  base:     { Icon: MapPin,        label: 'Base view' },
+  assets:   { Icon: Boxes,         label: 'Assets view' },
+  dispatch: { Icon: Radio,         label: 'Dispatch view' },
+  map:      { Icon: MapIcon,       label: 'Map view' },
+};


### PR DESCRIPTION
## Summary

PR 5 of the three-column layout series. Lights up the AppShell's `leftRail` slot with a fixed-width icon column, and pulls the lucide-icon-per-view registry out of `ProfileBar` into a shared module so future surfaces share one source of truth.

**Stacks on PR 4 (#407) → PR 3 (#406) → PR 2 (#405) → PR 1 (#404).** When the parents land this rebases onto `main`.

## What's in this PR

- **`src/ui/viewIcons.ts`** — new shared module exporting `VIEW_ICON_MAP` (view id → `{ Icon, label }`). Sole source of truth; ProfileBar + LeftRail import from here. Keyset stays aligned with `ALL_VIEWS` in `WorksCalendar.tsx`.
- **`src/ui/LeftRail.tsx` + `.module.css`** — fixed 56px icon column. Items rendered in order; unknown view ids silently skipped. Active button: `aria-pressed=true` + accent border + `--wc-surface-2` background. Token-only styling.
- **`src/ui/__tests__/LeftRail.test.tsx`** — 6 tests pinning render, active state, dispatch, unknown-id skip, hint→title fallback, navigation landmark label.
- **`src/ui/ProfileBar.tsx`** — drops the inline `VIEW_ICON_MAP` and now-unused lucide imports; imports from `viewIcons`. Pure refactor.
- **`src/WorksCalendar.tsx`** — wires `leftRail={<LeftRail items={VIEWS} activeId={cal.view} onSelect={cal.setView} />}`. Items come from the existing `VIEWS` list (filtered by `enabledViews` config), so the rail respects the same hide/show rules the header view-tab pills do.

## A11y disambiguation worth noting

Rail buttons use the descriptive form from `VIEW_ICON_MAP` ("Schedule view") as their `aria-label` — not the bare label ("Schedule"). Without this, `getByRole('button', { name: 'Schedule' })` matches both the rail icon AND the centered view-tab pill, breaking 16 integration tests in `scheduleWorkflow` / `scheduleModel.integration` / `employees.sync`. Caught and fixed in this PR.

## Reflow followup (carried over from PR 4)

PR 4's day-window pills update `cal.dayWindow` state but no view yet observes it — clicking a pill shifts the active swatch but the grid doesn't reflow. Wiring the views (TimelineView, BaseGanttView, AssetsView) to honour an arbitrary day span is a real per-view refactor (each hardcodes `startOfMonth..endOfMonth(currentDate)` math) and belongs in its own PR series, deliberately separated from the shell rework so layout PRs can ship and be reviewed independently of view-rendering changes.

This PR strengthens the comment on `dayWindow` in `useCalendar.ts` with an explicit `TODO(shell-rework reflow)` so the unfinished wiring is visible to anyone touching the file.

**Suggested reflow PR shape (when you're ready):**
1. Add `dayWindow?: number` prop to TimelineView; when present, replace the hardcoded `startOfMonth..endOfMonth(currentDate)` with `currentDate..addDays(currentDate, dayWindow - 1)`. Update header label to render the date range. Verify event positioning math still works for non-month-aligned spans.
2. Same for BaseGanttView.
3. Same for AssetsView.
4. Wire `cal.dayWindow` through `<sharedViewProps>` in WorksCalendar.tsx so the views actually receive it.
5. Decide what `cal.dayWindow` does in views that ignore it today (month/week/day) — probably nothing, but worth confirming the pills don't visually imply a control they don't have. Could hide the pills via `<DayWindowPills>`'s `options` prop or a `visible={...}` flag depending on `cal.view`.

## Test plan

- [x] `npm run type-check` clean
- [x] `npm run test` — 2107/2107 (6 new for LeftRail; 16 stale assertions caught and fixed via aria-label disambiguation)
- [x] `npm run build` clean
- [ ] Smoke on Vercel preview: rail renders left of the bordered card, clicking icons switches views, active view shows accent treatment
- [ ] Quick sanity on a wide and narrow viewport — rail width is fixed 56px

## Followups

- PR 6 — `RightPanel`
- PR 7 — Theme sweep across all 12 themes
- PR 8 — Catch e2e selectors up to new shell DOM
- (separate series) Reflow — wire `cal.dayWindow` into TimelineView / BaseGanttView / AssetsView

---
_Generated by [Claude Code](https://claude.ai/code/session_0129D5oFDywjK6gwjRU9dWLF)_