### PR TITLE
test+shell: rescue orphaned bot fixes (Auto pill, env-noise, edit-pen flake)

### DIFF
--- a/src/ui/DayWindowPills.tsx
+++ b/src/ui/DayWindowPills.tsx
@@ -5,13 +5,19 @@ const DEFAULT_OPTIONS = [7, 14, 30, 90] as const;
 export type DayWindowPillsProps = {
   /**
    * Currently selected day window (in days), or `null` for the "auto" /
-   * view-default state where no pill is highlighted.
+   * view-default state where no numeric pill is highlighted (the explicit
+   * "Auto" pill is active instead).
    */
   value: number | null;
-  /** Called when the user picks a different window. */
-  onChange: (next: number) => void;
+  /**
+   * Called when the user picks a different window. `null` means "auto" —
+   * the consumer should restore the view's intrinsic span (TimelineView /
+   * BaseGanttView / AssetsView fall back to their calendar-month default).
+   */
+  onChange: (next: number | null) => void;
   /**
    * Pill options to render. Defaults to [7, 14, 30, 90]. Order is preserved.
+   * The "Auto" pill is always rendered first regardless of this list.
    */
   options?: readonly number[];
 };
@@ -19,6 +25,11 @@ export type DayWindowPillsProps = {
 /**
  * Day-window pill set. A segmented selector that picks how many days the
  * timeline-style views (Schedule / Base / Assets) span at once.
+ *
+ * The first pill is "Auto" — selecting it clears the override and lets the
+ * view fall back to its intrinsic range (the calendar month around
+ * currentDate). Without this, users who clicked any numeric pill could not
+ * return to the auto state without remounting the calendar.
  *
  * Layout-only — the consuming hook owns the underlying state. Styling uses
  * theme tokens so all 12 themes restyle automatically.
@@ -28,8 +39,18 @@ export function DayWindowPills({
   onChange,
   options = DEFAULT_OPTIONS,
 }: DayWindowPillsProps) {
+  const autoActive = value === null;
   return (
     <div className={cls['root']} role="group" aria-label="Day window">
+      <button
+        type="button"
+        className={[cls['pill'], autoActive && cls['active']].filter(Boolean).join(' ')}
+        aria-pressed={autoActive}
+        onClick={() => onChange(null)}
+        title="Show the view's default range"
+      >
+        Auto
+      </button>
       {options.map(n => {
         const active = n === value;
         return (

--- a/src/ui/__tests__/DayWindowPills.test.tsx
+++ b/src/ui/__tests__/DayWindowPills.test.tsx
@@ -1,9 +1,9 @@
 // @vitest-environment happy-dom
 /**
- * DayWindowPills — segmented day-window selector.
+ * DayWindowPills — segmented day-window selector with leading "Auto" pill.
  *
- * Pins the rendering / selection / a11y contract so the sub-toolbar
- * integration is safe to refactor.
+ * Pins the rendering / selection / a11y / clear-to-auto contract so the
+ * sub-toolbar integration is safe to refactor.
  */
 import { render, screen, fireEvent } from '@testing-library/react';
 import { describe, it, expect, vi } from 'vitest';
@@ -12,34 +12,44 @@ import '@testing-library/jest-dom';
 import { DayWindowPills } from '../DayWindowPills';
 
 describe('DayWindowPills', () => {
-  it('renders the default 7 / 14 / 30 / 90 options', () => {
+  it('renders the Auto pill plus the default 7 / 14 / 30 / 90 options', () => {
     render(<DayWindowPills value={30} onChange={() => {}} />);
+    expect(screen.getByRole('button', { name: 'Auto' })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: '7 day' })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: '14 day' })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: '30 day' })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: '90 day' })).toBeInTheDocument();
   });
 
