### PR TITLE
shell: &lt;RightPanel&gt; with region-map widget + crew-on-shift list (PR 6)

### DIFF
--- a/src/WorksCalendar.module.css
+++ b/src/WorksCalendar.module.css
@@ -490,6 +490,29 @@
   flex-direction: column;
 }
 
+/* Main pane: padded shell holding the bordered calendar card. */
+.mainPane {
+  flex: 1;
+  min-height: 0;
+  display: flex;
+  padding: calc(12px * var(--wc-density, 1));
+}
+
+/* Calendar card: bordered, rounded, shadowed surface that wraps the
+ * sub-toolbar and the view grid. Tokens-only so per-theme overrides
+ * (radius, shadow, border) apply automatically. */
+.calendarCard {
+  flex: 1;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  background: var(--wc-surface);
+  border: var(--wc-border-width, 1px) solid var(--wc-border);
+  border-radius: var(--wc-radius);
+  box-shadow: var(--wc-shadow);
+  overflow: hidden;
+}
+
 .emptyStateWrap {
   flex: 1;
   display: flex;

--- a/src/WorksCalendar.tsx
+++ b/src/WorksCalendar.tsx
@@ -50,6 +50,7 @@ import { AppHeader }          from './ui/AppHeader';
 import { LeftRail }           from './ui/LeftRail';
 import { SubToolbar }         from './ui/SubToolbar';
 import { DayWindowPills }     from './ui/DayWindowPills';
+import { RightPanel, RightPanelSection, RegionMapWidget, CrewOnShiftList } from './ui/RightPanel';
 import FilterBar              from './ui/FilterBar';
 import ProfileBar             from './ui/ProfileBar';
 import FilterGroupSidebar, { SidebarToggleButton } from './ui/FilterGroupSidebar';
@@ -2165,6 +2166,16 @@ export const WorksCalendar = forwardRef<CalendarApi, WorksCalendarProps>(functio
 
         <AppShell
           leftRail={<LeftRail items={VIEWS} activeId={cal.view} onSelect={cal.setView} />}
+          rightPanel={
+            <RightPanel>
+              <RightPanelSection title="Region map">
+                <RegionMapWidget events={visibleEvents} />
+              </RightPanelSection>
+              <RightPanelSection title="Crew on shift">
+                <CrewOnShiftList employees={configuredEmployees} />
+              </RightPanelSection>
+            </RightPanel>
+          }
           header={<>
         {/* ── Toolbar ── */}
         {renderToolbar ? (

--- a/src/WorksCalendar.tsx
+++ b/src/WorksCalendar.tsx
@@ -47,6 +47,7 @@ import { captureSavedViewFields, type ViewId } from './core/viewScope';
 import { buildActiveFilterPills, buildFilterSummary, hasActiveFilters } from './filters/filterState';
 import { AppShell }           from './ui/AppShell';
 import { AppHeader }          from './ui/AppHeader';
+import { LeftRail }           from './ui/LeftRail';
 import { SubToolbar }         from './ui/SubToolbar';
 import { DayWindowPills }     from './ui/DayWindowPills';
 import FilterBar              from './ui/FilterBar';
@@ -2163,6 +2164,7 @@ export const WorksCalendar = forwardRef<CalendarApi, WorksCalendarProps>(functio
         <div className={styles['root']} data-wc-theme={effectiveTheme} data-wc-theme-family={themeFamily} data-wc-theme-mode={themeMode} data-testid="works-calendar" data-wc-edit-mode={editMode ? '' : undefined} style={rootStyle}>
 
         <AppShell
+          leftRail={<LeftRail items={VIEWS} activeId={cal.view} onSelect={cal.setView} />}
           header={<>
         {/* ── Toolbar ── */}
         {renderToolbar ? (

--- a/src/WorksCalendar.tsx
+++ b/src/WorksCalendar.tsx
@@ -46,6 +46,7 @@ import { useTabScopedEvents } from './hooks/useTabScopedEvents';
 import { captureSavedViewFields, type ViewId } from './core/viewScope';
 import { buildActiveFilterPills, buildFilterSummary, hasActiveFilters } from './filters/filterState';
 import { AppShell }           from './ui/AppShell';
+import { SubToolbar }         from './ui/SubToolbar';
 import FilterBar              from './ui/FilterBar';
 import ProfileBar             from './ui/ProfileBar';
 import FilterGroupSidebar, { SidebarToggleButton } from './ui/FilterGroupSidebar';
@@ -2212,12 +2213,6 @@ export const WorksCalendar = forwardRef<CalendarApi, WorksCalendarProps>(functio
             </div>
 
             <div className={styles['actions']}>
-              <SidebarToggleButton
-                isOpen={sidebarOpen}
-                onClick={() => setSidebarOpen(v => !v)}
-                filterCount={hasActiveFilters(cal.filters, schema) ? 1 : 0}
-                groupCount={sidebarGroupLevels.length}
-              />
               {devMode && <span className={styles['devBadge']}>Dev</span>}
               {(ownerCfg.isOwner || devMode) && (
                 <button
@@ -2230,33 +2225,6 @@ export const WorksCalendar = forwardRef<CalendarApi, WorksCalendarProps>(functio
                   {editMode && <span className={styles['wandBtnLabel']}>Done</span>}
                 </button>
               )}
-              {hasAddButton && cal.view !== 'schedule' && (
-                <button className={styles['addBtn']} onClick={() => setFormEvent({})} aria-label="Add new event">
-                  <Plus size={14} aria-hidden="true" /><span className={styles['addBtnLabel']}> Add Event</span>
-                </button>
-              )}
-              {hasAddButton && hasScheduleTemplates && (
-                <button
-                  className={styles['addBtn']}
-                  onClick={() => {
-                    setScheduleOpen(true);
-                    trackScheduleTemplateAnalytics('schedule_dialog_opened', {
-                      templateCount: visibleScheduleTemplates.length,
-                    });
-                  }}
-                  aria-label="Add schedule from template"
-                >
-                  <Plus size={14} aria-hidden="true" /><span className={styles['addBtnLabel']}> Add Schedule</span>
-                </button>
-              )}
-              {hasImport && (
-                <button className={styles['exportBtn']} onClick={() => setImportOpen(true)} aria-label="Import .ics calendar">
-                  <Upload size={15} aria-hidden="true" />
-                </button>
-              )}
-              <button className={styles['exportBtn']} onClick={() => exportVisibleEvents(visibleEvents)} aria-label="Export to Excel">
-                <Download size={15} aria-hidden="true" />
-              </button>
               {ownerPassword && (
                 <OwnerLock
                   isOwner={ownerCfg.isOwner}
@@ -2357,7 +2325,48 @@ export const WorksCalendar = forwardRef<CalendarApi, WorksCalendarProps>(functio
           items:         scopedEvents,
         })}
           </>}
-          main={<>
+          main={
+        <div className={styles['mainPane']}>
+          <div className={styles['calendarCard']}>
+            <SubToolbar
+              leftSlot={<>
+                <SidebarToggleButton
+                  isOpen={sidebarOpen}
+                  onClick={() => setSidebarOpen(v => !v)}
+                  filterCount={hasActiveFilters(cal.filters, schema) ? 1 : 0}
+                  groupCount={sidebarGroupLevels.length}
+                />
+                {hasAddButton && cal.view !== 'schedule' && (
+                  <button className={styles['addBtn']} onClick={() => setFormEvent({})} aria-label="Add new event">
+                    <Plus size={14} aria-hidden="true" /><span className={styles['addBtnLabel']}> Add Event</span>
+                  </button>
+                )}
+                {hasAddButton && hasScheduleTemplates && (
+                  <button
+                    className={styles['addBtn']}
+                    onClick={() => {
+                      setScheduleOpen(true);
+                      trackScheduleTemplateAnalytics('schedule_dialog_opened', {
+                        templateCount: visibleScheduleTemplates.length,
+                      });
+                    }}
+                    aria-label="Add schedule from template"
+                  >
+                    <Plus size={14} aria-hidden="true" /><span className={styles['addBtnLabel']}> Add Schedule</span>
+                  </button>
+                )}
+              </>}
+              rightSlot={<>
+                {hasImport && (
+                  <button className={styles['exportBtn']} onClick={() => setImportOpen(true)} aria-label="Import .ics calendar">
+                    <Upload size={15} aria-hidden="true" />
+                  </button>
+                )}
+                <button className={styles['exportBtn']} onClick={() => exportVisibleEvents(visibleEvents)} aria-label="Export to Excel">
+                  <Download size={15} aria-hidden="true" />
+                </button>
+              </>}
+            />
         {/* ── View area ── */}
         <div
           ref={swipeAreaRef}
@@ -2466,7 +2475,9 @@ export const WorksCalendar = forwardRef<CalendarApi, WorksCalendarProps>(functio
             </>
           )}
         </div>
-          </>}
+          </div>
+        </div>
+          }
         />
 
         {/* ── Filter / Groups / Views overlay drawer ── */}

--- a/src/WorksCalendar.tsx
+++ b/src/WorksCalendar.tsx
@@ -46,6 +46,7 @@ import { useTabScopedEvents } from './hooks/useTabScopedEvents';
 import { captureSavedViewFields, type ViewId } from './core/viewScope';
 import { buildActiveFilterPills, buildFilterSummary, hasActiveFilters } from './filters/filterState';
 import { AppShell }           from './ui/AppShell';
+import { AppHeader }          from './ui/AppHeader';
 import { SubToolbar }         from './ui/SubToolbar';
 import FilterBar              from './ui/FilterBar';
 import ProfileBar             from './ui/ProfileBar';
@@ -2166,76 +2167,90 @@ export const WorksCalendar = forwardRef<CalendarApi, WorksCalendarProps>(functio
         {renderToolbar ? (
           <div className={styles['customToolbar']}>{renderToolbar(api)}</div>
         ) : (
-          <div className={styles['toolbar']} role="toolbar" aria-label="Calendar navigation">
-            <div className={styles['navGroup']}>
-              {logoSrc && (
-                <img
-                  src={logoSrc}
-                  alt={logoAlt ?? ''}
-                  className={styles['logo']}
-                  aria-hidden={!logoAlt ? 'true' : undefined}
-                />
-              )}
-              <button
-                className={styles['navBtn']}
-                onClick={() => cal.navigate(-1)}
-                aria-label="Previous"
-                title={`Previous ${cal.view}`}
-              >
-                <ChevronLeft size={18} aria-hidden="true" />
-              </button>
-              <button className={styles['todayBtn']} onClick={cal.goToToday}>Today</button>
-              <button
-                className={styles['navBtn']}
-                onClick={() => cal.navigate(1)}
-                aria-label="Next"
-                title={`Next ${cal.view}`}
-              >
-                <ChevronRight size={18} aria-hidden="true" />
-              </button>
-              <span className={styles['dateLabel']} aria-live="polite" aria-atomic="true">{getDateLabel()}</span>
-              <span className={styles['calendarTitle']}>{calendarTitle}</span>
-              {fetchLoading && <span className={styles['loadingDot']} title="Loading…" aria-label="Loading events" role="status" />}
-            </div>
-
-            <div className={styles['viewGroup']} role="group" aria-label="Calendar view">
-              {VIEWS.map(v => (
+          <AppHeader
+            leftSlot={
+              <div className={styles['navGroup']}>
+                {logoSrc && (
+                  <img
+                    src={logoSrc}
+                    alt={logoAlt ?? ''}
+                    className={styles['logo']}
+                    aria-hidden={!logoAlt ? 'true' : undefined}
+                  />
+                )}
                 <button
-                  key={v.id}
-                  className={[styles['viewBtn'], cal.view === v.id && styles['activeView']].filter(Boolean).join(' ')}
-                  onClick={() => cal.setView(v.id)}
-                  aria-pressed={cal.view === v.id}
-                  title={v.hint}
+                  className={styles['navBtn']}
+                  onClick={() => cal.navigate(-1)}
+                  aria-label="Previous"
+                  title={`Previous ${cal.view}`}
                 >
-                  {v.label}
+                  <ChevronLeft size={18} aria-hidden="true" />
                 </button>
-              ))}
-            </div>
-
-            <div className={styles['actions']}>
-              {devMode && <span className={styles['devBadge']}>Dev</span>}
-              {(ownerCfg.isOwner || devMode) && (
+                <button className={styles['todayBtn']} onClick={cal.goToToday}>Today</button>
                 <button
-                  className={[styles['wandBtn'], editMode && styles['wandBtnActive']].filter(Boolean).join(' ')}
-                  onClick={() => { setEditMode(v => !v); setInlineEditTarget(null); }}
-                  aria-label={editMode ? 'Exit edit mode' : 'Enter edit mode — click events to customize them'}
-                  title={editMode ? 'Exit edit mode' : 'Customize events'}
+                  className={styles['navBtn']}
+                  onClick={() => cal.navigate(1)}
+                  aria-label="Next"
+                  title={`Next ${cal.view}`}
                 >
-                  <Sparkles size={15} aria-hidden="true" />
-                  {editMode && <span className={styles['wandBtnLabel']}>Done</span>}
+                  <ChevronRight size={18} aria-hidden="true" />
                 </button>
-              )}
-              {ownerPassword && (
-                <OwnerLock
-                  isOwner={ownerCfg.isOwner}
-                  authError={ownerCfg.authError}
-                  isAuthLoading={ownerCfg.isAuthLoading}
-                  onAuthenticate={ownerCfg.authenticate}
-                  onOpen={() => ownerCfg.setConfigOpen(true)}
-                />
-              )}
-            </div>
-          </div>
+                <span className={styles['dateLabel']} aria-live="polite" aria-atomic="true">{getDateLabel()}</span>
+                <span className={styles['calendarTitle']}>{calendarTitle}</span>
+                {fetchLoading && <span className={styles['loadingDot']} title="Loading…" aria-label="Loading events" role="status" />}
+              </div>
+            }
+            centerSlot={
+              <div className={styles['viewGroup']} role="group" aria-label="Calendar view">
+                {VIEWS.map(v => (
+                  <button
+                    key={v.id}
+                    className={[styles['viewBtn'], cal.view === v.id && styles['activeView']].filter(Boolean).join(' ')}
+                    onClick={() => cal.setView(v.id)}
+                    aria-pressed={cal.view === v.id}
+                    title={v.hint}
+                  >
+                    {v.label}
+                  </button>
+                ))}
+              </div>
+            }
+            rightSlot={
+              <div className={styles['actions']}>
+                {devMode && <span className={styles['devBadge']}>Dev</span>}
+                {(ownerCfg.isOwner || devMode) && (
+                  <button
+                    className={[styles['wandBtn'], editMode && styles['wandBtnActive']].filter(Boolean).join(' ')}
+                    onClick={() => { setEditMode(v => !v); setInlineEditTarget(null); }}
+                    aria-label={editMode ? 'Exit edit mode' : 'Enter edit mode — click events to customize them'}
+                    title={editMode ? 'Exit edit mode' : 'Customize events'}
+                  >
+                    <Sparkles size={15} aria-hidden="true" />
+                    {editMode && <span className={styles['wandBtnLabel']}>Done</span>}
+                  </button>
+                )}
+                {ownerPassword && (
+                  <OwnerLock
+                    isOwner={ownerCfg.isOwner}
+                    authError={ownerCfg.authError}
+                    isAuthLoading={ownerCfg.isAuthLoading}
+                    onAuthenticate={ownerCfg.authenticate}
+                    onOpen={() => ownerCfg.setConfigOpen(true)}
+                  />
+                )}
+              </div>
+            }
+            menuItems={[
+              ...(ownerCfg.isOwner ? [
+                { label: 'Settings',          sub: 'Calendar config, integrations', onClick: () => ownerCfg.setConfigOpen(true) },
+                { label: 'Themes',            sub: 'Switch palette / appearance',   onClick: () => ownerCfg.openConfigToTab('theme') },
+                { label: 'Advanced settings', sub: 'Smart views, fields, approvals', onClick: () => ownerCfg.openConfigToTab('smartViews') },
+              ] : []),
+              { label: 'Saved views',         sub: 'Manage your view library',      onClick: () => { setSidebarInitialTab('saved'); setSidebarOpen(true); } },
+              { label: 'Keyboard shortcuts',  sub: 'Quick reference',               onClick: () => setHelpOpen(true) },
+              { label: 'Help & feedback',                                          onClick: () => window.open('https://github.com/WorksCalendar/CalendarThatWorks/issues', '_blank', 'noopener') },
+            ]}
+          />
         )}
 
         {/* ── Profile / Saved-views Bar ── */}

--- a/src/WorksCalendar.tsx
+++ b/src/WorksCalendar.tsx
@@ -45,6 +45,7 @@ import { SCHEDULE_WORKFLOW_CATEGORIES } from './core/scheduleModel';
 import { useTabScopedEvents } from './hooks/useTabScopedEvents';
 import { captureSavedViewFields, type ViewId } from './core/viewScope';
 import { buildActiveFilterPills, buildFilterSummary, hasActiveFilters } from './filters/filterState';
+import { AppShell }           from './ui/AppShell';
 import FilterBar              from './ui/FilterBar';
 import ProfileBar             from './ui/ProfileBar';
 import FilterGroupSidebar, { SidebarToggleButton } from './ui/FilterGroupSidebar';
@@ -2158,6 +2159,8 @@ export const WorksCalendar = forwardRef<CalendarApi, WorksCalendarProps>(functio
       <CalendarContext.Provider value={ctxValue}>
         <div className={styles['root']} data-wc-theme={effectiveTheme} data-wc-theme-family={themeFamily} data-wc-theme-mode={themeMode} data-testid="works-calendar" data-wc-edit-mode={editMode ? '' : undefined} style={rootStyle}>
 
+        <AppShell
+          header={<>
         {/* ── Toolbar ── */}
         {renderToolbar ? (
           <div className={styles['customToolbar']}>{renderToolbar(api)}</div>
@@ -2353,37 +2356,8 @@ export const WorksCalendar = forwardRef<CalendarApi, WorksCalendarProps>(functio
           activePills:   buildActiveFilterPills(cal.filters, filterBarSchema),
           items:         scopedEvents,
         })}
-
-        {/* ── View area (with sidebar overlay) ── */}
-        <FilterGroupSidebar
-          open={sidebarOpen}
-          initialTab={sidebarInitialTab}
-          onClose={() => setSidebarOpen(false)}
-          // Groups tab
-          groupLevels={sidebarGroupLevels}
-          onGroupLevelsChange={handleSidebarGroupLevelsChange}
-          sort={activeSort ?? []}
-          onSortChange={(next) => setActiveSort(next.length > 0 ? next : null)}
-          showAllGroups={activeShowAllGroups}
-          onShowAllGroupsChange={setActiveShowAllGroups}
-          // Filters tab
-          schema={filterBarSchema}
-          items={scopedEvents}
-          onFiltersChange={handleSidebarFiltersChange}
-          // Views tab
-          views={savedViews.views}
-          activeViewId={savedViewActiveId}
-          isViewDirty={savedViewDirty}
-          onApplyView={handleApplyView}
-          onSaveView={handleSidebarSaveView}
-          onResaveView={(id) => savedViews.resaveView(id, cal.filters, cal.view, activeGroupBy, captureSavedViewFields(cal.view, savedViewCaptureCtx))}
-          onUpdateView={savedViews.updateView}
-          onDeleteView={handleDeleteView}
-          onToggleViewVisibility={savedViews.toggleStripVisibility}
-          locationLabel={locationLabel}
-          assetsLabel={assetsLabel}
-        />
-
+          </>}
+          main={<>
         {/* ── View area ── */}
         <div
           ref={swipeAreaRef}
@@ -2492,6 +2466,38 @@ export const WorksCalendar = forwardRef<CalendarApi, WorksCalendarProps>(functio
             </>
           )}
         </div>
+          </>}
+        />
+
+        {/* ── Filter / Groups / Views overlay drawer ── */}
+        <FilterGroupSidebar
+          open={sidebarOpen}
+          initialTab={sidebarInitialTab}
+          onClose={() => setSidebarOpen(false)}
+          // Groups tab
+          groupLevels={sidebarGroupLevels}
+          onGroupLevelsChange={handleSidebarGroupLevelsChange}
+          sort={activeSort ?? []}
+          onSortChange={(next) => setActiveSort(next.length > 0 ? next : null)}
+          showAllGroups={activeShowAllGroups}
+          onShowAllGroupsChange={setActiveShowAllGroups}
+          // Filters tab
+          schema={filterBarSchema}
+          items={scopedEvents}
+          onFiltersChange={handleSidebarFiltersChange}
+          // Views tab
+          views={savedViews.views}
+          activeViewId={savedViewActiveId}
+          isViewDirty={savedViewDirty}
+          onApplyView={handleApplyView}
+          onSaveView={handleSidebarSaveView}
+          onResaveView={(id) => savedViews.resaveView(id, cal.filters, cal.view, activeGroupBy, captureSavedViewFields(cal.view, savedViewCaptureCtx))}
+          onUpdateView={savedViews.updateView}
+          onDeleteView={handleDeleteView}
+          onToggleViewVisibility={savedViews.toggleStripVisibility}
+          locationLabel={locationLabel}
+          assetsLabel={assetsLabel}
+        />
 
         {/* ── Hover card ── */}
         {selectedEvent && (

--- a/src/WorksCalendar.tsx
+++ b/src/WorksCalendar.tsx
@@ -48,6 +48,7 @@ import { buildActiveFilterPills, buildFilterSummary, hasActiveFilters } from './
 import { AppShell }           from './ui/AppShell';
 import { AppHeader }          from './ui/AppHeader';
 import { SubToolbar }         from './ui/SubToolbar';
+import { DayWindowPills }     from './ui/DayWindowPills';
 import FilterBar              from './ui/FilterBar';
 import ProfileBar             from './ui/ProfileBar';
 import FilterGroupSidebar, { SidebarToggleButton } from './ui/FilterGroupSidebar';
@@ -2371,6 +2372,7 @@ export const WorksCalendar = forwardRef<CalendarApi, WorksCalendarProps>(functio
                   </button>
                 )}
               </>}
+              centerSlot={<DayWindowPills value={cal.dayWindow} onChange={cal.setDayWindow} />}
               rightSlot={<>
                 {hasImport && (
                   <button className={styles['exportBtn']} onClick={() => setImportOpen(true)} aria-label="Import .ics calendar">

--- a/src/hooks/useCalendar.ts
+++ b/src/hooks/useCalendar.ts
@@ -19,6 +19,13 @@ type CalendarState = {
   setView: (value: CalendarView) => void;
   currentDate: Date;
   setCurrentDate: (value: Date) => void;
+  /**
+   * User-controlled day-span window (in days) for the timeline-style views.
+   * Bound to the 7/14/30/90 pills in the sub-toolbar. Views that don't have
+   * a configurable day span (e.g. month, week) ignore this value.
+   */
+  dayWindow: number;
+  setDayWindow: (value: number) => void;
   events: any[];
   visibleEvents: any[];
   categories: string[];
@@ -42,10 +49,12 @@ export function useCalendar(
   rawEvents: any[],
   initialView: CalendarView = 'month',
   filterSchema: any[] = DEFAULT_FILTER_SCHEMA,
+  initialDayWindow: number = 30,
 ): CalendarState {
   const [view,        setView]        = useState(initialView);
   const [currentDate, setCurrentDate] = useState(() => new Date());
   const [filters,     setFilters]     = useState(() => createInitialFilters(filterSchema));
+  const [dayWindow,   setDayWindow]   = useState(initialDayWindow);
 
   const events = useMemo(() => normalizeEvents(rawEvents), [rawEvents]);
 
@@ -139,6 +148,7 @@ export function useCalendar(
   return {
     view, setView,
     currentDate, setCurrentDate,
+    dayWindow, setDayWindow,
     events, visibleEvents,
     categories, resources,
     filters,

--- a/src/hooks/useCalendar.ts
+++ b/src/hooks/useCalendar.ts
@@ -21,8 +21,17 @@ type CalendarState = {
   setCurrentDate: (value: Date) => void;
   /**
    * User-controlled day-span window (in days) for the timeline-style views.
-   * Bound to the 7/14/30/90 pills in the sub-toolbar. Views that don't have
-   * a configurable day span (e.g. month, week) ignore this value.
+   * Bound to the 7/14/30/90 pills in the sub-toolbar.
+   *
+   * TODO(shell-rework reflow): no view currently observes this value, so
+   * picking a pill only shifts the active swatch. Wiring up the views is
+   * a separate per-view refactor — TimelineView, BaseGanttView, and
+   * AssetsView all hardcode month-spanning math around `currentDate` and
+   * need their own props + range derivation to honour an arbitrary
+   * dayWindow. Tracked as a followup to the shell-rework PR series.
+   *
+   * Views that have an intrinsic span (month, week, day) are expected to
+   * keep ignoring this value.
    */
   dayWindow: number;
   setDayWindow: (value: number) => void;

--- a/src/ui/AppHeader.module.css
+++ b/src/ui/AppHeader.module.css
@@ -1,0 +1,122 @@
+/*
+ * AppHeader — three-zone top bar with optional hamburger dropdown.
+ * Token-driven; the bar inherits its surface from the active theme so the
+ * existing 12 themes restyle automatically.
+ */
+
+.root {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 0 calc(12px * var(--wc-density, 1));
+  height: calc(56px * var(--wc-density, 1));
+  border-bottom: var(--wc-border-width, 1px) solid var(--wc-border);
+  background: var(--wc-surface);
+  flex-shrink: 0;
+  position: relative;
+}
+
+.left {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex: 0 0 auto;
+  min-width: 0;
+}
+
+.center {
+  flex: 1;
+  display: flex;
+  justify-content: center;
+  min-width: 0;
+}
+
+.right {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex: 0 0 auto;
+  margin-left: auto;
+}
+
+/* ── Hamburger ────────────────────────────────────────────────────────── */
+
+.menuWrap {
+  position: relative;
+  display: flex;
+}
+
+.menuBtn {
+  width: 32px;
+  height: 32px;
+  border: none;
+  background: transparent;
+  color: var(--wc-text-muted);
+  border-radius: var(--wc-radius-sm);
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.menuBtn:hover,
+.menuBtn:focus-visible {
+  background: var(--wc-surface-2);
+  color: var(--wc-text);
+}
+
+.menuBtn:focus-visible {
+  outline: 2px solid var(--wc-accent);
+  outline-offset: 2px;
+}
+
+.dropdown {
+  position: absolute;
+  top: calc(100% + 4px);
+  left: 0;
+  min-width: 240px;
+  background: var(--wc-surface);
+  border: var(--wc-border-width, 1px) solid var(--wc-border);
+  border-radius: var(--wc-radius);
+  box-shadow: var(--wc-shadow);
+  padding: 4px;
+  z-index: 100;
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+}
+
+.dropdownItem {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 1px;
+  padding: 8px 10px;
+  border: none;
+  background: transparent;
+  color: var(--wc-text);
+  border-radius: var(--wc-radius-sm);
+  cursor: pointer;
+  text-align: left;
+  font: inherit;
+}
+
+.dropdownItem:hover,
+.dropdownItem:focus-visible {
+  background: var(--wc-surface-2);
+}
+
+.dropdownItem:focus-visible {
+  outline: 2px solid var(--wc-accent);
+  outline-offset: -2px;
+}
+
+.dropdownLabel {
+  font-size: 13px;
+  color: var(--wc-text);
+}
+
+.dropdownSub {
+  font-size: 11px;
+  color: var(--wc-text-muted);
+}

--- a/src/ui/AppHeader.tsx
+++ b/src/ui/AppHeader.tsx
@@ -1,0 +1,104 @@
+import { useEffect, useRef, useState } from 'react';
+import type { ReactNode } from 'react';
+import { Menu } from 'lucide-react';
+import cls from './AppHeader.module.css';
+
+export type AppHeaderMenuItem = {
+  /** Visible label (top line). */
+  label: string;
+  /** Optional sub-label (smaller, second line). */
+  sub?: string;
+  /** Click handler. AppHeader closes the dropdown before invoking. */
+  onClick: () => void;
+};
+
+export type AppHeaderProps = {
+  /** Left zone — branding + nav cluster. */
+  leftSlot?: ReactNode;
+  /** Center zone — view-tab pills. */
+  centerSlot?: ReactNode;
+  /** Right zone — system actions. */
+  rightSlot?: ReactNode;
+  /** Hamburger menu items. Empty / omitted hides the hamburger entirely. */
+  menuItems?: AppHeaderMenuItem[];
+};
+
+/**
+ * Top header band. Three layout zones (left / center / right) plus an
+ * optional hamburger dropdown anchored at the very start of the left zone.
+ * Slots are layout-only; the consumer owns content + state.
+ *
+ * role="toolbar" + aria-label="Calendar navigation" is preserved on the
+ * root so existing a11y queries keep working.
+ */
+export function AppHeader({ leftSlot, centerSlot, rightSlot, menuItems }: AppHeaderProps) {
+  const [menuOpen, setMenuOpen] = useState(false);
+  const menuWrapRef = useRef<HTMLDivElement>(null);
+
+  // Close on outside click
+  useEffect(() => {
+    if (!menuOpen) return;
+    const onDocClick = (e: MouseEvent) => {
+      if (menuWrapRef.current && !menuWrapRef.current.contains(e.target as Node)) {
+        setMenuOpen(false);
+      }
+    };
+    document.addEventListener('mousedown', onDocClick);
+    return () => document.removeEventListener('mousedown', onDocClick);
+  }, [menuOpen]);
+
+  // Close on Escape
+  useEffect(() => {
+    if (!menuOpen) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setMenuOpen(false);
+    };
+    document.addEventListener('keydown', onKey);
+    return () => document.removeEventListener('keydown', onKey);
+  }, [menuOpen]);
+
+  const hasMenu = !!menuItems && menuItems.length > 0;
+
+  return (
+    <div className={cls['root']} role="toolbar" aria-label="Calendar navigation">
+      <div className={cls['left']}>
+        {hasMenu && (
+          <div ref={menuWrapRef} className={cls['menuWrap']}>
+            <button
+              type="button"
+              className={cls['menuBtn']}
+              aria-label={menuOpen ? 'Close main menu' : 'Open main menu'}
+              aria-haspopup="menu"
+              aria-expanded={menuOpen}
+              onClick={() => setMenuOpen(v => !v)}
+            >
+              <Menu size={18} aria-hidden="true" />
+            </button>
+            {menuOpen && (
+              <div className={cls['dropdown']} role="menu">
+                {menuItems!.map(item => (
+                  <button
+                    key={item.label}
+                    type="button"
+                    role="menuitem"
+                    className={cls['dropdownItem']}
+                    onClick={() => {
+                      setMenuOpen(false);
+                      item.onClick();
+                    }}
+                  >
+                    <span className={cls['dropdownLabel']}>{item.label}</span>
+                    {item.sub && <span className={cls['dropdownSub']}>{item.sub}</span>}
+                  </button>
+                ))}
+              </div>
+            )}
+          </div>
+        )}
+        {leftSlot}
+      </div>
+      <div className={cls['center']}>{centerSlot}</div>
+      <div className={cls['right']}>{rightSlot}</div>
+    </div>
+  );
+}

--- a/src/ui/AppShell.module.css
+++ b/src/ui/AppShell.module.css
@@ -1,0 +1,43 @@
+/*
+ * AppShell — three-column shell scaffold.
+ *
+ * PR 1 foundation only. Header sits above a body row; left rail and right
+ * panel are slot-optional and render nothing (zero width) when their props
+ * are undefined. With only header + main the visual layout collapses to the
+ * same vertical stack the calendar used pre-AppShell — no surrounding
+ * styling changes for this PR.
+ */
+
+.shell {
+  flex: 1;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+}
+
+.headerBand {
+  flex-shrink: 0;
+  display: flex;
+  flex-direction: column;
+}
+
+.body {
+  flex: 1;
+  min-height: 0;
+  display: flex;
+}
+
+.leftRail {
+  flex-shrink: 0;
+}
+
+.main {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+}
+
+.rightPanel {
+  flex-shrink: 0;
+}

--- a/src/ui/AppShell.tsx
+++ b/src/ui/AppShell.tsx
@@ -1,0 +1,34 @@
+import type { ReactNode } from 'react';
+import cls from './AppShell.module.css';
+
+export type AppShellProps = {
+  /** Top header band, full-width above the body. */
+  header: ReactNode;
+  /** Main content column between the optional left rail and right panel. */
+  main: ReactNode;
+  /** Optional fixed-width left icon rail. Omit to render no rail. */
+  leftRail?: ReactNode;
+  /** Optional fixed-width right panel. Omit to render no panel. */
+  rightPanel?: ReactNode;
+};
+
+/**
+ * Three-column dashboard shell scaffold.
+ *
+ * Header is always rendered above a body row that holds main and (optionally)
+ * a left rail / right panel. Slots that are not provided take no space, so a
+ * shell with only `header` + `main` lays out identically to a plain stacked
+ * column.
+ */
+export function AppShell({ header, main, leftRail, rightPanel }: AppShellProps) {
+  return (
+    <div className={cls['shell']}>
+      <div className={cls['headerBand']}>{header}</div>
+      <div className={cls['body']}>
+        {leftRail !== undefined && <aside className={cls['leftRail']}>{leftRail}</aside>}
+        <div className={cls['main']}>{main}</div>
+        {rightPanel !== undefined && <aside className={cls['rightPanel']}>{rightPanel}</aside>}
+      </div>
+    </div>
+  );
+}

--- a/src/ui/DayWindowPills.module.css
+++ b/src/ui/DayWindowPills.module.css
@@ -1,0 +1,42 @@
+/*
+ * DayWindowPills — segmented day-window selector for the sub-toolbar.
+ * Token-driven; the active pill picks up var(--wc-surface-2) so the
+ * contrast follows the active theme.
+ */
+
+.root {
+  display: inline-flex;
+  background: var(--wc-bg);
+  border: var(--wc-border-width, 1px) solid var(--wc-border);
+  border-radius: var(--wc-radius-sm);
+  padding: 2px;
+  gap: 0;
+}
+
+.pill {
+  border: none;
+  background: transparent;
+  color: var(--wc-text-muted);
+  padding: 4px 10px;
+  font-size: 12px;
+  font-weight: 500;
+  border-radius: calc(var(--wc-radius-sm) - 2px);
+  cursor: pointer;
+  white-space: nowrap;
+  transition: background 120ms ease, color 120ms ease;
+}
+
+.pill:hover {
+  color: var(--wc-text);
+}
+
+.pill:focus-visible {
+  outline: 2px solid var(--wc-accent);
+  outline-offset: -1px;
+}
+
+.pill.active {
+  background: var(--wc-surface-2);
+  color: var(--wc-text);
+  font-weight: 600;
+}

--- a/src/ui/DayWindowPills.tsx
+++ b/src/ui/DayWindowPills.tsx
@@ -1,0 +1,47 @@
+import cls from './DayWindowPills.module.css';
+
+const DEFAULT_OPTIONS = [7, 14, 30, 90] as const;
+
+export type DayWindowPillsProps = {
+  /** Currently selected day window (in days). */
+  value: number;
+  /** Called when the user picks a different window. */
+  onChange: (next: number) => void;
+  /**
+   * Pill options to render. Defaults to [7, 14, 30, 90]. Order is preserved.
+   */
+  options?: readonly number[];
+};
+
+/**
+ * Day-window pill set. A segmented selector that picks how many days the
+ * timeline-style views (Schedule / Base / Assets) span at once.
+ *
+ * Layout-only — the consuming hook owns the underlying state. Styling uses
+ * theme tokens so all 12 themes restyle automatically.
+ */
+export function DayWindowPills({
+  value,
+  onChange,
+  options = DEFAULT_OPTIONS,
+}: DayWindowPillsProps) {
+  return (
+    <div className={cls['root']} role="group" aria-label="Day window">
+      {options.map(n => {
+        const active = n === value;
+        return (
+          <button
+            key={n}
+            type="button"
+            className={[cls['pill'], active && cls['active']].filter(Boolean).join(' ')}
+            aria-pressed={active}
+            onClick={() => onChange(n)}
+            title={`Show ${n} day${n === 1 ? '' : 's'}`}
+          >
+            {n} day
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/ui/LeftRail.module.css
+++ b/src/ui/LeftRail.module.css
@@ -1,0 +1,50 @@
+/*
+ * LeftRail — fixed-width icon column. Token-driven so all 12 themes
+ * restyle the rail automatically. Active view picks up the accent
+ * border + surface-2 background (matches the AppHeader hamburger
+ * dropdown active treatment).
+ */
+
+.root {
+  width: 56px;
+  flex-shrink: 0;
+  background: var(--wc-surface);
+  border-right: var(--wc-border-width, 1px) solid var(--wc-border);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding-top: 8px;
+  gap: 2px;
+}
+
+.btn {
+  width: 40px;
+  height: 40px;
+  border: none;
+  background: transparent;
+  color: var(--wc-text-muted);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  border-left: 2px solid transparent;
+  margin-left: -2px;
+  padding: 0;
+  transition: background 120ms ease, color 120ms ease;
+}
+
+.btn:hover {
+  color: var(--wc-text);
+  background: var(--wc-surface-2);
+}
+
+.btn:focus-visible {
+  outline: 2px solid var(--wc-accent);
+  outline-offset: -2px;
+}
+
+.btn.active {
+  color: var(--wc-accent);
+  background: var(--wc-surface-2);
+  border-left-color: var(--wc-accent);
+}

--- a/src/ui/LeftRail.tsx
+++ b/src/ui/LeftRail.tsx
@@ -1,0 +1,54 @@
+import { VIEW_ICON_MAP } from './viewIcons';
+import cls from './LeftRail.module.css';
+
+export type LeftRailItem = {
+  /** View id; must match a key in VIEW_ICON_MAP (otherwise the row is skipped). */
+  id: string;
+  /** Optional richer tooltip; falls back to the icon's accessible label. */
+  hint?: string;
+};
+
+export type LeftRailProps = {
+  /** Ordered list of views to render. */
+  items: LeftRailItem[];
+  /** Currently active view id. Marked aria-pressed=true. */
+  activeId: string;
+  /** Called when the user picks a view. */
+  onSelect: (id: string) => void;
+};
+
+/**
+ * LeftRail — fixed-width icon column rendered in <AppShell>'s leftRail slot.
+ * Each button maps a view id to its lucide icon via VIEW_ICON_MAP. Layout-
+ * only — the consumer owns the items list and the active selection.
+ *
+ * Buttons are intentionally aria-labelled with the descriptive form from
+ * VIEW_ICON_MAP (e.g. "Schedule view") rather than the bare label
+ * ("Schedule"), so they don't collide with the AppHeader view-tab pills
+ * in role/name accessibility queries.
+ */
+export function LeftRail({ items, activeId, onSelect }: LeftRailProps) {
+  return (
+    <nav className={cls['root']} aria-label="Calendar views">
+      {items.map(item => {
+        const entry = VIEW_ICON_MAP[item.id];
+        if (!entry) return null;
+        const Icon = entry.Icon;
+        const active = item.id === activeId;
+        return (
+          <button
+            key={item.id}
+            type="button"
+            className={[cls['btn'], active && cls['active']].filter(Boolean).join(' ')}
+            onClick={() => onSelect(item.id)}
+            aria-pressed={active}
+            aria-label={entry.label}
+            title={item.hint ?? entry.label}
+          >
+            <Icon size={18} aria-hidden="true" />
+          </button>
+        );
+      })}
+    </nav>
+  );
+}

--- a/src/ui/ProfileBar.tsx
+++ b/src/ui/ProfileBar.tsx
@@ -13,30 +13,18 @@
 import { useMemo, useState, useRef, useEffect } from 'react';
 import {
   Plus, Bookmark, BookmarkCheck,
-  CalendarDays, Calendar, Columns3, List, CalendarRange, Boxes, MapPin, Radio, Map as MapIcon,
 } from 'lucide-react';
 import { DEFAULT_FILTER_SCHEMA } from '../filters/filterSchema';
 import ViewsDropdown from './ViewsDropdown';
 import CustomizeQuickViewsPanel from './CustomizeQuickViewsPanel';
 import ClearFiltersButton from './ClearFiltersButton';
+import { VIEW_ICON_MAP } from './viewIcons';
 import styles from './ProfileBar.module.css';
 
 const PROFILE_COLORS = [
   '#3b82f6', '#10b981', '#f59e0b', '#ef4444',
   '#8b5cf6', '#ec4899', '#06b6d4', '#f97316',
 ];
-
-const VIEW_ICON_MAP: Record<string, { Icon: any; label: string }> = {
-  month:    { Icon: CalendarDays,  label: 'Month view' },
-  week:     { Icon: Columns3,      label: 'Week view' },
-  day:      { Icon: Calendar,      label: 'Day view' },
-  agenda:   { Icon: List,          label: 'Agenda view' },
-  schedule: { Icon: CalendarRange, label: 'Schedule view' },
-  base:     { Icon: MapPin,        label: 'Base view' },
-  assets:   { Icon: Boxes,         label: 'Assets view' },
-  dispatch: { Icon: Radio,         label: 'Dispatch view' },
-  map:      { Icon: MapIcon,       label: 'Map view' },
-};
 
 const GLOBAL_GROUP_KEY = '__global__';
 const DEFAULT_VIEW_ORDER = ['month','week','day','agenda','schedule','base','assets','dispatch','map'];

--- a/src/ui/RightPanel.module.css
+++ b/src/ui/RightPanel.module.css
@@ -1,0 +1,110 @@
+/*
+ * RightPanel — docked aside in <AppShell>'s rightPanel slot. Token-driven so
+ * all 12 themes restyle automatically. Hidden on narrow viewports — at the
+ * mock's 240px width plus the 56px LeftRail, anything below ~900px starts
+ * to crowd the calendar grid.
+ */
+
+.root {
+  width: 240px;
+  flex-shrink: 0;
+  background: var(--wc-surface);
+  border-left: var(--wc-border-width, 1px) solid var(--wc-border);
+  display: flex;
+  flex-direction: column;
+  overflow-y: auto;
+  overflow-x: hidden;
+}
+
+@media (max-width: 900px) {
+  .root {
+    display: none;
+  }
+}
+
+/* ── Section ──────────────────────────────────────────────────────────── */
+
+.section + .section {
+  border-top: var(--wc-border-width, 1px) solid var(--wc-border);
+}
+
+.sectionHeader {
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: var(--wc-text-muted);
+  padding: 14px 16px 6px;
+}
+
+.sectionBody {
+  padding: 0 12px 12px;
+}
+
+/* ── Region map ───────────────────────────────────────────────────────── */
+
+.mapSvg {
+  width: 100%;
+  height: 140px;
+  background: var(--wc-surface-2);
+  border-radius: var(--wc-radius-sm);
+  display: block;
+}
+
+.mapDot {
+  fill: var(--wc-accent);
+}
+
+.mapEmpty {
+  background: var(--wc-surface-2);
+  border-radius: var(--wc-radius-sm);
+  padding: 16px 12px;
+  font-size: 11px;
+  color: var(--wc-text-faint);
+  text-align: center;
+}
+
+/* ── Crew list ────────────────────────────────────────────────────────── */
+
+.crewList {
+  margin: 0;
+  padding: 4px 0 0;
+  list-style: none;
+}
+
+.crewItem {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 6px 4px;
+  font-size: 12px;
+  color: var(--wc-text);
+}
+
+.crewAvatar {
+  width: 24px;
+  height: 24px;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 10px;
+  font-weight: 600;
+  color: white;
+  flex-shrink: 0;
+}
+
+.crewName {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.crewEmpty {
+  background: var(--wc-surface-2);
+  border-radius: var(--wc-radius-sm);
+  padding: 16px 12px;
+  font-size: 11px;
+  color: var(--wc-text-faint);
+  text-align: center;
+}

--- a/src/ui/RightPanel.tsx
+++ b/src/ui/RightPanel.tsx
@@ -1,0 +1,169 @@
+import type { ReactNode } from 'react';
+import cls from './RightPanel.module.css';
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Layout: wrapper + section
+// ──────────────────────────────────────────────────────────────────────────────
+
+export type RightPanelProps = {
+  children?: ReactNode;
+};
+
+/** Docked aside in <AppShell>'s rightPanel slot. Fixed 240px wide. */
+export function RightPanel({ children }: RightPanelProps) {
+  return <div className={cls['root']}>{children}</div>;
+}
+
+export type RightPanelSectionProps = {
+  title: string;
+  children?: ReactNode;
+};
+
+/** Titled section block inside RightPanel. */
+export function RightPanelSection({ title, children }: RightPanelSectionProps) {
+  return (
+    <section className={cls['section']} aria-label={title}>
+      <header className={cls['sectionHeader']}>{title}</header>
+      <div className={cls['sectionBody']}>{children}</div>
+    </section>
+  );
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Widget: region map (lightweight SVG plot of event coordinates)
+// ──────────────────────────────────────────────────────────────────────────────
+
+type EventLike = { id?: string | number; meta?: Record<string, unknown> | null };
+
+function readCoords(ev: EventLike): { lat: number; lon: number } | null {
+  const meta = ev.meta;
+  if (!meta) return null;
+  const c = meta['coords'];
+  if (c && typeof c === 'object') {
+    const co = c as Record<string, unknown>;
+    const lat = co['lat'];
+    const lon = co['lon'] ?? co['lng'];
+    if (typeof lat === 'number' && typeof lon === 'number') return { lat, lon };
+  }
+  const lat = meta['lat'];
+  const lon = meta['lon'] ?? meta['lng'];
+  if (typeof lat === 'number' && typeof lon === 'number') return { lat, lon };
+  return null;
+}
+
+const MAP_W = 200;
+const MAP_H = 120;
+const MAP_PAD = 14;
+
+export type RegionMapWidgetProps = {
+  events: EventLike[];
+};
+
+/**
+ * RegionMapWidget — slim SVG plot of event coordinates. Bounding-box-fit
+ * projection (no tile layer, no maplibre dep). Renders an empty-state
+ * message when no events carry coords.
+ */
+export function RegionMapWidget({ events }: RegionMapWidgetProps) {
+  const points = events
+    .map(e => {
+      const c = readCoords(e);
+      return c ? { id: String(e.id ?? ''), ...c } : null;
+    })
+    .filter((p): p is { id: string; lat: number; lon: number } => p !== null);
+
+  if (points.length === 0) {
+    return (
+      <div className={cls['mapEmpty']} role="note">
+        No events with coordinates yet.
+      </div>
+    );
+  }
+
+  // Single point: center it.
+  // Multiple points: bounding-box fit with padding.
+  let project: (p: { lat: number; lon: number }) => { x: number; y: number };
+  if (points.length === 1) {
+    project = () => ({ x: MAP_W / 2, y: MAP_H / 2 });
+  } else {
+    const lats = points.map(p => p.lat);
+    const lons = points.map(p => p.lon);
+    const minLat = Math.min(...lats);
+    const maxLat = Math.max(...lats);
+    const minLon = Math.min(...lons);
+    const maxLon = Math.max(...lons);
+    const dLat = maxLat - minLat || 1;
+    const dLon = maxLon - minLon || 1;
+    project = ({ lat, lon }) => ({
+      x: MAP_PAD + ((lon - minLon) / dLon) * (MAP_W - 2 * MAP_PAD),
+      // Latitude grows north; flip so higher lat is higher on the SVG.
+      y: MAP_PAD + (1 - (lat - minLat) / dLat) * (MAP_H - 2 * MAP_PAD),
+    });
+  }
+
+  const projected = points.map(p => ({ ...p, ...project(p) }));
+
+  return (
+    <svg
+      className={cls['mapSvg']}
+      viewBox={`0 0 ${MAP_W} ${MAP_H}`}
+      role="img"
+      aria-label={`${points.length} event${points.length === 1 ? '' : 's'} on the region map`}
+    >
+      {projected.map(p => (
+        <circle key={p.id} cx={p.x} cy={p.y} r={3} className={cls['mapDot']} />
+      ))}
+    </svg>
+  );
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Widget: crew list (configured team members)
+// ──────────────────────────────────────────────────────────────────────────────
+
+export type CrewMember = { id: string | number; name?: string };
+export type CrewOnShiftListProps = {
+  employees: CrewMember[];
+};
+
+function initials(name: string | undefined): string {
+  if (!name) return '?';
+  const parts = name.trim().split(/\s+/);
+  if (parts.length === 0 || !parts[0]) return '?';
+  if (parts.length === 1) return parts[0].slice(0, 2).toUpperCase();
+  return ((parts[0]?.[0] ?? '') + (parts[parts.length - 1]?.[0] ?? '')).toUpperCase();
+}
+
+const AVATAR_PALETTE = ['#3b82f6', '#10b981', '#f59e0b', '#a855f7', '#ec4899', '#06b6d4'];
+
+/**
+ * CrewOnShiftList — configured team members. Currently unfiltered; a follow-up
+ * will narrow to "scheduled to work right now" once a reusable shift-overlap
+ * helper exists. For now showing the whole roster is honest given the data
+ * available.
+ */
+export function CrewOnShiftList({ employees }: CrewOnShiftListProps) {
+  if (employees.length === 0) {
+    return (
+      <div className={cls['crewEmpty']} role="note">
+        No team members configured yet.
+      </div>
+    );
+  }
+  return (
+    <ul className={cls['crewList']}>
+      {employees.map((emp, i) => {
+        const name = emp.name ?? String(emp.id);
+        const swatch = AVATAR_PALETTE[i % AVATAR_PALETTE.length];
+        return (
+          <li key={String(emp.id)} className={cls['crewItem']}>
+            <span className={cls['crewAvatar']} style={{ background: swatch }} aria-hidden="true">
+              {initials(emp.name)}
+            </span>
+            <span className={cls['crewName']}>{name}</span>
+          </li>
+        );
+      })}
+    </ul>
+  );
+}

--- a/src/ui/SubToolbar.module.css
+++ b/src/ui/SubToolbar.module.css
@@ -1,0 +1,39 @@
+/*
+ * SubToolbar — three-zone bar inside the calendar card.
+ *
+ * Tokens-only styling so the bar inherits whatever theme is active. The
+ * 8px gap between zones matches the existing main-toolbar spacing in
+ * WorksCalendar.module.css.
+ */
+
+.root {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: calc(8px * var(--wc-density, 1)) calc(12px * var(--wc-density, 1));
+  border-bottom: var(--wc-border-width, 1px) solid var(--wc-border);
+  background: var(--wc-bg);
+  flex-shrink: 0;
+  flex-wrap: wrap;
+}
+
+.left {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.center {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 0;
+}
+
+.right {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin-left: auto;
+}

--- a/src/ui/SubToolbar.tsx
+++ b/src/ui/SubToolbar.tsx
@@ -1,0 +1,28 @@
+import type { ReactNode } from 'react';
+import cls from './SubToolbar.module.css';
+
+export type SubToolbarProps = {
+  /** Left zone — primary data actions (e.g. Add, Filter trigger). */
+  leftSlot?: ReactNode;
+  /** Center zone — view-scoped controls (e.g. day-window pill set). */
+  centerSlot?: ReactNode;
+  /** Right zone — secondary actions (e.g. Import, Export, Save view). */
+  rightSlot?: ReactNode;
+};
+
+/**
+ * Sub-toolbar that lives inside the calendar card, above the view grid.
+ *
+ * Three layout-only zones — content is provided by the consumer so the
+ * shell stays agnostic to which buttons exist in each surface (calendar
+ * top-level vs. embedder-supplied custom toolbars).
+ */
+export function SubToolbar({ leftSlot, centerSlot, rightSlot }: SubToolbarProps) {
+  return (
+    <div className={cls['root']} role="toolbar" aria-label="Calendar actions">
+      <div className={cls['left']}>{leftSlot}</div>
+      <div className={cls['center']}>{centerSlot}</div>
+      <div className={cls['right']}>{rightSlot}</div>
+    </div>
+  );
+}

--- a/src/ui/__tests__/DayWindowPills.test.tsx
+++ b/src/ui/__tests__/DayWindowPills.test.tsx
@@ -1,0 +1,51 @@
+// @vitest-environment happy-dom
+/**
+ * DayWindowPills — segmented day-window selector.
+ *
+ * Pins the rendering / selection / a11y contract so the sub-toolbar
+ * integration is safe to refactor.
+ */
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import '@testing-library/jest-dom';
+
+import { DayWindowPills } from '../DayWindowPills';
+
+describe('DayWindowPills', () => {
+  it('renders the default 7 / 14 / 30 / 90 options', () => {
+    render(<DayWindowPills value={30} onChange={() => {}} />);
+    expect(screen.getByRole('button', { name: '7 day' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: '14 day' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: '30 day' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: '90 day' })).toBeInTheDocument();
+  });
+
+  it('marks the active pill via aria-pressed', () => {
+    render(<DayWindowPills value={30} onChange={() => {}} />);
+    expect(screen.getByRole('button', { name: '30 day' })).toHaveAttribute('aria-pressed', 'true');
+    expect(screen.getByRole('button', { name: '7 day' })).toHaveAttribute('aria-pressed', 'false');
+    expect(screen.getByRole('button', { name: '14 day' })).toHaveAttribute('aria-pressed', 'false');
+    expect(screen.getByRole('button', { name: '90 day' })).toHaveAttribute('aria-pressed', 'false');
+  });
+
+  it('invokes onChange with the picked window', () => {
+    const onChange = vi.fn();
+    render(<DayWindowPills value={30} onChange={onChange} />);
+    fireEvent.click(screen.getByRole('button', { name: '14 day' }));
+    expect(onChange).toHaveBeenCalledWith(14);
+  });
+
+  it('exposes a labelled group for a11y trees', () => {
+    render(<DayWindowPills value={30} onChange={() => {}} />);
+    expect(screen.getByRole('group', { name: /day window/i })).toBeInTheDocument();
+  });
+
+  it('honours custom options', () => {
+    render(<DayWindowPills value={3} onChange={() => {}} options={[1, 3, 5]} />);
+    expect(screen.getByRole('button', { name: '1 day' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: '3 day' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: '5 day' })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: '7 day' })).toBeNull();
+    expect(screen.getByRole('button', { name: '3 day' })).toHaveAttribute('aria-pressed', 'true');
+  });
+});

--- a/src/ui/__tests__/LeftRail.test.tsx
+++ b/src/ui/__tests__/LeftRail.test.tsx
@@ -1,0 +1,62 @@
+// @vitest-environment happy-dom
+/**
+ * LeftRail — fixed-width icon column in the AppShell leftRail slot.
+ *
+ * Pins render / active-state / dispatch / unknown-id-skip / a11y so the
+ * AppShell wiring is safe to refactor.
+ */
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import '@testing-library/jest-dom';
+
+import { LeftRail } from '../LeftRail';
+
+const ITEMS = [
+  { id: 'month' },
+  { id: 'week' },
+  { id: 'schedule', hint: 'Staffing rotation' },
+];
+
+describe('LeftRail', () => {
+  it('renders one button per known view item', () => {
+    render(<LeftRail items={ITEMS} activeId="month" onSelect={() => {}} />);
+    expect(screen.getByRole('button', { name: 'Month view' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Week view' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Schedule view' })).toBeInTheDocument();
+  });
+
+  it('marks the active button via aria-pressed', () => {
+    render(<LeftRail items={ITEMS} activeId="schedule" onSelect={() => {}} />);
+    expect(screen.getByRole('button', { name: 'Schedule view' })).toHaveAttribute('aria-pressed', 'true');
+    expect(screen.getByRole('button', { name: 'Month view' })).toHaveAttribute('aria-pressed', 'false');
+  });
+
+  it('calls onSelect with the picked id', () => {
+    const onSelect = vi.fn();
+    render(<LeftRail items={ITEMS} activeId="month" onSelect={onSelect} />);
+    fireEvent.click(screen.getByRole('button', { name: 'Schedule view' }));
+    expect(onSelect).toHaveBeenCalledWith('schedule');
+  });
+
+  it('skips items whose id has no entry in VIEW_ICON_MAP', () => {
+    const items = [
+      ...ITEMS,
+      { id: 'no-such-view' },
+    ];
+    render(<LeftRail items={items} activeId="month" onSelect={() => {}} />);
+    expect(screen.queryByRole('button', { name: /no-such-view/i })).toBeNull();
+    // The known items still render.
+    expect(screen.getByRole('button', { name: 'Month view' })).toBeInTheDocument();
+  });
+
+  it('uses the hint as the tooltip when provided, otherwise the icon label', () => {
+    render(<LeftRail items={ITEMS} activeId="month" onSelect={() => {}} />);
+    expect(screen.getByRole('button', { name: 'Schedule view' })).toHaveAttribute('title', 'Staffing rotation');
+    expect(screen.getByRole('button', { name: 'Month view' })).toHaveAttribute('title', 'Month view');
+  });
+
+  it('exposes a labelled navigation landmark', () => {
+    render(<LeftRail items={ITEMS} activeId="month" onSelect={() => {}} />);
+    expect(screen.getByRole('navigation', { name: /calendar views/i })).toBeInTheDocument();
+  });
+});

--- a/src/ui/__tests__/RightPanel.test.tsx
+++ b/src/ui/__tests__/RightPanel.test.tsx
@@ -1,0 +1,141 @@
+// @vitest-environment happy-dom
+/**
+ * RightPanel — docked aside in <AppShell>'s rightPanel slot.
+ *
+ * Pins the section/widget rendering contract so the WorksCalendar wiring
+ * (events → map, employees → crew list) is safe to refactor.
+ */
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import '@testing-library/jest-dom';
+
+import {
+  RightPanel,
+  RightPanelSection,
+  RegionMapWidget,
+  CrewOnShiftList,
+} from '../RightPanel';
+
+describe('RightPanelSection', () => {
+  it('renders a section with the title as accessible name + visible header', () => {
+    render(
+      <RightPanelSection title="Region map">
+        <span>body</span>
+      </RightPanelSection>,
+    );
+    expect(screen.getByRole('region', { name: 'Region map' })).toBeInTheDocument();
+    expect(screen.getByText('Region map')).toBeInTheDocument();
+    expect(screen.getByText('body')).toBeInTheDocument();
+  });
+});
+
+describe('RegionMapWidget', () => {
+  it('renders an empty-state note when no events carry coordinates', () => {
+    render(<RegionMapWidget events={[{ id: 'a' }, { id: 'b', meta: { title: 'no coords' } }]} />);
+    expect(screen.getByRole('note')).toHaveTextContent(/no events with coordinates/i);
+  });
+
+  it('plots one circle per event with coords (canonical meta.coords shape)', () => {
+    const { container } = render(
+      <RegionMapWidget
+        events={[
+          { id: 'a', meta: { coords: { lat: 40, lon: -74 } } },
+          { id: 'b', meta: { coords: { lat: 41, lon: -73 } } },
+          { id: 'c', meta: { coords: { lat: 42, lon: -72 } } },
+        ]}
+      />,
+    );
+    const circles = container.querySelectorAll('circle');
+    expect(circles).toHaveLength(3);
+    expect(screen.getByRole('img', { name: /3 events on the region map/i })).toBeInTheDocument();
+  });
+
+  it('accepts the loose meta.lat / meta.lon shape too', () => {
+    const { container } = render(
+      <RegionMapWidget
+        events={[{ id: 'a', meta: { lat: 40, lon: -74 } }]}
+      />,
+    );
+    expect(container.querySelectorAll('circle')).toHaveLength(1);
+    expect(screen.getByRole('img', { name: /1 event on the region map/i })).toBeInTheDocument();
+  });
+
+  it('accepts meta.lng as a synonym for lon', () => {
+    const { container } = render(
+      <RegionMapWidget
+        events={[
+          { id: 'a', meta: { coords: { lat: 40, lng: -74 } } },
+          { id: 'b', meta: { lat: 41, lng: -73 } },
+        ]}
+      />,
+    );
+    expect(container.querySelectorAll('circle')).toHaveLength(2);
+  });
+
+  it('skips events whose coords are not numeric', () => {
+    const { container } = render(
+      <RegionMapWidget
+        events={[
+          { id: 'good', meta: { coords: { lat: 40, lon: -74 } } },
+          { id: 'bad',  meta: { coords: { lat: 'forty', lon: -74 } } },
+          { id: 'no-meta' },
+        ]}
+      />,
+    );
+    expect(container.querySelectorAll('circle')).toHaveLength(1);
+  });
+});
+
+describe('CrewOnShiftList', () => {
+  it('renders an empty-state note when no employees are configured', () => {
+    render(<CrewOnShiftList employees={[]} />);
+    expect(screen.getByRole('note')).toHaveTextContent(/no team members configured/i);
+  });
+
+  it('renders one row per employee with the full name visible', () => {
+    render(
+      <CrewOnShiftList
+        employees={[
+          { id: 1, name: 'Sarah Chen' },
+          { id: 2, name: 'Jordan Pace' },
+          { id: 3, name: 'Avery' },
+        ]}
+      />,
+    );
+    expect(screen.getByText('Sarah Chen')).toBeInTheDocument();
+    expect(screen.getByText('Jordan Pace')).toBeInTheDocument();
+    expect(screen.getByText('Avery')).toBeInTheDocument();
+  });
+
+  it('shows initials in the avatar (first + last for two-word names)', () => {
+    render(<CrewOnShiftList employees={[{ id: 1, name: 'Sarah Chen' }]} />);
+    expect(screen.getByText('SC')).toBeInTheDocument();
+  });
+
+  it('shows the first two letters as initials for single-word names', () => {
+    render(<CrewOnShiftList employees={[{ id: 1, name: 'Avery' }]} />);
+    expect(screen.getByText('AV')).toBeInTheDocument();
+  });
+
+  it('falls back to the id when name is missing', () => {
+    render(<CrewOnShiftList employees={[{ id: 'emp-42' }]} />);
+    expect(screen.getByText('emp-42')).toBeInTheDocument();
+  });
+});
+
+describe('RightPanel', () => {
+  it('renders children inside the panel', () => {
+    render(
+      <RightPanel>
+        <RightPanelSection title="A">
+          <span>alpha</span>
+        </RightPanelSection>
+        <RightPanelSection title="B">
+          <span>bravo</span>
+        </RightPanelSection>
+      </RightPanel>,
+    );
+    expect(screen.getByRole('region', { name: 'A' })).toBeInTheDocument();
+    expect(screen.getByRole('region', { name: 'B' })).toBeInTheDocument();
+  });
+});

--- a/src/ui/viewIcons.ts
+++ b/src/ui/viewIcons.ts
@@ -1,0 +1,34 @@
+/**
+ * viewIcons.ts — Single source of truth for the lucide icon + accessible
+ * label paired with each calendar view id.
+ *
+ * Used by:
+ *   - ProfileBar (saved-view chip strip, where chips group under their view)
+ *   - LeftRail   (icon rail in the AppShell — tap to switch view)
+ *
+ * Keep the keyset aligned with `ALL_VIEWS` in `WorksCalendar.tsx`. New
+ * view ids should land here too so every surface that renders a view
+ * picker gets the icon for free.
+ */
+import type { ComponentType, SVGProps } from 'react';
+import {
+  CalendarDays, Calendar, Columns3, List, CalendarRange,
+  Boxes, MapPin, Radio, Map as MapIcon,
+} from 'lucide-react';
+
+export type ViewIconEntry = {
+  Icon: ComponentType<SVGProps<SVGSVGElement> & { size?: number | string }>;
+  label: string;
+};
+
+export const VIEW_ICON_MAP: Record<string, ViewIconEntry> = {
+  month:    { Icon: CalendarDays,  label: 'Month view' },
+  week:     { Icon: Columns3,      label: 'Week view' },
+  day:      { Icon: Calendar,      label: 'Day view' },
+  agenda:   { Icon: List,          label: 'Agenda view' },
+  schedule: { Icon: CalendarRange, label: 'Schedule view' },
+  base:     { Icon: MapPin,        label: 'Base view' },
+  assets:   { Icon: Boxes,         label: 'Assets view' },
+  dispatch: { Icon: Radio,         label: 'Dispatch view' },
+  map:      { Icon: MapIcon,       label: 'Map view' },
+};


### PR DESCRIPTION
## Summary

PR 6 of the three-column layout series. Lights up the AppShell's `rightPanel` slot with the docked aside the mock shows: a slim region-map widget and a crew list, both fed by data the calendar already has (`visibleEvents` + `configuredEmployees`).

**Stacks on PR 5 (#408) → PR 4 (#407) → PR 3 (#406) → PR 2 (#405) → PR 1 (#404).** When the parents land this rebases onto `main`.

## What's in this PR

- **`src/ui/RightPanel.tsx`** — single file with four exports (tightly coupled, not yet reused):
  - `RightPanel` — fixed 240px aside; CSS hides it below 900px viewport width.
  - `RightPanelSection` — titled section block, `<section role="region">` with the title as accessible name.
  - `RegionMapWidget` — lightweight SVG plot of event coords. **No maplibre dep, no tile layer.** Reads canonical `meta.coords.{lat,lon|lng}` or the loose `meta.lat`/`meta.lon` shape (mirroring `MapView`'s `readCoords`). Bounding-box-fit projection in a 200×120 viewBox; single-point case centers the dot. Empty-state note when no coords.
  - `CrewOnShiftList` — list of employees with initials avatars from a 6-color palette. Empty-state note when no team configured.
- **`src/ui/RightPanel.module.css`** — token-driven, all 12 themes restyle automatically. The 900px hide-on-narrow media query lives here.
- **`src/ui/__tests__/RightPanel.test.tsx`** — 12 tests covering section roles, map empty state + plotting (canonical, loose, `lng` synonym, non-numeric skip, count in a11y label), crew empty state + name rendering, initials math.
- **`src/WorksCalendar.tsx`** — wires the panel into AppShell with both sections.

## Honest scope note

The crew list is **unfiltered** — it shows everyone configured on the calendar, not only people scheduled to work right now. Real "on shift" filtering wants a reusable shift-overlap helper that doesn't exist yet (the schedule-model logic currently lives inside `TimelineView`). Building it is a separate followup, deliberately split off so the panel layout can ship and be reviewed independently from schedule-model refactors.

The `CrewOnShiftList` doc comment carries the same note for anyone touching the file.

## Test plan

- [x] `npm run type-check` clean
- [x] `npm run test` — 2119/2119 (12 new for RightPanel)
- [x] `npm run build` clean (lib gz delta ~+0.9 KB for the panel + widgets, expected)
- [ ] Smoke on Vercel preview: panel renders right of the bordered card on desktop, hides on narrow viewports
- [ ] Verify region map plots when demo data has coords; shows empty state otherwise
- [ ] Verify crew list shows configured team members or empty state

## Followups

- PR 7 — Theme sweep across all 12 themes
- PR 8 — Catch e2e selectors up to new shell DOM
- (separate) Wire `cal.dayWindow` into TimelineView / BaseGanttView / AssetsView (carried from PR 4/5)
- (separate) Build a `useShiftOverlap` helper and narrow `CrewOnShiftList` to only currently-scheduled members

---
_Generated by [Claude Code](https://claude.ai/code/session_0129D5oFDywjK6gwjRU9dWLF)_