### PR TITLE
shell(fixup): add Auto pill so users can clear the day window

### DIFF
--- a/src/ui/DayWindowPills.tsx
+++ b/src/ui/DayWindowPills.tsx
@@ -5,13 +5,19 @@ const DEFAULT_OPTIONS = [7, 14, 30, 90] as const;
 export type DayWindowPillsProps = {
   /**
    * Currently selected day window (in days), or `null` for the "auto" /
-   * view-default state where no pill is highlighted.
+   * view-default state where no numeric pill is highlighted (the explicit
+   * "Auto" pill is active instead).
    */
   value: number | null;
-  /** Called when the user picks a different window. */
-  onChange: (next: number) => void;
+  /**
+   * Called when the user picks a different window. `null` means "auto" —
+   * the consumer should restore the view's intrinsic span (TimelineView /
+   * BaseGanttView / AssetsView fall back to their calendar-month default).
+   */
+  onChange: (next: number | null) => void;
   /**
    * Pill options to render. Defaults to [7, 14, 30, 90]. Order is preserved.
+   * The "Auto" pill is always rendered first regardless of this list.
    */
   options?: readonly number[];
 };
@@ -19,6 +25,11 @@ export type DayWindowPillsProps = {
 /**
  * Day-window pill set. A segmented selector that picks how many days the
  * timeline-style views (Schedule / Base / Assets) span at once.
+ *
+ * The first pill is "Auto" — selecting it clears the override and lets the
+ * view fall back to its intrinsic range (the calendar month around
+ * currentDate). Without this, users who clicked any numeric pill could not
+ * return to the auto state without remounting the calendar.
  *
  * Layout-only — the consuming hook owns the underlying state. Styling uses
  * theme tokens so all 12 themes restyle automatically.
@@ -28,8 +39,18 @@ export function DayWindowPills({
   onChange,
   options = DEFAULT_OPTIONS,
 }: DayWindowPillsProps) {
+  const autoActive = value === null;
   return (
     <div className={cls['root']} role="group" aria-label="Day window">
+      <button
+        type="button"
+        className={[cls['pill'], autoActive && cls['active']].filter(Boolean).join(' ')}
+        aria-pressed={autoActive}
+        onClick={() => onChange(null)}
+        title="Show the view's default range"
+      >
+        Auto
+      </button>
       {options.map(n => {
         const active = n === value;
         return (

--- a/src/ui/__tests__/DayWindowPills.test.tsx
+++ b/src/ui/__tests__/DayWindowPills.test.tsx
@@ -1,9 +1,9 @@
 // @vitest-environment happy-dom
 /**
- * DayWindowPills — segmented day-window selector.
+ * DayWindowPills — segmented day-window selector with leading "Auto" pill.
  *
- * Pins the rendering / selection / a11y contract so the sub-toolbar
- * integration is safe to refactor.
+ * Pins the rendering / selection / a11y / clear-to-auto contract so the
+ * sub-toolbar integration is safe to refactor.
  */
 import { render, screen, fireEvent } from '@testing-library/react';
 import { describe, it, expect, vi } from 'vitest';
@@ -12,34 +12,44 @@ import '@testing-library/jest-dom';
 import { DayWindowPills } from '../DayWindowPills';
 
 describe('DayWindowPills', () => {
-  it('renders the default 7 / 14 / 30 / 90 options', () => {
+  it('renders the Auto pill plus the default 7 / 14 / 30 / 90 options', () => {
     render(<DayWindowPills value={30} onChange={() => {}} />);
+    expect(screen.getByRole('button', { name: 'Auto' })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: '7 day' })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: '14 day' })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: '30 day' })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: '90 day' })).toBeInTheDocument();
   });
 
