### PR TITLE
ui(pools): Level 3 advanced rules editor (#386)

### DIFF
--- a/docs/ResourcePools.md
+++ b/docs/ResourcePools.md
@@ -462,6 +462,44 @@ import { PoolBuilder } from 'works-calendar';
 The builder produces a concrete `ResourcePool`; persistence is the
 host's problem (typically wired through `onPoolsChange`).
 
+### Advanced rules — full DSL editor
+
+The `PoolBuilder` modal also exposes a collapsible **Advanced rules**
+section for query / hybrid pools. The simple-form fields (capability
+chips + radius) keep covering the common case; the advanced section
+lets power users edit anything else the DSL supports —
+`gt` / `gte` / `lt` / `lte`, `or`, `not`, fixed-point `within`,
+arbitrary `meta` paths, etc.
+
+The section opens automatically when an existing pool's query
+contains clauses the simple form can't model (so users can see what
+they're inheriting), and stays collapsed for "clean" simple-form
+pools so it doesn't add visual noise.
+
+Two opt-in components power the section and ship as standalone
+exports too:
+
+- **`AdvancedRulesEditor`** — flat list manager. Each row shows a
+  plain-English summary of the clause (via `summarizeQuery`) plus
+  Edit / Remove buttons. Add new rules via "+ Add rule".
+- **`ClauseEditor`** — recursive single-clause editor. Op picker
+  covers every DSL leaf and composite (`and` / `or` / `not`); inputs
+  type themselves to whichever op is active (number for gte, lat/lon
+  for fixed-point `within`, etc.).
+
+```tsx
+import { AdvancedRulesEditor } from 'works-calendar';
+
+<AdvancedRulesEditor
+  clauses={query.op === 'and' ? query.clauses : [query]}
+  onChange={(next) => persist(reAndWrap(next))}
+/>
+```
+
+Nesting is capped at depth 5 to keep the DOM bounded; deeper trees
+can still be authored via JSON / config and round-trip safely
+through `PoolBuilder` because they land in the preserved bucket.
+
 ### `summarizePool` / `summarizeQuery`
 
 Pure helpers that turn a pool or query into a `PoolSummary`

--- a/src/index.ts
+++ b/src/index.ts
@@ -190,6 +190,10 @@ export { default as PoolCard }    from './ui/pools/PoolCard';
 export type { PoolCardProps }      from './ui/pools/PoolCard';
 export { default as PoolBuilder } from './ui/pools/PoolBuilder';
 export type { PoolBuilderProps, CapabilityOption } from './ui/pools/PoolBuilder';
+export { default as ClauseEditor } from './ui/pools/ClauseEditor';
+export type { ClauseEditorProps } from './ui/pools/ClauseEditor';
+export { default as AdvancedRulesEditor } from './ui/pools/AdvancedRulesEditor';
+export type { AdvancedRulesEditorProps } from './ui/pools/AdvancedRulesEditor';
 export { summarizePool, summarizeQuery } from './ui/pools/poolSummary';
 export type { PoolSummary } from './ui/pools/poolSummary';
 

--- a/src/ui/pools/AdvancedRulesEditor.module.css
+++ b/src/ui/pools/AdvancedRulesEditor.module.css
@@ -1,0 +1,86 @@
+.root {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.empty {
+  margin: 0;
+  font-size: 12px;
+  color: var(--wc-text-muted, #6b7280);
+  font-style: italic;
+}
+
+.list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.row {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 8px 10px;
+  border: 1px solid var(--wc-border, #e5e7eb);
+  border-radius: 6px;
+  background: var(--wc-bg, #ffffff);
+}
+
+.rowHead {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.summary {
+  font-size: 13px;
+  font-family: var(--wc-font-mono, ui-monospace, monospace);
+  color: var(--wc-text, #111827);
+  word-break: break-word;
+}
+
+.rowActions {
+  display: flex;
+  gap: 4px;
+  flex-shrink: 0;
+}
+
+.rowBtn {
+  padding: 3px 9px;
+  font-size: 12px;
+  border: 1px solid var(--wc-border, #e5e7eb);
+  background: var(--wc-bg, #ffffff);
+  border-radius: 4px;
+  cursor: pointer;
+  color: var(--wc-text-muted, #6b7280);
+}
+
+.rowBtn:hover {
+  background: var(--wc-bg-muted, #f3f4f6);
+  color: var(--wc-text, #111827);
+}
+
+.rowBody {
+  padding-top: 4px;
+}
+
+.addBtn {
+  align-self: flex-start;
+  padding: 6px 12px;
+  font-size: 13px;
+  border: 1px dashed var(--wc-border, #d1d5db);
+  background: transparent;
+  border-radius: 6px;
+  cursor: pointer;
+  color: var(--wc-text-muted, #6b7280);
+}
+
+.addBtn:hover {
+  border-color: #2563eb;
+  color: #2563eb;
+}

--- a/src/ui/pools/AdvancedRulesEditor.tsx
+++ b/src/ui/pools/AdvancedRulesEditor.tsx
@@ -1,0 +1,95 @@
+/**
+ * AdvancedRulesEditor — flat list manager for advanced query
+ * clauses (issue #386 Level 3).
+ *
+ * Each row shows a clause's plain-English summary + a Remove button.
+ * Editing a row toggles a `ClauseEditor` inline. New clauses are
+ * added via "+ Add rule".
+ *
+ * Pure / controlled — operates on a `ResourceQuery[]` and emits
+ * changes via `onChange`. The parent (`PoolBuilder`) owns the array
+ * and AND-merges it with the simple-form clauses on save.
+ */
+import { useState } from 'react'
+import type { ResourceQuery } from '../../core/pools/poolQuerySchema'
+import ClauseEditor from './ClauseEditor'
+import { summarizeQuery } from './poolSummary'
+import styles from './AdvancedRulesEditor.module.css'
+
+export interface AdvancedRulesEditorProps {
+  readonly clauses: readonly ResourceQuery[]
+  readonly onChange: (next: readonly ResourceQuery[]) => void
+}
+
+const DEFAULT_NEW_CLAUSE: ResourceQuery = { op: 'eq', path: '', value: '' }
+
+export default function AdvancedRulesEditor({
+  clauses, onChange,
+}: AdvancedRulesEditorProps): JSX.Element {
+  const [editingIndex, setEditingIndex] = useState<number | null>(null)
+
+  const updateAt = (index: number, next: ResourceQuery) =>
+    onChange(clauses.map((c, i) => i === index ? next : c))
+  const removeAt = (index: number) => {
+    onChange(clauses.filter((_, i) => i !== index))
+    if (editingIndex === index) setEditingIndex(null)
+  }
+  const addNew = () => {
+    onChange([...clauses, DEFAULT_NEW_CLAUSE])
+    setEditingIndex(clauses.length) // open the new row in edit mode
+  }
+
+  return (
+    <div className={styles['root']} aria-label="Advanced rules editor">
+      {clauses.length === 0 && (
+        <p className={styles['empty']}>
+          No advanced rules yet. Use these to express AND/OR/NOT logic, numeric
+          ranges, fixed-point distances, or any other rule the simple form
+          doesn’t cover.
+        </p>
+      )}
+      <ul className={styles['list']}>
+        {clauses.map((c, i) => {
+          const phrase = summarizeQuery(c).join(' & ') || `${c.op}(...)`
+          const isEditing = editingIndex === i
+          return (
+            <li key={i} className={styles['row']}>
+              <div className={styles['rowHead']}>
+                <span className={styles['summary']} data-testid={`advanced-rule-summary-${i}`}>
+                  {phrase}
+                </span>
+                <span className={styles['rowActions']}>
+                  <button
+                    type="button"
+                    className={styles['rowBtn']}
+                    onClick={() => setEditingIndex(isEditing ? null : i)}
+                    aria-expanded={isEditing}
+                    aria-controls={`advanced-rule-body-${i}`}
+                  >
+                    {isEditing ? 'Done' : 'Edit'}
+                  </button>
+                  <button
+                    type="button"
+                    className={styles['rowBtn']}
+                    onClick={() => removeAt(i)}
+                    aria-label={`Remove rule ${i + 1}`}
+                  >
+                    Remove
+                  </button>
+                </span>
+              </div>
+              {isEditing && (
+                <div id={`advanced-rule-body-${i}`} className={styles['rowBody']}>
+                  <ClauseEditor clause={c} onChange={(next) => updateAt(i, next)} />
+                </div>
+              )}
+            </li>
+          )
+        })}
+      </ul>
+      <button type="button" className={styles['addBtn']} onClick={addNew}>
+        + Add rule
+      </button>
+    </div>
+  )
+}

--- a/src/ui/pools/ClauseEditor.module.css
+++ b/src/ui/pools/ClauseEditor.module.css
@@ -1,0 +1,169 @@
+.clause {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  align-items: center;
+  padding: 6px 8px;
+  border: 1px solid var(--wc-border, #e5e7eb);
+  border-radius: 6px;
+  background: var(--wc-bg, #ffffff);
+}
+
+.clause[data-op='and'],
+.clause[data-op='or'] {
+  align-items: stretch;
+  flex-direction: column;
+}
+
+.clause[data-depth='1'] { background: color-mix(in srgb, #2563eb 3%, var(--wc-bg, #ffffff)); }
+.clause[data-depth='2'] { background: color-mix(in srgb, #2563eb 5%, var(--wc-bg, #ffffff)); }
+.clause[data-depth='3'] { background: color-mix(in srgb, #2563eb 7%, var(--wc-bg, #ffffff)); }
+.clause[data-depth='4'] { background: color-mix(in srgb, #2563eb 9%, var(--wc-bg, #ffffff)); }
+.clause[data-depth='5'] { background: color-mix(in srgb, #2563eb 11%, var(--wc-bg, #ffffff)); }
+
+.opPicker,
+.valueKind,
+.fromKindPicker,
+.unitPicker {
+  padding: 4px 6px;
+  font-size: 12px;
+  border: 1px solid var(--wc-border, #e5e7eb);
+  border-radius: 4px;
+  background: var(--wc-bg, #ffffff);
+}
+
+.opPicker {
+  font-weight: 600;
+}
+
+.composite {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 6px 0 0;
+}
+
+.childList {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.child {
+  display: flex;
+  gap: 6px;
+  align-items: flex-start;
+}
+
+.child > .clause {
+  flex: 1;
+}
+
+.notBody {
+  flex: 1;
+}
+
+.leafBody {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  align-items: center;
+  flex: 1;
+}
+
+.pathInput {
+  flex: 1;
+  min-width: 160px;
+  padding: 4px 6px;
+  font-family: var(--wc-font-mono, ui-monospace, monospace);
+  font-size: 12px;
+  border: 1px solid var(--wc-border, #e5e7eb);
+  border-radius: 4px;
+  background: var(--wc-bg, #ffffff);
+}
+
+.valueRow {
+  display: inline-flex;
+  gap: 4px;
+  align-items: center;
+}
+
+.valueInput,
+.numInput,
+.valuesInput {
+  padding: 4px 6px;
+  font-size: 12px;
+  border: 1px solid var(--wc-border, #e5e7eb);
+  border-radius: 4px;
+  background: var(--wc-bg, #ffffff);
+  font-family: var(--wc-font-mono, ui-monospace, monospace);
+}
+
+.numInput {
+  width: 90px;
+}
+
+.valuesInput {
+  flex: 1;
+  min-width: 160px;
+}
+
+.latLonRow {
+  display: inline-flex;
+  gap: 4px;
+}
+
+.nullPlaceholder {
+  font-size: 12px;
+  color: var(--wc-text-muted, #6b7280);
+  font-style: italic;
+}
+
+.empty {
+  font-size: 12px;
+  color: var(--wc-text-muted, #6b7280);
+  font-style: italic;
+}
+
+.addBtn {
+  align-self: flex-start;
+  padding: 3px 10px;
+  font-size: 12px;
+  border: 1px dashed var(--wc-border, #d1d5db);
+  background: transparent;
+  border-radius: 4px;
+  cursor: pointer;
+  color: var(--wc-text-muted, #6b7280);
+}
+
+.addBtn:hover:not(:disabled) {
+  border-color: #2563eb;
+  color: #2563eb;
+}
+
+.addBtn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.removeBtn {
+  font-size: 14px;
+  width: 22px;
+  height: 22px;
+  padding: 0;
+  margin-top: 4px;
+  border: 1px solid var(--wc-border, #e5e7eb);
+  background: var(--wc-bg, #ffffff);
+  color: var(--wc-text-muted, #6b7280);
+  border-radius: 4px;
+  cursor: pointer;
+  flex-shrink: 0;
+}
+
+.removeBtn:hover {
+  color: #dc2626;
+  border-color: #dc2626;
+}

--- a/src/ui/pools/ClauseEditor.tsx
+++ b/src/ui/pools/ClauseEditor.tsx
@@ -1,0 +1,507 @@
+/**
+ * ClauseEditor — recursive editor for a single `ResourceQuery` node
+ * (issue #386 Level 3 advanced rules).
+ *
+ * Renders an op picker plus the inputs appropriate to whichever op
+ * is active. Composite ops (`and` / `or` / `not`) render their
+ * children recursively with add / remove controls.
+ *
+ * Pure / controlled — takes a clause and an `onChange(next)` callback.
+ * The component owns no state of its own; the parent (typically
+ * `AdvancedRulesEditor`) holds the tree.
+ *
+ * Out of scope deliberately: path autocomplete from live resources,
+ * drag-drop reordering of composite children, depth-line nesting
+ * visuals. Those land in follow-up slices once this primitive is
+ * stable.
+ */
+import type { ChangeEvent } from 'react'
+import type {
+  ResourceQuery, ResourceQueryValue, DistanceFrom,
+} from '../../core/pools/poolQuerySchema'
+import styles from './ClauseEditor.module.css'
+
+export interface ClauseEditorProps {
+  readonly clause: ResourceQuery
+  readonly onChange: (next: ResourceQuery) => void
+  /** Hide the op picker (used by the not-clause sub-renderer). */
+  readonly hideOpPicker?: boolean
+  /**
+   * Recursion depth; bounds for visual indentation and a hard cap
+   * at 5 to keep the DOM bounded. The hard cap can be raised once
+   * the editor has scrollable nesting indicators (follow-up).
+   */
+  readonly depth?: number
+}
+
+const ALL_OPS: readonly { value: ResourceQuery['op']; label: string; group: 'logic' | 'compare' | 'set' | 'geo' }[] = [
+  { value: 'and',    label: 'AND (all of)',  group: 'logic' },
+  { value: 'or',     label: 'OR (any of)',   group: 'logic' },
+  { value: 'not',    label: 'NOT',           group: 'logic' },
+  { value: 'eq',     label: '= equals',      group: 'compare' },
+  { value: 'neq',    label: '≠ not equal',   group: 'compare' },
+  { value: 'gt',     label: '> greater than', group: 'compare' },
+  { value: 'gte',    label: '≥ at least',    group: 'compare' },
+  { value: 'lt',     label: '< less than',   group: 'compare' },
+  { value: 'lte',    label: '≤ at most',     group: 'compare' },
+  { value: 'in',     label: 'is one of',     group: 'set' },
+  { value: 'exists', label: 'has value',     group: 'set' },
+  { value: 'within', label: 'within radius', group: 'geo' },
+]
+
+export default function ClauseEditor({
+  clause, onChange, hideOpPicker, depth = 0,
+}: ClauseEditorProps): JSX.Element {
+  // Hard cap to keep nesting from spiralling. The user can lift it by
+  // editing JSON externally; the editor just refuses to add more.
+  const atDepthCap = depth >= 5
+
+  return (
+    <div className={styles['clause']} data-depth={depth} data-op={clause.op}>
+      {!hideOpPicker && (
+        <select
+          className={styles['opPicker']}
+          value={clause.op}
+          aria-label="Operation"
+          onChange={(e: ChangeEvent<HTMLSelectElement>) =>
+            onChange(reshapeForOp(clause, e.target.value as ResourceQuery['op']))
+          }
+        >
+          <optgroup label="Logic">
+            {ALL_OPS.filter(o => o.group === 'logic').map(o =>
+              <option key={o.value} value={o.value}>{o.label}</option>)}
+          </optgroup>
+          <optgroup label="Compare">
+            {ALL_OPS.filter(o => o.group === 'compare').map(o =>
+              <option key={o.value} value={o.value}>{o.label}</option>)}
+          </optgroup>
+          <optgroup label="Set">
+            {ALL_OPS.filter(o => o.group === 'set').map(o =>
+              <option key={o.value} value={o.value}>{o.label}</option>)}
+          </optgroup>
+          <optgroup label="Geo">
+            {ALL_OPS.filter(o => o.group === 'geo').map(o =>
+              <option key={o.value} value={o.value}>{o.label}</option>)}
+          </optgroup>
+        </select>
+      )}
+
+      {(clause.op === 'and' || clause.op === 'or') && (
+        <CompositeBody clause={clause} onChange={onChange} depth={depth} atCap={atDepthCap} />
+      )}
+
+      {clause.op === 'not' && (
+        <NotBody clause={clause} onChange={onChange} depth={depth} />
+      )}
+
+      {(clause.op === 'eq' || clause.op === 'neq') && (
+        <EqBody clause={clause} onChange={onChange} />
+      )}
+
+      {(clause.op === 'gt' || clause.op === 'gte' || clause.op === 'lt' || clause.op === 'lte') && (
+        <NumericBody clause={clause} onChange={onChange} />
+      )}
+
+      {clause.op === 'in' && (
+        <InBody clause={clause} onChange={onChange} />
+      )}
+
+      {clause.op === 'exists' && (
+        <ExistsBody clause={clause} onChange={onChange} />
+      )}
+
+      {clause.op === 'within' && (
+        <WithinBody clause={clause} onChange={onChange} />
+      )}
+    </div>
+  )
+}
+
+// ─── Bodies ────────────────────────────────────────────────────────────────
+
+function CompositeBody({
+  clause, onChange, depth, atCap,
+}: {
+  clause: Extract<ResourceQuery, { op: 'and' | 'or' }>
+  onChange: (next: ResourceQuery) => void
+  depth: number
+  atCap: boolean
+}): JSX.Element {
+  return (
+    <div className={styles['composite']}>
+      {clause.clauses.length === 0 && (
+        <span className={styles['empty']}>
+          {clause.op === 'and' ? 'No sub-rules (matches everything)' : 'No sub-rules (matches nothing)'}
+        </span>
+      )}
+      <ul className={styles['childList']}>
+        {clause.clauses.map((c, i) => (
+          <li key={i} className={styles['child']}>
+            <ClauseEditor
+              clause={c}
+              depth={depth + 1}
+              onChange={(next) => onChange({
+                ...clause,
+                clauses: clause.clauses.map((existing, j) => j === i ? next : existing),
+              })}
+            />
+            <button
+              type="button"
+              className={styles['removeBtn']}
+              aria-label={`Remove sub-rule ${i + 1}`}
+              onClick={() => onChange({
+                ...clause,
+                clauses: clause.clauses.filter((_, j) => j !== i),
+              })}
+            >×</button>
+          </li>
+        ))}
+      </ul>
+      <button
+        type="button"
+        className={styles['addBtn']}
+        disabled={atCap}
+        title={atCap ? 'Maximum nesting depth reached' : ''}
+        onClick={() => onChange({
+          ...clause,
+          clauses: [...clause.clauses, defaultClause('eq')],
+        })}
+      >+ Add sub-rule</button>
+    </div>
+  )
+}
+
+function NotBody({
+  clause, onChange, depth,
+}: {
+  clause: Extract<ResourceQuery, { op: 'not' }>
+  onChange: (next: ResourceQuery) => void
+  depth: number
+}): JSX.Element {
+  return (
+    <div className={styles['notBody']}>
+      <ClauseEditor
+        clause={clause.clause}
+        depth={depth + 1}
+        onChange={(inner) => onChange({ ...clause, clause: inner })}
+      />
+    </div>
+  )
+}
+
+function EqBody({
+  clause, onChange,
+}: {
+  clause: Extract<ResourceQuery, { op: 'eq' | 'neq' }>
+  onChange: (next: ResourceQuery) => void
+}): JSX.Element {
+  return (
+    <div className={styles['leafBody']}>
+      <PathInput value={clause.path} onChange={(path) => onChange({ ...clause, path })} />
+      <ValueInput
+        value={clause.value}
+        onChange={(value) => onChange({ ...clause, value })}
+      />
+    </div>
+  )
+}
+
+function NumericBody({
+  clause, onChange,
+}: {
+  clause: Extract<ResourceQuery, { op: 'gt' | 'gte' | 'lt' | 'lte' }>
+  onChange: (next: ResourceQuery) => void
+}): JSX.Element {
+  return (
+    <div className={styles['leafBody']}>
+      <PathInput value={clause.path} onChange={(path) => onChange({ ...clause, path })} />
+      <input
+        type="number"
+        className={styles['numInput']}
+        value={Number.isFinite(clause.value) ? clause.value : 0}
+        aria-label="Value"
+        onChange={(e: ChangeEvent<HTMLInputElement>) =>
+          onChange({ ...clause, value: Number(e.target.value) })}
+      />
+    </div>
+  )
+}
+
+function InBody({
+  clause, onChange,
+}: {
+  clause: Extract<ResourceQuery, { op: 'in' }>
+  onChange: (next: ResourceQuery) => void
+}): JSX.Element {
+  return (
+    <div className={styles['leafBody']}>
+      <PathInput value={clause.path} onChange={(path) => onChange({ ...clause, path })} />
+      <input
+        type="text"
+        className={styles['valuesInput']}
+        value={clause.values.join(', ')}
+        placeholder="comma-separated"
+        aria-label="Values (comma-separated)"
+        onChange={(e: ChangeEvent<HTMLInputElement>) =>
+          onChange({
+            ...clause,
+            values: parseCommaList(e.target.value),
+          })}
+      />
+    </div>
+  )
+}
+
+function ExistsBody({
+  clause, onChange,
+}: {
+  clause: Extract<ResourceQuery, { op: 'exists' }>
+  onChange: (next: ResourceQuery) => void
+}): JSX.Element {
+  return (
+    <div className={styles['leafBody']}>
+      <PathInput value={clause.path} onChange={(path) => onChange({ ...clause, path })} />
+    </div>
+  )
+}
+
+function WithinBody({
+  clause, onChange,
+}: {
+  clause: Extract<ResourceQuery, { op: 'within' }>
+  onChange: (next: ResourceQuery) => void
+}): JSX.Element {
+  const fromKind = clause.from.kind
+  const usingMiles = clause.km == null
+  return (
+    <div className={styles['leafBody']}>
+      <PathInput value={clause.path} onChange={(path) => onChange({ ...clause, path })} />
+      <select
+        className={styles['fromKindPicker']}
+        value={fromKind}
+        aria-label="Reference point"
+        onChange={(e: ChangeEvent<HTMLSelectElement>) => {
+          const kind = e.target.value as DistanceFrom['kind']
+          const next: DistanceFrom = kind === 'point'
+            ? { kind: 'point', lat: 0, lon: 0 }
+            : { kind: 'proposed' }
+          onChange({ ...clause, from: next })
+        }}
+      >
+        <option value="proposed">event location</option>
+        <option value="point">fixed point</option>
+      </select>
+      {fromKind === 'point' && (
+        <span className={styles['latLonRow']}>
+          <input
+            type="number"
+            step="any"
+            className={styles['numInput']}
+            value={clause.from.kind === 'point' ? clause.from.lat : 0}
+            aria-label="Latitude"
+            onChange={(e: ChangeEvent<HTMLInputElement>) => onChange({
+              ...clause,
+              from: { kind: 'point',
+                lat: Number(e.target.value),
+                lon: clause.from.kind === 'point' ? clause.from.lon : 0 },
+            })}
+          />
+          <input
+            type="number"
+            step="any"
+            className={styles['numInput']}
+            value={clause.from.kind === 'point' ? clause.from.lon : 0}
+            aria-label="Longitude"
+            onChange={(e: ChangeEvent<HTMLInputElement>) => onChange({
+              ...clause,
+              from: { kind: 'point',
+                lat: clause.from.kind === 'point' ? clause.from.lat : 0,
+                lon: Number(e.target.value) },
+            })}
+          />
+        </span>
+      )}
+      <input
+        type="number"
+        min={0}
+        className={styles['numInput']}
+        value={(usingMiles ? clause.miles : clause.km) ?? ''}
+        aria-label="Radius"
+        onChange={(e: ChangeEvent<HTMLInputElement>) =>
+          onChange(setWithinRadius(clause, usingMiles, e.target.value === '' ? undefined : Number(e.target.value)))
+        }
+      />
+      <select
+        className={styles['unitPicker']}
+        value={usingMiles ? 'mi' : 'km'}
+        aria-label="Unit"
+        onChange={(e: ChangeEvent<HTMLSelectElement>) =>
+          onChange(setWithinUnit(clause, e.target.value === 'mi'))
+        }
+      >
+        <option value="mi">miles</option>
+        <option value="km">km</option>
+      </select>
+    </div>
+  )
+}
+
+// ─── Shared inputs ─────────────────────────────────────────────────────────
+
+function PathInput({ value, onChange }: { value: string; onChange: (v: string) => void }): JSX.Element {
+  return (
+    <input
+      type="text"
+      className={styles['pathInput']}
+      value={value}
+      placeholder="meta.capabilities.refrigerated"
+      aria-label="Field path"
+      onChange={(e: ChangeEvent<HTMLInputElement>) => onChange(e.target.value)}
+    />
+  )
+}
+
+function ValueInput({
+  value, onChange,
+}: { value: ResourceQueryValue; onChange: (v: ResourceQueryValue) => void }): JSX.Element {
+  // Type picker so the user can pick string / number / boolean / null
+  // explicitly — comparators behave very differently for `'80000'`
+  // vs `80000`, so we don't infer.
+  const kind: 'string' | 'number' | 'boolean' | 'null' =
+    value === null ? 'null'
+    : typeof value === 'number' ? 'number'
+    : typeof value === 'boolean' ? 'boolean'
+    : 'string'
+  return (
+    <span className={styles['valueRow']}>
+      <select
+        className={styles['valueKind']}
+        value={kind}
+        aria-label="Value type"
+        onChange={(e: ChangeEvent<HTMLSelectElement>) => {
+          switch (e.target.value) {
+            case 'string':  onChange(typeof value === 'string' ? value : String(value ?? '')); break
+            case 'number':  onChange(typeof value === 'number' ? value : 0); break
+            case 'boolean': onChange(value === true); break
+            case 'null':    onChange(null); break
+          }
+        }}
+      >
+        <option value="string">text</option>
+        <option value="number">number</option>
+        <option value="boolean">true/false</option>
+        <option value="null">null</option>
+      </select>
+      {kind === 'string' && (
+        <input
+          type="text"
+          className={styles['valueInput']}
+          value={String(value ?? '')}
+          aria-label="Value"
+          onChange={(e: ChangeEvent<HTMLInputElement>) => onChange(e.target.value)}
+        />
+      )}
+      {kind === 'number' && (
+        <input
+          type="number"
+          className={styles['numInput']}
+          value={typeof value === 'number' ? value : 0}
+          aria-label="Value"
+          onChange={(e: ChangeEvent<HTMLInputElement>) => onChange(Number(e.target.value))}
+        />
+      )}
+      {kind === 'boolean' && (
+        <select
+          className={styles['valueKind']}
+          value={value === true ? 'true' : 'false'}
+          aria-label="Value"
+          onChange={(e: ChangeEvent<HTMLSelectElement>) => onChange(e.target.value === 'true')}
+        >
+          <option value="true">true</option>
+          <option value="false">false</option>
+        </select>
+      )}
+      {kind === 'null' && <span className={styles['nullPlaceholder']}>(null)</span>}
+    </span>
+  )
+}
+
+// ─── Helpers ───────────────────────────────────────────────────────────────
+
+/**
+ * When the user picks a different op from the dropdown, fold the
+ * existing clause's `path` into the new shape if applicable; default
+ * everything else. This keeps the user's typed path from disappearing
+ * each time they tweak the comparator.
+ */
+function reshapeForOp(prev: ResourceQuery, op: ResourceQuery['op']): ResourceQuery {
+  const path = 'path' in prev ? prev.path : ''
+  switch (op) {
+    case 'and':    return { op: 'and',    clauses: 'clauses' in prev ? prev.clauses : [] }
+    case 'or':     return { op: 'or',     clauses: 'clauses' in prev ? prev.clauses : [] }
+    case 'not':    return { op: 'not',    clause: 'clause' in prev ? prev.clause : defaultClause('eq') }
+    case 'eq':     return { op: 'eq',     path, value: 'value' in prev ? prev.value as ResourceQueryValue : '' }
+    case 'neq':    return { op: 'neq',    path, value: 'value' in prev ? prev.value as ResourceQueryValue : '' }
+    case 'gt':     return { op: 'gt',     path, value: numericFrom(prev) }
+    case 'gte':    return { op: 'gte',    path, value: numericFrom(prev) }
+    case 'lt':     return { op: 'lt',     path, value: numericFrom(prev) }
+    case 'lte':    return { op: 'lte',    path, value: numericFrom(prev) }
+    case 'in':     return { op: 'in',     path, values: 'values' in prev ? prev.values : [] }
+    case 'exists': return { op: 'exists', path }
+    case 'within': return {
+      op: 'within', path: path || 'meta.location',
+      from: { kind: 'proposed' },
+      miles: 50,
+    }
+  }
+}
+
+function defaultClause(op: ResourceQuery['op']): ResourceQuery {
+  return reshapeForOp({ op: 'eq', path: '', value: '' } as ResourceQuery, op)
+}
+
+function numericFrom(prev: ResourceQuery): number {
+  if ('value' in prev && typeof prev.value === 'number') return prev.value
+  return 0
+}
+
+/**
+ * Rebuild a `within` clause with the chosen radius set on exactly
+ * one unit field. Spreading `{ miles, km: undefined }` leaks an
+ * explicit `undefined` into the object, which TypeScript treats
+ * differently from the field being absent — so we construct the
+ * result without the unwanted property.
+ */
+function setWithinRadius(
+  clause: Extract<ResourceQuery, { op: 'within' }>,
+  usingMiles: boolean,
+  value: number | undefined,
+): ResourceQuery {
+  const base = { op: 'within', path: clause.path, from: clause.from } as const
+  return value === undefined
+    ? base
+    : usingMiles
+      ? { ...base, miles: value }
+      : { ...base, km: value }
+}
+
+function setWithinUnit(
+  clause: Extract<ResourceQuery, { op: 'within' }>,
+  toMiles: boolean,
+): ResourceQuery {
+  const cur = clause.miles ?? clause.km
+  const base = { op: 'within', path: clause.path, from: clause.from } as const
+  if (cur === undefined) return base
+  return toMiles ? { ...base, miles: cur } : { ...base, km: cur }
+}
+
+function parseCommaList(raw: string): readonly ResourceQueryValue[] {
+  return raw.split(',').map(s => s.trim()).filter(s => s.length > 0).map((s) => {
+    if (s === 'true')  return true
+    if (s === 'false') return false
+    if (s === 'null')  return null
+    const n = Number(s)
+    if (!Number.isNaN(n) && /^-?\d+(\.\d+)?$/.test(s)) return n
+    return s
+  })
+}

--- a/src/ui/pools/PoolBuilder.module.css
+++ b/src/ui/pools/PoolBuilder.module.css
@@ -191,18 +191,32 @@
   font-variant-numeric: tabular-nums;
 }
 
-.preserved {
-  padding: 8px 12px;
-  font-size: 12px;
-  color: #92400e;
-  background: #fef3c7;
-  border: 1px solid #fcd34d;
-  border-radius: 6px;
+.advanced {
+  padding: 4px 0;
+  border-top: 1px solid var(--wc-border, #e5e7eb);
 }
 
-.preserved strong {
+.advancedSummary {
+  cursor: pointer;
+  font-size: 12px;
   font-weight: 600;
-  color: #78350f;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--wc-text-muted, #6b7280);
+  padding: 8px 0 6px;
+  list-style: revert;
+}
+
+.advancedSummary:hover {
+  color: var(--wc-text, #111827);
+}
+
+.advancedCount {
+  margin-left: 6px;
+  font-weight: 500;
+  text-transform: none;
+  letter-spacing: 0;
+  color: var(--wc-text-muted, #6b7280);
 }
 
 .previewExcluded {

--- a/src/ui/pools/PoolBuilder.tsx
+++ b/src/ui/pools/PoolBuilder.tsx
@@ -34,6 +34,7 @@ import type {
   ResourceQuery,
 } from '../../core/pools/poolQuerySchema'
 import type { EngineResource } from '../../core/engine/schema/resourceSchema'
+import AdvancedRulesEditor from './AdvancedRulesEditor'
 import styles from './PoolBuilder.module.css'
 
 export interface CapabilityOption {
@@ -287,17 +288,25 @@ export default function PoolBuilder(props: PoolBuilderProps): JSX.Element {
           )}
         </section>
 
-        {hasPreserved && (draft.type === 'query' || draft.type === 'hybrid') && (
-          <section
-            className={styles['preserved']}
-            data-testid="pool-builder-preserved"
-            role="note"
-            aria-label="Additional rules preserved on save"
+        {(draft.type === 'query' || draft.type === 'hybrid') && (
+          <details
+            className={styles['advanced']}
+            data-testid="pool-builder-advanced"
+            open={hasPreserved}
           >
-            <strong>{draft.preserved.length}</strong>{' '}
-            additional {draft.preserved.length === 1 ? 'rule isn’t' : 'rules aren’t'} editable here
-            {' '}— they’ll be preserved on save.
-          </section>
+            <summary className={styles['advancedSummary']}>
+              Advanced rules
+              {hasPreserved && (
+                <span className={styles['advancedCount']}>
+                  ({draft.preserved.length})
+                </span>
+              )}
+            </summary>
+            <AdvancedRulesEditor
+              clauses={draft.preserved}
+              onChange={(next) => setDraft(d => ({ ...d, preserved: next }))}
+            />
+          </details>
         )}
 
         <section className={styles['preview']} aria-label="Live match preview">

--- a/src/ui/pools/__tests__/AdvancedRulesEditor.test.tsx
+++ b/src/ui/pools/__tests__/AdvancedRulesEditor.test.tsx
@@ -1,0 +1,89 @@
+// @vitest-environment happy-dom
+/**
+ * AdvancedRulesEditor — flat list manager (#386 L3).
+ */
+import { render, screen, fireEvent } from '@testing-library/react'
+import { describe, it, expect } from 'vitest'
+import '@testing-library/jest-dom'
+import React, { useState } from 'react'
+
+import AdvancedRulesEditor from '../AdvancedRulesEditor'
+import type { ResourceQuery } from '../../../core/pools/poolQuerySchema'
+
+function Harness({ initial }: { initial: readonly ResourceQuery[] }) {
+  const [clauses, setClauses] = useState<readonly ResourceQuery[]>(initial)
+  return (
+    <div>
+      <AdvancedRulesEditor clauses={clauses} onChange={setClauses} />
+      <pre data-testid="clauses-state">{JSON.stringify(clauses)}</pre>
+    </div>
+  )
+}
+
+const stateOf = () => JSON.parse(screen.getByTestId('clauses-state').textContent ?? '[]')
+
+describe('AdvancedRulesEditor — empty state', () => {
+  it('shows a placeholder when there are no clauses', () => {
+    render(<Harness initial={[]} />)
+    expect(screen.getByText(/No advanced rules yet/)).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: '+ Add rule' })).toBeInTheDocument()
+  })
+})
+
+describe('AdvancedRulesEditor — add / remove', () => {
+  it('Add rule appends a default eq clause and opens it for editing', () => {
+    render(<Harness initial={[]} />)
+    fireEvent.click(screen.getByRole('button', { name: '+ Add rule' }))
+    expect(stateOf()).toEqual([{ op: 'eq', path: '', value: '' }])
+    // Newly added row is in edit mode → ClauseEditor is visible.
+    expect(screen.getByLabelText('Operation')).toBeInTheDocument()
+  })
+
+  it('Remove drops the chosen clause by index', () => {
+    render(<Harness initial={[
+      { op: 'eq', path: 'a', value: 1 },
+      { op: 'eq', path: 'b', value: 2 },
+    ]} />)
+    fireEvent.click(screen.getByRole('button', { name: 'Remove rule 1' }))
+    expect(stateOf()).toEqual([{ op: 'eq', path: 'b', value: 2 }])
+  })
+})
+
+describe('AdvancedRulesEditor — summaries + edit toggle', () => {
+  it('renders one summary phrase per clause', () => {
+    render(<Harness initial={[
+      { op: 'gte', path: 'meta.capabilities.capacity_lbs', value: 80000 },
+      { op: 'within', path: 'meta.location', from: { kind: 'proposed' }, miles: 50 },
+    ]} />)
+    expect(screen.getByTestId('advanced-rule-summary-0')).toHaveTextContent('capacity lbs ≥ 80,000')
+    expect(screen.getByTestId('advanced-rule-summary-1')).toHaveTextContent('within 50 mi of event')
+  })
+
+  it('Edit reveals the ClauseEditor; Done collapses it again', () => {
+    render(<Harness initial={[
+      { op: 'gte', path: 'meta.capabilities.capacity_lbs', value: 80000 },
+    ]} />)
+    expect(screen.queryByLabelText('Operation')).toBeNull()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Edit' }))
+    expect(screen.getByLabelText('Operation')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Done' })).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Done' }))
+    expect(screen.queryByLabelText('Operation')).toBeNull()
+  })
+
+  it('inline edits mutate the right clause without touching siblings', () => {
+    render(<Harness initial={[
+      { op: 'eq', path: 'a', value: 'x' },
+      { op: 'eq', path: 'b', value: 'y' },
+    ]} />)
+    // Open the second row's editor.
+    fireEvent.click(screen.getAllByRole('button', { name: 'Edit' })[1]!)
+    fireEvent.change(screen.getByLabelText('Field path'), { target: { value: 'renamed' } })
+    expect(stateOf()).toEqual([
+      { op: 'eq', path: 'a', value: 'x' },
+      { op: 'eq', path: 'renamed', value: 'y' },
+    ])
+  })
+})

--- a/src/ui/pools/__tests__/ClauseEditor.test.tsx
+++ b/src/ui/pools/__tests__/ClauseEditor.test.tsx
@@ -1,0 +1,189 @@
+// @vitest-environment happy-dom
+/**
+ * ClauseEditor — recursive editor for any ResourceQuery node (#386 L3).
+ */
+import { render, screen, fireEvent } from '@testing-library/react'
+import { describe, it, expect, vi } from 'vitest'
+import '@testing-library/jest-dom'
+import React, { useState } from 'react'
+
+import ClauseEditor from '../ClauseEditor'
+import type { ResourceQuery } from '../../../core/pools/poolQuerySchema'
+
+/**
+ * Wrapper that turns the controlled component into something we can
+ * inspect at the end of a test ("after these interactions, what does
+ * the clause look like?").
+ */
+function Harness({ initial }: { initial: ResourceQuery }) {
+  const [clause, setClause] = useState<ResourceQuery>(initial)
+  return (
+    <div>
+      <ClauseEditor clause={clause} onChange={setClause} />
+      <pre data-testid="clause-state">{JSON.stringify(clause)}</pre>
+    </div>
+  )
+}
+
+const stateOf = () => JSON.parse(screen.getByTestId('clause-state').textContent ?? '{}')
+
+describe('ClauseEditor — op switching reshapes the clause', () => {
+  it('preserves path when switching between leaf comparators', () => {
+    render(<Harness initial={{ op: 'eq', path: 'capabilities.refrigerated', value: true }} />)
+    fireEvent.change(screen.getByLabelText('Operation'), { target: { value: 'gte' } })
+    expect(stateOf()).toEqual({ op: 'gte', path: 'capabilities.refrigerated', value: 0 })
+  })
+
+  it('seeds within with sensible defaults (proposed event, miles, 50)', () => {
+    render(<Harness initial={{ op: 'eq', path: '', value: '' }} />)
+    fireEvent.change(screen.getByLabelText('Operation'), { target: { value: 'within' } })
+    expect(stateOf()).toEqual({
+      op: 'within',
+      path: 'meta.location',
+      from: { kind: 'proposed' },
+      miles: 50,
+    })
+  })
+})
+
+describe('ClauseEditor — leaf bodies', () => {
+  it('eq with a boolean value renders the true/false picker', () => {
+    render(<Harness initial={{ op: 'eq', path: 'capabilities.refrigerated', value: true }} />)
+    expect(screen.getByLabelText('Value')).toHaveValue('true')
+    fireEvent.change(screen.getByLabelText('Value'), { target: { value: 'false' } })
+    expect(stateOf().value).toBe(false)
+  })
+
+  it('eq with a numeric value uses the number input', () => {
+    render(<Harness initial={{ op: 'eq', path: 'capacity', value: 80 }} />)
+    expect(screen.getByLabelText('Value')).toHaveValue(80)
+    fireEvent.change(screen.getByLabelText('Value'), { target: { value: '100' } })
+    expect(stateOf().value).toBe(100)
+  })
+
+  it('switching value type from string to number coerces to 0', () => {
+    render(<Harness initial={{ op: 'eq', path: 'name', value: 'truck' }} />)
+    fireEvent.change(screen.getByLabelText('Value type'), { target: { value: 'number' } })
+    expect(stateOf().value).toBe(0)
+  })
+
+  it('numeric comparators (gte) render a single number input + path', () => {
+    render(<Harness initial={{ op: 'gte', path: 'meta.capabilities.capacity_lbs', value: 80000 }} />)
+    fireEvent.change(screen.getByLabelText('Value'), { target: { value: '100000' } })
+    expect(stateOf()).toEqual({
+      op: 'gte', path: 'meta.capabilities.capacity_lbs', value: 100000,
+    })
+  })
+
+  it('in clause parses a comma list, coercing numbers and booleans', () => {
+    render(<Harness initial={{ op: 'in', path: 'type', values: [] }} />)
+    fireEvent.change(screen.getByLabelText('Values (comma-separated)'), {
+      target: { value: 'vehicle, aircraft, 5, true' },
+    })
+    expect(stateOf().values).toEqual(['vehicle', 'aircraft', 5, true])
+  })
+
+  it('within with fixed point renders lat / lon inputs', () => {
+    render(<Harness initial={{
+      op: 'within', path: 'meta.location',
+      from: { kind: 'point', lat: 40, lon: -111 }, miles: 50,
+    }} />)
+    fireEvent.change(screen.getByLabelText('Latitude'),  { target: { value: '40.76' } })
+    fireEvent.change(screen.getByLabelText('Longitude'), { target: { value: '-111.89' } })
+    expect(stateOf().from).toEqual({ kind: 'point', lat: 40.76, lon: -111.89 })
+  })
+
+  it('within unit picker swaps miles/km exclusively', () => {
+    render(<Harness initial={{
+      op: 'within', path: 'meta.location', from: { kind: 'proposed' }, miles: 50,
+    }} />)
+    fireEvent.change(screen.getByLabelText('Unit'), { target: { value: 'km' } })
+    const s = stateOf()
+    expect(s.km).toBe(50)
+    expect(s.miles).toBeUndefined()
+  })
+
+  it('within reference-point picker swaps proposed ↔ point', () => {
+    render(<Harness initial={{
+      op: 'within', path: 'meta.location', from: { kind: 'proposed' }, miles: 50,
+    }} />)
+    fireEvent.change(screen.getByLabelText('Reference point'), { target: { value: 'point' } })
+    expect(stateOf().from).toEqual({ kind: 'point', lat: 0, lon: 0 })
+  })
+})
+
+describe('ClauseEditor — composite (and / or)', () => {
+  it('Add sub-rule appends a default eq clause', () => {
+    render(<Harness initial={{ op: 'and', clauses: [] }} />)
+    fireEvent.click(screen.getByRole('button', { name: '+ Add sub-rule' }))
+    expect(stateOf().clauses).toEqual([{ op: 'eq', path: '', value: '' }])
+  })
+
+  it('Remove drops the chosen child by index', () => {
+    render(<Harness initial={{
+      op: 'and',
+      clauses: [
+        { op: 'eq', path: 'a', value: 1 },
+        { op: 'eq', path: 'b', value: 2 },
+      ],
+    }} />)
+    fireEvent.click(screen.getByRole('button', { name: 'Remove sub-rule 1' }))
+    expect(stateOf().clauses).toEqual([{ op: 'eq', path: 'b', value: 2 }])
+  })
+
+  it('mutates a child clause without losing siblings', () => {
+    render(<Harness initial={{
+      op: 'and',
+      clauses: [
+        { op: 'eq', path: 'a', value: 1 },
+        { op: 'eq', path: 'b', value: 2 },
+      ],
+    }} />)
+    // First child's path input.
+    const pathInputs = screen.getAllByLabelText('Field path')
+    fireEvent.change(pathInputs[0]!, { target: { value: 'changed' } })
+    expect(stateOf().clauses[0]).toEqual({ op: 'eq', path: 'changed', value: 1 })
+    expect(stateOf().clauses[1]).toEqual({ op: 'eq', path: 'b', value: 2 })
+  })
+
+  it('blocks adding sub-rules past the depth cap', () => {
+    // Build a chain whose innermost composite is at depth 5 — its
+    // Add button must be disabled because the next child would land
+    // at depth 6, past the cap.
+    const deep: ResourceQuery = {
+      op: 'and', clauses: [{           // depth 0
+        op: 'and', clauses: [{         // depth 1
+          op: 'and', clauses: [{       // depth 2
+            op: 'and', clauses: [{     // depth 3
+              op: 'and', clauses: [{   // depth 4
+                op: 'and', clauses: [], // depth 5 — at cap
+              }],
+            }],
+          }],
+        }],
+      }],
+    }
+    render(<Harness initial={deep} />)
+    const addButtons = screen.getAllByRole('button', { name: '+ Add sub-rule' })
+    // Innermost button comes first in document order (depth-first
+    // rendering with the parent's button after its children's). It
+    // sits at the depth cap and must refuse a 7th level.
+    expect(addButtons[0]).toBeDisabled()
+    // Shallower ones stay enabled.
+    expect(addButtons[addButtons.length - 1]).toBeEnabled()
+  })
+})
+
+describe('ClauseEditor — not', () => {
+  it('renders the inner clause and propagates edits', () => {
+    render(<Harness initial={{
+      op: 'not',
+      clause: { op: 'eq', path: 'tenantId', value: 'banned' },
+    }} />)
+    fireEvent.change(screen.getByLabelText('Field path'), { target: { value: 'tenant' } })
+    expect(stateOf()).toEqual({
+      op: 'not',
+      clause: { op: 'eq', path: 'tenant', value: 'banned' },
+    })
+  })
+})

--- a/src/ui/pools/__tests__/PoolBuilder.test.tsx
+++ b/src/ui/pools/__tests__/PoolBuilder.test.tsx
@@ -199,7 +199,10 @@ describe('PoolBuilder — preserves advanced clauses through edits (#386 P1)', (
 
     // The form acknowledges the preserved gte but lets the user
     // edit the recognized refrigerated chip.
-    expect(screen.getByTestId('pool-builder-preserved')).toHaveTextContent(/1 additional rule/)
+    // Advanced section opens automatically when there's a preserved clause.
+    expect(screen.getByTestId('pool-builder-advanced')).toHaveAttribute('open')
+    expect(screen.getByTestId('pool-builder-advanced')).toHaveTextContent('(1)')
+    expect(screen.getByTestId('advanced-rule-summary-0')).toHaveTextContent('capacity lbs ≥ 80,000')
     fireEvent.click(screen.getByRole('button', { name: 'Save changes' }))
 
     const saved = onSave.mock.calls[0]![0] as ResourcePool
@@ -228,8 +231,12 @@ describe('PoolBuilder — preserves advanced clauses through edits (#386 P1)', (
     render(<PoolBuilder pool={pool} resources={fleet} onSave={onSave} onCancel={vi.fn()} />)
 
     // The whole `or` is preserved; capability chips start empty.
-    expect(screen.getByTestId('pool-builder-preserved')).toHaveTextContent(/1 additional rule/)
+    // Advanced section opens automatically when there's a preserved clause.
+    expect(screen.getByTestId('pool-builder-advanced')).toHaveAttribute('open')
+    expect(screen.getByTestId('pool-builder-advanced')).toHaveTextContent('(1)')
     expect(screen.getByRole('checkbox', { name: 'Refrigerated' })).toHaveAttribute('aria-checked', 'false')
+    // The preserved `or` is shown as a single advanced row, summarized as "any of …".
+    expect(screen.getByTestId('advanced-rule-summary-0')).toHaveTextContent('any of:')
 
     // User adds a refrigerated chip.
     fireEvent.click(screen.getByRole('checkbox', { name: 'Refrigerated' }))
@@ -269,7 +276,7 @@ describe('PoolBuilder — preserves advanced clauses through edits (#386 P1)', (
       strategy: 'first-available',
     }
     render(<PoolBuilder pool={pool} resources={fleet} onSave={onSave} onCancel={vi.fn()} />)
-    expect(screen.getByTestId('pool-builder-preserved')).toHaveTextContent(/2 additional rules/)
+    expect(screen.getByTestId('pool-builder-advanced')).toHaveTextContent('(2)')
     fireEvent.click(screen.getByRole('button', { name: 'Save changes' }))
 
     const saved = onSave.mock.calls[0]![0] as ResourcePool
@@ -284,7 +291,7 @@ describe('PoolBuilder — preserves advanced clauses through edits (#386 P1)', (
     })
   })
 
-  it('omits the preserved-clause notice when nothing was preserved', () => {
+  it('keeps the advanced section collapsed when nothing was preserved', () => {
     render(<PoolBuilder
       pool={{
         id: 'p', name: 'Simple', type: 'query', memberIds: [],
@@ -293,7 +300,37 @@ describe('PoolBuilder — preserves advanced clauses through edits (#386 P1)', (
       }}
       resources={fleet} onSave={vi.fn()} onCancel={vi.fn()}
     />)
-    expect(screen.queryByTestId('pool-builder-preserved')).toBeNull()
+    const advanced = screen.getByTestId('pool-builder-advanced')
+    expect(advanced).not.toHaveAttribute('open')
+    expect(advanced).not.toHaveTextContent('(1)')
+  })
+
+  it('lets users add a brand-new advanced rule via the embedded editor', () => {
+    const onSave = vi.fn()
+    const pool: ResourcePool = {
+      id: 'p', name: 'NewRule', type: 'query', memberIds: [],
+      // Start with a recognized rule so save is enabled by the simple form.
+      query: { op: 'eq', path: 'meta.capabilities.refrigerated', value: true },
+      strategy: 'first-available',
+    }
+    render(<PoolBuilder pool={pool} resources={fleet} onSave={onSave} onCancel={vi.fn()} />)
+
+    // Open advanced section, add a new rule, configure it as gte.
+    fireEvent.click(screen.getByText(/^Advanced rules/))
+    fireEvent.click(screen.getByRole('button', { name: '+ Add rule' }))
+    fireEvent.change(screen.getByLabelText('Operation'),  { target: { value: 'gte' } })
+    fireEvent.change(screen.getByLabelText('Field path'), { target: { value: 'meta.capabilities.capacity_lbs' } })
+    fireEvent.change(screen.getByLabelText('Value'),      { target: { value: '80000' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Save changes' }))
+
+    const saved = onSave.mock.calls[0]![0] as ResourcePool
+    expect(saved.query).toEqual({
+      op: 'and',
+      clauses: [
+        { op: 'eq',  path: 'meta.capabilities.refrigerated', value: true },
+        { op: 'gte', path: 'meta.capabilities.capacity_lbs', value: 80000 },
+      ],
+    })
   })
 
   it('lets the user save with only preserved rules (no UI clauses configured)', () => {


### PR DESCRIPTION
## Summary

**Level 3 of the progressive-disclosure UI from the issue thread.**
Surfaces the full `ResourceQuery` DSL inside `PoolBuilder` behind a
collapsible **Advanced rules** section. Simple-form fields keep
covering the 80% case; power users now have a path to edit anything
else without hand-writing JSON.

> ⚠ **Depends on #438** (`PoolCard` + `PoolBuilder`). Branch is
> stacked on `claude/issue-386-v2-ui-pool-builder`; expect noisy
> diff until #438 merges, then this rebases cleanly onto main.

### `ClauseEditor` — recursive single-clause editor

- Op picker spans every leaf (`eq` / `neq` / `in` / `gt` / `gte` /
  `lt` / `lte` / `exists` / `within`) and every composite (`and` /
  `or` / `not`).
- Inputs **type themselves** to the active op: number input for
  numeric comparators, true/false picker for boolean `eq`, lat / lon
  pair for fixed-point `within`, comma-list parsing for `in`
  (auto-coercing numbers and booleans).
- Op-switch reshapes the clause in place, preserving the typed
  `path` so users don't lose text when tweaking a comparator.
- Composites recurse with add / remove controls. Nesting is capped
  at **depth 5** to keep the DOM bounded; deeper trees authored via
  JSON / config still round-trip safely through `PoolBuilder`.

### `AdvancedRulesEditor` — flat list manager

- One row per clause; summary text via `summarizeQuery`, Edit /
  Remove buttons.
- Edit toggles a `ClauseEditor` inline.
- "+ Add rule" appends a default `eq` clause and auto-opens its
  editor.
- Pure / controlled — operates on a `ResourceQuery[]` and emits
  changes via `onChange`. The parent (`PoolBuilder`) AND-merges
  them with the simple-form clauses on save.

### `PoolBuilder` integration

The earlier P1 fix (#438 follow-up — preserve advanced clauses
through edits) becomes the canonical edit path: those clauses now
show up as editable rows instead of an opaque "+ N additional
rules" note. The `<details>` section opens automatically when an
existing pool carries advanced rules and stays collapsed otherwise.

## Test plan

- [x] `tsc --noEmit` clean
- [x] `vitest run` — 2323 passing, 2 skipped (existing PTO flakes), 0 failures (22 new component tests)
- [x] `ClauseEditor` — every leaf body, value-type picker, `within` reference-point + unit swap (mutually exclusive), op-switch path preservation, composite add/remove/mutate, depth-cap blocking, `not` propagation
- [x] `AdvancedRulesEditor` — add/remove/edit-toggle, inline mutation without touching siblings, summary rendering
- [x] `PoolBuilder` — end-to-end: open the advanced section, add a `gte` rule, save, verify the AND-merge produces the expected query

## Out of scope (future slices)

- Drag-drop reordering of composite children
- Path autocomplete from the live registry
- Validation of paths against actual resource shapes
- Visual depth-line indicators beyond existing background tinting
- Wizard / standard `config.json` export

https://claude.ai/code/session_01XojXzZPdEPuGbX2TyLY1pu

---
_Generated by [Claude Code](https://claude.ai/code/session_01XojXzZPdEPuGbX2TyLY1pu)_