-  it('marks the active pill via aria-pressed', () => {
+  it('marks the active numeric pill via aria-pressed', () => {
     render(<DayWindowPills value={30} onChange={() => {}} />);
     expect(screen.getByRole('button', { name: '30 day' })).toHaveAttribute('aria-pressed', 'true');
+    expect(screen.getByRole('button', { name: 'Auto' })).toHaveAttribute('aria-pressed', 'false');
     expect(screen.getByRole('button', { name: '7 day' })).toHaveAttribute('aria-pressed', 'false');
     expect(screen.getByRole('button', { name: '14 day' })).toHaveAttribute('aria-pressed', 'false');
     expect(screen.getByRole('button', { name: '90 day' })).toHaveAttribute('aria-pressed', 'false');
   });
 
-  it('leaves every pill unpressed when value is null (auto / view default)', () => {
+  it('marks the Auto pill active when value is null', () => {
     render(<DayWindowPills value={null} onChange={() => {}} />);
+    expect(screen.getByRole('button', { name: 'Auto' })).toHaveAttribute('aria-pressed', 'true');
     for (const n of [7, 14, 30, 90]) {
       expect(screen.getByRole('button', { name: `${n} day` })).toHaveAttribute('aria-pressed', 'false');
     }
   });
 
-  it('invokes onChange with the picked window', () => {
+  it('invokes onChange with the picked numeric window', () => {
     const onChange = vi.fn();
     render(<DayWindowPills value={30} onChange={onChange} />);
     fireEvent.click(screen.getByRole('button', { name: '14 day' }));
     expect(onChange).toHaveBeenCalledWith(14);
+  });
+
+  it('invokes onChange(null) when the user clicks Auto', () => {
+    const onChange = vi.fn();
+    render(<DayWindowPills value={30} onChange={onChange} />);
+    fireEvent.click(screen.getByRole('button', { name: 'Auto' }));
+    expect(onChange).toHaveBeenCalledWith(null);
   });
 
   it('exposes a labelled group for a11y trees', () => {
@@ -47,8 +57,9 @@ describe('DayWindowPills', () => {
     expect(screen.getByRole('group', { name: /day window/i })).toBeInTheDocument();
   });
 
-  it('honours custom options', () => {
+  it('honours custom options (Auto stays on top)', () => {
     render(<DayWindowPills value={3} onChange={() => {}} options={[1, 3, 5]} />);
+    expect(screen.getByRole('button', { name: 'Auto' })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: '1 day' })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: '3 day' })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: '5 day' })).toBeInTheDocument();

--- a/tests-e2e/calendar.demo.spec.ts
+++ b/tests-e2e/calendar.demo.spec.ts
@@ -9,17 +9,26 @@ const viewports = [
 
 /**
  * Errors caused by the runner environment, not the calendar code under test.
+ *
  * The chromium sandbox in some CI runners refuses external HTTPS requests
- * (tile servers, font CDNs, the demo PWA's own service-worker fetches) and
- * surfaces them as console.error("net::ERR_CERT_AUTHORITY_INVALID …") or as
- * the related "Failed to load resource" line. Filtering them keeps the
- * "loads without crashing" + "drag does not crash" assertions tight on the
- * code paths the suite actually owns.
+ * (tile servers, font CDNs) and surfaces them as
+ *   console.error("net::ERR_CERT_AUTHORITY_INVALID …")
+ * Those are unambiguously environmental — sandboxed chromium cannot validate
+ * arbitrary upstream certificates, full stop.
+ *
+ * What we explicitly DON'T filter is a blanket
+ *   /Failed to load resource.*4xx|5xx/
+ * because that would also swallow real same-origin failures (a broken local
+ * asset, a 500 from the demo's own data path, a 404 on a missing icon) —
+ * exactly the kind of regression the "loads without crashing" assertion is
+ * supposed to catch. If a specific external host's 4xx/5xx ends up being
+ * deterministic CI noise in the future, add a targeted host-scoped pattern
+ * here (e.g. /fonts\.gstatic\.com.*status of \d+/) rather than going broad.
  */
 const ENV_NOISE_PATTERNS: RegExp[] = [
   /net::ERR_CERT_AUTHORITY_INVALID/i,
   /net::ERR_CERT_DATE_INVALID/i,
-  /Failed to load resource.*the server responded with a status of (4|5)\d{2}/i,
+  /net::ERR_CERT_COMMON_NAME_INVALID/i,
 ];
 
 function ignoreEnvNoise(line: string): boolean {

--- a/tests-e2e/calendar.regressions.spec.ts
+++ b/tests-e2e/calendar.regressions.spec.ts
@@ -94,7 +94,12 @@ test.describe('WorksCalendar targeted regressions', () => {
     await page.setViewportSize({ width: 1280, height: 900 });
     await page.goto('/regression-bugs.html');
 
-    await page.getByRole('button', { name: /Edit Pen Fixture/i }).first().click();
+    // Wait for the fixture to hydrate before clicking — the bare click was
+    // racing the fixture's initial render in CI. The recurring-event test
+    // below has the same fix (added inline to keep the diff narrow).
+    const pen = page.getByRole('button', { name: /Edit Pen Fixture/i }).first();
+    await expect(pen).toBeVisible({ timeout: 10000 });
+    await pen.click();
 
     const dialog = page.getByRole('dialog', { name: /Event details: Edit Pen Fixture/i });
     await expect(dialog).toBeVisible();
@@ -110,7 +115,9 @@ test.describe('WorksCalendar targeted regressions', () => {
     await page.setViewportSize({ width: 1280, height: 900 });
     await page.goto('/regression-bugs.html');
 
-    await page.getByRole('button', { name: /Repeating Pencil Test/i }).first().click();
+    const pencil = page.getByRole('button', { name: /Repeating Pencil Test/i }).first();
+    await expect(pencil).toBeVisible({ timeout: 10000 });
+    await pencil.click();
 
     const dialog = page.getByRole('dialog', { name: /Event details: Repeating Pencil Test/i });
     await expect(dialog).toBeVisible();

--- a/tests-e2e/calendar.regressions.spec.ts
+++ b/tests-e2e/calendar.regressions.spec.ts
@@ -11,11 +11,14 @@ function dateKey(offsetDays = 0) {
 }
 
 // Same env-noise filter as calendar.demo.spec.ts — sandboxed runners surface
-// cert errors / network failures that aren't part of the calendar's contract.
+// chromium cert errors that aren't part of the calendar's contract. We do
+// NOT filter blanket 4xx/5xx here, since those can fire for real same-origin
+// regressions (a broken local asset, a 500 from the demo's own data path);
+// see the long comment in calendar.demo.spec.ts for the rationale.
 const ENV_NOISE_PATTERNS = [
   /net::ERR_CERT_AUTHORITY_INVALID/i,
   /net::ERR_CERT_DATE_INVALID/i,
-  /Failed to load resource.*the server responded with a status of (4|5)\d{2}/i,
+  /net::ERR_CERT_COMMON_NAME_INVALID/i,
 ];
 
 function ignoreEnvNoise(line) {


### PR DESCRIPTION
## Summary

Rescues two bot-feedback fixes that landed on already-merged PR branches (so they never made it to main) and includes the edit-pen e2e flake fix from the same CI run that surfaced the AppHeader narrow-wrap bug.

When PR 8 (#411) and PR 9 (#412) merged, my follow-up fixes for those PRs' bot comments were sitting on the head branches (`claude/e2e-shell-catchup` / `claude/timeline-day-window`) but those branches had no more PR pipeline to flow through. This PR cherry-picks them into a fresh branch off main so they actually land.

## Changes

### Cherry-picked from `claude/e2e-shell-catchup` (`1878427`)
**`tests-e2e/calendar.demo.spec.ts`** + **`tests-e2e/calendar.regressions.spec.ts`** — drop the blanket `/Failed to load resource.*4xx|5xx/` pattern from `ENV_NOISE_PATTERNS`. Keep only the cert-error patterns (`ERR_CERT_AUTHORITY_INVALID` / `_DATE_INVALID` / `_COMMON_NAME_INVALID`) since those are unambiguously environmental. Real same-origin 4xx/5xx errors from the app under test now surface again — the bot was right that the broad pattern was hiding real regressions.

### Cherry-picked from `claude/timeline-day-window` (`48d2355`)
**`src/ui/DayWindowPills.tsx`** + **`src/ui/__tests__/DayWindowPills.test.tsx`** — add a leading "Auto" pill that calls `onChange(null)`. Without this, once a user clicked any numeric pill they couldn't restore the view-default behaviour without remounting the calendar. `onChange` signature widened to `(next: number | null) => void`; `cal.setDayWindow` already accepted `null` so call sites are unchanged. Tests bumped from 6 → 7 with explicit Auto-render / Auto-active / Auto-dispatch coverage.

### New: edit-pen flake fix
**`tests-e2e/calendar.regressions.spec.ts`** — the `edit pen opens the editor with the matching event loaded` test was the 10th failure in the same CI run that surfaced the mobile AppHeader interception. Different failure mode: bare `click()` racing the fixture's initial render. Same fix as the parallel "drag a month pill" test in the same file — resolve the locator, `.toBeVisible({ timeout: 10000 })`, then click. Mirrored on the recurring-pencil test below it (identical pattern).

## Why this couldn't ride along on the open PRs

The two cherry-picks belong on already-merged PRs (#411, #412). Pushing additional commits to those branches now does nothing because the PRs are closed. Cherry-picking onto a fresh branch is the only path back to main for these fixes.

The edit-pen flake fix could have ridden on PR 16 (#419) but bundling it here keeps the e2e cleanup PR self-contained and easy to revert as a unit.

## Test plan

- [x] `npm run type-check` clean
- [x] `npm run test` — 2165/2165 (one transient flake on `WorksCalendar.scheduleModel.integration > keeps exactly one covering record when coverage is reassigned` which passes in isolation; not introduced by this PR — same suite-vs-isolation behaviour as before)
- [x] `npm run build` clean
- [ ] Once CI runs:
  - Auto pill: visible on Schedule / Base / Assets, click clears `dayWindow` back to `null`
  - Tightened env-noise filter: any same-origin 4xx/5xx now blocks the strict crash check (intended behaviour)
  - Edit-pen test: passes deterministically, no longer times out

---
_Generated by [Claude Code](https://claude.ai/code/session_0129D5oFDywjK6gwjRU9dWLF)_