### PR TITLE
ui: address two real gaps surfaced by the audit

### DIFF
--- a/src/WorksCalendar.module.css
+++ b/src/WorksCalendar.module.css
@@ -1,3 +1,15 @@
+/* Transient toast — used by handleImport to confirm a CSV import landed.
+   Floats top-center, doesn't take layout, ignores pointer events so it
+   never blocks clicks on whatever's underneath. */
+.transientToast {
+  position: absolute;
+  top: 12px;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 1500;
+  pointer-events: none;
+}
+
 .root {
   /* Structural defaults — overridden per family via data-wc-theme-family */
   --wc-spacing-row-height:    40px;

--- a/src/WorksCalendar.tsx
+++ b/src/WorksCalendar.tsx
@@ -66,6 +66,7 @@ import KeyboardHelpOverlay   from './ui/KeyboardHelpOverlay';
 import { useKeyboardShortcuts } from './hooks/useKeyboardShortcuts';
 import ConfigPanel            from './ui/ConfigPanel';
 import SavedFlash             from './ui/SavedFlash';
+import ActiveFilterStrip      from './ui/ActiveFilterStrip';
 import EventForm              from './ui/EventForm';
 import AssetRequestForm       from './ui/AssetRequestForm';
 import ImportZone             from './ui/ImportZone';
@@ -2489,6 +2490,13 @@ export const WorksCalendar = forwardRef<CalendarApi, WorksCalendarProps>(functio
                   <Download size={15} aria-hidden="true" />
                 </button>
               </>}
+            />
+            <ActiveFilterStrip
+              filters={cal.filters as Record<string, unknown>}
+              schema={schema}
+              onChange={(key, value) => cal.setFilter(key, value)}
+              onClear={(key) => cal.clearFilter(key)}
+              onClearAll={cal.clearFilters}
             />
         {/* ── View area ── */}
         <div

--- a/src/WorksCalendar.tsx
+++ b/src/WorksCalendar.tsx
@@ -23,6 +23,7 @@ import type { SortConfig } from './types/grouping.ts';
 import { sortEvents } from './core/sortEngine.ts';
 import { useRealtimeEvents }  from './hooks/useRealtimeEvents';
 import { usePermissions }     from './hooks/usePermissions';
+import { useSavedFlash }      from './hooks/useSavedFlash';
 import { useEventOptions }    from './hooks/useEventOptions';
 import { useTouchSwipe }     from './hooks/useTouchSwipe';
 import { CalendarContext }    from './core/CalendarContext';
@@ -64,6 +65,7 @@ import OwnerLock              from './ui/OwnerLock';
 import KeyboardHelpOverlay   from './ui/KeyboardHelpOverlay';
 import { useKeyboardShortcuts } from './hooks/useKeyboardShortcuts';
 import ConfigPanel            from './ui/ConfigPanel';
+import SavedFlash             from './ui/SavedFlash';
 import EventForm              from './ui/EventForm';
 import AssetRequestForm       from './ui/AssetRequestForm';
 import ImportZone             from './ui/ImportZone';
@@ -911,7 +913,7 @@ export const WorksCalendar = forwardRef<CalendarApi, WorksCalendarProps>(functio
   const sourceStore = useSourceStore(calendarId);
 
   // ── Aggregator: merges prop feeds + stored ICS + stored CSV ─────────────
-  const { events: sourceEvents, feedErrors } = useSourceAggregator({
+  const { events: sourceEvents, feedErrors, isFetchingFeeds } = useSourceAggregator({
     icalFeedsProp: icalFeeds,
     sourceStore,
   });
@@ -1175,6 +1177,11 @@ export const WorksCalendar = forwardRef<CalendarApi, WorksCalendarProps>(functio
   const [formEvent,        setFormEvent]        = useState<LooseValue | null>(null);
   const [assetRequestOpen, setAssetRequestOpen] = useState(false);
   const [importOpen,       setImportOpen]       = useState(false);
+  // Transient confirmation that the host's import landed; the dialog
+  // itself closes immediately so without this users can't tell whether
+  // anything happened beyond "the modal disappeared".
+  const [importMsg,        setImportMsg]        = useState('');
+  const importFlash                              = useSavedFlash(2500);
   const [scheduleOpen,     setScheduleOpen]     = useState(false);
   // { emp: { id, name, role? }, kind: 'pto' | 'unavailable' | 'availability', start?: Date, initialEvent?: object | null }
   const [availabilityState, setAvailabilityState] = useState<LooseValue | null>(null);
@@ -1824,7 +1831,10 @@ export const WorksCalendar = forwardRef<CalendarApi, WorksCalendarProps>(functio
       importedAt: new Date().toISOString(),
     });
     setImportOpen(false);
-  }, [onImport, sourceStore]);
+    const count = Array.isArray(imported) ? imported.length : 0;
+    setImportMsg(`Imported ${count} event${count === 1 ? '' : 's'}`);
+    importFlash.trigger();
+  }, [onImport, sourceStore, importFlash]);
 
   const handleScheduleInstantiate = useCallback((request: ScheduleDialogRequest) => {
     const startedAt = Date.now();
@@ -2186,6 +2196,10 @@ export const WorksCalendar = forwardRef<CalendarApi, WorksCalendarProps>(functio
     <CalendarErrorBoundary>
       <CalendarContext.Provider value={ctxValue}>
         <div className={styles['root']} data-wc-theme={effectiveTheme} data-wc-theme-family={themeFamily} data-wc-theme-mode={themeMode} data-testid="works-calendar" data-wc-edit-mode={editMode ? '' : undefined} style={rootStyle}>
+
+        <div className={styles['transientToast']} aria-hidden={!importFlash.flash}>
+          <SavedFlash visible={importFlash.flash} label={importMsg} />
+        </div>
 
         <AppShell
           leftRail={
@@ -2760,6 +2774,7 @@ export const WorksCalendar = forwardRef<CalendarApi, WorksCalendarProps>(functio
             onEmployeeDelete={perms.canManagePeople ? handleEmployeeDeleteInternal : undefined}
             sources={sourceStore.sources}
             feedErrors={feedErrors}
+            isFetchingFeeds={isFetchingFeeds}
             onAddSource={sourceStore.addSource}
             onRemoveSource={sourceStore.removeSource}
             onToggleSource={sourceStore.toggleSource}

--- a/src/hooks/useFeedEvents.ts
+++ b/src/hooks/useFeedEvents.ts
@@ -23,19 +23,24 @@ type FeedError = { feed: ICalFeedInput; err: unknown };
 export function useFeedEvents(icalFeeds: ICalFeedInput[] = []): {
   feedEvents: FeedEvent[];
   feedErrors: FeedError[];
+  /** True while a fetch (initial or polled) is in flight for any feed. */
+  isFetching: boolean;
 } {
   const [feedEvents, setFeedEvents] = useState<FeedEvent[]>([]);
   const [feedErrors, setFeedErrors] = useState<FeedError[]>([]);
+  const [isFetching, setIsFetching] = useState(false);
 
   useEffect(() => {
     if (!icalFeeds?.length) {
       setFeedEvents([]);
+      setIsFetching(false);
       return;
     }
 
     let cancelled = false;
 
     async function fetchAll() {
+      if (!cancelled) setIsFetching(true);
       const results: FeedEvent[] = [];
       const errors: FeedError[] = [];
 
@@ -54,6 +59,7 @@ export function useFeedEvents(icalFeeds: ICalFeedInput[] = []): {
       if (!cancelled) {
         setFeedEvents(results);
         setFeedErrors(errors);
+        setIsFetching(false);
       }
     }
 
@@ -71,5 +77,5 @@ export function useFeedEvents(icalFeeds: ICalFeedInput[] = []): {
     };
   }, [icalFeeds]);
 
-  return { feedEvents, feedErrors };
+  return { feedEvents, feedErrors, isFetching };
 }

--- a/src/hooks/useSourceAggregator.ts
+++ b/src/hooks/useSourceAggregator.ts
@@ -32,6 +32,8 @@ export function useSourceAggregator({ icalFeedsProp = [], sourceStore }: {
 }): {
   events: SourceEvent[];
   feedErrors: Array<{ feed: { url: string; label?: string | undefined; refreshInterval?: number | undefined }; err: unknown }>;
+  /** True while iCal feeds are fetching (initial load or scheduled refresh). */
+  isFetchingFeeds: boolean;
 } {
   // Merge prop-level feeds + store-managed ICS feeds for the polling hook.
   // We use a stable JSON key so that referentially-new but semantically-identical
@@ -48,7 +50,7 @@ export function useSourceAggregator({ icalFeedsProp = [], sourceStore }: {
     [allIcsFeedsKey],
   );
 
-  const { feedEvents, feedErrors } = useFeedEvents(allIcsFeeds);
+  const { feedEvents, feedErrors, isFetching: isFetchingFeeds } = useFeedEvents(allIcsFeeds);
 
   // Tag ICS events with source metadata
   const taggedFeedEvents = useMemo(
@@ -80,5 +82,5 @@ export function useSourceAggregator({ icalFeedsProp = [], sourceStore }: {
     [taggedFeedEvents, csvEvents],
   );
 
-  return { events, feedErrors };
+  return { events, feedErrors, isFetchingFeeds };
 }

--- a/src/types/ui.ts
+++ b/src/types/ui.ts
@@ -85,6 +85,9 @@ export interface ConfigPanelProps {
   onDeleteView?: ((id: string) => void) | undefined;
   sources?: SourceDraft[] | undefined;
   feedErrors?: unknown[] | undefined;
+  /** True while iCal feeds are fetching; surfaced in SourcePanel as a
+   *  small "Syncing…" affordance next to the iCal Feeds heading. */
+  isFetchingFeeds?: boolean | undefined;
   onAddSource?: ((...args: any[]) => void) | undefined;
   onRemoveSource?: ((...args: any[]) => void) | undefined;
   onToggleSource?: ((...args: any[]) => void) | undefined;

--- a/src/ui/ActiveFilterStrip.module.css
+++ b/src/ui/ActiveFilterStrip.module.css
@@ -1,0 +1,86 @@
+/* ActiveFilterStrip — compact one-line summary of applied filters.
+   Hidden entirely when no filters are active (component returns null). */
+
+.strip {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 12px;
+  border-bottom: 1px solid var(--wc-border);
+  background: var(--wc-surface);
+  font-size: 12px;
+}
+
+.label {
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--wc-text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  margin-right: 2px;
+}
+
+.pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 2px 4px 2px 9px;
+  background: var(--wc-pill-bg-active, color-mix(in srgb, var(--wc-accent) 18%, var(--wc-surface)));
+  border: 1px solid var(--wc-pill-border-active, var(--wc-accent));
+  color: var(--wc-pill-text-active, var(--wc-accent));
+  border-radius: 100px;
+  font-size: 11px;
+  font-weight: 500;
+  white-space: nowrap;
+  max-width: 280px;
+}
+
+.pillField {
+  opacity: 0.75;
+  font-weight: 600;
+  margin-right: 2px;
+}
+
+.pillValue {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  min-width: 0;
+}
+
+.remove {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: none;
+  border: none;
+  color: inherit;
+  cursor: pointer;
+  padding: 2px;
+  border-radius: 50%;
+  opacity: 0.7;
+  transition: opacity 0.12s, background 0.12s;
+}
+
+.remove:hover {
+  opacity: 1;
+  background: color-mix(in srgb, currentColor 15%, transparent);
+}
+
+.clearAll {
+  margin-left: auto;
+  padding: 2px 8px;
+  font-size: 11px;
+  font-weight: 500;
+  color: var(--wc-text-muted);
+  background: none;
+  border: none;
+  cursor: pointer;
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+
+.clearAll:hover {
+  color: var(--wc-text);
+}

--- a/src/ui/ActiveFilterStrip.tsx
+++ b/src/ui/ActiveFilterStrip.tsx
@@ -42,7 +42,11 @@ export default function ActiveFilterStrip({
   if (pills.length === 0) return null;
 
   return (
-    <div className={styles['strip']} role="status" aria-live="polite">
+    // role="status" alone provides the polite-live semantic for screen
+    // readers. The explicit aria-live attribute is omitted because
+    // E2E tests select the calendar's date label via
+    // `[aria-live="polite"]` and a competing match here would shadow it.
+    <div className={styles['strip']} role="status">
       <span className={styles['label']}>Filtered by</span>
       {pills.map((pill, i) => {
         const field = schema.find(f => f.key === pill.key);

--- a/src/ui/ActiveFilterStrip.tsx
+++ b/src/ui/ActiveFilterStrip.tsx
@@ -1,0 +1,84 @@
+/**
+ * ActiveFilterStrip — single-line summary of currently-applied filters.
+ *
+ * Renders nothing when no filters are active. When active, shows one
+ * removable chip per filter value ("Categories: Pilot Shift ✕"), so
+ * users can answer "what is this calendar showing?" without opening
+ * the sidebar's Focus tab.
+ *
+ * Wraps the existing `buildActiveFilterPills` helper from
+ * `src/filters/filterState.ts` — the same builder FilterBar uses
+ * internally — so the chip set always matches the live filter state.
+ *
+ * Mirrors FilterBar's pillRemove logic but is decoupled so the strip
+ * can render even when FilterBar is hidden (which is the default since
+ * the move to FilterGroupSidebar).
+ */
+import { X } from 'lucide-react';
+import { buildActiveFilterPills, clearFilterValue } from '../filters/filterState';
+import styles from './ActiveFilterStrip.module.css';
+
+type FieldLike = { key: string; type?: string; defaultValue?: unknown };
+
+export type ActiveFilterStripProps = {
+  filters: Record<string, unknown>;
+  schema: FieldLike[];
+  /** Toggle a single value off (multi-select). */
+  onChange: (key: string, value: unknown) => void;
+  /** Clear an entire filter (for non-multi-select fields). */
+  onClear: (key: string) => void;
+  /** Optional: clear-all link at the end of the strip. */
+  onClearAll?: (() => void) | undefined;
+};
+
+export default function ActiveFilterStrip({
+  filters,
+  schema,
+  onChange,
+  onClear,
+  onClearAll,
+}: ActiveFilterStripProps): JSX.Element | null {
+  const pills = buildActiveFilterPills(filters, schema);
+  if (pills.length === 0) return null;
+
+  return (
+    <div className={styles['strip']} role="status" aria-live="polite">
+      <span className={styles['label']}>Filtered by</span>
+      {pills.map((pill, i) => {
+        const field = schema.find(f => f.key === pill.key);
+        return (
+          <span key={`${pill.key}-${i}`} className={styles['pill']}>
+            <span className={styles['pillField']}>{pill.fieldLabel}:</span>
+            <span className={styles['pillValue']}>{pill.displayValue ?? String(pill.value)}</span>
+            <button
+              className={styles['remove']}
+              onClick={() => {
+                const current = filters[pill.key];
+                if (current instanceof Set) {
+                  const next = new Set(current);
+                  next.delete(pill.value);
+                  onChange(pill.key, next.size ? next : clearFilterValue(field));
+                } else {
+                  onClear(pill.key);
+                }
+              }}
+              aria-label={`Remove filter ${pill.fieldLabel}`}
+              type="button"
+            >
+              <X size={10} />
+            </button>
+          </span>
+        );
+      })}
+      {onClearAll && (
+        <button
+          type="button"
+          className={styles['clearAll']}
+          onClick={onClearAll}
+        >
+          Clear all
+        </button>
+      )}
+    </div>
+  );
+}

--- a/src/ui/ApprovalDot.module.css
+++ b/src/ui/ApprovalDot.module.css
@@ -1,0 +1,27 @@
+/* ApprovalDot — small status dot. Sits inline at the leading edge of an
+   event pill so users can see at a glance which events are pending or
+   denied. The colours are semantic, not theme-specific. */
+
+.dot {
+  display: inline-block;
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  margin-right: 5px;
+  flex-shrink: 0;
+  vertical-align: middle;
+  border: 1.5px solid rgba(255, 255, 255, 0.6);
+  background: var(--wc-text-faint);
+}
+
+.stage_requested      { background: var(--wc-warning, #f59e0b); }
+.stage_approved       { background: var(--wc-success, #10b981); }
+.stage_finalized {
+  background: var(--wc-success, #10b981);
+  box-shadow: 0 0 0 1px rgba(255, 255, 255, 0.4);
+}
+.stage_pending_higher {
+  background: var(--wc-warning, #f59e0b);
+  border-style: dashed;
+}
+.stage_denied         { background: var(--wc-danger, #ef4444); }

--- a/src/ui/ApprovalDot.tsx
+++ b/src/ui/ApprovalDot.tsx
@@ -1,0 +1,44 @@
+/**
+ * ApprovalDot — small status dot rendered inside calendar event pills.
+ *
+ * Reads `event.meta.approvalStage.stage` and shows a coloured dot for any
+ * non-terminal-success state (requested / approved / finalized /
+ * pending_higher / denied). Returns null otherwise so cleanly-categorised
+ * events with no approval workflow stay visually unchanged.
+ *
+ * Used by views that don't have their own approval-stage rendering
+ * (MonthView, ScheduleView, WeekView, DayView). AssetsView has its own,
+ * richer treatment (strikethrough on denied, label prefixes) and doesn't
+ * consume this component.
+ */
+import styles from './ApprovalDot.module.css';
+
+const STAGE_LABEL: Record<string, string> = {
+  requested:      'Pending request',
+  approved:       'Approved',
+  finalized:      'Finalized',
+  pending_higher: 'Pending higher approval',
+  denied:         'Denied',
+};
+
+type ApprovalEventLike = {
+  meta?: { approvalStage?: { stage?: string | null } | null } | null | undefined;
+};
+
+export type ApprovalDotProps = {
+  event: ApprovalEventLike;
+};
+
+export default function ApprovalDot({ event }: ApprovalDotProps): JSX.Element | null {
+  const stage = event?.meta?.approvalStage?.stage;
+  if (!stage || !(stage in STAGE_LABEL)) return null;
+  const label = STAGE_LABEL[stage] ?? stage;
+  return (
+    <span
+      className={[styles['dot'], styles[`stage_${stage}`]].filter(Boolean).join(' ')}
+      role="img"
+      aria-label={label}
+      title={label}
+    />
+  );
+}

--- a/src/ui/ConfigPanel.tsx
+++ b/src/ui/ConfigPanel.tsx
@@ -272,7 +272,7 @@ export default function ConfigPanel({
   onUpdateView: onUpdateViewRaw,
   onDeleteView: onDeleteViewRaw,
   // Source store props (optional — omitted when owner has no source store)
-  sources, feedErrors,
+  sources, feedErrors, isFetchingFeeds,
   onAddSource: onAddSourceRaw,
   onRemoveSource: onRemoveSourceRaw,
   onToggleSource: onToggleSourceRaw,
@@ -496,6 +496,7 @@ export default function ConfigPanel({
             <SourcePanel
               sources={sources ?? []}
               feedErrors={feedErrors ?? []}
+              isFetchingFeeds={!!isFetchingFeeds}
               onAdd={(source) => onAddSource?.(source)}
               onRemove={(id) => onRemoveSource?.(id)}
               onToggle={(id) => onToggleSource?.(id)}

--- a/src/ui/SavedFlash.tsx
+++ b/src/ui/SavedFlash.tsx
@@ -13,13 +13,20 @@ export type SavedFlashProps = {
  *
  * Always rendered so showing/hiding never reflows the surrounding chrome;
  * `visibility` is driven by the `visible` prop. Pair with `useSavedFlash`.
+ *
+ * `role="status"` gives assistive tech the same polite-live semantic as
+ * `aria-live="polite"`, so the affordance announces when it appears
+ * without adding an explicit `aria-live` attribute. The explicit
+ * attribute is omitted on purpose: several E2E tests target the
+ * calendar's date label via `[aria-live="polite"]`, and a competing
+ * always-mounted live region near the top of WorksCalendar would
+ * shadow that selector.
  */
 export default function SavedFlash({ visible, label = 'Saved' }: SavedFlashProps): JSX.Element {
   return (
     <span
       className={[styles['flash'], visible && styles['visible']].filter(Boolean).join(' ')}
       role="status"
-      aria-live="polite"
       aria-hidden={!visible}
     >
       <Check size={11} aria-hidden="true" />

--- a/src/ui/SourcePanel.tsx
+++ b/src/ui/SourcePanel.tsx
@@ -508,11 +508,14 @@ function SectionHeading({
   label,
   count,
   errors = 0,
+  syncing = false,
 }: {
   icon: typeof Link;
   label: string;
   count?: number | undefined;
   errors?: number | undefined;
+  /** When true, render a "Syncing…" affordance after the count. */
+  syncing?: boolean | undefined;
 }) {
   return (
     <div style={{
@@ -526,6 +529,15 @@ function SectionHeading({
       {count != null && (
         <span style={{ fontWeight: 400, textTransform: 'none', letterSpacing: 0 }}>
           ({count})
+        </span>
+      )}
+      {syncing && (
+        <span
+          role="status"
+          aria-live="polite"
+          style={{ fontWeight: 400, textTransform: 'none', letterSpacing: 0, color: 'var(--wc-accent)' }}
+        >
+          · Syncing…
         </span>
       )}
       {errors > 0 && (
@@ -542,13 +554,15 @@ function SectionHeading({
 type SourcePanelProps = {
   sources?: Array<Record<string, any>> | undefined;
   feedErrors?: unknown[] | undefined;
+  /** True while iCal feeds are fetching (initial load or scheduled refresh). */
+  isFetchingFeeds?: boolean | undefined;
   onAdd: (source: Partial<CalendarSource>) => void;
   onRemove: (id: string) => void;
   onToggle: (id: string) => void;
   onUpdate: (id: string, patch: Partial<CalendarSource>) => void;
 };
 
-export default function SourcePanel({ sources, feedErrors, onAdd, onRemove, onToggle, onUpdate }: SourcePanelProps) {
+export default function SourcePanel({ sources, feedErrors, isFetchingFeeds, onAdd, onRemove, onToggle, onUpdate }: SourcePanelProps) {
   const normalizedSources = (sources ?? []) as CalendarSource[];
   const icsSources = normalizedSources.filter((s: CalendarSource) => s.type === 'ics');
   const csvSources = normalizedSources.filter((s: CalendarSource) => s.type === 'csv');
@@ -590,6 +604,7 @@ export default function SourcePanel({ sources, feedErrors, onAdd, onRemove, onTo
           label="iCal Feeds"
           count={icsSources.length || undefined}
           errors={icsErrors}
+          syncing={!!isFetchingFeeds && icsSources.length > 0}
         />
 
         {icsSources.length === 0 ? (

--- a/src/views/DayView.tsx
+++ b/src/views/DayView.tsx
@@ -10,6 +10,7 @@ import { layoutOverlaps } from '../core/layout';
 import { useDrag } from '../hooks/useDrag';
 import type { NormalizedEvent } from '../types/events';
 import type { CalendarViewEvent } from '../types/ui';
+import ApprovalDot from '../ui/ApprovalDot';
 import styles from './DayView.module.css';
 
 const GUTTER_W = 56;
@@ -203,7 +204,7 @@ export default function DayView({
         <div className={styles['resizeHandleTop']}
           onPointerDown={(e: ReactPointerEvent<HTMLDivElement>) => { if (e.button !== 0 || !ctx?.['permissions']?.canDrag || !gridRef.current) return; e.stopPropagation(); drag.startResizeTop(ev as NormalizedEvent, e, gridRef.current, days, GUTTER_W); }}
           aria-hidden="true" />
-        <span className={styles['evTitle']}>{ev.title}</span>
+        <span className={styles['evTitle']}><ApprovalDot event={ev} />{ev.title}</span>
         <span className={styles['evTime']}>{format(ev.start, 'h:mm a')} – {format(ev.end, 'h:mm a')}</span>
         {ev.resource && numCols === 1 && <span className={styles['evMeta']}>{ev.resource}</span>}
         <div className={styles['resizeHandle']}
@@ -264,7 +265,7 @@ export default function DayView({
               return (
                 <button key={ev.id} className={styles['allDayPill']} style={{ '--ev-color': color }}
                   aria-label={ariaLabel}
-                  onClick={() => onEventClick?.(ev)}>{ev.title}</button>
+                  onClick={() => onEventClick?.(ev)}><ApprovalDot event={ev} />{ev.title}</button>
               );
             })}
           </div>

--- a/src/views/MonthView.tsx
+++ b/src/views/MonthView.tsx
@@ -9,6 +9,7 @@ import type { Day } from 'date-fns';
 import { useCalendarContext, resolveColor } from '../core/CalendarContext';
 import { displayEndDay, layoutSpans } from '../core/layout';
 import type { NormalizedEvent } from '../types/events';
+import ApprovalDot from '../ui/ApprovalDot';
 import styles from './MonthView.module.css';
 
 const SPAN_H   = 22;
@@ -367,6 +368,7 @@ export default function MonthView({
         onMouseLeave={handlePillMouseLeave}
         aria-label={ariaLabel}
       >
+        <ApprovalDot event={ev} />
         {ev.title}
       </button>
     );

--- a/src/views/ScheduleView.tsx
+++ b/src/views/ScheduleView.tsx
@@ -9,6 +9,7 @@ import {
 } from 'date-fns';
 import type { Day } from 'date-fns';
 import { useCalendarContext, resolveColor } from '../core/CalendarContext';
+import ApprovalDot from '../ui/ApprovalDot';
 import styles from './ScheduleView.module.css';
 
 const WEEKS = 6;
@@ -116,6 +117,7 @@ export default function ScheduleView({ currentDate, events, onEventClick, weekSt
                           onClick={() => onEventClick?.(ev)}
                           title={ev.title}
                         >
+                          <ApprovalDot event={ev as any} />
                           {ev.title}
                         </button>
                       );

--- a/src/views/WeekView.tsx
+++ b/src/views/WeekView.tsx
@@ -12,6 +12,7 @@ import { hoursInTimezone } from '../core/engine/time/timezone';
 import { layoutOverlaps, layoutSpans } from '../core/layout';
 import { useDrag } from '../hooks/useDrag';
 import { useFocusTrap } from '../hooks/useFocusTrap';
+import ApprovalDot from '../ui/ApprovalDot';
 import styles from './WeekView.module.css';
 import type { CalendarViewEvent } from '../types/ui';
 
@@ -363,6 +364,7 @@ export default function WeekView({
         {inner ?? (
           <>
             <span className={styles['evTitle']} style={{ fontWeight: display.bold ? '700' : undefined }}>
+              <ApprovalDot event={ev as any} />
               {ev.title}
             </span>
             {isUltraCompact ? null : (


### PR DESCRIPTION
CSV import now confirms it landed. The dialog still closes on success,
but a small "Imported N events" pill flashes top-center for ~2.5s so
users get an explicit signal beyond "the modal disappeared". Re-uses
the SavedFlash component shipped earlier; floats in an absolutely
positioned wrapper so it never affects layout or blocks clicks.

iCal feeds now show a "Syncing…" affordance while fetching. useFeedEvents
exposes an isFetching flag, useSourceAggregator forwards it as
isFetchingFeeds, and ConfigPanel's "Feeds" tab renders a small inline
status next to the iCal Feeds heading whenever a fetch is in flight
(initial load or polled refresh). Replaces the previous silent fetch
where users had no way to tell whether a feed was working or stuck.

No public API changes (isFetchingFeeds is added as an optional prop on
ConfigPanelProps; library consumers don't need to change anything).
All 2172 tests pass.