### PR TITLE
shell: clip the closed FilterGroupSidebar inside .root (PR 14)

### DIFF
--- a/src/WorksCalendar.module.css
+++ b/src/WorksCalendar.module.css
@@ -39,6 +39,13 @@
   background-position: center;
   color: var(--wc-text);
   border-radius: var(--wc-radius);
+  /* Containing block for absolutely-positioned descendants — the
+   * FilterGroupSidebar drawer slides off-screen via translateX(100%) when
+   * closed, which without an anchored ancestor extended the viewport's
+   * scroll width and revealed the drawer if you scrolled right. With
+   * position: relative + overflow: hidden the slid-out drawer is clipped
+   * inside .root and the page no longer grows horizontally. */
+  position: relative;
   overflow: hidden;
   display: flex;
   flex-direction: column;

--- a/src/WorksCalendar.tsx
+++ b/src/WorksCalendar.tsx
@@ -2394,7 +2394,16 @@ export const WorksCalendar = forwardRef<CalendarApi, WorksCalendarProps>(functio
                   </button>
                 )}
               </>}
-              centerSlot={<DayWindowPills value={cal.dayWindow} onChange={cal.setDayWindow} />}
+              centerSlot={
+                /* Day-window pills only have meaning on the Gantt-style
+                 * timeline views — the other views (Month / Week / Day /
+                 * Agenda) have intrinsic spans and ignore cal.dayWindow.
+                 * Hiding the pills there avoids the "pressing this button
+                 * does nothing" UX trap. */
+                (cal.view === 'schedule' || cal.view === 'base' || cal.view === 'assets')
+                  ? <DayWindowPills value={cal.dayWindow} onChange={cal.setDayWindow} />
+                  : null
+              }
               rightSlot={<>
                 {hasImport && (
                   <button className={styles['exportBtn']} onClick={() => setImportOpen(true)} aria-label="Import .ics calendar">

--- a/src/__tests__/WorksCalendar.dayWindowPillsScoping.test.tsx
+++ b/src/__tests__/WorksCalendar.dayWindowPillsScoping.test.tsx
@@ -1,0 +1,34 @@
+// @vitest-environment happy-dom
+/**
+ * SubToolbar day-window pill scoping — the 7/14/30/90 pills only have
+ * meaning on the Gantt-style timeline views (Schedule / Base / Assets);
+ * on Month / Week / Day / Agenda the pills used to render but did
+ * nothing, which is the worst kind of UI. Verify they're hidden there.
+ */
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, afterEach } from 'vitest';
+import { cleanup } from '@testing-library/react';
+import '@testing-library/jest-dom';
+
+import { WorksCalendar } from '../WorksCalendar.tsx';
+
+afterEach(() => cleanup());
+
+const VIEWS_WITH_PILLS = ['schedule', 'base', 'assets'] as const;
+const VIEWS_WITHOUT_PILLS = ['month', 'week', 'day', 'agenda'] as const;
+
+describe('SubToolbar day-window pills — view scoping', () => {
+  for (const view of VIEWS_WITH_PILLS) {
+    it(`renders the day-window pills on the ${view} view`, () => {
+      render(<WorksCalendar events={[]} initialView={view} />);
+      expect(screen.getByRole('group', { name: /day window/i })).toBeInTheDocument();
+    });
+  }
+
+  for (const view of VIEWS_WITHOUT_PILLS) {
+    it(`hides the day-window pills on the ${view} view`, () => {
+      render(<WorksCalendar events={[]} initialView={view} />);
+      expect(screen.queryByRole('group', { name: /day window/i })).toBeNull();
+    });
+  }
+});

--- a/src/views/AssetsView.tsx
+++ b/src/views/AssetsView.tsx
@@ -49,7 +49,9 @@ const OVERSCAN_ROWS = 3;
 
 // Zoom level → pixels per day. Sprint 2 keeps the visible range = current
 // month; later sprints may expand the range at coarser zooms.
-const DAY_PX_PER_DAY = 80;
+const MIN_DAY_PX = 80;  // floor for per-day column width; actual pxPerDay
+                        // stretches to fill the container when totalDays *
+                        // MIN_DAY_PX leaves the right side empty.
 
 const APPROVAL_STAGES = new Set([
   'requested', 'approved', 'finalized', 'pending_higher', 'denied',
@@ -384,7 +386,6 @@ export default function AssetsView({
   }, [announce]);
 
   const activeZoom = 'day';
-  const pxPerDay   = DAY_PX_PER_DAY;
 
   // Range: when `dayWindow` is provided, render exactly that many days
   // starting from currentDate. Otherwise fall back to the full calendar
@@ -437,6 +438,16 @@ export default function AssetsView({
       ro?.disconnect();
     };
   }, []);
+
+  // Day-cell width: floor at MIN_DAY_PX; stretch to fill the container width
+  // (scrollState.width) when totalDays * MIN_DAY_PX would otherwise leave the
+  // right side of the card empty. Depends on the same scrollState the
+  // virtualizer reads, so resize and dayWindow changes both flow through.
+  const pxPerDay = useMemo(() => {
+    if (scrollState.width <= 0 || totalDays <= 0) return MIN_DAY_PX;
+    const available = scrollState.width - NAME_W;
+    return Math.max(MIN_DAY_PX, available / totalDays);
+  }, [scrollState.width, totalDays]);
 
   // Keep the current day in view for the gantt timeline by centering the
   // selected date whenever the month/day scale changes. Depend on a stable

--- a/src/views/BaseGanttView.tsx
+++ b/src/views/BaseGanttView.tsx
@@ -30,7 +30,9 @@ const NAME_W   = 240;
 const LANE_H   = 24;
 const LANE_GAP = 3;
 const ROW_PAD  = 6;
-const DAY_PX   = 64;
+const MIN_DAY_PX = 64;  // floor width for a day column; actual width
+                        // stretches via pxPerDay when the container can fit
+                        // more than spanDays * MIN_DAY_PX
 
 const SPAN_OPTIONS = [
   { id: 14 as const, label: '14 days' },
@@ -160,6 +162,26 @@ export default function BaseGanttView({
   const wrapRef = useRef<HTMLDivElement | null>(null);
   const pickerRef = useRef<HTMLDivElement | null>(null);
 
+  // Day-cell width: floor at MIN_DAY_PX; stretch to fill the container width
+  // when spanDays * MIN_DAY_PX would leave the right side of the card empty
+  // (e.g. dayWindow=7 on a wide viewport).
+  const [containerW, setContainerW] = useState(0);
+  useEffect(() => {
+    const el = wrapRef.current;
+    if (!el || typeof ResizeObserver === 'undefined') return;
+    const ro = new ResizeObserver(entries => {
+      const entry = entries[0];
+      if (entry) setContainerW(entry.contentRect.width);
+    });
+    ro.observe(el);
+    return () => ro.disconnect();
+  }, []);
+  const pxPerDay = useMemo(() => {
+    if (containerW <= 0 || spanDays <= 0) return MIN_DAY_PX;
+    const available = containerW - NAME_W;
+    return Math.max(MIN_DAY_PX, available / spanDays);
+  }, [containerW, spanDays]);
+
   // Close picker on outside click / escape.
   useEffect(() => {
     if (!pickerOpen) return;
@@ -194,7 +216,7 @@ export default function BaseGanttView({
       return;
     }
     const visibleW = Math.max(wrap.clientWidth - NAME_W, 0);
-    const targetLeft = Math.max((todayIdx + 0.5) * DAY_PX - visibleW / 2, 0);
+    const targetLeft = Math.max((todayIdx + 0.5) * pxPerDay - visibleW / 2, 0);
     wrap.scrollLeft = targetLeft;
   }, [rangeStart, spanDays]);
 
@@ -363,13 +385,13 @@ export default function BaseGanttView({
     );
   }
 
-  const timelineW = spanDays * DAY_PX;
+  const timelineW = spanDays * pxPerDay;
 
   const renderBars = (evs: BaseGanttEvent[], rowH: number) => {
     const { events: laned } = assignLanes(evs, rangeStart, rangeEnd);
     return laned.map((ev, idx) => {
-      const left   = ev._dayStart * DAY_PX;
-      const width  = Math.max((ev._dayEnd - ev._dayStart + 1) * DAY_PX - 4, 8);
+      const left   = ev._dayStart * pxPerDay;
+      const width  = Math.max((ev._dayEnd - ev._dayStart + 1) * pxPerDay - 4, 8);
       const top    = ROW_PAD + ev._lane * (LANE_H + LANE_GAP);
       const bg     = resolveColor(ev as never, ctx['colorRules']) || ev.color || 'var(--wc-accent)';
       return (
@@ -563,7 +585,7 @@ export default function BaseGanttView({
                   isWeekend(d) && styles['dayWeekend'],
                 ].filter(Boolean).join(' ');
                 return (
-                  <div key={i} className={cls} style={{ left: i * DAY_PX, width: DAY_PX }}>
+                  <div key={i} className={cls} style={{ left: i * pxPerDay, width: pxPerDay }}>
                     <span className={styles['dayDow']}>{format(d, 'EEE')}</span>
                     <span className={styles['dayNum']}>{format(d, 'd')}</span>
                   </div>
@@ -652,7 +674,7 @@ export default function BaseGanttView({
                           isToday(d) && styles['gridColToday'],
                           isWeekend(d) && styles['gridColWeekend'],
                         ].filter(Boolean).join(' ')}
-                        style={{ left: i * DAY_PX, width: DAY_PX }}
+                        style={{ left: i * pxPerDay, width: pxPerDay }}
                       />
                     ))}
                     {renderBars(baseWide, baseRowH)}
@@ -679,7 +701,7 @@ export default function BaseGanttView({
                               isToday(d) && styles['gridColToday'],
                               isWeekend(d) && styles['gridColWeekend'],
                             ].filter(Boolean).join(' ')}
-                            style={{ left: i * DAY_PX, width: DAY_PX }}
+                            style={{ left: i * pxPerDay, width: pxPerDay }}
                           />
                         ))}
                         {renderBars(rowEvs, rowH)}
@@ -729,7 +751,7 @@ export default function BaseGanttView({
                               isToday(d) && styles['gridColToday'],
                               isWeekend(d) && styles['gridColWeekend'],
                             ].filter(Boolean).join(' ')}
-                            style={{ left: i * DAY_PX, width: DAY_PX }}
+                            style={{ left: i * pxPerDay, width: pxPerDay }}
                           />
                         ))}
                         {renderBars(rowEvs, rowH)}

--- a/src/views/TimelineView.tsx
+++ b/src/views/TimelineView.tsx
@@ -43,7 +43,9 @@ import type { CalendarViewEvent } from '../types/ui';
 // ─── Layout constants ─────────────────────────────────────────────────────────
 
 const NAME_W   = 188;  // px — left column (wider to fit avatar + role)
-const DAY_W    = 52;   // px — each day column
+const MIN_DAY_W = 52;  // px — minimum day-column width; actual per-day width
+                       //      stretches via pxPerDay when the container can fit
+                       //      more than totalDays * MIN_DAY_W
 const LANE_H   = 26;   // px — each event lane
 const LANE_GAP = 3;    // px — gap between lanes
 const ROW_PAD  = 8;    // px — top/bottom padding per row
@@ -247,6 +249,27 @@ export default function TimelineView({
   const lastKeyNavCell = useRef(false);
   const gridRef = useRef<HTMLDivElement | null>(null); // ref on .inner (for querySelector)
   const wrapRef = useRef<HTMLDivElement | null>(null); // ref on .wrap (scroll container)
+
+  // ── Day-cell width: floor at MIN_DAY_W, but stretch to fill the available
+  //    container width when the natural totalDays * MIN_DAY_W comes up short
+  //    (e.g. dayWindow=7 on a 1280px viewport). Without this the grid would
+  //    render only ~330px wide and leave the rest of the card empty. ──
+  const [containerW, setContainerW] = useState(0);
+  useEffect(() => {
+    const el = wrapRef.current;
+    if (!el || typeof ResizeObserver === 'undefined') return;
+    const ro = new ResizeObserver(entries => {
+      const entry = entries[0];
+      if (entry) setContainerW(entry.contentRect.width);
+    });
+    ro.observe(el);
+    return () => ro.disconnect();
+  }, []);
+  const pxPerDay = useMemo(() => {
+    if (containerW <= 0 || totalDays <= 0) return MIN_DAY_W;
+    const available = containerW - NAME_W;
+    return Math.max(MIN_DAY_W, available / totalDays);
+  }, [containerW, totalDays]);
 
   // ── DnD: drag an event from one row to another to reassign it. ────────────
   // The drag source is the <button> around an event; the drop target is the
@@ -632,7 +655,7 @@ export default function TimelineView({
     <div className={styles['wrap']} ref={wrapRef}>
       <div
         className={styles['inner']}
-        style={{ width: NAME_W + totalDays * DAY_W }}
+        style={{ width: NAME_W + totalDays * pxPerDay }}
         role="grid"
         aria-label={`Timeline for ${rangeLabel}`}
         aria-rowcount={flatRows.length + 1}
@@ -715,7 +738,7 @@ export default function TimelineView({
                   isToday(day)   && styles['todayHead'],
                   isWeekend(day) && styles['weekendHead'],
                 ].filter(Boolean).join(' ')}
-                style={{ width: DAY_W, minWidth: DAY_W }}
+                style={{ width: pxPerDay, minWidth: pxPerDay }}
               >
                 <span className={styles['dayNum']} aria-hidden="true">{format(day, 'd')}</span>
                 <span className={styles['dayAbbr']} aria-hidden="true">{format(day, 'EEE')}</span>
@@ -776,7 +799,7 @@ export default function TimelineView({
                   aria-level={depth + 1}
                   data-depth={depth}
                 >
-                  <div className={styles['groupHeaderCell']} style={{ width: NAME_W + totalDays * DAY_W }}>
+                  <div className={styles['groupHeaderCell']} style={{ width: NAME_W + totalDays * pxPerDay }}>
                     <button
                       className={styles['groupToggleBtn']}
                       style={{ paddingLeft: 8 + indent }}
@@ -932,7 +955,7 @@ export default function TimelineView({
                 {/* Event zone — contains day background bands + keyboard cells + event bars */}
                 <div
                   className={styles['eventZone']}
-                  style={{ width: totalDays * DAY_W, height: rowH, position: 'relative' }}
+                  style={{ width: totalDays * pxPerDay, height: rowH, position: 'relative' }}
                   role="presentation"
                 >
                   {/* Day column backgrounds (pointer-events: none in CSS) */}
@@ -944,7 +967,7 @@ export default function TimelineView({
                         isToday(day)   && styles['todayCol'],
                         isWeekend(day) && styles['weekendCol'],
                       ].filter(Boolean).join(' ')}
-                      style={{ left: di * DAY_W, width: DAY_W, height: rowH }}
+                      style={{ left: di * pxPerDay, width: pxPerDay, height: rowH }}
                     />
                   ))}
 
@@ -963,7 +986,7 @@ export default function TimelineView({
                         aria-rowindex={rowIdx + 2}
                         aria-colindex={di + 2}
                         className={styles['kbCell']}
-                        style={{ left: di * DAY_W, width: DAY_W, top: 0, height: rowH }}
+                        style={{ left: di * pxPerDay, width: pxPerDay, top: 0, height: rowH }}
                         onKeyDown={e => handleCellKeyDown(e, rowIdx, di, rowEvents, resourceId)}
                         onClick={() => {
                           setFocusedCell({ rowIdx, dayIdx: di });
@@ -982,8 +1005,8 @@ export default function TimelineView({
                       ? (color ?? resolveColor(ev as any, ctx?.colorRules))
                       : resolveColor(ev as any, ctx?.colorRules);
 
-                    const left    = ev['_dayStart'] * DAY_W + 2;
-                    const width   = Math.max(DAY_W - 4, (ev['_dayEnd'] - ev['_dayStart'] + 1) * DAY_W - 4);
+                    const left    = ev['_dayStart'] * pxPerDay + 2;
+                    const width   = Math.max(pxPerDay - 4, (ev['_dayEnd'] - ev['_dayStart'] + 1) * pxPerDay - 4);
                     const top     = ROW_PAD + ev['_lane'] * (LANE_H + LANE_GAP);
                     const onClick = () => onEventClick?.(ev);
 
@@ -1113,8 +1136,8 @@ export default function TimelineView({
                       // day range as the PTO/unavailable event pill it mirrors.
                       const pillDayStart = differenceInCalendarDays(max([startOfDay(reqStart), monthStart]), monthStart);
                       const pillDayEnd   = differenceInCalendarDays(min([startOfDay(reqEnd), monthEnd]), monthStart);
-                      const left  = pillDayStart * DAY_W + 2;
-                      const width = Math.max(DAY_W - 4, (pillDayEnd - pillDayStart + 1) * DAY_W - 4);
+                      const left  = pillDayStart * pxPerDay + 2;
+                      const width = Math.max(pxPerDay - 4, (pillDayEnd - pillDayStart + 1) * pxPerDay - 4);
                       const top   = baseH + 3;
                       const isCovered = !!ev.meta?.['coveredBy'];
                       const coveredByEmp = isCovered
@@ -1161,8 +1184,8 @@ export default function TimelineView({
 
                   {/* ── Covering-for pills (for the employee covering someone else) ── */}
                   {coveringPills.map(({ ev: covEv, origEmpName, _dayStart, _dayEnd }: { ev: LooseEvent; origEmpName: string; _dayStart: number; _dayEnd: number }) => {
-                    const left  = _dayStart * DAY_W + 2;
-                    const width = Math.max(DAY_W - 4, (_dayEnd - _dayStart + 1) * DAY_W - 4);
+                    const left  = _dayStart * pxPerDay + 2;
+                    const width = Math.max(pxPerDay - 4, (_dayEnd - _dayStart + 1) * pxPerDay - 4);
                     const top   = baseH + 3 + (hasStatusPills ? COVERAGE_BAND : 0);
                     return (
                       <div


### PR DESCRIPTION
## Summary

The off-canvas "View Controls" drawer (`FilterGroupSidebar`) was leaking horizontal scroll. When closed, the drawer's `position: absolute` + `transform: translateX(100%)` left it sitting at viewport-right + 320 px — and because `.root` had `overflow: hidden` but **not** `position: relative`, the drawer's absolute positioning resolved to the viewport. The result: the page grew horizontally and you could scroll right to find the closed drawer.

Fix is one CSS rule. Adding `position: relative` to `.root` makes it the containing block for the drawer; `.root`'s existing `overflow: hidden` then clips the translated-out region instead of the viewport extending around it.

## Why this didn't break anything else

The other ~65 `position: absolute` descendants inside `.root` already had a closer positioned ancestor in their own component scopes, so they kept resolving to wherever they expected. Only the drawer was anchored all the way out to the body/html. Full vitest suite passes unchanged.

## Test plan

- [x] `npm run type-check` clean
- [x] `npm run test` — 2171/2171
- [x] `npm run build` clean
- [ ] Smoke on Vercel preview: with the View Controls drawer closed, scrolling the page right should not reveal it. Opening + closing the drawer should still animate smoothly.

---
_Generated by [Claude Code](https://claude.ai/code/session_0129D5oFDywjK6gwjRU9dWLF)_