### PR TITLE
ui(pools): polish UX gaps from #386 (a11y + location + tried-trail)

### DIFF
--- a/src/WorksCalendar.tsx
+++ b/src/WorksCalendar.tsx
@@ -292,6 +292,14 @@ export type WorksCalendarProps = {
   onConflictCheck?: (event: WorksCalendarEvent, candidate: WorksCalendarEvent) => Promise<unknown>;
   onApprovalAction?: (event: WorksCalendarEvent, action: string) => void | Promise<void>;
   renderAssetLocation?: (locationData: AssetLocationData, asset: { id: string }) => ReactNode;
+  /**
+   * Optional renderer for the location banner of a pool row. Pools
+   * aggregate multiple resources, so the per-resource locations map
+   * has no entry — the banner stays empty by default. Provide a
+   * renderer if your domain has a natural aggregation (centroid,
+   * dominant region, "N/A · mixed", etc.). Issue #386 item #9.
+   */
+  renderPoolLocation?: (pool: { id: string; memberIds: readonly string[] }) => ReactNode;
   renderAssetBadges?: (asset: { id: string }) => ReactNode;
   /** Maintenance rules offered in the EventForm. When non-empty, the form
    *  shows a Maintenance section; lifecycle='complete' triggers a built-in
@@ -566,6 +574,7 @@ export const WorksCalendar = forwardRef<CalendarApi, WorksCalendarProps>(functio
     onConflictCheck,
     onApprovalAction,
     renderAssetLocation,
+    renderPoolLocation,
     renderAssetBadges,
     maintenanceRules,
     renderConflictBody,
@@ -2619,6 +2628,7 @@ export const WorksCalendar = forwardRef<CalendarApi, WorksCalendarProps>(functio
                   onCollapsedGroupsChange={setActiveAssetsCollapsed}
                   locationProvider={effectiveLocationProvider}
                   renderAssetLocation={renderAssetLocation}
+                  renderPoolLocation={renderPoolLocation}
                   renderAssetBadges={renderAssetBadges}
                   onEditAssets={ownerCfg.isOwner ? () => ownerCfg.openConfigToTab('assets') : undefined}
                   onRequestAsset={canRequestAsset ? () => setAssetRequestOpen(true) : undefined}

--- a/src/__tests__/WorksCalendar.scheduleModel.integration.test.tsx
+++ b/src/__tests__/WorksCalendar.scheduleModel.integration.test.tsx
@@ -101,7 +101,12 @@ describe('WorksCalendar schedule model integration', () => {
     });
   }, 30000);
 
-  it('does not create duplicate open-shift records when PTO is re-saved', async () => {
+  // Suspended on CI — calls requestPtoForAlex() twice with a button-find
+  // in between, routinely brushes the 30s timeout on slow runners. Locally
+  // it's stable. Re-enable (and bump timeout if needed) on any PR that
+  // alters the PTO workflow / shift coverage path so the regression
+  // signal isn't lost. Tracked alongside #386.
+  it.skip('does not create duplicate open-shift records when PTO is re-saved', async () => {
     const apiRef = createRef<any>();
     render(<WorksCalendar ref={apiRef} employees={employees} events={[baseShift]} />);
 

--- a/src/ui/ConflictModal.module.css
+++ b/src/ui/ConflictModal.module.css
@@ -108,6 +108,14 @@
   color: var(--wc-text-muted, #6b7280);
 }
 
+.poolEvaluated {
+  flex-basis: 100%;
+  font-family: var(--wc-font-mono, ui-monospace, monospace);
+  font-size: 11px;
+  color: var(--wc-text-muted, #6b7280);
+  padding-left: 28px;
+}
+
 .footer {
   display: flex;
   justify-content: flex-end;

--- a/src/ui/ConflictModal.module.css
+++ b/src/ui/ConflictModal.module.css
@@ -109,7 +109,10 @@
 }
 
 .poolEvaluated {
-  flex-basis: 100%;
+  /* `.item` is a 3-column grid (auto 1fr auto); span the whole row
+     so a long evaluated list lays out as a full-width second row
+     instead of compressing the message column. */
+  grid-column: 1 / -1;
   font-family: var(--wc-font-mono, ui-monospace, monospace);
   font-size: 11px;
   color: var(--wc-text-muted, #6b7280);

--- a/src/ui/ConflictModal.tsx
+++ b/src/ui/ConflictModal.tsx
@@ -59,20 +59,43 @@ export default function ConflictModal({
         </div>
 
         <ul className={styles['list']} aria-label="Conflict violations">
-          {result.violations.map((v: any, i: number) => (
-            <li
-              key={`${v.rule}:${v.conflictingEventId ?? i}`}
-              className={styles['item']}
-              data-severity={v.severity}
-              data-rule={v.rule}
-            >
-              <span className={styles['severityTag']}>{v.severity}</span>
-              <span className={styles['message']}>{v.message}</span>
-              <span className={styles['ruleTag']} aria-label={`rule ${v.rule}`}>
-                {v.rule}
-              </span>
-            </li>
-          ))}
+          {result.violations.map((v: any, i: number) => {
+            // Pool-unresolvable rejections carry an `evaluated` trail
+            // (the ordered list of members the resolver actually
+            // tried) and a structured error `code`. Surface both so
+            // the user can see "tried A, B; both conflicted" instead
+            // of a bare "no member available" — issue #386 item #8.
+            const isPoolFailure = v.rule === 'pool-unresolvable';
+            const evaluated: readonly string[] = isPoolFailure && Array.isArray(v.details?.evaluated)
+              ? v.details.evaluated
+              : [];
+            const code = isPoolFailure && typeof v.details?.code === 'string'
+              ? v.details.code
+              : null;
+            return (
+              <li
+                key={`${v.rule}:${v.conflictingEventId ?? i}`}
+                className={styles['item']}
+                data-severity={v.severity}
+                data-rule={v.rule}
+              >
+                <span className={styles['severityTag']}>{v.severity}</span>
+                <span className={styles['message']}>{v.message}</span>
+                <span className={styles['ruleTag']} aria-label={`rule ${v.rule}`}>
+                  {code ?? v.rule}
+                </span>
+                {evaluated.length > 0 && (
+                  <span
+                    className={styles['poolEvaluated']}
+                    aria-label={`Pool members tried: ${evaluated.join(', ')}`}
+                    data-testid="pool-evaluated"
+                  >
+                    Tried members: {evaluated.join(', ')}
+                  </span>
+                )}
+              </li>
+            );
+          })}
         </ul>
 
         <div className={styles['footer']}>

--- a/src/ui/__tests__/ConflictModal.test.tsx
+++ b/src/ui/__tests__/ConflictModal.test.tsx
@@ -96,3 +96,60 @@ describe('ConflictModal — actions', () => {
     expect(onCancel).toHaveBeenCalledTimes(1);
   });
 });
+
+describe('ConflictModal — pool-unresolvable details (#386 item #8)', () => {
+  const poolResult = {
+    violations: [
+      {
+        rule: 'pool-unresolvable',
+        severity: 'hard',
+        message: 'Pool "drivers" has no available member for the requested window.',
+        details: {
+          poolId: 'drivers',
+          code: 'NO_AVAILABLE_MEMBER',
+          evaluated: ['d1', 'd2', 'd3'],
+        },
+      },
+    ],
+    severity: 'hard',
+    allowed: false,
+  };
+
+  it('renders the ordered evaluated trail so users see which members were tried', () => {
+    render(<ConflictModal result={poolResult} onProceed={vi.fn()} onCancel={vi.fn()} />);
+    const evaluated = screen.getByTestId('pool-evaluated');
+    expect(evaluated).toHaveTextContent('Tried members: d1, d2, d3');
+    // Screen-reader friendly aria-label spells the same thing out.
+    expect(evaluated).toHaveAttribute('aria-label', 'Pool members tried: d1, d2, d3');
+  });
+
+  it('shows the structured error code in place of the rule tag', () => {
+    render(<ConflictModal result={poolResult} onProceed={vi.fn()} onCancel={vi.fn()} />);
+    expect(screen.getByText('NO_AVAILABLE_MEMBER')).toBeInTheDocument();
+  });
+
+  it('omits the evaluated row when the trail is empty (e.g. POOL_DISABLED)', () => {
+    const disabledResult = {
+      violations: [
+        {
+          rule: 'pool-unresolvable',
+          severity: 'hard',
+          message: 'Pool "drivers" is disabled.',
+          details: { poolId: 'drivers', code: 'POOL_DISABLED', evaluated: [] },
+        },
+      ],
+      severity: 'hard',
+      allowed: false,
+    };
+    render(<ConflictModal result={disabledResult} onProceed={vi.fn()} onCancel={vi.fn()} />);
+    expect(screen.queryByTestId('pool-evaluated')).toBeNull();
+    // Code still surfaces in the rule slot.
+    expect(screen.getByText('POOL_DISABLED')).toBeInTheDocument();
+  });
+
+  it('does not affect non-pool violations (regression guard)', () => {
+    render(<ConflictModal result={hardResult} onProceed={vi.fn()} onCancel={vi.fn()} />);
+    expect(screen.queryByTestId('pool-evaluated')).toBeNull();
+    expect(screen.getByText('ovr')).toBeInTheDocument();
+  });
+});

--- a/src/views/AssetsView.tsx
+++ b/src/views/AssetsView.tsx
@@ -93,6 +93,14 @@ interface AssetsViewProps {
   categoriesConfig?: { categories?: Array<{ id?: string; color?: string }>; pillStyle?: string } | undefined;
   locationProvider?: LocationProvider | null | undefined;
   renderAssetLocation?: ((locationData: LocationData | null, asset: { id: string }) => ReactNode) | undefined;
+  /**
+   * Optional renderer for the location banner of a pool row. Pools
+   * don't appear in the per-resource locations map (they aggregate
+   * members), so the banner stays empty by default. Provide a renderer
+   * if your domain has a natural aggregation (centroid, dominant
+   * region, "N/A · mixed", etc.) — issue #386 item #9.
+   */
+  renderPoolLocation?: ((pool: { id: string; memberIds: readonly string[] }) => ReactNode) | undefined;
   renderAssetBadges?: ((asset: { id: string }) => ReactNode) | undefined;
   collapsedGroups?: Set<string> | string[] | undefined;
   onCollapsedGroupsChange?: ((next: Set<string>) => void) | undefined;
@@ -310,6 +318,7 @@ export default function AssetsView({
   categoriesConfig,
   locationProvider,
   renderAssetLocation,
+  renderPoolLocation,
   renderAssetBadges,
   collapsedGroups: collapsedGroupsProp,
   onCollapsedGroupsChange,
@@ -1146,6 +1155,14 @@ export default function AssetsView({
                   style={{ width: NAME_W, minWidth: NAME_W, height: rowH }}
                   role="rowheader"
                   aria-label={isPool ? `Pool: ${displayLabel}` : displayLabel}
+                  // Pool rows aggregate multiple resources — without an
+                  // aria-roledescription a screen reader presents them
+                  // as a single resource named "Pool: <name>". The
+                  // hidden description spells out the aggregate semantic
+                  // and member count so non-sighted users know clicking
+                  // books any one member (issue #386 item #10).
+                  aria-roledescription={isPool ? 'resource pool' : undefined}
+                  aria-describedby={isPool ? `pool-desc-${rowData.poolId}` : undefined}
                   data-resource={resource}
                   title={memberTooltip}
                 >
@@ -1156,6 +1173,14 @@ export default function AssetsView({
                     </span>
                     {sublabel && (
                       <span className={styles['assetSublabel']}>{sublabel}</span>
+                    )}
+                    {isPool && (
+                      <span
+                        id={`pool-desc-${rowData.poolId}`}
+                        className={styles['srOnly']}
+                      >
+                        {`Resource pool aggregating ${rowData.memberIds.length} ${rowData.memberIds.length === 1 ? 'member' : 'members'}; selecting a date books one of them.`}
+                      </span>
                     )}
                     {!isPool && renderAssetBadges && (
                       <div data-testid="asset-badges" style={{ marginTop: 2 }}>
@@ -1177,6 +1202,15 @@ export default function AssetsView({
                           ? <span className={styles['locationText']}>{locationData.text}</span>
                           : <span className={styles['locationPlaceholder']}>Location —</span>
                       }
+                    </div>
+                  )}
+                  {isPool && renderPoolLocation && (
+                    <div
+                      className={styles['locationBanner']}
+                      aria-label="Pool location"
+                      data-status="pool"
+                    >
+                      {renderPoolLocation({ id: rowData.poolId, memberIds: rowData.memberIds })}
                     </div>
                   )}
                 </div>

--- a/src/views/__tests__/AssetsView.pools.test.tsx
+++ b/src/views/__tests__/AssetsView.pools.test.tsx
@@ -177,6 +177,58 @@ describe('AssetsView — resource pools (issue #212)', () => {
     expect(pill.getAttribute('aria-label')).toContain('resolved from pool West Fleet');
   });
 
+  it('marks pool rowheaders with aria-roledescription and a hidden description (#386 item #10)', () => {
+    // A screen reader presented "Pool: West Fleet" as a single
+    // resource without the aggregate cue. The hidden description and
+    // aria-roledescription together announce the pool semantic and
+    // member count so non-sighted users know the click books any one.
+    renderView({
+      assets: basicAssets,
+      pools:  [{ id: 'fleet-west', name: 'West Fleet', memberIds: ['N121AB', 'N505CD'], strategy: 'round-robin' }],
+    });
+    const header = screen.getByRole('rowheader', { name: 'Pool: West Fleet' });
+    expect(header).toHaveAttribute('aria-roledescription', 'resource pool');
+    const describedBy = header.getAttribute('aria-describedby');
+    expect(describedBy).toBe('pool-desc-fleet-west');
+    const desc = document.getElementById(describedBy!);
+    expect(desc).not.toBeNull();
+    expect(desc!.textContent).toContain('aggregating 2 members');
+    expect(desc!.textContent).toContain('selecting a date books one of them');
+  });
+
+  it('does not stamp aria-roledescription on regular asset rowheaders', () => {
+    renderView({
+      assets: basicAssets,
+      pools:  [{ id: 'fleet-west', name: 'West Fleet', memberIds: ['N121AB'], strategy: 'round-robin' }],
+    });
+    const assetHeader = screen.getByRole('rowheader', { name: 'N505CD' });
+    expect(assetHeader).not.toHaveAttribute('aria-roledescription');
+    expect(assetHeader).not.toHaveAttribute('aria-describedby');
+  });
+
+  it('renders a pool location banner only when renderPoolLocation is provided (#386 item #9)', () => {
+    const renderPoolLocation = vi.fn(({ memberIds }) => `${memberIds.length} aircraft`);
+    renderView({
+      assets: basicAssets,
+      pools:  [{ id: 'fleet-west', name: 'West Fleet', memberIds: ['N121AB', 'N505CD'], strategy: 'round-robin' }],
+      renderPoolLocation,
+    });
+    expect(screen.getByLabelText('Pool location')).toBeInTheDocument();
+    expect(screen.getByText('2 aircraft')).toBeInTheDocument();
+    expect(renderPoolLocation).toHaveBeenCalledWith({
+      id: 'fleet-west',
+      memberIds: ['N121AB', 'N505CD'],
+    });
+  });
+
+  it('omits the pool location banner when renderPoolLocation is not provided (default behavior)', () => {
+    renderView({
+      assets: basicAssets,
+      pools:  [{ id: 'fleet-west', name: 'West Fleet', memberIds: ['N121AB'], strategy: 'round-robin' }],
+    });
+    expect(screen.queryByLabelText('Pool location')).toBeNull();
+  });
+
   it('does not render disabled pools as rows', () => {
     // Disabled pools stay in history but can't accept new bookings — the
     // resolver rejects them as POOL_DISABLED — so they must not render as


### PR DESCRIPTION
## Summary

Slice 2 of #386 — three small UX polish items on the resource-pools
surface. Each ships as an opt-in extension that defaults to today's
behavior.

- **#10 a11y** — Pool rowheaders carry `aria-roledescription="resource pool"`
  plus a visually-hidden description (member count + "selecting a date
  books one of them") referenced via `aria-describedby`. Screen
  readers used to present "Pool: West Fleet" as a single resource;
  this cue makes the aggregate semantic explicit.
- **#9 location banner** — `AssetsView` gains an optional
  `renderPoolLocation({ id, memberIds }) => ReactNode` prop;
  `WorksCalendar` threads it through. Hosts with a natural
  aggregation (centroid, dominant region, "N/A · mixed") render a
  banner; otherwise pool rows stay visually empty as before.
- **#8 ConflictModal** — Pool-unresolvable rejections render
  "Tried members: A, B, C" beneath the message when
  `details.evaluated` is non-empty, and surface the structured code
  (`NO_AVAILABLE_MEMBER`, `POOL_DISABLED`, …) in place of the rule
  tag. Empty trails (`POOL_DISABLED`/`POOL_EMPTY`/`POOL_UNKNOWN`)
  still omit the row. Non-pool violations are unchanged.

Also includes the same flaky-PTO-test suspension as #432 (cherry-pick),
since the slice 2 branch was forked off main before that fix landed.
The duplicate commit will dissolve when this PR rebases off main
post-#432.

## Test plan

- [x] `tsc --noEmit` clean
- [x] `vitest run` — 2181 passing, 0 failures (7 new tests)
- [x] AssetsView a11y test asserts `aria-roledescription`, the
      hidden description, and that asset rows are unaffected
- [x] AssetsView pool-location test asserts the banner renders only
      when `renderPoolLocation` is provided, and is called with the
      expected `{ id, memberIds }` shape
- [x] ConflictModal tests cover the evaluated trail (rendered
      contents + aria-label), the structured code in place of the
      rule tag, the empty-trail omission, and a regression guard
      that non-pool violations stay unchanged

Issue #386 is left open for the v2 query-pool engine direction in
the comment thread (a much larger, separate design pass).

https://claude.ai/code/session_01XojXzZPdEPuGbX2TyLY1pu

---
_Generated by [Claude Code](https://claude.ai/code/session_01XojXzZPdEPuGbX2TyLY1pu)_