### PR TITLE
fix(month): include grid spillover days when fetching occurrences

### DIFF
--- a/src/WorksCalendar.tsx
+++ b/src/WorksCalendar.tsx
@@ -443,7 +443,21 @@ function viewRange(view: LooseValue, date: LooseValue, weekStartDay: 0 | 1 | 2 |
       // materialize the 90-day window so toggling in-view doesn't require
       // a re-fetch and occurrences at the end of the span aren't missing.
       return { start: startOfDay(date), end: addDays(startOfDay(date), 90) };
-    default: // month, agenda, schedule (timeline), assets
+    case 'month': {
+      // MonthView renders a calendar grid that spills into the previous
+      // month's tail and the next month's head (startOfWeek(monthStart)
+      // → endOfWeek(monthEnd)). The fetched range needs to match the grid,
+      // not just the calendar month — otherwise events that fall on
+      // visible spillover days (e.g. May 1-2 in an April grid) are
+      // dropped before reaching the view and silently disappear.
+      const monthStart = startOfMonth(date);
+      const monthEnd   = endOfMonth(date);
+      return {
+        start: startOfWeek(monthStart, { weekStartsOn: weekStartDay }),
+        end:   endOfWeek(monthEnd,     { weekStartsOn: weekStartDay }),
+      };
+    }
+    default: // agenda, schedule (timeline), assets
       return { start: startOfMonth(date), end: endOfMonth(date) };
   }
 }


### PR DESCRIPTION
## Summary

Long-standing date-sensitive bug. MonthView's grid spans `startOfWeek(monthStart)` → `endOfWeek(monthEnd)` — typically 4-5 rows showing trailing days from the previous month and leading days from the next month. But `viewRange()` was only fetching events in the calendar month proper, so any event landing on a visible spillover day was dropped from `expandedEvents` before it could reach MonthView's `singleByDay` map.

## Visible symptom

Events render or vanish based on what day the calendar runs. The `calendar.regressions.spec.ts > edit pen opens the editor with the matching event loaded` e2e test seeds an event at `today + 4 days`. When today is e.g. April 28 (a recent CI run), today + 4 = May 2 — Saturday of the last visible row in the April grid. The cell renders but its events list is empty; the test's button locator times out.

This was the 10th failure that survived PR 16 + PR 17. PR 17 added a `toBeVisible({ timeout: 10000 })` wait before the click, but there was nothing to wait for — the event had already been filtered out at the data layer before MonthView ever saw it.

## Diagnosis

Repro test in vitest + happy-dom (now removed) confirmed the bug:
- `[data-date="2026-05-02"]` cell renders correctly
- That cell's `[class*="events"]` div has zero children
- `singleByDay` map only had entries for dates ≤ `endOfMonth(currentDate)`

Tracing back: `expandedEvents = engine.getOccurrencesInRange(range.start, range.end)`. `range` comes from `viewRange()`. The `default:` branch covered `month` and returned `startOfMonth..endOfMonth`. May 2 wasn't in that range.

## Fix

`viewRange()` gets a dedicated `'month'` branch that matches the grid:
```ts
start = startOfWeek(monthStart, { weekStartsOn: weekStartDay })
end   = endOfWeek(monthEnd,     { weekStartsOn: weekStartDay })
```

Other views unchanged. The default branch for `agenda` / `schedule` / `assets` still returns the calendar-month range — those views don't spill into adjacent months and a wider fetch would just return events they wouldn't display.

## Test plan

- [x] `npm run type-check` clean
- [x] `npm run test` — 2172/2172 (no unit test was asserting against the bug; happy-dom doesn't run e2e)
- [x] `npm run build` clean
- [ ] CI: `calendar.regressions.spec.ts > edit pen opens` should go green on next run regardless of when the runner clock starts. Worth re-running on a couple of different system dates to confirm date-insensitivity.

---
_Generated by [Claude Code](https://claude.ai/code/session_0129D5oFDywjK6gwjRU9dWLF)_