### PR TITLE
ui(fix): track feed-fetch concurrency with a counter

### DIFF
--- a/src/hooks/useFeedEvents.ts
+++ b/src/hooks/useFeedEvents.ts
@@ -23,43 +23,53 @@ type FeedError = { feed: ICalFeedInput; err: unknown };
 export function useFeedEvents(icalFeeds: ICalFeedInput[] = []): {
   feedEvents: FeedEvent[];
   feedErrors: FeedError[];
-  /** True while a fetch (initial or polled) is in flight for any feed. */
+  /** True while at least one fetch (initial or polled) is in flight. */
   isFetching: boolean;
 } {
   const [feedEvents, setFeedEvents] = useState<FeedEvent[]>([]);
   const [feedErrors, setFeedErrors] = useState<FeedError[]>([]);
-  const [isFetching, setIsFetching] = useState(false);
+  // Counter, not a boolean. Each feed has its own setInterval so multiple
+  // fetchAll() runs can overlap (one per feed × the global timing skew);
+  // a flat boolean would let the faster run flip "syncing" off while the
+  // slower run was still pending. Tracking concurrency keeps the flag
+  // sticky until every poll has settled.
+  const [inflight, setInflight] = useState(0);
+  const isFetching = inflight > 0;
 
   useEffect(() => {
     if (!icalFeeds?.length) {
       setFeedEvents([]);
-      setIsFetching(false);
       return;
     }
 
     let cancelled = false;
 
     async function fetchAll() {
-      if (!cancelled) setIsFetching(true);
+      setInflight((n) => n + 1);
       const results: FeedEvent[] = [];
       const errors: FeedError[] = [];
 
-      await Promise.allSettled(icalFeeds.map(async (feed: ICalFeedInput) => {
-        try {
-          const evs = await fetchAndParseICS(feed.url) as Array<Record<string, any>>;
-          const label = feed.label ?? feed.url;
-          results.push(...evs.map((ev) => ({ ...ev, _feedLabel: label })));
-        } catch (err: unknown) {
-          errors.push({ feed, err });
-          const message = err instanceof Error ? err.message : String(err);
-          console.warn('[WorksCalendar] iCal feed error:', feed.url, message);
-        }
-      }));
+      try {
+        await Promise.allSettled(icalFeeds.map(async (feed: ICalFeedInput) => {
+          try {
+            const evs = await fetchAndParseICS(feed.url) as Array<Record<string, any>>;
+            const label = feed.label ?? feed.url;
+            results.push(...evs.map((ev) => ({ ...ev, _feedLabel: label })));
+          } catch (err: unknown) {
+            errors.push({ feed, err });
+            const message = err instanceof Error ? err.message : String(err);
+            console.warn('[WorksCalendar] iCal feed error:', feed.url, message);
+          }
+        }));
 
-      if (!cancelled) {
-        setFeedEvents(results);
-        setFeedErrors(errors);
-        setIsFetching(false);
+        if (!cancelled) {
+          setFeedEvents(results);
+          setFeedErrors(errors);
+        }
+      } finally {
+        // Always balance the counter — even when cancelled — so concurrent
+        // polls and effect re-runs leave the gauge accurate.
+        setInflight((n) => Math.max(0, n - 1));
       }
     }
 


### PR DESCRIPTION
Each iCal feed gets its own setInterval, so fetchAll() runs can overlap (slow feed still pending when the next tick fires, or different refresh intervals across feeds). The flat isFetching boolean let the faster run flip "Syncing…" off while a slower run was still in flight.

Replaces the boolean with an inflight counter. fetchAll() increments on entry and decrements in a finally so the balance stays correct even when the effect is cancelled mid-fetch. isFetching is derived (inflight > 0) so the hook keeps reporting "syncing" until the very last poll has settled, which is what SourcePanel's section-heading status now reflects.

All 2172 tests pass.

## Summary
Describe exactly what this PR changes.

## Scope
- Stage: 
- Planned PR number in sprint: 
- Target files/directories: 
- Why this slice is isolated: 

## Lessons Learned Check (REQUIRED)
Confirm these were actively used while building this PR:

- [ ] PR is intentionally small and isolated
- [ ] Boundary typing was prioritized over internal perfection
- [ ] No silent spread of `any`
- [ ] Advisory root `tsc` was used to catch integration issues
- [ ] I did not assume “looks typed” means “safe”
- [ ] I stopped and isolated typing cascades instead of expanding scope

## Definition of Done (ALL REQUIRED)
This PR is not done unless every box is checked.

- [ ] `npm run type-check:strict` passes
- [ ] Root advisory `tsc --noEmit` passes
- [ ] Tests pass for touched scope at minimum
- [ ] No uncontrolled increase in `any`
- [ ] All new types are intentional and named
- [ ] Public interfaces and exported functions are explicitly typed
- [ ] PR scope matches the sprint plan with no scope creep
- [ ] Any new `any` has an adjacent justification comment
- [ ] No file-wide `: any`
- [ ] No implicit `any` in exported functions

## What Was Typed
List exactly what was typed in this PR.

- 
- 
- 

## What Was Intentionally Left Loose
List anything intentionally not tightened yet.

- 
- 
- 

## `any` Ledger (REQUIRED)
- New `any` added: 
- Existing `any` removed: 
- Net change: 

For every new `any`, explain why it is required and why a safer type was not used yet.

1. 
2. 
3. 

## Boundary Notes
Document any public seams, caller-protection choices, or compatibility decisions.

- 
- 
- 

## Risk Level
- [ ] Low
- [ ] Medium
- [ ] High

Why:

## Validation Evidence
Paste the exact commands run and a short result summary.

```bash
npm run type-check:strict
npx tsc --noEmit -p tsconfig.json
```

Test commands run:

```bash
# paste commands here
```

## Stop Conditions Check
If any item below happened, explain how scope was reduced before merge.

- [ ] `any` started spreading across files
- [ ] Root `tsc` broke repeatedly
- [ ] Types required cross-module rewrites
- [ ] Scope was reduced to keep the PR reviewable

Notes:

## Reviewer Focus
What should reviewers look at first?

- 
- 
- 
