### PR TITLE
ui(pools): PoolCard + PoolBuilder for v2 query/hybrid pools (#386)

### DIFF
--- a/docs/ResourcePools.md
+++ b/docs/ResourcePools.md
@@ -401,6 +401,82 @@ to whichever array drives ordering: `pool.memberIds` for `manual` /
 the candidate set (resource removed, no longer matches the filter)
 don't break rotation — the modulo math wraps as before.
 
+## UI components
+
+`works-calendar` ships two opt-in UI components for surfacing and
+editing pools. Hosts mount them wherever their config UI lives —
+they take pools in / out via props and don't depend on any
+particular layout.
+
+### `PoolCard`
+
+Read-only summary card. Renders the pool name, a type chip (Manual /
+Query / Hybrid), a plain-English clause list ("refrigerated · within
+50 mi of event"), and an optional live "Matches N · M excluded"
+counter when a `resources` registry is provided.
+
+```tsx
+import { PoolCard } from 'works-calendar';
+
+<PoolCard
+  pool={pool}
+  resources={resources}                      // optional: drives live counts
+  onEdit={() => setEditing(pool)}            // optional: shows Edit button
+  onToggleDisabled={() => toggle(pool.id)}   // optional: Disable / Enable
+/>
+```
+
+### `PoolBuilder`
+
+Guided create / edit modal. Walks the user through type → name →
+rules → strategy with progressive disclosure:
+
+- **Manual pools** — checkbox list of resources to include.
+- **Query / hybrid pools** — capability chips (auto-derived from each
+  resource's `meta.capabilities` boolean keys, or supplied as a
+  curated `capabilityCatalog` prop) plus an optional radius clause
+  ("within N miles of the event").
+- **Strategy picker** — `first-available` / `least-loaded` /
+  `round-robin` / `closest`. The builder blocks Save with an inline
+  warning when `closest` is picked without a radius clause, so the
+  new strategy never ships without a reference point.
+
+A live "Matches N · M excluded" preview tracks the draft as the user
+types, using `evaluateQuery` against the live registry.
+
+```tsx
+import { PoolBuilder } from 'works-calendar';
+
+<PoolBuilder
+  pool={editing}                             // null to create a new one
+  resources={resources}
+  capabilityCatalog={[                       // optional curation
+    { id: 'refrigerated', label: 'Refrigerated' },
+    { id: 'heavy_haul',   label: 'Heavy Haul' },
+  ]}
+  onSave={(next) => persist(next)}
+  onCancel={() => setEditing(null)}
+/>
+```
+
+The builder produces a concrete `ResourcePool`; persistence is the
+host's problem (typically wired through `onPoolsChange`).
+
+### `summarizePool` / `summarizeQuery`
+
+Pure helpers that turn a pool or query into a `PoolSummary`
+object — `{ typeLabel, strategyLabel, clauseLabels, headline }`.
+Useful when you want the same plain-English text in non-React
+surfaces (audit log entries, plain text emails, command-palette
+hints) without re-rendering a component.
+
+```ts
+import { summarizePool } from 'works-calendar';
+
+const { headline, clauseLabels } = summarizePool(pool);
+// → "Query pool · refrigerated · within 50 mi of event"
+```
+
 ## Sequence counter on onPoolsChange
 
 `onPoolsChange(pools, meta)` receives a monotonic `meta.sequence`

--- a/src/index.ts
+++ b/src/index.ts
@@ -185,6 +185,13 @@ export {
   createMetaPathLocationAdapter,
 } from './core/pools/locationAdapters';
 export type { ResourceLocation, ResourceLocationAdapter } from './core/pools/locationAdapters';
+// ── Resource pools v2 — UI components (#386) ──────────────────────────────
+export { default as PoolCard }    from './ui/pools/PoolCard';
+export type { PoolCardProps }      from './ui/pools/PoolCard';
+export { default as PoolBuilder } from './ui/pools/PoolBuilder';
+export type { PoolBuilderProps, CapabilityOption } from './ui/pools/PoolBuilder';
+export { summarizePool, summarizeQuery } from './ui/pools/poolSummary';
+export type { PoolSummary } from './ui/pools/poolSummary';
 
 // ── Lifecycle event bus (#216) ──────────────────────────────────────────────
 export { EventBus, channelForApprovalTransition } from './core/engine/eventBus';

--- a/src/ui/pools/PoolBuilder.module.css
+++ b/src/ui/pools/PoolBuilder.module.css
@@ -191,6 +191,20 @@
   font-variant-numeric: tabular-nums;
 }
 
+.preserved {
+  padding: 8px 12px;
+  font-size: 12px;
+  color: #92400e;
+  background: #fef3c7;
+  border: 1px solid #fcd34d;
+  border-radius: 6px;
+}
+
+.preserved strong {
+  font-weight: 600;
+  color: #78350f;
+}
+
 .previewExcluded {
   color: var(--wc-text-muted, #6b7280);
 }

--- a/src/ui/pools/PoolBuilder.module.css
+++ b/src/ui/pools/PoolBuilder.module.css
@@ -1,0 +1,236 @@
+.overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 100;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 24px;
+  background: color-mix(in srgb, #111827 55%, transparent);
+}
+
+.panel {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  width: min(100%, 560px);
+  max-height: calc(100vh - 48px);
+  overflow-y: auto;
+  padding: 18px 22px 16px;
+  background: var(--wc-bg, #ffffff);
+  border-radius: 10px;
+  box-shadow: 0 14px 48px color-mix(in srgb, #111827 30%, transparent);
+}
+
+.head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding-bottom: 10px;
+  border-bottom: 1px solid var(--wc-border, #e5e7eb);
+}
+
+.title {
+  margin: 0;
+  font-size: 16px;
+  font-weight: 600;
+  color: var(--wc-text, #111827);
+}
+
+.closeBtn {
+  font-size: 20px;
+  line-height: 1;
+  width: 28px;
+  height: 28px;
+  border: none;
+  background: transparent;
+  cursor: pointer;
+  color: var(--wc-text-muted, #6b7280);
+}
+
+.closeBtn:hover {
+  color: var(--wc-text, #111827);
+}
+
+.section {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.label {
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--wc-text-muted, #6b7280);
+}
+
+.input,
+.inputNum,
+.select {
+  padding: 8px 10px;
+  font-size: 14px;
+  border: 1px solid var(--wc-border, #e5e7eb);
+  border-radius: 6px;
+  background: var(--wc-bg, #ffffff);
+}
+
+.inputNum {
+  width: 100px;
+}
+
+.typeRow {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: 8px;
+}
+
+.typeOption {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  padding: 10px 12px;
+  border: 1px solid var(--wc-border, #e5e7eb);
+  border-radius: 8px;
+  cursor: pointer;
+  background: var(--wc-bg, #ffffff);
+}
+
+.typeOption[data-selected='true'] {
+  border-color: #2563eb;
+  background: color-mix(in srgb, #2563eb 6%, var(--wc-bg, #ffffff));
+}
+
+.typeOption input {
+  position: absolute;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.typeLabel {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--wc-text, #111827);
+}
+
+.typeDesc {
+  font-size: 11px;
+  color: var(--wc-text-muted, #6b7280);
+}
+
+.memberList {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  max-height: 180px;
+  overflow-y: auto;
+  padding: 6px 8px;
+  border: 1px solid var(--wc-border, #e5e7eb);
+  border-radius: 6px;
+}
+
+.memberOption {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  font-size: 13px;
+  cursor: pointer;
+}
+
+.empty {
+  font-size: 12px;
+  color: var(--wc-text-muted, #6b7280);
+  font-style: italic;
+}
+
+.chipRow {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.capChip {
+  padding: 5px 10px;
+  font-size: 12px;
+  border: 1px solid var(--wc-border, #e5e7eb);
+  background: var(--wc-bg, #ffffff);
+  border-radius: 999px;
+  cursor: pointer;
+}
+
+.capChip[data-selected='true'] {
+  border-color: #2563eb;
+  background: color-mix(in srgb, #2563eb 10%, var(--wc-bg, #ffffff));
+  color: #1e40af;
+}
+
+.radiusRow {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.unit {
+  font-size: 13px;
+  color: var(--wc-text-muted, #6b7280);
+}
+
+.warning {
+  font-size: 12px;
+  color: #b45309;
+}
+
+.preview {
+  padding: 10px 12px;
+  font-size: 13px;
+  color: var(--wc-text, #111827);
+  background: var(--wc-bg-muted, #f3f4f6);
+  border-radius: 6px;
+  font-variant-numeric: tabular-nums;
+}
+
+.previewExcluded {
+  color: var(--wc-text-muted, #6b7280);
+}
+
+.foot {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  padding-top: 10px;
+  border-top: 1px solid var(--wc-border, #e5e7eb);
+}
+
+.btnSecondary,
+.btnPrimary {
+  padding: 6px 14px;
+  font-size: 13px;
+  font-weight: 600;
+  border-radius: 6px;
+  border: 1px solid var(--wc-border, #e5e7eb);
+  cursor: pointer;
+}
+
+.btnPrimary {
+  border-color: #2563eb;
+  background: #2563eb;
+  color: #ffffff;
+}
+
+.btnPrimary:disabled {
+  background: var(--wc-bg-muted, #e5e7eb);
+  border-color: var(--wc-border, #e5e7eb);
+  color: var(--wc-text-muted, #6b7280);
+  cursor: not-allowed;
+}
+
+.btnSecondary {
+  background: var(--wc-bg, #ffffff);
+  color: var(--wc-text, #111827);
+}
+
+.btnSecondary:hover {
+  background: var(--wc-bg-muted, #f3f4f6);
+}

--- a/src/ui/pools/PoolBuilder.tsx
+++ b/src/ui/pools/PoolBuilder.tsx
@@ -1,0 +1,448 @@
+/**
+ * PoolBuilder — guided create/edit modal for `ResourcePool` (issue #386).
+ *
+ * Progressive disclosure per the issue thread: the host picks
+ * type → name → rules → strategy in stages, and we render a live
+ * "Matches N · excluded N" preview against `resources` so users see
+ * their query take effect as they type. The builder produces a
+ * concrete `ResourcePool` via `onSave`; persistence is the host's
+ * problem (typically wired to `onPoolsChange`).
+ *
+ * Deliberately minimal for v1:
+ *   - Manual pools: pick members from the asset registry.
+ *   - Query / hybrid pools: capability checkboxes + "within N mi/km
+ *     of event" radius. Capabilities are sourced from the host's
+ *     `capabilityCatalog` prop or auto-derived from `meta.capabilities`
+ *     on the live resources.
+ *   - Strategy picker, including `closest` (only enabled when a
+ *     `within` clause is configured so the new strategy has a
+ *     reference point).
+ *
+ * Out of scope here (separate UI PRs): a Level-3 raw rule builder
+ * with arbitrary AND/OR/NOT, capacity/numeric range pickers, multi-
+ * source location adapters config, and the wizard-level config
+ * export.
+ */
+import { useEffect, useMemo, useState } from 'react'
+import type { ChangeEvent, MouseEvent } from 'react'
+import { useFocusTrap } from '../../hooks/useFocusTrap'
+import { evaluateQuery } from '../../core/pools/evaluateQuery'
+import type {
+  ResourcePool, PoolStrategy, PoolType,
+} from '../../core/pools/resourcePoolSchema'
+import type {
+  ResourceQuery,
+} from '../../core/pools/poolQuerySchema'
+import type { EngineResource } from '../../core/engine/schema/resourceSchema'
+import styles from './PoolBuilder.module.css'
+
+export interface CapabilityOption {
+  /** Path under `meta.capabilities` (e.g. `refrigerated`). */
+  readonly id: string
+  readonly label: string
+}
+
+export interface PoolBuilderProps {
+  /** Existing pool to edit; pass `null` to create a new one. */
+  readonly pool: ResourcePool | null
+  /** Live registry — drives the live match preview. */
+  readonly resources?: ReadonlyMap<string, EngineResource> | readonly EngineResource[]
+  /**
+   * Capabilities the host wants to expose as checkboxes. When
+   * omitted, the builder auto-derives them from each resource's
+   * `meta.capabilities` keys (boolean values only). Hosts that want
+   * a curated list (chips with custom labels) pass it explicitly.
+   */
+  readonly capabilityCatalog?: readonly CapabilityOption[]
+  readonly onSave: (pool: ResourcePool) => void
+  readonly onCancel: () => void
+}
+
+const STRATEGIES: readonly { value: PoolStrategy; label: string }[] = [
+  { value: 'first-available', label: 'First available' },
+  { value: 'least-loaded',    label: 'Least loaded' },
+  { value: 'round-robin',     label: 'Round robin' },
+  { value: 'closest',         label: 'Closest to event' },
+]
+
+const TYPES: readonly { value: PoolType; label: string; description: string }[] = [
+  { value: 'manual', label: 'Manual',
+    description: 'Pick specific members.' },
+  { value: 'query',  label: 'Query',
+    description: 'Match resources by their attributes (capabilities, location, …).' },
+  { value: 'hybrid', label: 'Hybrid',
+    description: 'A curated list filtered by query attributes.' },
+]
+
+interface DraftState {
+  name: string
+  type: PoolType
+  memberIds: readonly string[]
+  capabilities: readonly string[]   // selected capability ids
+  withinMiles: number | null         // null means "no radius clause"
+  strategy: PoolStrategy
+}
+
+export default function PoolBuilder(props: PoolBuilderProps): JSX.Element {
+  const { pool, resources, capabilityCatalog, onSave, onCancel } = props
+  const trapRef = useFocusTrap<HTMLDivElement>(onCancel)
+
+  const resourceList = useMemo(
+    () => normalizeResources(resources),
+    [resources],
+  )
+
+  const catalog = useMemo(
+    () => capabilityCatalog ?? deriveCapabilityCatalog(resourceList),
+    [capabilityCatalog, resourceList],
+  )
+
+  const [draft, setDraft] = useState<DraftState>(() => fromPool(pool))
+  // Reset when a different pool is passed in.
+  useEffect(() => { setDraft(fromPool(pool)) }, [pool])
+
+  const built = useMemo(() => buildPool(draft, pool), [draft, pool])
+  const stats = useMemo(
+    () => previewStats(built, resourceList),
+    [built, resourceList],
+  )
+
+  const closestRequiresRadius = draft.strategy === 'closest' && draft.withinMiles == null
+  const canSave = draft.name.trim().length > 0
+    && (draft.type === 'manual'
+      ? draft.memberIds.length > 0
+      : draft.capabilities.length > 0 || draft.withinMiles != null)
+
+  return (
+    <div
+      className={styles['overlay']}
+      onClick={(e: MouseEvent<HTMLDivElement>) => e.target === e.currentTarget && onCancel()}
+    >
+      <div
+        ref={trapRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="pool-builder-title"
+        className={styles['panel']}
+      >
+        <header className={styles['head']}>
+          <h2 id="pool-builder-title" className={styles['title']}>
+            {pool ? `Edit pool: ${pool.name}` : 'Create pool'}
+          </h2>
+          <button
+            type="button"
+            className={styles['closeBtn']}
+            onClick={onCancel}
+            aria-label="Close pool builder"
+          >×</button>
+        </header>
+
+        <section className={styles['section']}>
+          <label htmlFor="pool-name" className={styles['label']}>Pool name</label>
+          <input
+            id="pool-name"
+            className={styles['input']}
+            type="text"
+            value={draft.name}
+            placeholder="e.g. Nearby Refrigerated Trucks"
+            onChange={(e: ChangeEvent<HTMLInputElement>) => setDraft(d => ({ ...d, name: e.target.value }))}
+          />
+        </section>
+
+        <section className={styles['section']} aria-labelledby="pool-type-label">
+          <span id="pool-type-label" className={styles['label']}>Type</span>
+          <div className={styles['typeRow']} role="radiogroup" aria-labelledby="pool-type-label">
+            {TYPES.map(t => (
+              <label key={t.value} className={styles['typeOption']} data-selected={draft.type === t.value}>
+                <input
+                  type="radio"
+                  name="pool-type"
+                  value={t.value}
+                  checked={draft.type === t.value}
+                  onChange={() => setDraft(d => ({ ...d, type: t.value }))}
+                />
+                <span className={styles['typeLabel']}>{t.label}</span>
+                <span className={styles['typeDesc']}>{t.description}</span>
+              </label>
+            ))}
+          </div>
+        </section>
+
+        {(draft.type === 'manual' || draft.type === 'hybrid') && (
+          <section className={styles['section']} aria-labelledby="pool-members-label">
+            <span id="pool-members-label" className={styles['label']}>
+              {draft.type === 'manual' ? 'Members' : 'Curated members (filtered by rules below)'}
+            </span>
+            <div className={styles['memberList']}>
+              {resourceList.length === 0 && (
+                <span className={styles['empty']}>No resources available.</span>
+              )}
+              {resourceList.map(r => (
+                <label key={r.id} className={styles['memberOption']}>
+                  <input
+                    type="checkbox"
+                    checked={draft.memberIds.includes(r.id)}
+                    onChange={() => setDraft(d => ({
+                      ...d,
+                      memberIds: d.memberIds.includes(r.id)
+                        ? d.memberIds.filter(x => x !== r.id)
+                        : [...d.memberIds, r.id],
+                    }))}
+                  />
+                  <span>{r.name}</span>
+                </label>
+              ))}
+            </div>
+          </section>
+        )}
+
+        {(draft.type === 'query' || draft.type === 'hybrid') && (
+          <>
+            <section className={styles['section']} aria-labelledby="pool-caps-label">
+              <span id="pool-caps-label" className={styles['label']}>Required capabilities</span>
+              {catalog.length === 0 && (
+                <span className={styles['empty']}>
+                  No capabilities discovered. Hosts can pass a `capabilityCatalog` prop.
+                </span>
+              )}
+              <div className={styles['chipRow']}>
+                {catalog.map(c => {
+                  const selected = draft.capabilities.includes(c.id)
+                  return (
+                    <button
+                      key={c.id}
+                      type="button"
+                      role="checkbox"
+                      aria-checked={selected}
+                      data-selected={selected}
+                      className={styles['capChip']}
+                      onClick={() => setDraft(d => ({
+                        ...d,
+                        capabilities: selected
+                          ? d.capabilities.filter(x => x !== c.id)
+                          : [...d.capabilities, c.id],
+                      }))}
+                    >
+                      {c.label}
+                    </button>
+                  )
+                })}
+              </div>
+            </section>
+
+            <section className={styles['section']}>
+              <label htmlFor="pool-radius" className={styles['label']}>
+                Radius in miles (leave blank for no radius)
+              </label>
+              <div className={styles['radiusRow']}>
+                <input
+                  id="pool-radius"
+                  type="number"
+                  min={0}
+                  step={1}
+                  className={styles['inputNum']}
+                  value={draft.withinMiles ?? ''}
+                  placeholder="50"
+                  onChange={(e: ChangeEvent<HTMLInputElement>) => {
+                    const v = e.target.value
+                    setDraft(d => ({ ...d, withinMiles: v === '' ? null : Number(v) }))
+                  }}
+                />
+                <span className={styles['unit']}>miles of event</span>
+              </div>
+            </section>
+          </>
+        )}
+
+        <section className={styles['section']}>
+          <label htmlFor="pool-strategy" className={styles['label']}>Selection strategy</label>
+          <select
+            id="pool-strategy"
+            className={styles['select']}
+            value={draft.strategy}
+            onChange={(e: ChangeEvent<HTMLSelectElement>) => setDraft(d => ({
+              ...d, strategy: e.target.value as PoolStrategy,
+            }))}
+          >
+            {STRATEGIES.map(s => (
+              <option key={s.value} value={s.value}>{s.label}</option>
+            ))}
+          </select>
+          {closestRequiresRadius && (
+            <span className={styles['warning']} role="alert">
+              "Closest to event" needs a radius clause so it has a reference point.
+            </span>
+          )}
+        </section>
+
+        <section className={styles['preview']} aria-label="Live match preview">
+          <strong>{stats.matched}</strong> {stats.matched === 1 ? 'match' : 'matches'}
+          {stats.excluded > 0 && (
+            <span className={styles['previewExcluded']}>
+              {' '}· {stats.excluded} excluded
+            </span>
+          )}
+        </section>
+
+        <footer className={styles['foot']}>
+          <button type="button" className={styles['btnSecondary']} onClick={onCancel}>
+            Cancel
+          </button>
+          <button
+            type="button"
+            className={styles['btnPrimary']}
+            disabled={!canSave || closestRequiresRadius}
+            onClick={() => onSave(built)}
+            title={canSave ? 'Save pool' : 'Add at least one rule or member to save'}
+          >
+            {pool ? 'Save changes' : 'Create pool'}
+          </button>
+        </footer>
+      </div>
+    </div>
+  )
+}
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+function fromPool(pool: ResourcePool | null): DraftState {
+  if (!pool) {
+    return {
+      name: '',
+      type: 'manual',
+      memberIds: [],
+      capabilities: [],
+      withinMiles: null,
+      strategy: 'first-available',
+    }
+  }
+  return {
+    name: pool.name,
+    type: pool.type ?? 'manual',
+    memberIds: pool.memberIds,
+    capabilities: extractCapabilityIds(pool.query),
+    withinMiles: extractWithinMiles(pool.query),
+    strategy: pool.strategy,
+  }
+}
+
+function buildPool(draft: DraftState, base: ResourcePool | null): ResourcePool {
+  // Reuse the existing id when editing so persistence keys stay stable.
+  const id = base?.id ?? (slugify(draft.name) || `pool-${Date.now()}`)
+  const out: ResourcePool = {
+    id,
+    name: draft.name.trim() || id,
+    type: draft.type,
+    memberIds: draft.type === 'query' ? [] : draft.memberIds,
+    strategy: draft.strategy,
+    ...(base?.disabled !== undefined ? { disabled: base.disabled } : {}),
+    ...(base?.rrCursor !== undefined ? { rrCursor: base.rrCursor } : {}),
+  }
+  if (draft.type === 'query' || draft.type === 'hybrid') {
+    const query = composeQuery(draft.capabilities, draft.withinMiles)
+    if (query) (out as { query?: ResourceQuery }).query = query
+  }
+  return out
+}
+
+function composeQuery(
+  capabilityIds: readonly string[],
+  withinMiles: number | null,
+): ResourceQuery | null {
+  const clauses: ResourceQuery[] = []
+  for (const id of capabilityIds) {
+    clauses.push({ op: 'eq', path: `meta.capabilities.${id}`, value: true })
+  }
+  if (withinMiles != null && Number.isFinite(withinMiles)) {
+    clauses.push({
+      op: 'within',
+      path: 'meta.location',
+      from: { kind: 'proposed' },
+      miles: withinMiles,
+    })
+  }
+  if (clauses.length === 0) return null
+  if (clauses.length === 1) return clauses[0]!
+  return { op: 'and', clauses }
+}
+
+function extractCapabilityIds(q: ResourceQuery | undefined): readonly string[] {
+  if (!q) return []
+  const ids: string[] = []
+  walkLeaves(q, (clause) => {
+    if (clause.op === 'eq' && clause.value === true && clause.path.startsWith('meta.capabilities.')) {
+      ids.push(clause.path.slice('meta.capabilities.'.length))
+    }
+  })
+  return ids
+}
+
+function extractWithinMiles(q: ResourceQuery | undefined): number | null {
+  if (!q) return null
+  let result: number | null = null
+  walkLeaves(q, (clause) => {
+    if (clause.op === 'within' && clause.miles != null) result = clause.miles
+  })
+  return result
+}
+
+function walkLeaves(q: ResourceQuery, fn: (leaf: ResourceQuery) => void): void {
+  if (q.op === 'and' || q.op === 'or') {
+    for (const c of q.clauses) walkLeaves(c, fn)
+  } else if (q.op === 'not') {
+    walkLeaves(q.clause, fn)
+  } else {
+    fn(q)
+  }
+}
+
+function deriveCapabilityCatalog(resources: readonly EngineResource[]): readonly CapabilityOption[] {
+  const seen = new Map<string, CapabilityOption>()
+  for (const r of resources) {
+    const caps = (r.meta?.['capabilities'] ?? null) as Record<string, unknown> | null
+    if (!caps || typeof caps !== 'object') continue
+    for (const [id, v] of Object.entries(caps)) {
+      if (typeof v !== 'boolean') continue   // numeric capabilities need range UI; skip in v1
+      if (seen.has(id)) continue
+      seen.set(id, { id, label: humanize(id) })
+    }
+  }
+  return Array.from(seen.values())
+}
+
+function previewStats(
+  pool: ResourcePool,
+  resources: readonly EngineResource[],
+): { matched: number; excluded: number } {
+  if (pool.type === 'manual' || pool.type === undefined) {
+    const known = new Set(resources.map(r => r.id))
+    const matched = pool.memberIds.filter(id => known.has(id)).length
+    return { matched, excluded: pool.memberIds.length - matched }
+  }
+  if (!pool.query) return { matched: 0, excluded: resources.length }
+  const result = evaluateQuery(pool.query, resources)
+  if (pool.type === 'hybrid') {
+    const allowed = new Set(result.matched)
+    const matched = pool.memberIds.filter(id => allowed.has(id)).length
+    return { matched, excluded: resources.length - matched }
+  }
+  return { matched: result.matched.length, excluded: result.excluded.length }
+}
+
+function normalizeResources(
+  resources: ReadonlyMap<string, EngineResource> | readonly EngineResource[] | undefined,
+): readonly EngineResource[] {
+  if (!resources) return []
+  if (resources instanceof Map) return Array.from(resources.values())
+  return resources as readonly EngineResource[]
+}
+
+function humanize(id: string): string {
+  return id.replace(/[_-]+/g, ' ').replace(/\b\w/g, c => c.toUpperCase())
+}
+
+function slugify(s: string): string {
+  return s.trim().toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+}

--- a/src/ui/pools/PoolBuilder.tsx
+++ b/src/ui/pools/PoolBuilder.tsx
@@ -81,6 +81,15 @@ interface DraftState {
   capabilities: readonly string[]   // selected capability ids
   withinMiles: number | null         // null means "no radius clause"
   strategy: PoolStrategy
+  /**
+   * Clauses from the original `pool.query` that the simple form
+   * doesn't recognize (e.g. numeric `gte`, `or`, `not`, non-capability
+   * eq). Carried through edits and re-AND'd into the saved query so
+   * that hosts who configured advanced rules elsewhere don't lose
+   * them when a user opens the builder. Surfaced as an inline note
+   * in the UI so the user knows additional rules are in play.
+   */
+  preserved: readonly ResourceQuery[]
 }
 
 export default function PoolBuilder(props: PoolBuilderProps): JSX.Element {
@@ -108,10 +117,13 @@ export default function PoolBuilder(props: PoolBuilderProps): JSX.Element {
   )
 
   const closestRequiresRadius = draft.strategy === 'closest' && draft.withinMiles == null
+  const hasPreserved = draft.preserved.length > 0
   const canSave = draft.name.trim().length > 0
     && (draft.type === 'manual'
       ? draft.memberIds.length > 0
-      : draft.capabilities.length > 0 || draft.withinMiles != null)
+      : draft.capabilities.length > 0
+        || draft.withinMiles != null
+        || hasPreserved)
 
   return (
     <div
@@ -275,6 +287,19 @@ export default function PoolBuilder(props: PoolBuilderProps): JSX.Element {
           )}
         </section>
 
+        {hasPreserved && (draft.type === 'query' || draft.type === 'hybrid') && (
+          <section
+            className={styles['preserved']}
+            data-testid="pool-builder-preserved"
+            role="note"
+            aria-label="Additional rules preserved on save"
+          >
+            <strong>{draft.preserved.length}</strong>{' '}
+            additional {draft.preserved.length === 1 ? 'rule isn’t' : 'rules aren’t'} editable here
+            {' '}— they’ll be preserved on save.
+          </section>
+        )}
+
         <section className={styles['preview']} aria-label="Live match preview">
           <strong>{stats.matched}</strong> {stats.matched === 1 ? 'match' : 'matches'}
           {stats.excluded > 0 && (
@@ -314,16 +339,76 @@ function fromPool(pool: ResourcePool | null): DraftState {
       capabilities: [],
       withinMiles: null,
       strategy: 'first-available',
+      preserved: [],
     }
   }
+  const { capabilities, withinMiles, preserved } = partitionQuery(pool.query)
   return {
     name: pool.name,
     type: pool.type ?? 'manual',
     memberIds: pool.memberIds,
-    capabilities: extractCapabilityIds(pool.query),
-    withinMiles: extractWithinMiles(pool.query),
+    capabilities,
+    withinMiles,
     strategy: pool.strategy,
+    preserved,
   }
+}
+
+/**
+ * Split an existing pool query into the buckets the form can edit
+ * (capabilities, withinMiles) plus a list of *preserved* clauses
+ * the form can't model. Recognized clauses are pulled out; anything
+ * else — `gte`, `lte`, `or`, `not`, non-capability `eq`, a second
+ * `within`, etc. — is collected verbatim so it can be re-AND'd onto
+ * the user's edits at save time.
+ *
+ * Conservative: when the root op isn't `and`, the entire query goes
+ * into `preserved` rather than being inspected for inner clauses
+ * we'd later strip. The form starts with empty capabilities/radius,
+ * and the user's additions are AND'd onto the original tree.
+ */
+function partitionQuery(q: ResourceQuery | undefined): {
+  capabilities: readonly string[]
+  withinMiles: number | null
+  preserved: readonly ResourceQuery[]
+} {
+  if (!q) return { capabilities: [], withinMiles: null, preserved: [] }
+  const capabilities: string[] = []
+  let withinMiles: number | null = null
+  const preserved: ResourceQuery[] = []
+  const consume = (clause: ResourceQuery): boolean => {
+    if (
+      clause.op === 'eq'
+      && clause.value === true
+      && clause.path.startsWith('meta.capabilities.')
+    ) {
+      capabilities.push(clause.path.slice('meta.capabilities.'.length))
+      return true
+    }
+    // Recognize the exact `within` shape the form emits — same path,
+    // proposed-mode, miles. Anything else (km, literal-point, custom
+    // path) goes through preserved so we don't smuggle a different
+    // clause back into the saved query.
+    if (
+      clause.op === 'within'
+      && clause.path === 'meta.location'
+      && clause.from.kind === 'proposed'
+      && clause.miles != null
+      && withinMiles == null
+    ) {
+      withinMiles = clause.miles
+      return true
+    }
+    return false
+  }
+  if (q.op === 'and') {
+    for (const c of q.clauses) {
+      if (!consume(c)) preserved.push(c)
+    }
+  } else if (!consume(q)) {
+    preserved.push(q)
+  }
+  return { capabilities, withinMiles, preserved }
 }
 
 function buildPool(draft: DraftState, base: ResourcePool | null): ResourcePool {
@@ -339,7 +424,7 @@ function buildPool(draft: DraftState, base: ResourcePool | null): ResourcePool {
     ...(base?.rrCursor !== undefined ? { rrCursor: base.rrCursor } : {}),
   }
   if (draft.type === 'query' || draft.type === 'hybrid') {
-    const query = composeQuery(draft.capabilities, draft.withinMiles)
+    const query = composeQuery(draft.capabilities, draft.withinMiles, draft.preserved)
     if (query) (out as { query?: ResourceQuery }).query = query
   }
   return out
@@ -348,6 +433,7 @@ function buildPool(draft: DraftState, base: ResourcePool | null): ResourcePool {
 function composeQuery(
   capabilityIds: readonly string[],
   withinMiles: number | null,
+  preserved: readonly ResourceQuery[],
 ): ResourceQuery | null {
   const clauses: ResourceQuery[] = []
   for (const id of capabilityIds) {
@@ -361,39 +447,12 @@ function composeQuery(
       miles: withinMiles,
     })
   }
+  // Append preserved clauses verbatim so editing a pool that has
+  // advanced rules (gte, or, not, …) doesn't drop them on save.
+  clauses.push(...preserved)
   if (clauses.length === 0) return null
   if (clauses.length === 1) return clauses[0]!
   return { op: 'and', clauses }
-}
-
-function extractCapabilityIds(q: ResourceQuery | undefined): readonly string[] {
-  if (!q) return []
-  const ids: string[] = []
-  walkLeaves(q, (clause) => {
-    if (clause.op === 'eq' && clause.value === true && clause.path.startsWith('meta.capabilities.')) {
-      ids.push(clause.path.slice('meta.capabilities.'.length))
-    }
-  })
-  return ids
-}
-
-function extractWithinMiles(q: ResourceQuery | undefined): number | null {
-  if (!q) return null
-  let result: number | null = null
-  walkLeaves(q, (clause) => {
-    if (clause.op === 'within' && clause.miles != null) result = clause.miles
-  })
-  return result
-}
-
-function walkLeaves(q: ResourceQuery, fn: (leaf: ResourceQuery) => void): void {
-  if (q.op === 'and' || q.op === 'or') {
-    for (const c of q.clauses) walkLeaves(c, fn)
-  } else if (q.op === 'not') {
-    walkLeaves(q.clause, fn)
-  } else {
-    fn(q)
-  }
 }
 
 function deriveCapabilityCatalog(resources: readonly EngineResource[]): readonly CapabilityOption[] {

--- a/src/ui/pools/PoolCard.module.css
+++ b/src/ui/pools/PoolCard.module.css
@@ -1,0 +1,123 @@
+.card {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  padding: 14px 16px;
+  border: 1px solid var(--wc-border, #e5e7eb);
+  border-radius: 8px;
+  background: var(--wc-bg, #ffffff);
+}
+
+.card[data-disabled='true'] {
+  opacity: 0.6;
+}
+
+.head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.titleBlock {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px;
+}
+
+.title {
+  margin: 0;
+  font-size: 15px;
+  font-weight: 600;
+  color: var(--wc-text, #111827);
+}
+
+.typeChip {
+  display: inline-block;
+  padding: 2px 8px;
+  font-size: 11px;
+  font-weight: 500;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+  color: var(--wc-text-muted, #6b7280);
+  background: var(--wc-bg-muted, #f3f4f6);
+  border-radius: 999px;
+}
+
+.typeChip[data-type='query']  { color: #1e40af; background: #dbeafe; }
+.typeChip[data-type='hybrid'] { color: #6b21a8; background: #ede9fe; }
+
+.disabledChip {
+  display: inline-block;
+  padding: 2px 8px;
+  font-size: 11px;
+  color: var(--wc-text-muted, #6b7280);
+  background: var(--wc-bg-muted, #f3f4f6);
+  border-radius: 999px;
+}
+
+.actions {
+  display: flex;
+  gap: 6px;
+  flex-shrink: 0;
+}
+
+.editBtn,
+.toggleBtn {
+  padding: 4px 10px;
+  font-size: 12px;
+  font-weight: 500;
+  border: 1px solid var(--wc-border, #e5e7eb);
+  background: var(--wc-bg, #ffffff);
+  border-radius: 6px;
+  cursor: pointer;
+}
+
+.editBtn:hover,
+.toggleBtn:hover {
+  background: var(--wc-bg-muted, #f3f4f6);
+}
+
+.clauseList {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.clauseChip {
+  display: inline-block;
+  padding: 3px 9px;
+  font-size: 12px;
+  color: var(--wc-text, #111827);
+  background: var(--wc-bg-muted, #f3f4f6);
+  border-radius: 999px;
+}
+
+.foot {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  font-size: 12px;
+  color: var(--wc-text-muted, #6b7280);
+}
+
+.strategy {
+  font-weight: 500;
+}
+
+.stats {
+  font-variant-numeric: tabular-nums;
+}
+
+.stats strong {
+  color: var(--wc-text, #111827);
+}
+
+.excluded {
+  color: var(--wc-text-muted, #6b7280);
+}

--- a/src/ui/pools/PoolCard.tsx
+++ b/src/ui/pools/PoolCard.tsx
@@ -1,0 +1,132 @@
+/**
+ * PoolCard — read-only summary card for a `ResourcePool` (issue #386).
+ *
+ * Shows the pool's friendly name, plain-English summary of its
+ * rules, the chosen strategy, and an optional live "Matches N
+ * resources" count when a registry is provided. Renders for any
+ * pool type (manual / query / hybrid). Mounting is the host's call
+ * — drop one in a settings tab, a config sidebar, a profile picker.
+ *
+ * The card itself is read-only; pass `onEdit` to surface an Edit
+ * button that opens whatever builder the host has wired (typically
+ * `PoolBuilder` from this directory).
+ */
+import type { ReactNode } from 'react'
+import type { ResourcePool } from '../../core/pools/resourcePoolSchema'
+import type { EngineResource } from '../../core/engine/schema/resourceSchema'
+import { evaluateQuery } from '../../core/pools/evaluateQuery'
+import { summarizePool } from './poolSummary'
+import styles from './PoolCard.module.css'
+
+export interface PoolCardProps {
+  readonly pool: ResourcePool
+  /**
+   * Live registry — when provided, the card runs `evaluateQuery`
+   * against it to render "Matches N resources" / readiness counts.
+   * Omit to skip the live stats.
+   */
+  readonly resources?: ReadonlyMap<string, EngineResource> | readonly EngineResource[]
+  /** Called when the user clicks the Edit button. Omit to hide it. */
+  readonly onEdit?: () => void
+  /** Called when the user clicks the Disable / Enable toggle. */
+  readonly onToggleDisabled?: () => void
+  /** Optional slot for host-provided actions (e.g. Delete). */
+  readonly actions?: ReactNode
+}
+
+export default function PoolCard({
+  pool, resources, onEdit, onToggleDisabled, actions,
+}: PoolCardProps) {
+  const summary = summarizePool(pool)
+  const stats   = resources ? computeStats(pool, resources) : null
+
+  return (
+    <article
+      className={styles['card']}
+      data-disabled={pool.disabled ? 'true' : 'false'}
+      aria-label={`Pool: ${pool.name}`}
+    >
+      <header className={styles['head']}>
+        <div className={styles['titleBlock']}>
+          <h3 className={styles['title']}>{pool.name}</h3>
+          <span className={styles['typeChip']} data-type={pool.type ?? 'manual'}>
+            {summary.typeLabel}
+          </span>
+          {pool.disabled && (
+            <span className={styles['disabledChip']}>Disabled</span>
+          )}
+        </div>
+        <div className={styles['actions']}>
+          {onEdit && (
+            <button type="button" className={styles['editBtn']} onClick={onEdit}>
+              Edit
+            </button>
+          )}
+          {onToggleDisabled && (
+            <button
+              type="button"
+              className={styles['toggleBtn']}
+              onClick={onToggleDisabled}
+              aria-label={pool.disabled ? `Enable pool ${pool.name}` : `Disable pool ${pool.name}`}
+            >
+              {pool.disabled ? 'Enable' : 'Disable'}
+            </button>
+          )}
+          {actions}
+        </div>
+      </header>
+
+      {summary.clauseLabels.length > 0 && (
+        <ul className={styles['clauseList']} aria-label="Pool rules">
+          {summary.clauseLabels.map((c) => (
+            <li key={c} className={styles['clauseChip']}>{c}</li>
+          ))}
+        </ul>
+      )}
+
+      <footer className={styles['foot']}>
+        <span className={styles['strategy']} aria-label={`Selection: ${summary.strategyLabel}`}>
+          {summary.strategyLabel}
+        </span>
+        {stats && (
+          <span
+            className={styles['stats']}
+            data-testid="pool-card-stats"
+            aria-label={`${stats.matched} matched, ${stats.excluded} excluded`}
+          >
+            <strong>{stats.matched}</strong>{' '}
+            {stats.matched === 1 ? 'match' : 'matches'}
+            {stats.excluded > 0 && (
+              <span className={styles['excluded']}>
+                {' '}· {stats.excluded} excluded
+              </span>
+            )}
+          </span>
+        )}
+      </footer>
+    </article>
+  )
+}
+
+function computeStats(
+  pool: ResourcePool,
+  resources: ReadonlyMap<string, EngineResource> | readonly EngineResource[],
+): { matched: number; excluded: number } {
+  const list = resources instanceof Map
+    ? Array.from(resources.values())
+    : (resources as readonly EngineResource[])
+  const known = new Set(list.map(r => r.id))
+
+  if (pool.type === 'manual' || pool.type === undefined) {
+    const matched = pool.memberIds.filter(id => known.has(id)).length
+    return { matched, excluded: pool.memberIds.length - matched }
+  }
+  if (!pool.query) return { matched: 0, excluded: list.length }
+  const result = evaluateQuery(pool.query, list)
+  if (pool.type === 'hybrid') {
+    const allowed = new Set(result.matched)
+    const matched = pool.memberIds.filter(id => allowed.has(id)).length
+    return { matched, excluded: list.length - matched }
+  }
+  return { matched: result.matched.length, excluded: result.excluded.length }
+}

--- a/src/ui/pools/__tests__/PoolBuilder.test.tsx
+++ b/src/ui/pools/__tests__/PoolBuilder.test.tsx
@@ -175,6 +175,147 @@ describe('PoolBuilder — editing existing pools', () => {
   })
 })
 
+describe('PoolBuilder — preserves advanced clauses through edits (#386 P1)', () => {
+  // The form only models capability-eq(true) and a proposed-mode
+  // miles `within`. Anything else (gte, or, not, non-capability eq,
+  // a literal-point within) must round-trip unchanged so a user
+  // editing the friendly fields doesn't silently drop the host's
+  // advanced rules.
+
+  it('preserves a gte clause AND-merged with the user\'s edits', () => {
+    const onSave = vi.fn()
+    const pool: ResourcePool = {
+      id: 'p', name: 'Reefers', type: 'query', memberIds: [],
+      query: {
+        op: 'and',
+        clauses: [
+          { op: 'eq',  path: 'meta.capabilities.refrigerated', value: true },
+          { op: 'gte', path: 'meta.capabilities.capacity_lbs', value: 80000 },
+        ],
+      },
+      strategy: 'first-available',
+    }
+    render(<PoolBuilder pool={pool} resources={fleet} onSave={onSave} onCancel={vi.fn()} />)
+
+    // The form acknowledges the preserved gte but lets the user
+    // edit the recognized refrigerated chip.
+    expect(screen.getByTestId('pool-builder-preserved')).toHaveTextContent(/1 additional rule/)
+    fireEvent.click(screen.getByRole('button', { name: 'Save changes' }))
+
+    const saved = onSave.mock.calls[0]![0] as ResourcePool
+    expect(saved.query).toEqual({
+      op: 'and',
+      clauses: [
+        { op: 'eq',  path: 'meta.capabilities.refrigerated', value: true },
+        { op: 'gte', path: 'meta.capabilities.capacity_lbs', value: 80000 },
+      ],
+    })
+  })
+
+  it('preserves an `or` root by AND-wrapping the user\'s additions', () => {
+    const onSave = vi.fn()
+    const pool: ResourcePool = {
+      id: 'p', name: 'EitherWay', type: 'query', memberIds: [],
+      query: {
+        op: 'or',
+        clauses: [
+          { op: 'eq', path: 'type', value: 'vehicle' },
+          { op: 'eq', path: 'type', value: 'aircraft' },
+        ],
+      },
+      strategy: 'first-available',
+    }
+    render(<PoolBuilder pool={pool} resources={fleet} onSave={onSave} onCancel={vi.fn()} />)
+
+    // The whole `or` is preserved; capability chips start empty.
+    expect(screen.getByTestId('pool-builder-preserved')).toHaveTextContent(/1 additional rule/)
+    expect(screen.getByRole('checkbox', { name: 'Refrigerated' })).toHaveAttribute('aria-checked', 'false')
+
+    // User adds a refrigerated chip.
+    fireEvent.click(screen.getByRole('checkbox', { name: 'Refrigerated' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Save changes' }))
+
+    const saved = onSave.mock.calls[0]![0] as ResourcePool
+    expect(saved.query).toEqual({
+      op: 'and',
+      clauses: [
+        { op: 'eq', path: 'meta.capabilities.refrigerated', value: true },
+        // The original `or` is preserved verbatim alongside the new chip.
+        {
+          op: 'or',
+          clauses: [
+            { op: 'eq', path: 'type', value: 'vehicle' },
+            { op: 'eq', path: 'type', value: 'aircraft' },
+          ],
+        },
+      ],
+    })
+  })
+
+  it('preserves a `not` clause and a literal-point `within` (which the form can\'t model)', () => {
+    const onSave = vi.fn()
+    const pool: ResourcePool = {
+      id: 'p', name: 'Mixed', type: 'query', memberIds: [],
+      query: {
+        op: 'and',
+        clauses: [
+          { op: 'eq', path: 'meta.capabilities.refrigerated', value: true },
+          { op: 'not', clause: { op: 'eq', path: 'tenantId', value: 'banned' } },
+          // Literal-point within is a different shape from the
+          // form's proposed-mode within — must be preserved.
+          { op: 'within', path: 'meta.location', from: { kind: 'point', lat: 40, lon: -111 }, miles: 100 },
+        ],
+      },
+      strategy: 'first-available',
+    }
+    render(<PoolBuilder pool={pool} resources={fleet} onSave={onSave} onCancel={vi.fn()} />)
+    expect(screen.getByTestId('pool-builder-preserved')).toHaveTextContent(/2 additional rules/)
+    fireEvent.click(screen.getByRole('button', { name: 'Save changes' }))
+
+    const saved = onSave.mock.calls[0]![0] as ResourcePool
+    // Recognized clause + both preserved clauses survive, in order.
+    expect(saved.query).toEqual({
+      op: 'and',
+      clauses: [
+        { op: 'eq',  path: 'meta.capabilities.refrigerated', value: true },
+        { op: 'not', clause: { op: 'eq', path: 'tenantId', value: 'banned' } },
+        { op: 'within', path: 'meta.location', from: { kind: 'point', lat: 40, lon: -111 }, miles: 100 },
+      ],
+    })
+  })
+
+  it('omits the preserved-clause notice when nothing was preserved', () => {
+    render(<PoolBuilder
+      pool={{
+        id: 'p', name: 'Simple', type: 'query', memberIds: [],
+        query: { op: 'eq', path: 'meta.capabilities.refrigerated', value: true },
+        strategy: 'first-available',
+      }}
+      resources={fleet} onSave={vi.fn()} onCancel={vi.fn()}
+    />)
+    expect(screen.queryByTestId('pool-builder-preserved')).toBeNull()
+  })
+
+  it('lets the user save with only preserved rules (no UI clauses configured)', () => {
+    // A pool whose query is entirely advanced — the user opens it,
+    // doesn't change anything, and can still hit Save without being
+    // forced to add a recognized clause.
+    const onSave = vi.fn()
+    const pool: ResourcePool = {
+      id: 'p', name: 'AdvancedOnly', type: 'query', memberIds: [],
+      query: { op: 'gte', path: 'meta.capabilities.capacity_lbs', value: 80000 },
+      strategy: 'first-available',
+    }
+    render(<PoolBuilder pool={pool} resources={fleet} onSave={onSave} onCancel={vi.fn()} />)
+    expect(screen.getByRole('button', { name: 'Save changes' })).toBeEnabled()
+    fireEvent.click(screen.getByRole('button', { name: 'Save changes' }))
+    const saved = onSave.mock.calls[0]![0] as ResourcePool
+    expect(saved.query).toEqual({
+      op: 'gte', path: 'meta.capabilities.capacity_lbs', value: 80000,
+    })
+  })
+})
+
 describe('PoolBuilder — capability discovery', () => {
   it('uses the host-provided catalog when one is passed', () => {
     render(<PoolBuilder

--- a/src/ui/pools/__tests__/PoolBuilder.test.tsx
+++ b/src/ui/pools/__tests__/PoolBuilder.test.tsx
@@ -1,0 +1,190 @@
+// @vitest-environment happy-dom
+/**
+ * PoolBuilder — guided create/edit modal (#386 UI).
+ */
+import { render, screen, fireEvent } from '@testing-library/react'
+import { describe, it, expect, vi } from 'vitest'
+import '@testing-library/jest-dom'
+import React from 'react'
+
+import PoolBuilder from '../PoolBuilder'
+import type { ResourcePool } from '../../../core/pools/resourcePoolSchema'
+import type { EngineResource } from '../../../core/engine/schema/resourceSchema'
+
+const r = (id: string, meta: Record<string, unknown> = {}): EngineResource =>
+  ({ id, name: id.toUpperCase(), meta } as EngineResource)
+
+const fleet: readonly EngineResource[] = [
+  r('t1', { capabilities: { refrigerated: true,  heavy_haul: false }, location: { lat: 40.7608, lon: -111.8910 } }),
+  r('t2', { capabilities: { refrigerated: true,  heavy_haul: true  }, location: { lat: 39.7392, lon: -104.9903 } }),
+  r('t3', { capabilities: { refrigerated: false, heavy_haul: true  }, location: { lat: 37.6189, lon: -122.3750 } }),
+]
+
+describe('PoolBuilder — open / close', () => {
+  it('renders the dialog with a "Create pool" header when pool is null', () => {
+    render(<PoolBuilder pool={null} onSave={vi.fn()} onCancel={vi.fn()} />)
+    expect(screen.getByRole('dialog', { name: 'Create pool' })).toBeInTheDocument()
+  })
+
+  it('renders an "Edit pool: <name>" header when editing', () => {
+    render(<PoolBuilder
+      pool={{ id: 'p', name: 'Drivers', memberIds: ['t1'], strategy: 'first-available' }}
+      onSave={vi.fn()} onCancel={vi.fn()}
+    />)
+    expect(screen.getByRole('dialog', { name: 'Edit pool: Drivers' })).toBeInTheDocument()
+  })
+
+  it('Cancel and the close button both fire onCancel', () => {
+    const onCancel = vi.fn()
+    render(<PoolBuilder pool={null} onSave={vi.fn()} onCancel={onCancel} />)
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Close pool builder' }))
+    expect(onCancel).toHaveBeenCalledTimes(2)
+  })
+})
+
+describe('PoolBuilder — manual pool', () => {
+  it('saves a manual pool with selected members', () => {
+    const onSave = vi.fn()
+    render(<PoolBuilder pool={null} resources={fleet} onSave={onSave} onCancel={vi.fn()} />)
+
+    fireEvent.change(screen.getByLabelText('Pool name'), { target: { value: 'West Fleet' } })
+    fireEvent.click(screen.getByLabelText('T1'))
+    fireEvent.click(screen.getByLabelText('T2'))
+    fireEvent.click(screen.getByRole('button', { name: 'Create pool' }))
+
+    expect(onSave).toHaveBeenCalledTimes(1)
+    const saved = onSave.mock.calls[0]![0] as ResourcePool
+    expect(saved.name).toBe('West Fleet')
+    expect(saved.type).toBe('manual')
+    expect([...saved.memberIds].sort()).toEqual(['t1', 't2'])
+    expect(saved.strategy).toBe('first-available')
+  })
+
+  it('disables Save until name + at least one member are set', () => {
+    render(<PoolBuilder pool={null} resources={fleet} onSave={vi.fn()} onCancel={vi.fn()} />)
+    const save = screen.getByRole('button', { name: 'Create pool' })
+    expect(save).toBeDisabled()
+
+    fireEvent.change(screen.getByLabelText('Pool name'), { target: { value: 'X' } })
+    expect(save).toBeDisabled()
+
+    fireEvent.click(screen.getByLabelText('T1'))
+    expect(save).toBeEnabled()
+  })
+})
+
+describe('PoolBuilder — query pool', () => {
+  it('emits an `eq` clause per selected capability and an `and` wrapper when there are multiple', () => {
+    const onSave = vi.fn()
+    render(<PoolBuilder pool={null} resources={fleet} onSave={onSave} onCancel={vi.fn()} />)
+
+    fireEvent.change(screen.getByLabelText('Pool name'), { target: { value: 'Reefers' } })
+    // Switch to query type.
+    fireEvent.click(screen.getByLabelText(/Match resources by their attributes/))
+    // Capability chips: one chip per derived capability.
+    fireEvent.click(screen.getByRole('checkbox', { name: 'Refrigerated' }))
+    fireEvent.click(screen.getByRole('checkbox', { name: 'Heavy Haul' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Create pool' }))
+
+    const saved = onSave.mock.calls[0]![0] as ResourcePool
+    expect(saved.type).toBe('query')
+    expect(saved.memberIds).toEqual([])
+    expect(saved.query).toEqual({
+      op: 'and',
+      clauses: [
+        { op: 'eq', path: 'meta.capabilities.refrigerated', value: true },
+        { op: 'eq', path: 'meta.capabilities.heavy_haul',   value: true },
+      ],
+    })
+  })
+
+  it('emits a single `within` clause (no AND wrapper) when only a radius is set', () => {
+    const onSave = vi.fn()
+    render(<PoolBuilder pool={null} resources={fleet} onSave={onSave} onCancel={vi.fn()} />)
+    fireEvent.change(screen.getByLabelText('Pool name'), { target: { value: 'Nearby' } })
+    fireEvent.click(screen.getByLabelText(/Match resources by their attributes/))
+    fireEvent.change(screen.getByLabelText(/Radius in miles/), { target: { value: '50' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Create pool' }))
+
+    const saved = onSave.mock.calls[0]![0] as ResourcePool
+    expect(saved.query).toEqual({
+      op: 'within',
+      path: 'meta.location',
+      from: { kind: 'proposed' },
+      miles: 50,
+    })
+  })
+
+  it('blocks Save when "closest" is picked without a radius clause', () => {
+    render(<PoolBuilder pool={null} resources={fleet} onSave={vi.fn()} onCancel={vi.fn()} />)
+    fireEvent.change(screen.getByLabelText('Pool name'), { target: { value: 'X' } })
+    fireEvent.click(screen.getByLabelText(/Match resources by their attributes/))
+    fireEvent.click(screen.getByRole('checkbox', { name: 'Refrigerated' }))
+    fireEvent.change(screen.getByLabelText('Selection strategy'), { target: { value: 'closest' } })
+    expect(screen.getByRole('alert')).toHaveTextContent('Closest to event')
+    expect(screen.getByRole('button', { name: 'Create pool' })).toBeDisabled()
+
+    fireEvent.change(screen.getByLabelText(/Radius in miles/), { target: { value: '50' } })
+    expect(screen.getByRole('button', { name: 'Create pool' })).toBeEnabled()
+  })
+
+  it('renders a live "Matches N · M excluded" preview that tracks the query', () => {
+    render(<PoolBuilder pool={null} resources={fleet} onSave={vi.fn()} onCancel={vi.fn()} />)
+    fireEvent.change(screen.getByLabelText('Pool name'), { target: { value: 'Reefers' } })
+    fireEvent.click(screen.getByLabelText(/Match resources by their attributes/))
+    fireEvent.click(screen.getByRole('checkbox', { name: 'Refrigerated' }))
+    const preview = screen.getByLabelText('Live match preview')
+    // 2 of 3 trucks are refrigerated.
+    expect(preview).toHaveTextContent('2 matches')
+    expect(preview).toHaveTextContent('1 excluded')
+  })
+})
+
+describe('PoolBuilder — editing existing pools', () => {
+  it('seeds capability chips and radius from an existing query pool', () => {
+    const pool: ResourcePool = {
+      id: 'p', name: 'Existing', type: 'query', memberIds: [],
+      query: {
+        op: 'and',
+        clauses: [
+          { op: 'eq',     path: 'meta.capabilities.refrigerated', value: true },
+          { op: 'within', path: 'meta.location', from: { kind: 'proposed' }, miles: 75 },
+        ],
+      },
+      strategy: 'closest',
+    }
+    render(<PoolBuilder pool={pool} resources={fleet} onSave={vi.fn()} onCancel={vi.fn()} />)
+    expect(screen.getByRole('checkbox', { name: 'Refrigerated' })).toHaveAttribute('aria-checked', 'true')
+    expect(screen.getByLabelText(/Radius in miles/)).toHaveValue(75)
+  })
+
+  it('preserves id and disabled flag when saving edits', () => {
+    const onSave = vi.fn()
+    const pool: ResourcePool = {
+      id: 'preserved-id', name: 'Old',
+      memberIds: ['t1'], strategy: 'first-available', disabled: true,
+    }
+    render(<PoolBuilder pool={pool} resources={fleet} onSave={onSave} onCancel={vi.fn()} />)
+    fireEvent.change(screen.getByLabelText('Pool name'), { target: { value: 'Renamed' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Save changes' }))
+    const saved = onSave.mock.calls[0]![0] as ResourcePool
+    expect(saved.id).toBe('preserved-id')
+    expect(saved.disabled).toBe(true)
+    expect(saved.name).toBe('Renamed')
+  })
+})
+
+describe('PoolBuilder — capability discovery', () => {
+  it('uses the host-provided catalog when one is passed', () => {
+    render(<PoolBuilder
+      pool={null}
+      resources={fleet}
+      capabilityCatalog={[{ id: 'cdl', label: 'Driver CDL' }]}
+      onSave={vi.fn()} onCancel={vi.fn()}
+    />)
+    fireEvent.click(screen.getByLabelText(/Match resources by their attributes/))
+    expect(screen.getByRole('checkbox', { name: 'Driver CDL' })).toBeInTheDocument()
+    expect(screen.queryByRole('checkbox', { name: 'Refrigerated' })).toBeNull()
+  })
+})

--- a/src/ui/pools/__tests__/PoolCard.test.tsx
+++ b/src/ui/pools/__tests__/PoolCard.test.tsx
@@ -1,0 +1,117 @@
+// @vitest-environment happy-dom
+/**
+ * PoolCard — read-only summary card with optional live stats (#386 UI).
+ */
+import { render, screen, fireEvent } from '@testing-library/react'
+import { describe, it, expect, vi } from 'vitest'
+import '@testing-library/jest-dom'
+import React from 'react'
+
+import PoolCard from '../PoolCard'
+import type { ResourcePool } from '../../../core/pools/resourcePoolSchema'
+import type { EngineResource } from '../../../core/engine/schema/resourceSchema'
+
+const r = (id: string, meta: Record<string, unknown> = {}): EngineResource =>
+  ({ id, name: id.toUpperCase(), meta } as EngineResource)
+
+describe('PoolCard — header', () => {
+  it('renders the pool name + type chip', () => {
+    render(<PoolCard pool={{
+      id: 'p', name: 'West Fleet',
+      memberIds: ['a', 'b'], strategy: 'first-available',
+    }} />)
+    expect(screen.getByRole('article', { name: 'Pool: West Fleet' })).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: 'West Fleet' })).toBeInTheDocument()
+    expect(screen.getByText('Manual pool')).toBeInTheDocument()
+  })
+
+  it('marks disabled pools with a chip and a `data-disabled` attribute', () => {
+    render(<PoolCard pool={{
+      id: 'p', name: 'Retired', memberIds: [], strategy: 'first-available', disabled: true,
+    }} />)
+    expect(screen.getByText('Disabled')).toBeInTheDocument()
+    const card = screen.getByRole('article', { name: 'Pool: Retired' })
+    expect(card).toHaveAttribute('data-disabled', 'true')
+  })
+})
+
+describe('PoolCard — actions', () => {
+  it('renders the Edit button only when onEdit is provided', () => {
+    const { rerender } = render(<PoolCard pool={{
+      id: 'p', name: 'X', memberIds: ['a'], strategy: 'first-available',
+    }} />)
+    expect(screen.queryByRole('button', { name: 'Edit' })).toBeNull()
+
+    const onEdit = vi.fn()
+    rerender(<PoolCard pool={{
+      id: 'p', name: 'X', memberIds: ['a'], strategy: 'first-available',
+    }} onEdit={onEdit} />)
+    fireEvent.click(screen.getByRole('button', { name: 'Edit' }))
+    expect(onEdit).toHaveBeenCalledTimes(1)
+  })
+
+  it('toggle button announces the right action via aria-label', () => {
+    const onToggle = vi.fn()
+    const { rerender } = render(<PoolCard pool={{
+      id: 'p', name: 'X', memberIds: ['a'], strategy: 'first-available',
+    }} onToggleDisabled={onToggle} />)
+    expect(screen.getByRole('button', { name: 'Disable pool X' })).toBeInTheDocument()
+
+    rerender(<PoolCard pool={{
+      id: 'p', name: 'X', memberIds: ['a'], strategy: 'first-available', disabled: true,
+    }} onToggleDisabled={onToggle} />)
+    expect(screen.getByRole('button', { name: 'Enable pool X' })).toBeInTheDocument()
+  })
+})
+
+describe('PoolCard — live stats', () => {
+  const reefers = [
+    r('t1', { capabilities: { refrigerated: true } }),
+    r('t2', { capabilities: { refrigerated: true } }),
+    r('t3', { capabilities: { refrigerated: false } }),
+  ]
+
+  it('omits stats when no resources are passed', () => {
+    render(<PoolCard pool={{
+      id: 'p', name: 'X', memberIds: ['t1'], strategy: 'first-available',
+    }} />)
+    expect(screen.queryByTestId('pool-card-stats')).toBeNull()
+  })
+
+  it('counts manual-pool members against the live registry', () => {
+    render(<PoolCard
+      pool={{ id: 'p', name: 'Curated', memberIds: ['t1', 'gone'], strategy: 'first-available' }}
+      resources={reefers}
+    />)
+    const stats = screen.getByTestId('pool-card-stats')
+    expect(stats).toHaveTextContent('1')
+    expect(stats).toHaveTextContent('1 excluded')
+  })
+
+  it('runs the query for query pools and renders matched / excluded counts', () => {
+    render(<PoolCard
+      pool={{
+        id: 'p', name: 'Reefers', type: 'query', memberIds: [],
+        query: { op: 'eq', path: 'meta.capabilities.refrigerated', value: true },
+        strategy: 'first-available',
+      }}
+      resources={reefers}
+    />)
+    const stats = screen.getByTestId('pool-card-stats')
+    expect(stats).toHaveAttribute('aria-label', '2 matched, 1 excluded')
+  })
+
+  it('intersects memberIds with query results for hybrid pools', () => {
+    render(<PoolCard
+      pool={{
+        id: 'p', name: 'OurReefers', type: 'hybrid',
+        memberIds: ['t2', 't3'],   // t3 doesn't match the query
+        query: { op: 'eq', path: 'meta.capabilities.refrigerated', value: true },
+        strategy: 'first-available',
+      }}
+      resources={reefers}
+    />)
+    const stats = screen.getByTestId('pool-card-stats')
+    expect(stats).toHaveTextContent('1')
+  })
+})

--- a/src/ui/pools/__tests__/poolSummary.test.ts
+++ b/src/ui/pools/__tests__/poolSummary.test.ts
@@ -1,0 +1,131 @@
+/**
+ * poolSummary — pure plain-English description of a pool (#386 UI).
+ */
+import { describe, it, expect } from 'vitest'
+import { summarizePool, summarizeQuery } from '../poolSummary'
+import type { ResourcePool } from '../../../core/pools/resourcePoolSchema'
+import type { ResourceQuery } from '../../../core/pools/poolQuerySchema'
+
+const base = (patch: Partial<ResourcePool> & Pick<ResourcePool, 'id' | 'name'>): ResourcePool => ({
+  memberIds: [],
+  strategy: 'first-available',
+  ...patch,
+})
+
+describe('summarizePool — type label', () => {
+  it('labels a manual pool', () => {
+    const s = summarizePool(base({ id: 'p', name: 'Drivers' }))
+    expect(s.typeLabel).toBe('Manual pool')
+    expect(s.headline).toMatch(/^Manual pool/)
+  })
+
+  it('labels a query pool', () => {
+    const s = summarizePool(base({ id: 'p', name: 'Reefers', type: 'query' }))
+    expect(s.typeLabel).toBe('Query pool')
+  })
+
+  it('labels a hybrid pool', () => {
+    const s = summarizePool(base({ id: 'p', name: 'Curated reefers', type: 'hybrid' }))
+    expect(s.typeLabel).toBe('Hybrid pool')
+  })
+
+  it('falls back to bare "Pool" for unknown type strings (defensive)', () => {
+    const s = summarizePool({ ...base({ id: 'p', name: 'X' }), type: 'graphql' as any })
+    expect(s.typeLabel).toBe('Pool')
+  })
+})
+
+describe('summarizePool — clauses', () => {
+  it('counts members on a manual pool', () => {
+    const s = summarizePool(base({ id: 'p', name: 'D', memberIds: ['a', 'b', 'c'] }))
+    expect(s.clauseLabels).toEqual(['3 members'])
+  })
+
+  it('renders capability + radius clauses for a query pool', () => {
+    const pool = base({
+      id: 'p', name: 'Nearby reefers', type: 'query',
+      query: {
+        op: 'and',
+        clauses: [
+          { op: 'eq',     path: 'meta.capabilities.refrigerated', value: true },
+          { op: 'within', path: 'meta.location', from: { kind: 'proposed' }, miles: 50 },
+        ],
+      },
+    })
+    const s = summarizePool(pool)
+    expect(s.clauseLabels).toEqual(['refrigerated', 'within 50 mi of event'])
+    expect(s.headline).toContain('refrigerated')
+    expect(s.headline).toContain('within 50 mi')
+  })
+
+  it('appends curated-member count for a hybrid pool', () => {
+    const pool = base({
+      id: 'p', name: 'Our reefers', type: 'hybrid',
+      memberIds: ['t1', 't2'],
+      query: { op: 'eq', path: 'meta.capabilities.refrigerated', value: true },
+    })
+    const s = summarizePool(pool)
+    expect(s.clauseLabels).toContain('refrigerated')
+    expect(s.clauseLabels).toContain('limited to 2 curated members')
+  })
+})
+
+describe('summarizeQuery — leaf operators', () => {
+  it('renders eq with boolean true as a bare capability name', () => {
+    expect(summarizeQuery({ op: 'eq', path: 'capabilities.refrigerated', value: true }))
+      .toEqual(['refrigerated'])
+  })
+
+  it('renders eq with boolean false as "not <capability>"', () => {
+    expect(summarizeQuery({ op: 'eq', path: 'capabilities.refrigerated', value: false }))
+      .toEqual(['not refrigerated'])
+  })
+
+  it('renders numeric gte naturally', () => {
+    expect(summarizeQuery({ op: 'gte', path: 'capabilities.capacity_lbs', value: 80000 }))
+      .toEqual(['capacity lbs ≥ 80,000'])
+  })
+
+  it('renders within with a literal point', () => {
+    expect(summarizeQuery({
+      op: 'within', path: 'meta.location',
+      from: { kind: 'point', lat: 40.7608, lon: -111.8910 }, miles: 50,
+    })).toEqual(['within 50 mi of 40.76, -111.89'])
+  })
+
+  it('renders within with kind: proposed against the event', () => {
+    expect(summarizeQuery({
+      op: 'within', path: 'meta.location', from: { kind: 'proposed' }, km: 100,
+    })).toEqual(['within 100 km of event'])
+  })
+
+  it('flattens nested ANDs into a single phrase list', () => {
+    const q: ResourceQuery = {
+      op: 'and',
+      clauses: [
+        { op: 'eq',  path: 'meta.capabilities.refrigerated', value: true },
+        { op: 'gte', path: 'meta.capabilities.capacity_lbs', value: 80000 },
+      ],
+    }
+    expect(summarizeQuery(q)).toEqual(['refrigerated', 'capacity lbs ≥ 80,000'])
+  })
+
+  it('renders OR as "any of …" so meaning isn\'t lost', () => {
+    const q: ResourceQuery = {
+      op: 'or',
+      clauses: [
+        { op: 'eq', path: 'type', value: 'vehicle' },
+        { op: 'eq', path: 'type', value: 'aircraft' },
+      ],
+    }
+    expect(summarizeQuery(q)).toEqual(['any of: type = vehicle / type = aircraft'])
+  })
+
+  it('renders NOT as "not (…)"', () => {
+    const q: ResourceQuery = {
+      op: 'not',
+      clause: { op: 'eq', path: 'meta.capabilities.refrigerated', value: true },
+    }
+    expect(summarizeQuery(q)).toEqual(['not (refrigerated)'])
+  })
+})

--- a/src/ui/pools/poolSummary.ts
+++ b/src/ui/pools/poolSummary.ts
@@ -1,0 +1,158 @@
+/**
+ * Plain-English description of a `ResourcePool` for the v2 UI
+ * components (issue #386).
+ *
+ * Pure function — turns a structural pool + query into the kind of
+ * sentence the issue thread asks for ("Refrigerated · within 50 mi
+ * of event · capacity ≥ 80,000 lb"). Lives outside the React layer
+ * so it's easy to test, easy to reuse from non-UI surfaces (plain
+ * text emails, audit log entries), and easy to swap for a
+ * localization layer later.
+ *
+ * Returns a list of human-readable phrases — the renderer chooses
+ * how to join them (chips vs. comma list vs. bullet list).
+ */
+import type { ResourcePool } from '../../core/pools/resourcePoolSchema'
+import type { ResourceQuery } from '../../core/pools/poolQuerySchema'
+
+export interface PoolSummary {
+  /** "Pool", "Manual pool", "Query pool", "Hybrid pool" */
+  readonly typeLabel: string
+  /**
+   * Strategy in plain English ("First available", "Least loaded",
+   * "Round robin", "Closest to event").
+   */
+  readonly strategyLabel: string
+  /**
+   * Each clause as one short phrase. Empty for `manual` pools and
+   * for `query` pools that have no recognizable clauses.
+   */
+  readonly clauseLabels: readonly string[]
+  /**
+   * One-line headline that combines the above. Useful for default
+   * card headers when a richer layout isn't needed.
+   */
+  readonly headline: string
+}
+
+const TYPE_LABEL: Record<string, string> = {
+  manual: 'Manual pool',
+  query:  'Query pool',
+  hybrid: 'Hybrid pool',
+}
+
+const STRATEGY_LABEL: Record<string, string> = {
+  'first-available': 'First available',
+  'least-loaded':    'Least loaded',
+  'round-robin':     'Round robin',
+  'closest':         'Closest to event',
+}
+
+export function summarizePool(pool: ResourcePool): PoolSummary {
+  const typeLabel     = TYPE_LABEL[pool.type ?? 'manual'] ?? 'Pool'
+  const strategyLabel = STRATEGY_LABEL[pool.strategy] ?? pool.strategy
+
+  const clauseLabels: string[] = []
+  if (pool.type === 'manual' || pool.type === undefined) {
+    if (pool.memberIds.length > 0) {
+      clauseLabels.push(`${pool.memberIds.length} ${pluralize('member', pool.memberIds.length)}`)
+    }
+  } else if (pool.query) {
+    clauseLabels.push(...summarizeQuery(pool.query))
+    if (pool.type === 'hybrid' && pool.memberIds.length > 0) {
+      clauseLabels.push(`limited to ${pool.memberIds.length} curated ${pluralize('member', pool.memberIds.length)}`)
+    }
+  }
+
+  const headline = clauseLabels.length > 0
+    ? `${typeLabel} · ${clauseLabels.join(' · ')}`
+    : typeLabel
+
+  return { typeLabel, strategyLabel, clauseLabels, headline }
+}
+
+/**
+ * Turn a query tree into a flat list of human phrases. Boolean
+ * composites flatten unless a clause has no plain-English form, in
+ * which case it falls back to a generic "matches custom rule".
+ */
+export function summarizeQuery(q: ResourceQuery): readonly string[] {
+  const phrases: string[] = []
+  walk(q, phrases)
+  return phrases
+}
+
+function walk(q: ResourceQuery, out: string[]): void {
+  switch (q.op) {
+    case 'and':
+      for (const c of q.clauses) walk(c, out)
+      return
+    case 'or': {
+      // OR can't flatten without losing meaning — render the whole
+      // sub-tree as a single "any of …" phrase.
+      const inner = q.clauses.flatMap(c => summarizeQuery(c))
+      if (inner.length > 0) out.push(`any of: ${inner.join(' / ')}`)
+      return
+    }
+    case 'not': {
+      const inner = summarizeQuery(q.clause).join(' & ')
+      if (inner) out.push(`not (${inner})`)
+      return
+    }
+    case 'within': {
+      const unit = q.miles != null ? `${q.miles} mi` : q.km != null ? `${q.km} km` : 'distance'
+      const ref = q.from.kind === 'proposed' ? 'event' : `${q.from.lat.toFixed(2)}, ${q.from.lon.toFixed(2)}`
+      out.push(`within ${unit} of ${ref}`)
+      return
+    }
+    case 'eq': {
+      const friendly = friendlyPath(q.path)
+      if (q.value === true)  out.push(friendly)
+      else if (q.value === false) out.push(`not ${friendly}`)
+      else if (q.value === null)  out.push(`${friendly} is empty`)
+      else out.push(`${friendly} = ${formatValue(q.value)}`)
+      return
+    }
+    case 'neq':
+      out.push(`${friendlyPath(q.path)} ≠ ${formatValue(q.value)}`)
+      return
+    case 'in':
+      out.push(`${friendlyPath(q.path)} in {${q.values.map(formatValue).join(', ')}}`)
+      return
+    case 'gt':
+      out.push(`${friendlyPath(q.path)} > ${formatValue(q.value)}`)
+      return
+    case 'gte':
+      out.push(`${friendlyPath(q.path)} ≥ ${formatValue(q.value)}`)
+      return
+    case 'lt':
+      out.push(`${friendlyPath(q.path)} < ${formatValue(q.value)}`)
+      return
+    case 'lte':
+      out.push(`${friendlyPath(q.path)} ≤ ${formatValue(q.value)}`)
+      return
+    case 'exists':
+      out.push(`has ${friendlyPath(q.path)}`)
+      return
+  }
+}
+
+/**
+ * `meta.capabilities.refrigerated` → `refrigerated`
+ * `capabilities.capacity_lbs`      → `capacity lbs`
+ * `tenantId`                       → `tenant`
+ */
+function friendlyPath(path: string): string {
+  const trimmed = path.replace(/^meta\./, '').replace(/^capabilities\./, '')
+  return trimmed.split('.').pop()!.replace(/[_-]+/g, ' ')
+}
+
+function formatValue(v: unknown): string {
+  if (typeof v === 'number') return v.toLocaleString()
+  if (v === null) return 'null'
+  return String(v)
+}
+
+function pluralize(word: string, n: number): string {
+  return n === 1 ? word : `${word}s`
+}


### PR DESCRIPTION
## Summary

**First UI slice on top of the v2 engine.** Two opt-in components
hosts mount wherever their config UI lives — no engine changes,
no host wiring required beyond the existing `pools` /
`onPoolsChange` props.

### `PoolCard`

Read-only summary card. Renders pool name, a type chip
(Manual / Query / Hybrid), a plain-English clause list
("refrigerated · within 50 mi of event"), the chosen strategy, and
(when `resources` is passed) a live **"Matches N · M excluded"**
counter. Optional `onEdit` / `onToggleDisabled` / `actions` slots so
hosts can wire their own affordances.

```tsx
<PoolCard
  pool={pool}
  resources={resources}
  onEdit={() => setEditing(pool)}
  onToggleDisabled={() => toggle(pool.id)}
/>
```

### `PoolBuilder`

Guided create / edit modal — progressive disclosure per the issue
thread:

- **Type picker** (manual / query / hybrid) with one-line descriptions.
- **Name input.**
- **Manual pools** — checkbox list of resources to include.
- **Query / hybrid pools** — capability chips (auto-derived from each
  resource's `meta.capabilities` boolean keys, or curated via a
  `capabilityCatalog` prop) + a "within N miles of event" radius.
- **Strategy picker** with an inline alert that **blocks Save** when
  `closest` is picked without a radius clause — keeps the new
  strategy from shipping without a reference point.
- **Live preview**: `Matches N · M excluded` runs `evaluateQuery`
  against the live registry as the draft changes.

### `summarizePool` / `summarizeQuery`

Pure helpers that turn a pool or query into a `PoolSummary` object
(`{ typeLabel, strategyLabel, clauseLabels, headline }`). Drive the
`PoolCard` summary and are reusable from non-React surfaces (audit
logs, plain-text emails, command palettes) without re-rendering.

### Out of scope (each warrants its own follow-up slice)

- Level-3 advanced rule editor with arbitrary AND / OR / NOT
- Numeric capability range pickers (`capacity_lbs ≥ N`)
- Multi-source location-adapter config UI
- The wizard / standard `config.json` export

## Test plan

- [x] `tsc --noEmit` clean
- [x] `vitest run` — 2296 passing, 2 skipped (existing PTO flakes), 0 failures (35 new component tests)
- [x] `poolSummary` covers every leaf op, AND flattening, OR rendered as `any of …`, NOT, capability shorthand (`refrigerated` vs `not refrigerated`), and the headline assembly
- [x] `PoolCard` covers header chips, the disabled state, conditional `Edit`/`Toggle` buttons, manual-vs-query stat math, the hybrid intersection, and missing-resources fallback
- [x] `PoolBuilder` covers manual save, query save with single-clause and multi-clause `and` wrappers, the closest-without-radius save block, the live preview tracking the draft, edit-existing seeds capabilities + radius, id/disabled preservation on save, host-supplied catalog overriding auto-discovery, and the cancel/close paths

Issue #386 stays open for the remaining UI slices (advanced rule
editor, numeric range pickers, location-adapter config, wizard).

https://claude.ai/code/session_01XojXzZPdEPuGbX2TyLY1pu

---
_Generated by [Claude Code](https://claude.ai/code/session_01XojXzZPdEPuGbX2TyLY1pu)_