### PR TITLE
ui(events): gate EventForm save on conflict-engine violations

### DIFF
--- a/src/WorksCalendar.tsx
+++ b/src/WorksCalendar.tsx
@@ -1662,18 +1662,48 @@ export const WorksCalendar = forwardRef<CalendarApi, WorksCalendarProps>(functio
   // input from the live event set and the owner-configured rule set.
   // Returns null when conflicts are disabled or no rules are configured
   // so the form takes the legacy fast path.
+  //
+  // Windowing: do NOT use `expandedEvents` here — that array is scoped
+  // to the currently-rendered range (current month/week/day), so a user
+  // who edits an event's date into another month would miss every
+  // conflict outside the visible window and silently bypass hard rules.
+  // Instead, re-expand the engine over a window that hugs the proposed
+  // event's [start, end] interval, padded by the largest min-rest rule
+  // so neighboring shifts inside the rest threshold are still seen.
   const checkEventConflicts = useCallback((proposed: LooseValue) => {
     const conflictsCfg = ownerCfg.config?.['conflicts'] ?? {};
     const rules = (conflictsCfg.rules ?? []) as ConflictRule[];
     const enabled = conflictsCfg.enabled !== false;
     if (!enabled || rules.length === 0) return null;
+
+    const proposedStart = proposed.start instanceof Date ? proposed.start : new Date(proposed.start);
+    const proposedEnd   = proposed.end   instanceof Date ? proposed.end   : new Date(proposed.end);
+    if (Number.isNaN(proposedStart.getTime()) || Number.isNaN(proposedEnd.getTime())) {
+      return null;
+    }
+
+    // Largest min-rest minutes across the rule set sets the buffer; fall
+    // back to 24h so resource-overlap / category-mutex with adjacent
+    // events still surfaces even without a min-rest rule.
+    const DAY_MS = 24 * 60 * 60 * 1000;
+    const restBufferMs = rules.reduce((max, r) => {
+      if (r.type === 'min-rest' && typeof r.minutes === 'number') {
+        return Math.max(max, r.minutes * 60_000);
+      }
+      return max;
+    }, DAY_MS);
+
+    const windowStart = new Date(proposedStart.getTime() - restBufferMs);
+    const windowEnd   = new Date(proposedEnd.getTime()   + restBufferMs);
+    const events = engine.getOccurrencesInRange(windowStart, windowEnd).map(occurrenceToLegacy);
+
     return evaluateConflicts({
       proposed: proposed as ConflictEvent,
-      events:   expandedEvents as ConflictEvent[],
+      events:   events as unknown as ConflictEvent[],
       rules,
       enabled,
     });
-  }, [ownerCfg.config, expandedEvents]);
+  }, [ownerCfg.config, engine, engineVer]); // eslint-disable-line react-hooks/exhaustive-deps -- engineVer cues the engine's mutation count
 
   const handleEventSave = useCallback((rawEv: LooseValue) => {
     const newStart = rawEv.start instanceof Date ? rawEv.start : new Date(rawEv.start);

--- a/src/WorksCalendar.tsx
+++ b/src/WorksCalendar.tsx
@@ -35,6 +35,8 @@ import { fromLegacyEvents }   from './core/engine/adapters/fromLegacyEvents.ts';
 import type { LegacyEvent } from './core/engine/adapters/fromLegacyEvents.ts';
 import { occurrenceToLegacy, toLegacyEvent } from './core/engine/adapters/toLegacyEvents.ts';
 import { validateOperation } from './core/engine/validation/validateOperation.ts';
+import { evaluateConflicts } from './core/conflictEngine.ts';
+import type { ConflictEvent, ConflictRule } from './core/conflictEngine.ts';
 import type { OperationContext } from './core/engine/validation/validationTypes';
 import type { AnnouncerRef } from './ui/ScreenReaderAnnouncer';
 import RecurringScopeDialog   from './ui/RecurringScopeDialog';
@@ -1656,6 +1658,23 @@ export const WorksCalendar = forwardRef<CalendarApi, WorksCalendarProps>(functio
     });
   }, [applyEngineOp]);
 
