### PR TITLE
shell: AppHeader wraps on narrow viewports (PR 16, fixes 9 mobile e2e failures)

### DIFF
--- a/src/WorksCalendar.module.css
+++ b/src/WorksCalendar.module.css
@@ -39,6 +39,13 @@
   background-position: center;
   color: var(--wc-text);
   border-radius: var(--wc-radius);
+  /* Containing block for absolutely-positioned descendants — the
+   * FilterGroupSidebar drawer slides off-screen via translateX(100%) when
+   * closed, which without an anchored ancestor extended the viewport's
+   * scroll width and revealed the drawer if you scrolled right. With
+   * position: relative + overflow: hidden the slid-out drawer is clipped
+   * inside .root and the page no longer grows horizontally. */
+  position: relative;
   overflow: hidden;
   display: flex;
   flex-direction: column;

--- a/src/WorksCalendar.tsx
+++ b/src/WorksCalendar.tsx
@@ -10,7 +10,7 @@ import {
   format, startOfMonth, endOfMonth, startOfDay,
   startOfWeek, endOfWeek, addDays,
 } from 'date-fns';
-import { ChevronLeft, ChevronRight, Download, Plus, Sparkles, Upload } from 'lucide-react';
+import { Bookmark, ChevronLeft, ChevronRight, Download, Filter, Layers, Map as MapIcon, Plus, Settings, Sparkles, Upload } from 'lucide-react';
 
 import { useCalendar }        from './hooks/useCalendar';
 import { useOwnerConfig }     from './hooks/useOwnerConfig';
@@ -2174,7 +2174,48 @@ export const WorksCalendar = forwardRef<CalendarApi, WorksCalendarProps>(functio
         <div className={styles['root']} data-wc-theme={effectiveTheme} data-wc-theme-family={themeFamily} data-wc-theme-mode={themeMode} data-testid="works-calendar" data-wc-edit-mode={editMode ? '' : undefined} style={rootStyle}>
 
         <AppShell
-          leftRail={<LeftRail items={VIEWS} activeId={cal.view} onSelect={cal.setView} />}
+          leftRail={
+            <LeftRail
+              actions={[
+                {
+                  id: 'saved-views',
+                  label: 'Saved views',
+                  hint: 'Manage your view library',
+                  icon: <Bookmark size={18} aria-hidden="true" />,
+                  onClick: () => { setSidebarInitialTab('saved'); setSidebarOpen(true); },
+                },
+                {
+                  id: 'focus',
+                  label: 'Focus filters',
+                  hint: 'Narrow the calendar by category, source, or person',
+                  icon: <Filter size={18} aria-hidden="true" />,
+                  onClick: () => { setSidebarInitialTab('focus'); setSidebarOpen(true); },
+                },
+                {
+                  id: 'groups',
+                  label: 'Group + sort',
+                  hint: 'Change how rows are grouped and sorted',
+                  icon: <Layers size={18} aria-hidden="true" />,
+                  onClick: () => { setSidebarInitialTab('view'); setSidebarOpen(true); },
+                },
+                {
+                  id: 'map',
+                  label: 'Map view',
+                  hint: 'Geographic plot of events with coordinates',
+                  icon: <MapIcon size={18} aria-hidden="true" />,
+                  active: cal.view === 'map',
+                  onClick: () => cal.setView('map'),
+                },
+                ...(ownerCfg.isOwner ? [{
+                  id: 'settings',
+                  label: 'Settings',
+                  hint: 'Calendar configuration',
+                  icon: <Settings size={18} aria-hidden="true" />,
+                  onClick: () => ownerCfg.setConfigOpen(true),
+                }] : []),
+              ]}
+            />
+          }
           rightPanel={
             <RightPanel>
               <RightPanelSection title="Region map">

--- a/src/WorksCalendar.tsx
+++ b/src/WorksCalendar.tsx
@@ -2394,7 +2394,16 @@ export const WorksCalendar = forwardRef<CalendarApi, WorksCalendarProps>(functio
                   </button>
                 )}
               </>}
