### PR TITLE
ui(fix): preserve approvalStage on EventForm save across category-clear

### DIFF
--- a/src/ui/EventForm.tsx
+++ b/src/ui/EventForm.tsx
@@ -127,11 +127,24 @@ export default function EventForm({
       }
     }
 
-    // Auto-tag approvalStage when the chosen category routes through the
-    // approval state machine. Only seed a *new* stage — never overwrite
-    // an existing approvalStage that's already moved past 'requested'
-    // (approved / finalized / denied) since editing the event shouldn't
-    // rewind the lifecycle.
+    // Preserve the original approvalStage across `useEventDraftState`'s
+    // mount-time category-clear effect. That effect rebuilds
+    // `draft.values.meta` from scratch on every category change (and on
+    // mount), keeping only template metadata — so by the time we land
+    // here, an approved/finalized/denied event has lost its stage from
+    // the draft. Reading off `event.meta.approvalStage` (the prop, not
+    // the draft) restores the original lifecycle so the save doesn't
+    // regress workflow state.
+    const originalStage = (event?.meta?.approvalStage as Record<string, unknown> | null | undefined) ?? null;
+    if (originalStage && !meta?.['approvalStage']) {
+      meta = { ...(meta ?? {}), approvalStage: originalStage };
+    }
+
+    // Auto-tag a fresh approvalStage when the chosen category routes
+    // through the approval state machine AND the event has no stage
+    // yet (post-restoration). Never overwrites a stage that already
+    // moved past requested — editing an approved event must not rewind
+    // the lifecycle to requested.
     const draftCategory = draft.values.category || null;
     const categoryNeedsApproval = !!draftCategory && approvalCategorySet.has(String(draftCategory));
     const existingStage = (meta?.['approvalStage'] as { stage?: string } | undefined)?.stage;


### PR DESCRIPTION
useEventDraftState's mount-time category effect (hooks/useEventDraftState .ts:161-168) rebuilds draft.values.meta from scratch every time the category changes — and it fires once on mount — so by the time handleSubmit runs, an event whose original meta carried approvalStage: { stage: 'approved' | 'finalized' | 'denied' } has lost that stage from the draft. Two consequences:

- The save payload merged `{ ...event, ..., meta }` where `meta` was the cleared draft meta, silently dropping the original stage.
- The new auto-tag block from this PR's previous commit then saw existingStage === undefined and re-injected approvalStage: { stage: 'requested' }, regressing approved / finalized / denied events back to requested on any field edit.

Fix reads the original approvalStage off `event.meta.approvalStage` (the prop, which the draft hook can't touch) and restores it onto the draft meta before the auto-tag block runs. After restoration:

- Edits to an approved event keep stage='approved' on save.
- New events with an approval-required category still get stage='requested'.
- Events whose category was changed FROM non-approval TO approval still get stage='requested' (no original stage to restore).

Scoped to approvalStage only — the broader question of whether the draft hook should drop arbitrary meta on category change is a separate concern, but this regression had to ship as a fix.

All 2172 tests pass.

## Summary
Describe exactly what this PR changes.

## Scope
- Stage: 
- Planned PR number in sprint: 
- Target files/directories: 
- Why this slice is isolated: 

## Lessons Learned Check (REQUIRED)
Confirm these were actively used while building this PR:

- [ ] PR is intentionally small and isolated
- [ ] Boundary typing was prioritized over internal perfection
- [ ] No silent spread of `any`
- [ ] Advisory root `tsc` was used to catch integration issues
- [ ] I did not assume “looks typed” means “safe”
- [ ] I stopped and isolated typing cascades instead of expanding scope

## Definition of Done (ALL REQUIRED)
This PR is not done unless every box is checked.

- [ ] `npm run type-check:strict` passes
- [ ] Root advisory `tsc --noEmit` passes
- [ ] Tests pass for touched scope at minimum
- [ ] No uncontrolled increase in `any`
- [ ] All new types are intentional and named
- [ ] Public interfaces and exported functions are explicitly typed
- [ ] PR scope matches the sprint plan with no scope creep
- [ ] Any new `any` has an adjacent justification comment
- [ ] No file-wide `: any`
- [ ] No implicit `any` in exported functions

## What Was Typed
List exactly what was typed in this PR.

- 
- 
- 

## What Was Intentionally Left Loose
List anything intentionally not tightened yet.

- 
- 
- 

## `any` Ledger (REQUIRED)
- New `any` added: 
- Existing `any` removed: 
- Net change: 

For every new `any`, explain why it is required and why a safer type was not used yet.

1. 
2. 
3. 

## Boundary Notes
Document any public seams, caller-protection choices, or compatibility decisions.

- 
- 
- 

## Risk Level
- [ ] Low
- [ ] Medium
- [ ] High

Why:

## Validation Evidence
Paste the exact commands run and a short result summary.

```bash
npm run type-check:strict
npx tsc --noEmit -p tsconfig.json
```

Test commands run:

```bash
# paste commands here
```

## Stop Conditions Check
If any item below happened, explain how scope was reduced before merge.

- [ ] `any` started spreading across files
- [ ] Root `tsc` broke repeatedly
- [ ] Types required cross-module rewrites
- [ ] Scope was reduced to keep the PR reviewable

Notes:

## Reviewer Focus
What should reviewers look at first?

- 
- 
- 