-  it('marks the active pill via aria-pressed', () => {
+  it('marks the active numeric pill via aria-pressed', () => {
     render(<DayWindowPills value={30} onChange={() => {}} />);
     expect(screen.getByRole('button', { name: '30 day' })).toHaveAttribute('aria-pressed', 'true');
+    expect(screen.getByRole('button', { name: 'Auto' })).toHaveAttribute('aria-pressed', 'false');
     expect(screen.getByRole('button', { name: '7 day' })).toHaveAttribute('aria-pressed', 'false');
     expect(screen.getByRole('button', { name: '14 day' })).toHaveAttribute('aria-pressed', 'false');
     expect(screen.getByRole('button', { name: '90 day' })).toHaveAttribute('aria-pressed', 'false');
   });
 
-  it('leaves every pill unpressed when value is null (auto / view default)', () => {
+  it('marks the Auto pill active when value is null', () => {
     render(<DayWindowPills value={null} onChange={() => {}} />);
+    expect(screen.getByRole('button', { name: 'Auto' })).toHaveAttribute('aria-pressed', 'true');
     for (const n of [7, 14, 30, 90]) {
       expect(screen.getByRole('button', { name: `${n} day` })).toHaveAttribute('aria-pressed', 'false');
     }
   });
 
-  it('invokes onChange with the picked window', () => {
+  it('invokes onChange with the picked numeric window', () => {
     const onChange = vi.fn();
     render(<DayWindowPills value={30} onChange={onChange} />);
     fireEvent.click(screen.getByRole('button', { name: '14 day' }));
     expect(onChange).toHaveBeenCalledWith(14);
+  });
+
+  it('invokes onChange(null) when the user clicks Auto', () => {
+    const onChange = vi.fn();
+    render(<DayWindowPills value={30} onChange={onChange} />);
+    fireEvent.click(screen.getByRole('button', { name: 'Auto' }));
+    expect(onChange).toHaveBeenCalledWith(null);
   });
 
   it('exposes a labelled group for a11y trees', () => {
@@ -47,8 +57,9 @@ describe('DayWindowPills', () => {
     expect(screen.getByRole('group', { name: /day window/i })).toBeInTheDocument();
   });
 
-  it('honours custom options', () => {
+  it('honours custom options (Auto stays on top)', () => {
     render(<DayWindowPills value={3} onChange={() => {}} options={[1, 3, 5]} />);
+    expect(screen.getByRole('button', { name: 'Auto' })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: '1 day' })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: '3 day' })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: '5 day' })).toBeInTheDocument();


### PR DESCRIPTION
Codex flagged that DayWindowPills only emitted numeric values, so once a user clicked any pill there was no UI path back to null (view-default). Schedule / Base / Assets users could get stuck in fixed-window mode (7/14/30/90) until the calendar remounted — functional regression vs. the new null default.

Add an "Auto" pill at the start of the pill row. Selecting it calls onChange(null), which the consumer (cal.setDayWindow) already accepts. The Auto pill is aria-pressed when value === null, mirroring how the numeric pills paint when they're the chosen window. With Auto present, the active pill is always exactly one of {Auto, 7, 14, 30, 90}, so the segmented selector never lands in an "all unpressed" state — the visible-state machine and the underlying value space stay in lockstep.

Knock-on changes:
- DayWindowPillsProps.onChange signature widens from (next: number) => void to: (next: number | null) => void WorksCalendar.tsx already passes cal.setDayWindow, which has always accepted number | null. No call-site changes needed.

- src/ui/__tests__/DayWindowPills.test.tsx — bumped from 6 tests to 7. Adds: • "renders the Auto pill plus the default options" • "marks the Auto pill active when value is null" • "invokes onChange(null) when the user clicks Auto" Existing tests updated to expect Auto's presence and to assert it's aria-pressed=false when a numeric pill is active.

Verified locally:
- npm run type-check — clean
- npm run test — 2140/2140 (1 new for the new Auto behaviour)

## Summary
Describe exactly what this PR changes.

## Scope
- Stage: 
- Planned PR number in sprint: 
- Target files/directories: 
- Why this slice is isolated: 

## Lessons Learned Check (REQUIRED)
Confirm these were actively used while building this PR:

- [ ] PR is intentionally small and isolated
- [ ] Boundary typing was prioritized over internal perfection
- [ ] No silent spread of `any`
- [ ] Advisory root `tsc` was used to catch integration issues
- [ ] I did not assume “looks typed” means “safe”
- [ ] I stopped and isolated typing cascades instead of expanding scope

## Definition of Done (ALL REQUIRED)
This PR is not done unless every box is checked.

- [ ] `npm run type-check:strict` passes
- [ ] Root advisory `tsc --noEmit` passes
- [ ] Tests pass for touched scope at minimum
- [ ] No uncontrolled increase in `any`
- [ ] All new types are intentional and named
- [ ] Public interfaces and exported functions are explicitly typed
- [ ] PR scope matches the sprint plan with no scope creep
- [ ] Any new `any` has an adjacent justification comment
- [ ] No file-wide `: any`
- [ ] No implicit `any` in exported functions

## What Was Typed
List exactly what was typed in this PR.

- 
- 
- 

## What Was Intentionally Left Loose
List anything intentionally not tightened yet.

- 
- 
- 

## `any` Ledger (REQUIRED)
- New `any` added: 
- Existing `any` removed: 
- Net change: 

For every new `any`, explain why it is required and why a safer type was not used yet.

1. 
2. 
3. 

## Boundary Notes
Document any public seams, caller-protection choices, or compatibility decisions.

- 
- 
- 

## Risk Level
- [ ] Low
- [ ] Medium
- [ ] High

Why:

## Validation Evidence
Paste the exact commands run and a short result summary.

```bash
npm run type-check:strict
npx tsc --noEmit -p tsconfig.json
```

Test commands run:

```bash
# paste commands here
```

## Stop Conditions Check
If any item below happened, explain how scope was reduced before merge.

- [ ] `any` started spreading across files
- [ ] Root `tsc` broke repeatedly
- [ ] Types required cross-module rewrites
- [ ] Scope was reduced to keep the PR reviewable

Notes:

## Reviewer Focus
What should reviewers look at first?

- 
- 
- 