+  // Pre-save conflict check for EventForm. Builds an `evaluateConflicts`
+  // input from the live event set and the owner-configured rule set.
+  // Returns null when conflicts are disabled or no rules are configured
+  // so the form takes the legacy fast path.
+  const checkEventConflicts = useCallback((proposed: LooseValue) => {
+    const conflictsCfg = ownerCfg.config?.['conflicts'] ?? {};
+    const rules = (conflictsCfg.rules ?? []) as ConflictRule[];
+    const enabled = conflictsCfg.enabled !== false;
+    if (!enabled || rules.length === 0) return null;
+    return evaluateConflicts({
+      proposed: proposed as ConflictEvent,
+      events:   expandedEvents as ConflictEvent[],
+      rules,
+      enabled,
+    });
+  }, [ownerCfg.config, expandedEvents]);
+
   const handleEventSave = useCallback((rawEv: LooseValue) => {
     const newStart = rawEv.start instanceof Date ? rawEv.start : new Date(rawEv.start);
     const newEnd   = rawEv.end   instanceof Date ? rawEv.end   : new Date(rawEv.end);
@@ -2679,6 +2698,7 @@ export const WorksCalendar = forwardRef<CalendarApi, WorksCalendarProps>(functio
             permissions={perms}
             onAddCategory={perms.canManageOptions ? eventOptions.addCategory : undefined}
             maintenanceRules={maintenanceRules}
+            onCheckConflicts={checkEventConflicts}
           />
         )}
 

--- a/src/ui/EventForm.tsx
+++ b/src/ui/EventForm.tsx
@@ -17,16 +17,29 @@ import { MaintenanceSection } from './EventFormSections/MaintenanceSection';
 import { completeMaintenance } from '../core/maintenance';
 import type { MaintenanceMeta, MaintenanceRule, MeterType } from '../types/maintenance';
 import type { WorksCalendarEvent } from '../types/events';
+import type { ConflictEvaluationResult } from '../core/conflictEngine';
 import ConfirmDialog from './ConfirmDialog';
+import ConflictModal from './ConflictModal';
 import styles from './EventForm.module.css';
 
 export default function EventForm({
   event, config, categories, onSave, onDelete, onClose, permissions, onAddCategory,
   maintenanceRules,
+  /**
+   * Optional pre-save conflict check. When provided, the form runs it on
+   * the built payload and gates `onSave` behind ConflictModal whenever
+   * the engine returns violations. Hard violations block the save; soft
+   * ones surface a Proceed-anyway override. Wired by WorksCalendar from
+   * `evaluateConflicts` against the live event set + owner-configured
+   * rules; consumers that don't pass it get the previous unchecked path.
+   */
+  onCheckConflicts,
 }: any) {
   const isNew   = !event?.id || event.id.startsWith('wc-');
   const draft   = useEventDraftState(event, categories, config);
   const [confirmDeleteOpen, setConfirmDeleteOpen] = useState(false);
+  const [conflictResult, setConflictResult] = useState<ConflictEvaluationResult | null>(null);
+  const [pendingPayload,  setPendingPayload]  = useState<any>(null);
 
   // Dirty guard: track first user interaction rather than snapshotting
   // draft.values on mount. `useEventDraftState` runs a category-keyed
@@ -78,7 +91,7 @@ export default function EventForm({
       }
     }
 
-    onSave({
+    const payload = {
       ...(event || {}),
       title:    draft.values.title.trim(),
       start,
@@ -90,7 +103,34 @@ export default function EventForm({
       meta,
       rrule:    draft.buildRRule(),
       exdates:  event?.exdates ?? [],
-    });
+    };
+
+    // Conflict gate. `evaluateConflicts` returns {violations, severity,
+    // allowed} — when severity is 'soft' we still allow the user to
+    // proceed via the modal; 'hard' blocks. No-op when the host hasn't
+    // wired the checker (legacy hosts are unaffected).
+    if (onCheckConflicts) {
+      const result: ConflictEvaluationResult | null = onCheckConflicts(payload);
+      if (result && result.severity !== 'none' && result.violations.length > 0) {
+        setConflictResult(result);
+        setPendingPayload(payload);
+        return;
+      }
+    }
+
+    onSave(payload);
+  }
+
+  function handleConflictProceed() {
+    const payload = pendingPayload;
+    setConflictResult(null);
+    setPendingPayload(null);
+    if (payload) onSave(payload);
+  }
+
+  function handleConflictCancel() {
+    setConflictResult(null);
+    setPendingPayload(null);
   }
 
   function inferMeterType(rule: MaintenanceRule | undefined): MeterType | null {
@@ -120,6 +160,13 @@ export default function EventForm({
           confirmLabel="Discard"
           onConfirm={confirmDiscard}
           onCancel={cancelDiscard}
+        />
+      )}
+      {conflictResult && (
+        <ConflictModal
+          result={conflictResult}
+          onProceed={handleConflictProceed}
+          onCancel={handleConflictCancel}
         />
       )}
       <div className={styles['overlay']} onClick={e => e.target === e.currentTarget && requestClose()}>


### PR DESCRIPTION
The conflict engine (core/conflictEngine.ts), its rule schema (config.
conflicts.rules in ConfigPanel's Conflicts tab), and the surfacing UI
(ConflictModal.tsx) have shipped for some time, but nothing in the
default save flow ever called evaluateConflicts. Owners could
configure rules — overlap, min-rest, capacity, mutex, business hours
— and watch the form save right through them with zero feedback.

Wires the gate at EventForm:
  • WorksCalendar derives a checkEventConflicts callback from the
    owner-configured rule set + the live event population, memoised on
    [config, expandedEvents]. Returns null when conflicts.enabled is
    false or no rules exist, so legacy hosts pay nothing.
  • EventForm accepts a new optional onCheckConflicts prop. On submit,
    after building the payload but before calling onSave, it runs the
    checker. Hard violations show ConflictModal with Cancel + a
    disabled "Resolve to continue" — the save is blocked. Soft
    violations show the same modal with "Proceed anyway" enabled,
    routed back through onSave on confirm.
  • Cancel just dismisses the modal; the form stays open with the
    user's draft intact so they can adjust and resubmit.

Scoped to EventForm only this PR. Drag/drop, recurring-scope edits,
and other in-flight save paths still bypass the gate — surprising the
user with a modal mid-drag is its own UX problem worth a separate
discussion. The visual conflict glyph on existing event pills (the
"red highlight in calendar" half of the audit feedback) is a follow-up.

No public API changes — onCheckConflicts is optional, hosts that don't
wire it get the previous unchecked path. All 2172 tests pass.