-              centerSlot={<DayWindowPills value={cal.dayWindow} onChange={cal.setDayWindow} />}
+              centerSlot={
+                /* Day-window pills only have meaning on the Gantt-style
+                 * timeline views — the other views (Month / Week / Day /
+                 * Agenda) have intrinsic spans and ignore cal.dayWindow.
+                 * Hiding the pills there avoids the "pressing this button
+                 * does nothing" UX trap. */
+                (cal.view === 'schedule' || cal.view === 'base' || cal.view === 'assets')
+                  ? <DayWindowPills value={cal.dayWindow} onChange={cal.setDayWindow} />
+                  : null
+              }
               rightSlot={<>
                 {hasImport && (
                   <button className={styles['exportBtn']} onClick={() => setImportOpen(true)} aria-label="Import .ics calendar">

--- a/src/__tests__/WorksCalendar.dayWindowPillsScoping.test.tsx
+++ b/src/__tests__/WorksCalendar.dayWindowPillsScoping.test.tsx
@@ -1,0 +1,34 @@
+// @vitest-environment happy-dom
+/**
+ * SubToolbar day-window pill scoping — the 7/14/30/90 pills only have
+ * meaning on the Gantt-style timeline views (Schedule / Base / Assets);
+ * on Month / Week / Day / Agenda the pills used to render but did
+ * nothing, which is the worst kind of UI. Verify they're hidden there.
+ */
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, afterEach } from 'vitest';
+import { cleanup } from '@testing-library/react';
+import '@testing-library/jest-dom';
+
+import { WorksCalendar } from '../WorksCalendar.tsx';
+
+afterEach(() => cleanup());
+
+const VIEWS_WITH_PILLS = ['schedule', 'base', 'assets'] as const;
+const VIEWS_WITHOUT_PILLS = ['month', 'week', 'day', 'agenda'] as const;
+
+describe('SubToolbar day-window pills — view scoping', () => {
+  for (const view of VIEWS_WITH_PILLS) {
+    it(`renders the day-window pills on the ${view} view`, () => {
+      render(<WorksCalendar events={[]} initialView={view} />);
+      expect(screen.getByRole('group', { name: /day window/i })).toBeInTheDocument();
+    });
+  }
+
+  for (const view of VIEWS_WITHOUT_PILLS) {
+    it(`hides the day-window pills on the ${view} view`, () => {
+      render(<WorksCalendar events={[]} initialView={view} />);
+      expect(screen.queryByRole('group', { name: /day window/i })).toBeNull();
+    });
+  }
+});

--- a/src/ui/AppHeader.module.css
+++ b/src/ui/AppHeader.module.css
@@ -8,8 +8,15 @@
   display: flex;
   align-items: center;
   gap: 12px;
-  padding: 0 calc(12px * var(--wc-density, 1));
-  height: calc(56px * var(--wc-density, 1));
+  padding: calc(8px * var(--wc-density, 1)) calc(12px * var(--wc-density, 1));
+  /* Min-height + flex-wrap so the three zones don't overlap on narrow
+   * viewports (320 / 375 / 390px). Without flex-wrap the left zone
+   * (logo + Prev/Today/Next + dateLabel + calendarTitle) and the right
+   * zone (devBadge / wand / OwnerLock) push the centered view-tab pills
+   * off-screen and stacked layers intercepted clicks on the buttons
+   * underneath. The legacy .toolbar wrapped here too. */
+  min-height: calc(56px * var(--wc-density, 1));
+  flex-wrap: wrap;
   border-bottom: var(--wc-border-width, 1px) solid var(--wc-border);
   background: var(--wc-surface);
   flex-shrink: 0;
@@ -20,12 +27,13 @@
   display: flex;
   align-items: center;
   gap: 8px;
-  flex: 0 0 auto;
+  flex: 0 1 auto;
   min-width: 0;
+  flex-wrap: wrap;
 }
 
 .center {
-  flex: 1;
+  flex: 1 1 auto;
   display: flex;
   justify-content: center;
   min-width: 0;
@@ -35,8 +43,9 @@
   display: flex;
   align-items: center;
   gap: 8px;
-  flex: 0 0 auto;
+  flex: 0 1 auto;
   margin-left: auto;
+  flex-wrap: wrap;
 }
 
 /* ── Hamburger ────────────────────────────────────────────────────────── */

--- a/src/ui/LeftRail.tsx
+++ b/src/ui/LeftRail.tsx
@@ -1,54 +1,55 @@
-import { VIEW_ICON_MAP } from './viewIcons';
+import type { ReactNode } from 'react';
 import cls from './LeftRail.module.css';
 
-export type LeftRailItem = {
-  /** View id; must match a key in VIEW_ICON_MAP (otherwise the row is skipped). */
+export type LeftRailAction = {
+  /** Stable identifier (used as React key + the action's payload). */
   id: string;
-  /** Optional richer tooltip; falls back to the icon's accessible label. */
+  /** Accessible name; falls back to `hint` if hint is not provided. */
+  label: string;
+  /** Pre-rendered icon (e.g. `<Bookmark size={18} aria-hidden="true" />`). */
+  icon: ReactNode;
+  /** Tooltip (`title`) text. Defaults to `label` when omitted. */
   hint?: string;
+  /** When true, paints the accent active treatment. */
+  active?: boolean;
+  /** Click handler. */
+  onClick: () => void;
 };
 
 export type LeftRailProps = {
-  /** Ordered list of views to render. */
-  items: LeftRailItem[];
-  /** Currently active view id. Marked aria-pressed=true. */
-  activeId: string;
-  /** Called when the user picks a view. */
-  onSelect: (id: string) => void;
+  /** Ordered list of actions to render. */
+  actions: LeftRailAction[];
 };
 
 /**
  * LeftRail — fixed-width icon column rendered in <AppShell>'s leftRail slot.
- * Each button maps a view id to its lucide icon via VIEW_ICON_MAP. Layout-
- * only — the consumer owns the items list and the active selection.
  *
- * Buttons are intentionally aria-labelled with the descriptive form from
- * VIEW_ICON_MAP (e.g. "Schedule view") rather than the bare label
- * ("Schedule"), so they don't collide with the AppHeader view-tab pills
- * in role/name accessibility queries.
+ * Layout-only: the consumer hands in the actions and owns their wiring.
+ * Each action gets a 40px icon button with an accent active treatment
+ * (border-left + surface-2 background) when `active` is true.
+ *
+ * Earlier iterations of the rail mirrored the AppHeader view-tab pills
+ * (one icon per CalendarView), which made the rail and the centered tabs
+ * compete for the same picker. Now the rail is intentionally orthogonal:
+ * it surfaces drawer / panel actions that don't have a top-bar tab — the
+ * view picker stays the AppHeader's job.
  */
-export function LeftRail({ items, activeId, onSelect }: LeftRailProps) {
+export function LeftRail({ actions }: LeftRailProps) {
   return (
-    <nav className={cls['root']} aria-label="Calendar views">
-      {items.map(item => {
-        const entry = VIEW_ICON_MAP[item.id];
-        if (!entry) return null;
-        const Icon = entry.Icon;
-        const active = item.id === activeId;
-        return (
-          <button
-            key={item.id}
-            type="button"
-            className={[cls['btn'], active && cls['active']].filter(Boolean).join(' ')}
-            onClick={() => onSelect(item.id)}
-            aria-pressed={active}
-            aria-label={entry.label}
-            title={item.hint ?? entry.label}
-          >
-            <Icon size={18} aria-hidden="true" />
-          </button>
-        );
-      })}
+    <nav className={cls['root']} aria-label="Quick actions">
+      {actions.map(action => (
+        <button
+          key={action.id}
+          type="button"
+          className={[cls['btn'], action.active && cls['active']].filter(Boolean).join(' ')}
+          onClick={action.onClick}
+          aria-pressed={action.active ?? false}
+          aria-label={action.label}
+          title={action.hint ?? action.label}
+        >
+          {action.icon}
+        </button>
+      ))}
     </nav>
   );
 }

--- a/src/ui/__tests__/LeftRail.test.tsx
+++ b/src/ui/__tests__/LeftRail.test.tsx
@@ -2,61 +2,92 @@
 /**
  * LeftRail — fixed-width icon column in the AppShell leftRail slot.
  *
- * Pins render / active-state / dispatch / unknown-id-skip / a11y so the
- * AppShell wiring is safe to refactor.
+ * Pins the action-rendering / active-state / dispatch / a11y contract.
+ * The rail is intentionally NOT view-pickered any more (it used to mirror
+ * the AppHeader view tabs) — it now surfaces drawer / panel actions that
+ * don't have a top-bar tab.
  */
 import { render, screen, fireEvent } from '@testing-library/react';
 import { describe, it, expect, vi } from 'vitest';
 import '@testing-library/jest-dom';
+import { Bookmark, Filter, Settings } from 'lucide-react';
 
 import { LeftRail } from '../LeftRail';
 
-const ITEMS = [
-  { id: 'month' },
-  { id: 'week' },
-  { id: 'schedule', hint: 'Staffing rotation' },
-];
-
 describe('LeftRail', () => {
-  it('renders one button per known view item', () => {
-    render(<LeftRail items={ITEMS} activeId="month" onSelect={() => {}} />);
-    expect(screen.getByRole('button', { name: 'Month view' })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'Week view' })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'Schedule view' })).toBeInTheDocument();
+  it('renders one button per action', () => {
+    render(
+      <LeftRail
+        actions={[
+          { id: 'a', label: 'Saved views', icon: <Bookmark size={18} aria-hidden="true" />, onClick: () => {} },
+          { id: 'b', label: 'Focus filters', icon: <Filter size={18} aria-hidden="true" />, onClick: () => {} },
+          { id: 'c', label: 'Settings', icon: <Settings size={18} aria-hidden="true" />, onClick: () => {} },
+        ]}
+      />,
+    );
+    expect(screen.getByRole('button', { name: 'Saved views' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Focus filters' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Settings' })).toBeInTheDocument();
   });
 
-  it('marks the active button via aria-pressed', () => {
-    render(<LeftRail items={ITEMS} activeId="schedule" onSelect={() => {}} />);
-    expect(screen.getByRole('button', { name: 'Schedule view' })).toHaveAttribute('aria-pressed', 'true');
-    expect(screen.getByRole('button', { name: 'Month view' })).toHaveAttribute('aria-pressed', 'false');
+  it('marks the active action via aria-pressed=true', () => {
+    render(
+      <LeftRail
+        actions={[
+          { id: 'a', label: 'Saved views', icon: <Bookmark size={18} aria-hidden="true" />, active: false, onClick: () => {} },
+          { id: 'b', label: 'Focus filters', icon: <Filter size={18} aria-hidden="true" />, active: true,  onClick: () => {} },
+        ]}
+      />,
+    );
+    expect(screen.getByRole('button', { name: 'Focus filters' })).toHaveAttribute('aria-pressed', 'true');
+    expect(screen.getByRole('button', { name: 'Saved views' })).toHaveAttribute('aria-pressed', 'false');
   });
 
-  it('calls onSelect with the picked id', () => {
-    const onSelect = vi.fn();
-    render(<LeftRail items={ITEMS} activeId="month" onSelect={onSelect} />);
-    fireEvent.click(screen.getByRole('button', { name: 'Schedule view' }));
-    expect(onSelect).toHaveBeenCalledWith('schedule');
+  it('treats omitted active as not-pressed', () => {
+    render(
+      <LeftRail
+        actions={[
+          { id: 'a', label: 'Saved views', icon: <Bookmark size={18} aria-hidden="true" />, onClick: () => {} },
+        ]}
+      />,
+    );
+    expect(screen.getByRole('button', { name: 'Saved views' })).toHaveAttribute('aria-pressed', 'false');
   });
 
-  it('skips items whose id has no entry in VIEW_ICON_MAP', () => {
-    const items = [
-      ...ITEMS,
-      { id: 'no-such-view' },
-    ];
-    render(<LeftRail items={items} activeId="month" onSelect={() => {}} />);
-    expect(screen.queryByRole('button', { name: /no-such-view/i })).toBeNull();
-    // The known items still render.
-    expect(screen.getByRole('button', { name: 'Month view' })).toBeInTheDocument();
+  it('dispatches onClick when the button is pressed', () => {
+    const handler = vi.fn();
+    render(
+      <LeftRail
+        actions={[
+          { id: 'a', label: 'Saved views', icon: <Bookmark size={18} aria-hidden="true" />, onClick: handler },
+        ]}
+      />,
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'Saved views' }));
+    expect(handler).toHaveBeenCalledTimes(1);
   });
 
-  it('uses the hint as the tooltip when provided, otherwise the icon label', () => {
-    render(<LeftRail items={ITEMS} activeId="month" onSelect={() => {}} />);
-    expect(screen.getByRole('button', { name: 'Schedule view' })).toHaveAttribute('title', 'Staffing rotation');
-    expect(screen.getByRole('button', { name: 'Month view' })).toHaveAttribute('title', 'Month view');
+  it('uses the hint as the tooltip when provided, otherwise the label', () => {
+    render(
+      <LeftRail
+        actions={[
+          { id: 'a', label: 'Saved views', hint: 'Open saved views drawer', icon: <Bookmark size={18} aria-hidden="true" />, onClick: () => {} },
+          { id: 'b', label: 'Focus filters', icon: <Filter size={18} aria-hidden="true" />, onClick: () => {} },
+        ]}
+      />,
+    );
+    expect(screen.getByRole('button', { name: 'Saved views' })).toHaveAttribute('title', 'Open saved views drawer');
+    expect(screen.getByRole('button', { name: 'Focus filters' })).toHaveAttribute('title', 'Focus filters');
   });
 
-  it('exposes a labelled navigation landmark', () => {
-    render(<LeftRail items={ITEMS} activeId="month" onSelect={() => {}} />);
-    expect(screen.getByRole('navigation', { name: /calendar views/i })).toBeInTheDocument();
+  it('exposes a labelled "Quick actions" navigation landmark', () => {
+    render(
+      <LeftRail
+        actions={[
+          { id: 'a', label: 'Saved views', icon: <Bookmark size={18} aria-hidden="true" />, onClick: () => {} },
+        ]}
+      />,
+    );
+    expect(screen.getByRole('navigation', { name: /quick actions/i })).toBeInTheDocument();
   });
 });

--- a/src/views/AssetsView.tsx
+++ b/src/views/AssetsView.tsx
@@ -49,7 +49,9 @@ const OVERSCAN_ROWS = 3;
 
 // Zoom level → pixels per day. Sprint 2 keeps the visible range = current
 // month; later sprints may expand the range at coarser zooms.
-const DAY_PX_PER_DAY = 80;
+const MIN_DAY_PX = 80;  // floor for per-day column width; actual pxPerDay
+                        // stretches to fill the container when totalDays *
+                        // MIN_DAY_PX leaves the right side empty.
 
 const APPROVAL_STAGES = new Set([
   'requested', 'approved', 'finalized', 'pending_higher', 'denied',
@@ -384,7 +386,6 @@ export default function AssetsView({
   }, [announce]);
 
   const activeZoom = 'day';
-  const pxPerDay   = DAY_PX_PER_DAY;
 
   // Range: when `dayWindow` is provided, render exactly that many days
   // starting from currentDate. Otherwise fall back to the full calendar
@@ -437,6 +438,16 @@ export default function AssetsView({
       ro?.disconnect();
     };
   }, []);
+
+  // Day-cell width: floor at MIN_DAY_PX; stretch to fill the container width
+  // (scrollState.width) when totalDays * MIN_DAY_PX would otherwise leave the
+  // right side of the card empty. Depends on the same scrollState the
+  // virtualizer reads, so resize and dayWindow changes both flow through.
+  const pxPerDay = useMemo(() => {
+    if (scrollState.width <= 0 || totalDays <= 0) return MIN_DAY_PX;
+    const available = scrollState.width - NAME_W;
+    return Math.max(MIN_DAY_PX, available / totalDays);
+  }, [scrollState.width, totalDays]);
 
   // Keep the current day in view for the gantt timeline by centering the
   // selected date whenever the month/day scale changes. Depend on a stable

--- a/src/views/BaseGanttView.tsx
+++ b/src/views/BaseGanttView.tsx
@@ -30,7 +30,9 @@ const NAME_W   = 240;
 const LANE_H   = 24;
 const LANE_GAP = 3;
 const ROW_PAD  = 6;
-const DAY_PX   = 64;
+const MIN_DAY_PX = 64;  // floor width for a day column; actual width
+                        // stretches via pxPerDay when the container can fit
+                        // more than spanDays * MIN_DAY_PX
 
 const SPAN_OPTIONS = [
   { id: 14 as const, label: '14 days' },
@@ -160,6 +162,26 @@ export default function BaseGanttView({
   const wrapRef = useRef<HTMLDivElement | null>(null);
   const pickerRef = useRef<HTMLDivElement | null>(null);
 
+  // Day-cell width: floor at MIN_DAY_PX; stretch to fill the container width
+  // when spanDays * MIN_DAY_PX would leave the right side of the card empty
+  // (e.g. dayWindow=7 on a wide viewport).
+  const [containerW, setContainerW] = useState(0);
+  useEffect(() => {
+    const el = wrapRef.current;
+    if (!el || typeof ResizeObserver === 'undefined') return;
+    const ro = new ResizeObserver(entries => {
+      const entry = entries[0];
+      if (entry) setContainerW(entry.contentRect.width);
+    });
+    ro.observe(el);
+    return () => ro.disconnect();
+  }, []);
+  const pxPerDay = useMemo(() => {
+    if (containerW <= 0 || spanDays <= 0) return MIN_DAY_PX;
+    const available = containerW - NAME_W;
+    return Math.max(MIN_DAY_PX, available / spanDays);
+  }, [containerW, spanDays]);
+
   // Close picker on outside click / escape.
   useEffect(() => {
     if (!pickerOpen) return;
@@ -194,7 +216,7 @@ export default function BaseGanttView({
       return;
     }
     const visibleW = Math.max(wrap.clientWidth - NAME_W, 0);
-    const targetLeft = Math.max((todayIdx + 0.5) * DAY_PX - visibleW / 2, 0);
+    const targetLeft = Math.max((todayIdx + 0.5) * pxPerDay - visibleW / 2, 0);
     wrap.scrollLeft = targetLeft;
   }, [rangeStart, spanDays]);
 
@@ -363,13 +385,13 @@ export default function BaseGanttView({
     );
   }
 
-  const timelineW = spanDays * DAY_PX;
+  const timelineW = spanDays * pxPerDay;
 
   const renderBars = (evs: BaseGanttEvent[], rowH: number) => {
     const { events: laned } = assignLanes(evs, rangeStart, rangeEnd);
     return laned.map((ev, idx) => {
-      const left   = ev._dayStart * DAY_PX;
-      const width  = Math.max((ev._dayEnd - ev._dayStart + 1) * DAY_PX - 4, 8);
+      const left   = ev._dayStart * pxPerDay;
+      const width  = Math.max((ev._dayEnd - ev._dayStart + 1) * pxPerDay - 4, 8);
       const top    = ROW_PAD + ev._lane * (LANE_H + LANE_GAP);
       const bg     = resolveColor(ev as never, ctx['colorRules']) || ev.color || 'var(--wc-accent)';
       return (
@@ -563,7 +585,7 @@ export default function BaseGanttView({
                   isWeekend(d) && styles['dayWeekend'],
                 ].filter(Boolean).join(' ');
                 return (
-                  <div key={i} className={cls} style={{ left: i * DAY_PX, width: DAY_PX }}>
+                  <div key={i} className={cls} style={{ left: i * pxPerDay, width: pxPerDay }}>
                     <span className={styles['dayDow']}>{format(d, 'EEE')}</span>
                     <span className={styles['dayNum']}>{format(d, 'd')}</span>
                   </div>
@@ -652,7 +674,7 @@ export default function BaseGanttView({
                           isToday(d) && styles['gridColToday'],
                           isWeekend(d) && styles['gridColWeekend'],
                         ].filter(Boolean).join(' ')}
-                        style={{ left: i * DAY_PX, width: DAY_PX }}
+                        style={{ left: i * pxPerDay, width: pxPerDay }}
                       />
                     ))}
                     {renderBars(baseWide, baseRowH)}
@@ -679,7 +701,7 @@ export default function BaseGanttView({
                               isToday(d) && styles['gridColToday'],
                               isWeekend(d) && styles['gridColWeekend'],
                             ].filter(Boolean).join(' ')}
-                            style={{ left: i * DAY_PX, width: DAY_PX }}
+                            style={{ left: i * pxPerDay, width: pxPerDay }}
                           />
                         ))}
                         {renderBars(rowEvs, rowH)}
@@ -729,7 +751,7 @@ export default function BaseGanttView({
                               isToday(d) && styles['gridColToday'],
                               isWeekend(d) && styles['gridColWeekend'],
                             ].filter(Boolean).join(' ')}
-                            style={{ left: i * DAY_PX, width: DAY_PX }}
+                            style={{ left: i * pxPerDay, width: pxPerDay }}
                           />
                         ))}
                         {renderBars(rowEvs, rowH)}

--- a/src/views/TimelineView.tsx
+++ b/src/views/TimelineView.tsx
@@ -43,7 +43,9 @@ import type { CalendarViewEvent } from '../types/ui';
 // ─── Layout constants ─────────────────────────────────────────────────────────
 
 const NAME_W   = 188;  // px — left column (wider to fit avatar + role)
-const DAY_W    = 52;   // px — each day column
+const MIN_DAY_W = 52;  // px — minimum day-column width; actual per-day width
+                       //      stretches via pxPerDay when the container can fit
+                       //      more than totalDays * MIN_DAY_W
 const LANE_H   = 26;   // px — each event lane
 const LANE_GAP = 3;    // px — gap between lanes
 const ROW_PAD  = 8;    // px — top/bottom padding per row
@@ -247,6 +249,27 @@ export default function TimelineView({
   const lastKeyNavCell = useRef(false);
   const gridRef = useRef<HTMLDivElement | null>(null); // ref on .inner (for querySelector)
   const wrapRef = useRef<HTMLDivElement | null>(null); // ref on .wrap (scroll container)
+
+  // ── Day-cell width: floor at MIN_DAY_W, but stretch to fill the available
+  //    container width when the natural totalDays * MIN_DAY_W comes up short
+  //    (e.g. dayWindow=7 on a 1280px viewport). Without this the grid would
+  //    render only ~330px wide and leave the rest of the card empty. ──
+  const [containerW, setContainerW] = useState(0);
+  useEffect(() => {
+    const el = wrapRef.current;
+    if (!el || typeof ResizeObserver === 'undefined') return;
+    const ro = new ResizeObserver(entries => {
+      const entry = entries[0];
+      if (entry) setContainerW(entry.contentRect.width);
+    });
+    ro.observe(el);
+    return () => ro.disconnect();
+  }, []);
+  const pxPerDay = useMemo(() => {
+    if (containerW <= 0 || totalDays <= 0) return MIN_DAY_W;
+    const available = containerW - NAME_W;
+    return Math.max(MIN_DAY_W, available / totalDays);
+  }, [containerW, totalDays]);
 
   // ── DnD: drag an event from one row to another to reassign it. ────────────
   // The drag source is the <button> around an event; the drop target is the
@@ -632,7 +655,7 @@ export default function TimelineView({
     <div className={styles['wrap']} ref={wrapRef}>
       <div
         className={styles['inner']}
-        style={{ width: NAME_W + totalDays * DAY_W }}
+        style={{ width: NAME_W + totalDays * pxPerDay }}
         role="grid"
         aria-label={`Timeline for ${rangeLabel}`}
         aria-rowcount={flatRows.length + 1}
@@ -715,7 +738,7 @@ export default function TimelineView({
                   isToday(day)   && styles['todayHead'],
                   isWeekend(day) && styles['weekendHead'],
                 ].filter(Boolean).join(' ')}
-                style={{ width: DAY_W, minWidth: DAY_W }}
+                style={{ width: pxPerDay, minWidth: pxPerDay }}
               >
                 <span className={styles['dayNum']} aria-hidden="true">{format(day, 'd')}</span>
                 <span className={styles['dayAbbr']} aria-hidden="true">{format(day, 'EEE')}</span>
@@ -776,7 +799,7 @@ export default function TimelineView({
                   aria-level={depth + 1}
                   data-depth={depth}
                 >
-                  <div className={styles['groupHeaderCell']} style={{ width: NAME_W + totalDays * DAY_W }}>
+                  <div className={styles['groupHeaderCell']} style={{ width: NAME_W + totalDays * pxPerDay }}>
                     <button
                       className={styles['groupToggleBtn']}
                       style={{ paddingLeft: 8 + indent }}
@@ -932,7 +955,7 @@ export default function TimelineView({
                 {/* Event zone — contains day background bands + keyboard cells + event bars */}
                 <div
                   className={styles['eventZone']}
-                  style={{ width: totalDays * DAY_W, height: rowH, position: 'relative' }}
+                  style={{ width: totalDays * pxPerDay, height: rowH, position: 'relative' }}
                   role="presentation"
                 >
                   {/* Day column backgrounds (pointer-events: none in CSS) */}
@@ -944,7 +967,7 @@ export default function TimelineView({
                         isToday(day)   && styles['todayCol'],
                         isWeekend(day) && styles['weekendCol'],
                       ].filter(Boolean).join(' ')}
-                      style={{ left: di * DAY_W, width: DAY_W, height: rowH }}
+                      style={{ left: di * pxPerDay, width: pxPerDay, height: rowH }}
                     />
                   ))}
 
@@ -963,7 +986,7 @@ export default function TimelineView({
                         aria-rowindex={rowIdx + 2}
                         aria-colindex={di + 2}
                         className={styles['kbCell']}
-                        style={{ left: di * DAY_W, width: DAY_W, top: 0, height: rowH }}
+                        style={{ left: di * pxPerDay, width: pxPerDay, top: 0, height: rowH }}
                         onKeyDown={e => handleCellKeyDown(e, rowIdx, di, rowEvents, resourceId)}
                         onClick={() => {
                           setFocusedCell({ rowIdx, dayIdx: di });
@@ -982,8 +1005,8 @@ export default function TimelineView({
                       ? (color ?? resolveColor(ev as any, ctx?.colorRules))
                       : resolveColor(ev as any, ctx?.colorRules);
 
-                    const left    = ev['_dayStart'] * DAY_W + 2;
-                    const width   = Math.max(DAY_W - 4, (ev['_dayEnd'] - ev['_dayStart'] + 1) * DAY_W - 4);
+                    const left    = ev['_dayStart'] * pxPerDay + 2;
+                    const width   = Math.max(pxPerDay - 4, (ev['_dayEnd'] - ev['_dayStart'] + 1) * pxPerDay - 4);
                     const top     = ROW_PAD + ev['_lane'] * (LANE_H + LANE_GAP);
                     const onClick = () => onEventClick?.(ev);
 
@@ -1113,8 +1136,8 @@ export default function TimelineView({
                       // day range as the PTO/unavailable event pill it mirrors.
                       const pillDayStart = differenceInCalendarDays(max([startOfDay(reqStart), monthStart]), monthStart);
                       const pillDayEnd   = differenceInCalendarDays(min([startOfDay(reqEnd), monthEnd]), monthStart);
-                      const left  = pillDayStart * DAY_W + 2;
-                      const width = Math.max(DAY_W - 4, (pillDayEnd - pillDayStart + 1) * DAY_W - 4);
+                      const left  = pillDayStart * pxPerDay + 2;
+                      const width = Math.max(pxPerDay - 4, (pillDayEnd - pillDayStart + 1) * pxPerDay - 4);
                       const top   = baseH + 3;
                       const isCovered = !!ev.meta?.['coveredBy'];
                       const coveredByEmp = isCovered
@@ -1161,8 +1184,8 @@ export default function TimelineView({
 
                   {/* ── Covering-for pills (for the employee covering someone else) ── */}
                   {coveringPills.map(({ ev: covEv, origEmpName, _dayStart, _dayEnd }: { ev: LooseEvent; origEmpName: string; _dayStart: number; _dayEnd: number }) => {
-                    const left  = _dayStart * DAY_W + 2;
-                    const width = Math.max(DAY_W - 4, (_dayEnd - _dayStart + 1) * DAY_W - 4);
+                    const left  = _dayStart * pxPerDay + 2;
+                    const width = Math.max(pxPerDay - 4, (_dayEnd - _dayStart + 1) * pxPerDay - 4);
                     const top   = baseH + 3 + (hasStatusPills ? COVERAGE_BAND : 0);
                     return (
                       <div


### PR DESCRIPTION
## Summary

CI surfaced 9 e2e failures on mobile viewports (320 / 375 / 390 px) where playwright couldn't click the centered view-tab pills:

```
<span class="_calendarTitle_..."> Air EMS Operations </span>
  from <div class="_left_..."> subtree intercepts pointer events
```

The AppHeader's three-zone flex layout had a fixed `height: 56px` and no `flex-wrap`. On viewports too narrow for left + center + right to fit on one line, the children overflowed instead of wrapping — left and right zones stacked over the centered `viewGroup` and intercepted clicks on the buttons underneath.

The legacy `.toolbar` had `flex-wrap: wrap` for exactly this reason. PR 3 ate it when AppHeader replaced the toolbar inline. Bring it back.

**Stacks on PR 15 (#418).**

## Fix

- `height` → `min-height` so the bar grows when zones wrap.
- `flex-wrap: wrap` on `.root`, plus on `.left` / `.right` (so individual buttons inside a zone can wrap if a single zone is itself wider than the viewport — matters at 320 px).
- `.left` / `.right` shrink to fit (`flex: 0 1 auto`) so wrapping closes the natural gap.
- Slight padding bump for breathing room when wrapped.

## Behaviour by viewport

| Width | Layout |
|---|---|
| ≥ 768 (tablet/desktop) | Unchanged — single row, three zones side by side |
| ≤ ~640 (mobile) | Zones wrap to two or three rows; centered view-tab pills land on their own line; left zone may itself wrap (Today + dateLabel can fall to a new line). All buttons hit-testable. |

## Test plan

- [x] `npm run type-check` clean
- [x] `npm run test` — 2171/2171 (jsdom doesn't exercise pointer-event interception; the real verification is the e2e suite)
- [x] `npm run build` clean
- [ ] Once CI runs: the 9 mobile failures (`calendar.demo.spec.ts mobile / mobile-small > all views can be selected / add event dialog opens`, `calendar.embed.spec.ts mobile / mobile-small > embedded calendar views can be selected`, `visual-qa.spec.ts Mobile (375×812) > {month, week, agenda} view mobile`) should go green.

## What this PR does *not* touch

The 10th failure — `calendar.regressions.spec.ts > edit pen opens the editor with the matching event loaded` — is a different failure mode (timeout waiting for the "Edit Pen Fixture" button to appear on `/regression-bugs.html`, not a click-interception). Investigating separately.

---
_Generated by [Claude Code](https://claude.ai/code/session_0129D5oFDywjK6gwjRU9dWLF)_