### PR TITLE
test(e2e): tighten env-noise filter — cert-only, no blanket 4xx/5xx

### DIFF
--- a/tests-e2e/calendar.demo.spec.ts
+++ b/tests-e2e/calendar.demo.spec.ts
@@ -9,17 +9,26 @@ const viewports = [
 
 /**
  * Errors caused by the runner environment, not the calendar code under test.
+ *
  * The chromium sandbox in some CI runners refuses external HTTPS requests
- * (tile servers, font CDNs, the demo PWA's own service-worker fetches) and
- * surfaces them as console.error("net::ERR_CERT_AUTHORITY_INVALID …") or as
- * the related "Failed to load resource" line. Filtering them keeps the
- * "loads without crashing" + "drag does not crash" assertions tight on the
- * code paths the suite actually owns.
+ * (tile servers, font CDNs) and surfaces them as
+ *   console.error("net::ERR_CERT_AUTHORITY_INVALID …")
+ * Those are unambiguously environmental — sandboxed chromium cannot validate
+ * arbitrary upstream certificates, full stop.
+ *
+ * What we explicitly DON'T filter is a blanket
+ *   /Failed to load resource.*4xx|5xx/
+ * because that would also swallow real same-origin failures (a broken local
+ * asset, a 500 from the demo's own data path, a 404 on a missing icon) —
+ * exactly the kind of regression the "loads without crashing" assertion is
+ * supposed to catch. If a specific external host's 4xx/5xx ends up being
+ * deterministic CI noise in the future, add a targeted host-scoped pattern
+ * here (e.g. /fonts\.gstatic\.com.*status of \d+/) rather than going broad.
  */
 const ENV_NOISE_PATTERNS: RegExp[] = [
   /net::ERR_CERT_AUTHORITY_INVALID/i,
   /net::ERR_CERT_DATE_INVALID/i,
-  /Failed to load resource.*the server responded with a status of (4|5)\d{2}/i,
+  /net::ERR_CERT_COMMON_NAME_INVALID/i,
 ];
 
 function ignoreEnvNoise(line: string): boolean {

--- a/tests-e2e/calendar.regressions.spec.ts
+++ b/tests-e2e/calendar.regressions.spec.ts
@@ -11,11 +11,14 @@ function dateKey(offsetDays = 0) {
 }
 
 // Same env-noise filter as calendar.demo.spec.ts — sandboxed runners surface
-// cert errors / network failures that aren't part of the calendar's contract.
+// chromium cert errors that aren't part of the calendar's contract. We do
+// NOT filter blanket 4xx/5xx here, since those can fire for real same-origin
+// regressions (a broken local asset, a 500 from the demo's own data path);
+// see the long comment in calendar.demo.spec.ts for the rationale.
 const ENV_NOISE_PATTERNS = [
   /net::ERR_CERT_AUTHORITY_INVALID/i,
   /net::ERR_CERT_DATE_INVALID/i,
-  /Failed to load resource.*the server responded with a status of (4|5)\d{2}/i,
+  /net::ERR_CERT_COMMON_NAME_INVALID/i,
 ];
 
 function ignoreEnvNoise(line) {


### PR DESCRIPTION
Codex flagged that the previous /Failed to load resource.*4xx|5xx/ pattern in ENV_NOISE_PATTERNS suppressed every 4xx/5xx — including real same-origin failures from the app under test (a broken local asset, a 500 from the demo's own data path, a missing icon 404). That weakens the "loads without crashing" assertion: real regressions slip through whenever the UI still mounts.

Drop the blanket pattern. Keep the cert-only patterns since cert errors are unambiguously environmental (sandboxed chromium can't validate arbitrary upstream certificates) — and add ERR_CERT_COMMON_NAME_INVALID since that's the third common cert flake mode.

If a specific external host's 4xx/5xx ends up being deterministic CI noise in the future, add a host-scoped pattern (e.g. /fonts\.gstatic\.com.*status of \d+/) instead of going broad.

Both spec files updated symmetrically — calendar.demo.spec.ts (strict crash check) and calendar.regressions.spec.ts (drag-pill crash check) share this filter shape.

Verified locally:
- npm run type-check — clean
- npm run test — 2132/2132 (no unit-test impact; the change is in the e2e specs only)

## Summary
Describe exactly what this PR changes.

## Scope
- Stage: 
- Planned PR number in sprint: 
- Target files/directories: 
- Why this slice is isolated: 

## Lessons Learned Check (REQUIRED)
Confirm these were actively used while building this PR:

- [ ] PR is intentionally small and isolated
- [ ] Boundary typing was prioritized over internal perfection
- [ ] No silent spread of `any`
- [ ] Advisory root `tsc` was used to catch integration issues
- [ ] I did not assume “looks typed” means “safe”
- [ ] I stopped and isolated typing cascades instead of expanding scope

## Definition of Done (ALL REQUIRED)
This PR is not done unless every box is checked.

- [ ] `npm run type-check:strict` passes
- [ ] Root advisory `tsc --noEmit` passes
- [ ] Tests pass for touched scope at minimum
- [ ] No uncontrolled increase in `any`
- [ ] All new types are intentional and named
- [ ] Public interfaces and exported functions are explicitly typed
- [ ] PR scope matches the sprint plan with no scope creep
- [ ] Any new `any` has an adjacent justification comment
- [ ] No file-wide `: any`
- [ ] No implicit `any` in exported functions

## What Was Typed
List exactly what was typed in this PR.

- 
- 
- 

## What Was Intentionally Left Loose
List anything intentionally not tightened yet.

- 
- 
- 

## `any` Ledger (REQUIRED)
- New `any` added: 
- Existing `any` removed: 
- Net change: 

For every new `any`, explain why it is required and why a safer type was not used yet.

1. 
2. 
3. 

## Boundary Notes
Document any public seams, caller-protection choices, or compatibility decisions.

- 
- 
- 

## Risk Level
- [ ] Low
- [ ] Medium
- [ ] High

Why:

## Validation Evidence
Paste the exact commands run and a short result summary.

```bash
npm run type-check:strict
npx tsc --noEmit -p tsconfig.json
```

Test commands run:

```bash
# paste commands here
```

## Stop Conditions Check
If any item below happened, explain how scope was reduced before merge.

- [ ] `any` started spreading across files
- [ ] Root `tsc` broke repeatedly
- [ ] Types required cross-module rewrites
- [ ] Scope was reduced to keep the PR reviewable

Notes:

## Reviewer Focus
What should reviewers look at first?

- 
- 
- 
