### PR TITLE
core(config): standard CalendarConfig schema + parse/serialize (#386)

### DIFF
--- a/docs/CalendarConfig.md
+++ b/docs/CalendarConfig.md
@@ -1,0 +1,121 @@
+# `CalendarConfig` — standard config.json shape
+
+The `CalendarConfig` interface is the canonical top-level shape for
+hand-authoring (or wizard-generating) a complete WorksCalendar
+setup. One JSON object describes label overrides, resource and role
+catalogs, the resource registry, pool definitions, requirement
+templates, seed events, and top-level settings.
+
+It's the standard output format proposed in the [#386 comment
+thread](https://github.com/WorksCalendar/CalendarThatWorks/issues/386)
+(*"Wizard Output: Standard config.json Structure"*). Every section
+is optional so partial configs (e.g. just `{ resources: [...] }`)
+are valid.
+
+## Top-level shape
+
+```json
+{
+  "profile": "trucking",
+  "labels": { "resource": "Truck", "event": "Load" },
+  "resourceTypes": [{ "id": "vehicle", "label": "Truck" }],
+  "roles":         [{ "id": "driver",  "label": "Driver" }],
+  "resources":     [{ "id": "t1", "name": "Truck 101", "type": "vehicle",
+                      "capabilities": { "refrigerated": true, "capacity_lbs": 80000 },
+                      "location": { "lat": 40.7608, "lon": -111.8910 } }],
+  "pools": [
+    {
+      "id": "nearby_reefers", "name": "Nearby Reefers",
+      "type": "query", "memberIds": [],
+      "query": {
+        "op": "and",
+        "clauses": [
+          { "op": "eq",     "path": "meta.capabilities.refrigerated", "value": true },
+          { "op": "within", "path": "meta.location",
+                            "from": { "kind": "proposed" }, "miles": 50 }
+        ]
+      },
+      "strategy": "closest"
+    }
+  ],
+  "requirements": [
+    {
+      "eventType": "load",
+      "requires": [
+        { "role": "driver",         "count": 1 },
+        { "pool": "nearby_reefers", "count": 1 }
+      ]
+    }
+  ],
+  "events": [
+    {
+      "id": "e1", "title": "SLC → Denver",
+      "start": "2026-04-20T09:00:00Z", "end": "2026-04-20T18:00:00Z",
+      "eventType": "load", "resourcePoolId": "nearby_reefers"
+    }
+  ],
+  "settings": { "conflictMode": "block", "timezone": "America/Denver" }
+}
+```
+
+## Reading a config
+
+```ts
+import { parseConfig } from 'works-calendar';
+
+const { config, errors, dropped } = parseConfig(JSON.parse(text));
+if (errors.length > 0) {
+  console.warn(`Dropped ${dropped} entries while parsing config`, errors);
+}
+```
+
+`parseConfig` is **defensive** — it never throws. Malformed entries
+within a section are dropped (with a count plus a human-readable
+error trail) so a single bad pool doesn't reject the whole config.
+A non-object root yields `{ config: {}, errors: [...], dropped: 0 }`.
+
+Cross-section integrity (does `requirements[0].requires[0].role`
+match a `roles[].id`?) is **not** checked — those references
+typically come from external sources and the engine's own runtime
+validators handle them when they fire.
+
+## Writing a config
+
+```ts
+import { serializeConfig } from 'works-calendar';
+
+const text = JSON.stringify(serializeConfig(config), null, 2);
+```
+
+`serializeConfig` returns a plain JSON-safe object; callers stringify
+themselves so they can pick formatting. Sections that are absent
+from the input are **omitted** from the output — a pristine `{}`
+config produces `{}`, not a noisy stub with empty arrays for every
+section.
+
+## Round-trip guarantee
+
+`parseConfig(JSON.parse(JSON.stringify(serializeConfig(config))))`
+returns `{ config, errors: [], dropped: 0 }` for any valid
+`CalendarConfig`. Tests pin the contract.
+
+## Section reference
+
+| Section          | Type                                        | Notes |
+|------------------|---------------------------------------------|-------|
+| `profile`        | `string`                                    | Industry preset hint; informational only. |
+| `labels`         | `{ resource?, event?, location?, [k]?: string }` | UI string overrides; free-form keys allowed. |
+| `resourceTypes`  | `{ id, label }[]`                           | Catalog of resource kinds (vehicle, person, …). |
+| `roles`          | `{ id, label }[]`                           | Catalog of roles (driver, dispatcher, …). |
+| `resources`      | `{ id, name, type?, capabilities?, location?, meta? }[]` | The resource registry. `capabilities` and `location` map to the v2 query DSL conventions. |
+| `pools`          | `ResourcePool[]`                            | Same shape as the runtime pool definitions. Manual / query / hybrid types all round-trip. |
+| `requirements`   | `{ eventType, requires: ({role,count}\|{pool,count})[] }[]` | Templates declaring what each event type needs. **Not yet consumed by the runtime engine** — the type lives here so the wizard's output round-trips losslessly. |
+| `events`         | `{ id, title, start, end, eventType?, resourceId?, resourcePoolId?, meta? }[]` | Seed events for demos / config-driven setup. ISO 8601 strings on the wire; the runtime parses them when loading. |
+| `settings`       | `{ conflictMode?, timezone? }`              | `conflictMode` is whitelisted to `block` / `soft` / `off`. Not yet enforced at runtime. |
+
+## Wizard
+
+The `CalendarConfig` shape is the wizard's output target. The
+wizard UI itself ships in a follow-up PR; the schema lands first so
+hosts who want to hand-author or generate configs from custom flows
+can do so today.

--- a/src/core/config/__tests__/parseConfig.test.ts
+++ b/src/core/config/__tests__/parseConfig.test.ts
@@ -1,0 +1,236 @@
+/**
+ * `parseConfig` — defensive unmarshalling for the standard
+ * config.json shape (#386 wizard).
+ */
+import { describe, it, expect } from 'vitest'
+import { parseConfig } from '../parseConfig'
+
+describe('parseConfig — root shape', () => {
+  it('returns an empty config + a single error for non-object roots', () => {
+    expect(parseConfig(null)).toEqual({ config: {}, errors: ['root: expected an object'], dropped: 0 })
+    expect(parseConfig([])).toEqual({ config: {}, errors: ['root: expected an object'], dropped: 0 })
+    expect(parseConfig(7)).toEqual({ config: {}, errors: ['root: expected an object'], dropped: 0 })
+    expect(parseConfig(undefined)).toEqual({ config: {}, errors: ['root: expected an object'], dropped: 0 })
+  })
+
+  it('accepts an empty object as a valid (empty) config', () => {
+    expect(parseConfig({})).toEqual({ config: {}, errors: [], dropped: 0 })
+  })
+
+  it('reads profile when it is a string', () => {
+    const r = parseConfig({ profile: 'trucking' })
+    expect(r.config.profile).toBe('trucking')
+    expect(r.errors).toEqual([])
+  })
+
+  it('logs an error for non-string profile', () => {
+    const r = parseConfig({ profile: 42 })
+    expect(r.config.profile).toBeUndefined()
+    expect(r.errors).toContain('profile: expected string, ignoring')
+  })
+})
+
+describe('parseConfig — labels', () => {
+  it('keeps known and unknown string keys, drops non-string values', () => {
+    const r = parseConfig({
+      labels: { resource: 'Truck', event: 'Load', custom: 'X', bogus: 5 },
+    })
+    expect(r.config.labels).toEqual({ resource: 'Truck', event: 'Load', custom: 'X' })
+    expect(r.errors).toContain('labels.bogus: expected string, ignoring')
+  })
+
+  it('rejects a non-object labels block', () => {
+    const r = parseConfig({ labels: 'oops' })
+    expect(r.config.labels).toBeUndefined()
+    expect(r.errors).toContain('labels: expected object, ignoring')
+  })
+})
+
+describe('parseConfig — resourceTypes / roles', () => {
+  it('keeps well-formed entries and drops the rest', () => {
+    const r = parseConfig({
+      resourceTypes: [
+        { id: 'vehicle', label: 'Truck' },
+        { id: 'person',  label: 'Driver' },
+        { id: 'broken' }, // missing label
+        'wrong shape',
+      ],
+    })
+    expect(r.config.resourceTypes).toEqual([
+      { id: 'vehicle', label: 'Truck' },
+      { id: 'person',  label: 'Driver' },
+    ])
+    expect(r.dropped).toBe(2)
+    expect(r.errors).toContain('resourceTypes[2]: expected { id: string, label: string }, dropping')
+  })
+
+  it('logs an error and yields [] when the section is not an array', () => {
+    const r = parseConfig({ roles: { drivers: [] } })
+    expect(r.config.roles).toEqual([])
+    expect(r.errors).toContain('roles: expected array, ignoring')
+  })
+})
+
+describe('parseConfig — resources', () => {
+  it('preserves type, capabilities, and location when present', () => {
+    const r = parseConfig({
+      resources: [
+        {
+          id: 't1', name: 'Truck 1', type: 'vehicle',
+          capabilities: { refrigerated: true, capacity_lbs: 80000 },
+          location: { lat: 40.76, lon: -111.89 },
+          meta: { vin: 'XYZ' },
+        },
+      ],
+    })
+    expect(r.config.resources).toEqual([{
+      id: 't1', name: 'Truck 1', type: 'vehicle',
+      capabilities: { refrigerated: true, capacity_lbs: 80000 },
+      location: { lat: 40.76, lon: -111.89 },
+      meta: { vin: 'XYZ' },
+    }])
+  })
+
+  it('drops malformed coordinate objects rather than letting them through', () => {
+    const r = parseConfig({
+      resources: [
+        { id: 't1', name: 'T1', location: { lat: 40.76, lon: 'oops' } },
+      ],
+    })
+    expect(r.config.resources![0]!.location).toBeUndefined()
+    expect(r.dropped).toBe(0) // the resource itself stays; just the bad coord is ignored
+  })
+
+  it('drops resources missing id or name', () => {
+    const r = parseConfig({
+      resources: [
+        { id: 't1' },                       // missing name
+        { name: 'NoId' },                   // missing id
+        { id: 't2', name: 'T2' },
+      ],
+    })
+    expect(r.config.resources!.map(x => x.id)).toEqual(['t2'])
+    expect(r.dropped).toBe(2)
+  })
+})
+
+describe('parseConfig — pools', () => {
+  it('round-trips a query pool with strategy + type + query', () => {
+    const r = parseConfig({
+      pools: [{
+        id: 'reefers', name: 'Reefers', type: 'query', memberIds: [],
+        query: { op: 'eq', path: 'meta.capabilities.refrigerated', value: true },
+        strategy: 'closest',
+      }],
+    })
+    expect(r.config.pools![0]).toEqual({
+      id: 'reefers', name: 'Reefers', type: 'query', memberIds: [],
+      query: { op: 'eq', path: 'meta.capabilities.refrigerated', value: true },
+      strategy: 'closest',
+    })
+  })
+
+  it('drops pools with an invalid strategy', () => {
+    const r = parseConfig({
+      pools: [{ id: 'p', name: 'P', memberIds: ['x'], strategy: 'first-came' }],
+    })
+    expect(r.config.pools).toEqual([])
+    expect(r.dropped).toBe(1)
+  })
+
+  it('ignores an unknown type but keeps the pool with the rest of its fields', () => {
+    const r = parseConfig({
+      pools: [{ id: 'p', name: 'P', memberIds: ['x'], strategy: 'round-robin', type: 'graphql' }],
+    })
+    expect(r.config.pools![0]).toEqual({
+      id: 'p', name: 'P', memberIds: ['x'], strategy: 'round-robin',
+    })
+    expect(r.errors.some(e => e.includes('type'))).toBe(true)
+  })
+})
+
+describe('parseConfig — requirements', () => {
+  it('parses role and pool slots with counts', () => {
+    const r = parseConfig({
+      requirements: [{
+        eventType: 'load',
+        requires: [
+          { role: 'driver', count: 1 },
+          { pool: 'any_truck', count: 1 },
+        ],
+      }],
+    })
+    expect(r.config.requirements).toEqual([{
+      eventType: 'load',
+      requires: [
+        { role: 'driver', count: 1 },
+        { pool: 'any_truck', count: 1 },
+      ],
+    }])
+  })
+
+  it('drops the whole requirement when every slot is malformed', () => {
+    const r = parseConfig({
+      requirements: [{
+        eventType: 'load',
+        requires: [{ broken: true }],
+      }],
+    })
+    expect(r.config.requirements).toEqual([])
+    expect(r.dropped).toBe(1)
+  })
+
+  it('keeps valid slots and drops just the malformed ones when mixed', () => {
+    const r = parseConfig({
+      requirements: [{
+        eventType: 'load',
+        requires: [{ role: 'driver', count: 1 }, { broken: true }],
+      }],
+    })
+    expect(r.config.requirements![0]!.requires).toEqual([{ role: 'driver', count: 1 }])
+    expect(r.errors.some(e => e.includes('requires[1]'))).toBe(true)
+  })
+})
+
+describe('parseConfig — events (seed)', () => {
+  it('keeps id/title/start/end and the optional resource hooks', () => {
+    const r = parseConfig({
+      events: [{
+        id: 'e1', title: 'Run', start: '2026-04-20T09:00:00Z', end: '2026-04-20T10:00:00Z',
+        resourcePoolId: 'pool-1',
+      }],
+    })
+    expect(r.config.events![0]).toEqual({
+      id: 'e1', title: 'Run', start: '2026-04-20T09:00:00Z', end: '2026-04-20T10:00:00Z',
+      resourcePoolId: 'pool-1',
+    })
+  })
+
+  it('drops events missing any of the required string fields', () => {
+    const r = parseConfig({
+      events: [
+        { id: 'e1', title: 'OK',   start: '2026-04-20', end: '2026-04-21' },
+        { id: 'e2', title: 'Bad' /* no start/end */ },
+      ],
+    })
+    expect(r.config.events!.length).toBe(1)
+    expect(r.dropped).toBe(1)
+  })
+})
+
+describe('parseConfig — settings', () => {
+  it('whitelists the conflictMode values', () => {
+    expect(parseConfig({ settings: { conflictMode: 'block' } }).config.settings).toEqual({ conflictMode: 'block' })
+    expect(parseConfig({ settings: { conflictMode: 'soft'  } }).config.settings).toEqual({ conflictMode: 'soft' })
+    expect(parseConfig({ settings: { conflictMode: 'off'   } }).config.settings).toEqual({ conflictMode: 'off' })
+
+    const bad = parseConfig({ settings: { conflictMode: 'maybe' } })
+    expect(bad.config.settings).toEqual({})
+    expect(bad.errors.some(e => e.includes('conflictMode'))).toBe(true)
+  })
+
+  it('keeps a string timezone', () => {
+    const r = parseConfig({ settings: { timezone: 'America/Denver' } })
+    expect(r.config.settings).toEqual({ timezone: 'America/Denver' })
+  })
+})

--- a/src/core/config/__tests__/serializeConfig.test.ts
+++ b/src/core/config/__tests__/serializeConfig.test.ts
@@ -1,0 +1,155 @@
+/**
+ * `serializeConfig` + round-trip via `parseConfig` (#386 wizard).
+ */
+import { describe, it, expect } from 'vitest'
+import { serializeConfig } from '../serializeConfig'
+import { parseConfig } from '../parseConfig'
+import type { CalendarConfig } from '../calendarConfig'
+
+describe('serializeConfig — section omission', () => {
+  it('emits an empty object for an empty config (no noisy stubs)', () => {
+    expect(serializeConfig({})).toEqual({})
+  })
+
+  it('omits each missing section rather than emitting empty arrays', () => {
+    const out = serializeConfig({ profile: 'trucking' })
+    expect(out).toEqual({ profile: 'trucking' })
+    // Spot-check that no section keys leaked through.
+    expect(Object.keys(out)).toEqual(['profile'])
+  })
+})
+
+describe('serializeConfig — section shapes', () => {
+  it('serializes labels as a plain string map', () => {
+    expect(serializeConfig({
+      labels: { resource: 'Truck', event: 'Load' },
+    })).toEqual({ labels: { resource: 'Truck', event: 'Load' } })
+  })
+
+  it('serializes resources with all optional fields when present', () => {
+    const out = serializeConfig({
+      resources: [{
+        id: 't1', name: 'Truck 1', type: 'vehicle',
+        capabilities: { refrigerated: true, capacity_lbs: 80000 },
+        location: { lat: 40.76, lon: -111.89 },
+        meta: { vin: 'XYZ' },
+      }],
+    })
+    expect(out).toEqual({
+      resources: [{
+        id: 't1', name: 'Truck 1', type: 'vehicle',
+        capabilities: { refrigerated: true, capacity_lbs: 80000 },
+        location: { lat: 40.76, lon: -111.89 },
+        meta: { vin: 'XYZ' },
+      }],
+    })
+  })
+
+  it('serializes pools with strategy + type + query in a single pass', () => {
+    expect(serializeConfig({
+      pools: [{
+        id: 'reefers', name: 'Reefers', type: 'query', memberIds: [],
+        query: { op: 'eq', path: 'meta.capabilities.refrigerated', value: true },
+        strategy: 'closest',
+      }],
+    })).toEqual({
+      pools: [{
+        id: 'reefers', name: 'Reefers', type: 'query', memberIds: [],
+        query: { op: 'eq', path: 'meta.capabilities.refrigerated', value: true },
+        strategy: 'closest',
+      }],
+    })
+  })
+
+  it('discriminates role vs. pool slots in requirements', () => {
+    expect(serializeConfig({
+      requirements: [{
+        eventType: 'load',
+        requires: [
+          { role: 'driver',    count: 1 },
+          { pool: 'any_truck', count: 1 },
+        ],
+      }],
+    })).toEqual({
+      requirements: [{
+        eventType: 'load',
+        requires: [
+          { role: 'driver',    count: 1 },
+          { pool: 'any_truck', count: 1 },
+        ],
+      }],
+    })
+  })
+})
+
+describe('serializeConfig + parseConfig — round-trip', () => {
+  it('round-trips a fully populated config losslessly', () => {
+    const config: CalendarConfig = {
+      profile: 'trucking',
+      labels: { resource: 'Truck', event: 'Load', location: 'Depot' },
+      resourceTypes: [
+        { id: 'vehicle', label: 'Truck' },
+        { id: 'person',  label: 'Driver' },
+      ],
+      roles: [
+        { id: 'driver',     label: 'Driver' },
+        { id: 'dispatcher', label: 'Dispatcher' },
+      ],
+      resources: [
+        {
+          id: 't1', name: 'Truck 101', type: 'vehicle',
+          capabilities: { refrigerated: true, capacity_lbs: 80000 },
+          location: { lat: 40.7608, lon: -111.8910 },
+          meta: { vin: 'XYZ' },
+        },
+      ],
+      pools: [
+        {
+          id: 'nearby_reefers', name: 'Nearby Reefers',
+          type: 'query', memberIds: [],
+          query: {
+            op: 'and',
+            clauses: [
+              { op: 'eq',     path: 'meta.capabilities.refrigerated', value: true },
+              { op: 'within', path: 'meta.location', from: { kind: 'proposed' }, miles: 50 },
+            ],
+          },
+          strategy: 'closest',
+        },
+      ],
+      requirements: [
+        {
+          eventType: 'load',
+          requires: [
+            { role: 'driver',           count: 1 },
+            { pool: 'nearby_reefers',   count: 1 },
+          ],
+        },
+      ],
+      events: [
+        {
+          id: 'e1', title: 'SLC → Denver',
+          start: '2026-04-20T09:00:00Z',
+          end:   '2026-04-20T18:00:00Z',
+          eventType: 'load',
+          resourcePoolId: 'nearby_reefers',
+        },
+      ],
+      settings: { conflictMode: 'block', timezone: 'America/Denver' },
+    }
+
+    const wire = serializeConfig(config)
+    const json = JSON.parse(JSON.stringify(wire))
+    const round = parseConfig(json)
+
+    expect(round.errors).toEqual([])
+    expect(round.dropped).toBe(0)
+    expect(round.config).toEqual(config)
+  })
+
+  it('round-trips an empty config without losing or inventing fields', () => {
+    const round = parseConfig(serializeConfig({}))
+    expect(round.config).toEqual({})
+    expect(round.errors).toEqual([])
+  })
+})

--- a/src/core/config/calendarConfig.ts
+++ b/src/core/config/calendarConfig.ts
@@ -1,0 +1,124 @@
+/**
+ * `CalendarConfig` — the standard top-level config.json structure
+ * proposed in the issue thread (issue #386 wizard slice).
+ *
+ * One object describes everything a host needs to bootstrap a
+ * WorksCalendar instance: label overrides, resource / role
+ * catalogs, the resource registry, pools, requirement templates,
+ * seed events, and top-level settings. Hosts can hand-author it,
+ * generate it via the eventual setup wizard, or round-trip it
+ * through `parseConfig` / `serializeConfig`.
+ *
+ * This module is *only* the data structure. The runtime engine
+ * doesn't yet consume `requirements` (that's a separate follow-up);
+ * the type lives here so the wizard's output can round-trip without
+ * loss when that consumer lands.
+ *
+ * Every section is optional so a partial config (e.g. just
+ * `{ resources: [...] }`) is valid — the wizard generates section
+ * stubs as it walks the user through setup.
+ */
+
+import type { ResourcePool } from '../pools/resourcePoolSchema'
+import type { LatLon } from '../pools/geo'
+
+export interface CalendarConfig {
+  /**
+   * Industry profile preset hint — informational only. Used by the
+   * wizard / demos to apply default labels and capability lists.
+   * The engine doesn't enforce or validate the value.
+   */
+  readonly profile?: string
+  /** UI label overrides — what to call resources / events / etc. */
+  readonly labels?: ConfigLabels
+  /** Resource type catalog (e.g. "vehicle", "person"). */
+  readonly resourceTypes?: readonly ConfigResourceType[]
+  /** Role catalog (e.g. "driver", "dispatcher"). */
+  readonly roles?: readonly ConfigRole[]
+  /** Resource registry — typed wrapper around the runtime shape. */
+  readonly resources?: readonly ConfigResource[]
+  /** Pool definitions — same shape as the runtime `ResourcePool`. */
+  readonly pools?: readonly ResourcePool[]
+  /** Requirement templates (event type → roles / pools needed). */
+  readonly requirements?: readonly ConfigRequirement[]
+  /** Seed events (initial fixtures for demos / config-driven setup). */
+  readonly events?: readonly ConfigSeedEvent[]
+  /** Top-level settings. */
+  readonly settings?: ConfigSettings
+}
+
+export interface ConfigLabels {
+  /** What to call a resource (e.g. "Truck", "Aircraft", "Room"). */
+  readonly resource?: string
+  /** What to call an event (e.g. "Load", "Charter", "Booking"). */
+  readonly event?: string
+  /** What to call a location (e.g. "Depot", "Origin"). */
+  readonly location?: string
+  /** Free-form additional label overrides. */
+  readonly [k: string]: string | undefined
+}
+
+export interface ConfigResourceType {
+  readonly id: string
+  readonly label: string
+}
+
+export interface ConfigRole {
+  readonly id: string
+  readonly label: string
+}
+
+/**
+ * The wizard / config-driven shape for a resource. Strict-typed
+ * `type`, `capabilities`, and `location` map to the runtime
+ * `EngineResource.meta.*` convention used by the v2 query engine.
+ */
+export interface ConfigResource {
+  readonly id: string
+  readonly name: string
+  /** FK into `ConfigResourceType.id`. */
+  readonly type?: string
+  /** Boolean / numeric / string capability flags. */
+  readonly capabilities?: Readonly<Record<string, unknown>>
+  /** lat/lon convention used by the v2 distance ops. */
+  readonly location?: LatLon
+  /** Free-form additional metadata. Merged into the runtime `meta`. */
+  readonly meta?: Readonly<Record<string, unknown>>
+}
+
+export interface ConfigRequirement {
+  /** Matches against the `eventType` of a runtime event. */
+  readonly eventType: string
+  readonly requires: readonly ConfigRequirementSlot[]
+}
+
+export type ConfigRequirementSlot =
+  | { readonly role: string; readonly count: number }
+  | { readonly pool: string; readonly count: number }
+
+export interface ConfigSeedEvent {
+  readonly id: string
+  readonly title: string
+  /** ISO 8601 timestamp. Stored as a string for JSON round-trip. */
+  readonly start: string
+  readonly end: string
+  readonly eventType?: string
+  /** Optional concrete resource pin — interchangeable with `resourcePoolId`. */
+  readonly resourceId?: string
+  readonly resourcePoolId?: string
+  readonly meta?: Readonly<Record<string, unknown>>
+}
+
+export interface ConfigSettings {
+  /**
+   * How to handle hard-conflict resolutions on submit.
+   *  - `block` — reject (default; matches the runtime engine today).
+   *  - `soft`  — flag but allow.
+   *  - `off`   — skip the check entirely.
+   * The runtime engine doesn't yet consume this field; it's
+   * round-tripped so the wizard's output isn't lossy.
+   */
+  readonly conflictMode?: 'block' | 'soft' | 'off'
+  /** IANA timezone identifier (e.g. "America/Denver"). */
+  readonly timezone?: string
+}

--- a/src/core/config/parseConfig.ts
+++ b/src/core/config/parseConfig.ts
@@ -1,0 +1,328 @@
+/**
+ * `parseConfig` — validate and coerce an unknown blob into a
+ * `CalendarConfig` (issue #386 wizard slice).
+ *
+ * Defensive: never throws. Malformed entries within a section are
+ * dropped (with a count + human-readable error trail) so a single
+ * bad pool doesn't reject the whole config. Top-level shape errors
+ * (wrong root type, JSON parse failure) yield an empty config plus
+ * an error message.
+ *
+ * Pure / sync. The matching `serializeConfig` reverses the process
+ * for write-out; round-trip is total for valid inputs.
+ */
+
+import type {
+  CalendarConfig, ConfigLabels, ConfigResourceType, ConfigRole,
+  ConfigResource, ConfigRequirement, ConfigRequirementSlot,
+  ConfigSeedEvent, ConfigSettings,
+} from './calendarConfig'
+import type { ResourcePool, PoolStrategy, PoolType } from '../pools/resourcePoolSchema'
+import type { LatLon } from '../pools/geo'
+
+export interface ParseConfigResult {
+  /** Best-effort parsed config — sections may be missing or empty. */
+  readonly config: CalendarConfig
+  /**
+   * Human-readable error messages — one per dropped entry or
+   * top-level shape problem. Empty when the input parses cleanly.
+   */
+  readonly errors: readonly string[]
+  /** Total count of dropped entries across every section. */
+  readonly dropped: number
+}
+
+const STRATEGIES: readonly PoolStrategy[] = ['first-available', 'least-loaded', 'round-robin', 'closest']
+const POOL_TYPES: readonly PoolType[] = ['manual', 'query', 'hybrid']
+const CONFLICT_MODES: readonly NonNullable<ConfigSettings['conflictMode']>[] = ['block', 'soft', 'off']
+
+export function parseConfig(raw: unknown): ParseConfigResult {
+  const errors: string[] = []
+  let dropped = 0
+
+  if (raw == null || typeof raw !== 'object' || Array.isArray(raw)) {
+    return {
+      config: {},
+      errors: ['root: expected an object'],
+      dropped: 0,
+    }
+  }
+
+  const r = raw as Record<string, unknown>
+  const out: { -readonly [K in keyof CalendarConfig]: CalendarConfig[K] } = {}
+
+  // ── profile ───────────────────────────────────────────────────────────
+  if (typeof r['profile'] === 'string') out.profile = r['profile']
+  else if (r['profile'] !== undefined) {
+    errors.push('profile: expected string, ignoring')
+  }
+
+  // ── labels ────────────────────────────────────────────────────────────
+  if (r['labels'] !== undefined) {
+    const labels = parseLabels(r['labels'], errors)
+    if (labels) out.labels = labels
+  }
+
+  // ── resourceTypes / roles (same shape) ───────────────────────────────
+  if (r['resourceTypes'] !== undefined) {
+    const { items, dropped: d } = parseLabeledIdList(r['resourceTypes'], 'resourceTypes', errors)
+    dropped += d
+    out.resourceTypes = items as readonly ConfigResourceType[]
+  }
+  if (r['roles'] !== undefined) {
+    const { items, dropped: d } = parseLabeledIdList(r['roles'], 'roles', errors)
+    dropped += d
+    out.roles = items as readonly ConfigRole[]
+  }
+
+  // ── resources ─────────────────────────────────────────────────────────
+  if (r['resources'] !== undefined) {
+    const { items, dropped: d } = parseList(r['resources'], 'resources', errors, parseResource)
+    dropped += d
+    out.resources = items
+  }
+
+  // ── pools ─────────────────────────────────────────────────────────────
+  if (r['pools'] !== undefined) {
+    const { items, dropped: d } = parseList(r['pools'], 'pools', errors, parsePool)
+    dropped += d
+    out.pools = items
+  }
+
+  // ── requirements ──────────────────────────────────────────────────────
+  if (r['requirements'] !== undefined) {
+    const { items, dropped: d } = parseList(r['requirements'], 'requirements', errors, parseRequirement)
+    dropped += d
+    out.requirements = items
+  }
+
+  // ── events (seed) ─────────────────────────────────────────────────────
+  if (r['events'] !== undefined) {
+    const { items, dropped: d } = parseList(r['events'], 'events', errors, parseSeedEvent)
+    dropped += d
+    out.events = items
+  }
+
+  // ── settings ──────────────────────────────────────────────────────────
+  if (r['settings'] !== undefined) {
+    const settings = parseSettings(r['settings'], errors)
+    if (settings) out.settings = settings
+  }
+
+  return { config: out, errors, dropped }
+}
+
+// ─── Section parsers ────────────────────────────────────────────────────────
+
+function parseLabels(raw: unknown, errors: string[]): ConfigLabels | null {
+  if (!isObject(raw)) {
+    errors.push('labels: expected object, ignoring')
+    return null
+  }
+  const out: { [k: string]: string } = {}
+  for (const [key, value] of Object.entries(raw)) {
+    if (typeof value === 'string') out[key] = value
+    else errors.push(`labels.${key}: expected string, ignoring`)
+  }
+  return out
+}
+
+function parseLabeledIdList(
+  raw: unknown,
+  section: 'resourceTypes' | 'roles',
+  errors: string[],
+): { items: readonly { id: string; label: string }[]; dropped: number } {
+  if (!Array.isArray(raw)) {
+    errors.push(`${section}: expected array, ignoring`)
+    return { items: [], dropped: 0 }
+  }
+  const items: { id: string; label: string }[] = []
+  let dropped = 0
+  raw.forEach((item, i) => {
+    if (
+      isObject(item)
+      && typeof item['id'] === 'string'
+      && typeof item['label'] === 'string'
+    ) {
+      items.push({ id: item['id'], label: item['label'] })
+    } else {
+      errors.push(`${section}[${i}]: expected { id: string, label: string }, dropping`)
+      dropped++
+    }
+  })
+  return { items, dropped }
+}
+
+function parseResource(raw: unknown, path: string, errors: string[]): ConfigResource | null {
+  if (!isObject(raw)) {
+    errors.push(`${path}: expected object, dropping`)
+    return null
+  }
+  if (typeof raw['id'] !== 'string' || typeof raw['name'] !== 'string') {
+    errors.push(`${path}: missing id or name, dropping`)
+    return null
+  }
+  const out: { -readonly [K in keyof ConfigResource]: ConfigResource[K] } = {
+    id: raw['id'], name: raw['name'],
+  }
+  if (typeof raw['type'] === 'string') out.type = raw['type']
+  if (isObject(raw['capabilities'])) out.capabilities = raw['capabilities']
+  if (isLatLon(raw['location'])) out.location = raw['location'] as LatLon
+  if (isObject(raw['meta'])) out.meta = raw['meta']
+  return out
+}
+
+function parsePool(raw: unknown, path: string, errors: string[]): ResourcePool | null {
+  if (!isObject(raw)) {
+    errors.push(`${path}: expected object, dropping`)
+    return null
+  }
+  if (typeof raw['id'] !== 'string' || typeof raw['name'] !== 'string') {
+    errors.push(`${path}: missing id or name, dropping`)
+    return null
+  }
+  if (
+    !Array.isArray(raw['memberIds'])
+    || !raw['memberIds'].every((m) => typeof m === 'string')
+  ) {
+    errors.push(`${path}: memberIds must be string[], dropping`)
+    return null
+  }
+  if (typeof raw['strategy'] !== 'string' || !STRATEGIES.includes(raw['strategy'] as PoolStrategy)) {
+    errors.push(`${path}: invalid strategy "${String(raw['strategy'])}", dropping`)
+    return null
+  }
+  const out: { -readonly [K in keyof ResourcePool]: ResourcePool[K] } = {
+    id: raw['id'],
+    name: raw['name'],
+    memberIds: raw['memberIds'] as string[],
+    strategy: raw['strategy'] as PoolStrategy,
+  }
+  if (raw['type'] !== undefined) {
+    if (typeof raw['type'] === 'string' && POOL_TYPES.includes(raw['type'] as PoolType)) {
+      out.type = raw['type'] as PoolType
+    } else {
+      errors.push(`${path}.type: invalid value "${String(raw['type'])}", ignoring`)
+    }
+  }
+  if (raw['query'] !== undefined) {
+    if (isObject(raw['query'])) out.query = raw['query'] as NonNullable<ResourcePool['query']>
+    else errors.push(`${path}.query: expected object, ignoring`)
+  }
+  if (typeof raw['rrCursor'] === 'number') out.rrCursor = raw['rrCursor']
+  if (typeof raw['disabled'] === 'boolean') out.disabled = raw['disabled']
+  return out
+}
+
+function parseRequirement(raw: unknown, path: string, errors: string[]): ConfigRequirement | null {
+  if (!isObject(raw)) {
+    errors.push(`${path}: expected object, dropping`)
+    return null
+  }
+  if (typeof raw['eventType'] !== 'string') {
+    errors.push(`${path}: missing eventType, dropping`)
+    return null
+  }
+  if (!Array.isArray(raw['requires'])) {
+    errors.push(`${path}: requires must be an array, dropping`)
+    return null
+  }
+  const requires: ConfigRequirementSlot[] = []
+  let slotsDropped = 0
+  raw['requires'].forEach((slot, i) => {
+    if (isObject(slot) && typeof slot['count'] === 'number' && slot['count'] >= 0) {
+      if (typeof slot['role'] === 'string') {
+        requires.push({ role: slot['role'], count: slot['count'] })
+        return
+      }
+      if (typeof slot['pool'] === 'string') {
+        requires.push({ pool: slot['pool'], count: slot['count'] })
+        return
+      }
+    }
+    errors.push(`${path}.requires[${i}]: expected { role|pool, count }, dropping`)
+    slotsDropped++
+  })
+  if (requires.length === 0 && raw['requires'].length > 0 && slotsDropped > 0) {
+    // Every slot was malformed — drop the whole requirement so the
+    // host's "this event needs a driver" rule doesn't silently
+    // become "this event has no requirements".
+    return null
+  }
+  return { eventType: raw['eventType'], requires }
+}
+
+function parseSeedEvent(raw: unknown, path: string, errors: string[]): ConfigSeedEvent | null {
+  if (!isObject(raw)) {
+    errors.push(`${path}: expected object, dropping`)
+    return null
+  }
+  if (
+    typeof raw['id'] !== 'string'
+    || typeof raw['title'] !== 'string'
+    || typeof raw['start'] !== 'string'
+    || typeof raw['end'] !== 'string'
+  ) {
+    errors.push(`${path}: missing id / title / start / end (all strings), dropping`)
+    return null
+  }
+  const out: { -readonly [K in keyof ConfigSeedEvent]: ConfigSeedEvent[K] } = {
+    id: raw['id'], title: raw['title'], start: raw['start'], end: raw['end'],
+  }
+  if (typeof raw['eventType']      === 'string') out.eventType = raw['eventType']
+  if (typeof raw['resourceId']     === 'string') out.resourceId = raw['resourceId']
+  if (typeof raw['resourcePoolId'] === 'string') out.resourcePoolId = raw['resourcePoolId']
+  if (isObject(raw['meta']))                     out.meta = raw['meta']
+  return out
+}
+
+function parseSettings(raw: unknown, errors: string[]): ConfigSettings | null {
+  if (!isObject(raw)) {
+    errors.push('settings: expected object, ignoring')
+    return null
+  }
+  const out: { -readonly [K in keyof ConfigSettings]: ConfigSettings[K] } = {}
+  if (raw['conflictMode'] !== undefined) {
+    if (
+      typeof raw['conflictMode'] === 'string'
+      && CONFLICT_MODES.includes(raw['conflictMode'] as NonNullable<ConfigSettings['conflictMode']>)
+    ) {
+      out.conflictMode = raw['conflictMode'] as NonNullable<ConfigSettings['conflictMode']>
+    } else {
+      errors.push(`settings.conflictMode: invalid value "${String(raw['conflictMode'])}", ignoring`)
+    }
+  }
+  if (typeof raw['timezone'] === 'string') out.timezone = raw['timezone']
+  return out
+}
+
+// ─── Internals ──────────────────────────────────────────────────────────────
+
+function parseList<T>(
+  raw: unknown,
+  section: string,
+  errors: string[],
+  parseItem: (item: unknown, path: string, errors: string[]) => T | null,
+): { items: readonly T[]; dropped: number } {
+  if (!Array.isArray(raw)) {
+    errors.push(`${section}: expected array, ignoring`)
+    return { items: [], dropped: 0 }
+  }
+  const items: T[] = []
+  let dropped = 0
+  raw.forEach((item, i) => {
+    const parsed = parseItem(item, `${section}[${i}]`, errors)
+    if (parsed) items.push(parsed)
+    else dropped++
+  })
+  return { items, dropped }
+}
+
+function isObject(v: unknown): v is Record<string, unknown> {
+  return v != null && typeof v === 'object' && !Array.isArray(v)
+}
+
+function isLatLon(v: unknown): boolean {
+  if (!isObject(v)) return false
+  return Number.isFinite(v['lat']) && Number.isFinite(v['lon'])
+}

--- a/src/core/config/serializeConfig.ts
+++ b/src/core/config/serializeConfig.ts
@@ -1,0 +1,96 @@
+/**
+ * `serializeConfig` — pure converter from `CalendarConfig` to a
+ * JSON-safe plain object (issue #386 wizard slice).
+ *
+ * The matching `parseConfig` reverses the process. Round-trip is
+ * lossless for every field defined in `calendarConfig.ts`. Callers
+ * stringify the result themselves so they can pick formatting:
+ *
+ *   const text = JSON.stringify(serializeConfig(config), null, 2)
+ *
+ * Sections that are absent from the input are omitted from the
+ * output — a pristine `{}` config produces `{}`, not a noisy stub
+ * with empty arrays for every section.
+ */
+
+import type {
+  CalendarConfig, ConfigLabels, ConfigResource, ConfigRequirement,
+  ConfigSeedEvent, ConfigSettings, ConfigResourceType, ConfigRole,
+} from './calendarConfig'
+import type { ResourcePool } from '../pools/resourcePoolSchema'
+
+export function serializeConfig(config: CalendarConfig): Record<string, unknown> {
+  const out: Record<string, unknown> = {}
+  if (config.profile        !== undefined) out['profile'] = config.profile
+  if (config.labels         !== undefined) out['labels'] = serializeLabels(config.labels)
+  if (config.resourceTypes  !== undefined) out['resourceTypes'] = config.resourceTypes.map(serializeIdLabel)
+  if (config.roles          !== undefined) out['roles'] = config.roles.map(serializeIdLabel)
+  if (config.resources      !== undefined) out['resources'] = config.resources.map(serializeResource)
+  if (config.pools          !== undefined) out['pools'] = config.pools.map(serializePool)
+  if (config.requirements   !== undefined) out['requirements'] = config.requirements.map(serializeRequirement)
+  if (config.events         !== undefined) out['events'] = config.events.map(serializeSeedEvent)
+  if (config.settings       !== undefined) out['settings'] = serializeSettings(config.settings)
+  return out
+}
+
+// ─── Section serializers ───────────────────────────────────────────────────
+
+function serializeLabels(labels: ConfigLabels): Record<string, string> {
+  const out: Record<string, string> = {}
+  for (const [k, v] of Object.entries(labels)) {
+    if (typeof v === 'string') out[k] = v
+  }
+  return out
+}
+
+function serializeIdLabel(item: ConfigResourceType | ConfigRole): Record<string, unknown> {
+  return { id: item.id, label: item.label }
+}
+
+function serializeResource(r: ConfigResource): Record<string, unknown> {
+  const out: Record<string, unknown> = { id: r.id, name: r.name }
+  if (r.type         !== undefined) out['type']         = r.type
+  if (r.capabilities !== undefined) out['capabilities'] = r.capabilities
+  if (r.location     !== undefined) out['location']     = { lat: r.location.lat, lon: r.location.lon }
+  if (r.meta         !== undefined) out['meta']         = r.meta
+  return out
+}
+
+function serializePool(p: ResourcePool): Record<string, unknown> {
+  const out: Record<string, unknown> = {
+    id: p.id, name: p.name, memberIds: [...p.memberIds], strategy: p.strategy,
+  }
+  if (p.type     !== undefined) out['type']     = p.type
+  if (p.query    !== undefined) out['query']    = p.query
+  if (p.rrCursor !== undefined) out['rrCursor'] = p.rrCursor
+  if (p.disabled !== undefined) out['disabled'] = p.disabled
+  return out
+}
+
+function serializeRequirement(r: ConfigRequirement): Record<string, unknown> {
+  return {
+    eventType: r.eventType,
+    requires: r.requires.map((slot) =>
+      'role' in slot
+        ? { role: slot.role, count: slot.count }
+        : { pool: slot.pool, count: slot.count }),
+  }
+}
+
+function serializeSeedEvent(e: ConfigSeedEvent): Record<string, unknown> {
+  const out: Record<string, unknown> = {
+    id: e.id, title: e.title, start: e.start, end: e.end,
+  }
+  if (e.eventType      !== undefined) out['eventType']      = e.eventType
+  if (e.resourceId     !== undefined) out['resourceId']     = e.resourceId
+  if (e.resourcePoolId !== undefined) out['resourcePoolId'] = e.resourcePoolId
+  if (e.meta           !== undefined) out['meta']           = e.meta
+  return out
+}
+
+function serializeSettings(s: ConfigSettings): Record<string, unknown> {
+  const out: Record<string, unknown> = {}
+  if (s.conflictMode !== undefined) out['conflictMode'] = s.conflictMode
+  if (s.timezone     !== undefined) out['timezone']     = s.timezone
+  return out
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -196,6 +196,15 @@ export { default as AdvancedRulesEditor } from './ui/pools/AdvancedRulesEditor';
 export type { AdvancedRulesEditorProps } from './ui/pools/AdvancedRulesEditor';
 export { summarizePool, summarizeQuery } from './ui/pools/poolSummary';
 export type { PoolSummary } from './ui/pools/poolSummary';
+// ── CalendarConfig — standard config.json shape (#386 wizard) ─────────────
+export { parseConfig } from './core/config/parseConfig';
+export type { ParseConfigResult } from './core/config/parseConfig';
+export { serializeConfig } from './core/config/serializeConfig';
+export type {
+  CalendarConfig, ConfigLabels, ConfigResourceType, ConfigRole,
+  ConfigResource, ConfigRequirement, ConfigRequirementSlot,
+  ConfigSeedEvent, ConfigSettings,
+} from './core/config/calendarConfig';
 
 // ── Lifecycle event bus (#216) ──────────────────────────────────────────────
 export { EventBus, channelForApprovalTransition } from './core/engine/eventBus';


### PR DESCRIPTION
## Summary

**The wizard-output shape from the [#386 comment thread](https://github.com/WorksCalendar/CalendarThatWorks/issues/386), lifted into a typed, defensive, reversible primitive.** The wizard UI itself follows in a separate PR; the schema lands first so hosts who want to hand-author or generate configs from custom flows can do so today, and the engine round-trips them losslessly.

### `CalendarConfig`

Top-level interface covering:

- `profile` — industry preset hint
- `labels` — UI string overrides
- `resourceTypes`, `roles` — `{ id, label }` catalogs
- `resources` — typed registry with `capabilities` / `location` mapping to v2 query DSL conventions
- `pools` — same shape as the runtime `ResourcePool` (manual / query / hybrid all round-trip)
- `requirements` — `{ eventType, requires: ({role,count}|{pool,count})[] }`
- `events` — seed events for demos / config-driven setup
- `settings` — `conflictMode`, `timezone`

Every section is optional, so partial configs (e.g. just `{ resources: [...] }`) are valid.

### `parseConfig(raw): { config, errors, dropped }`

**Defensive — never throws.** Malformed entries within a section are dropped with a count plus a human-readable error trail so a single bad pool doesn't reject the whole config. A non-object root yields `{ config: {}, errors: [...], dropped: 0 }`. Cross-section integrity is *not* checked — those references typically come from external sources and the engine's own runtime validators handle them when they fire.

### `serializeConfig(config): Record<string, unknown>`

Pure mirror. Returns a JSON-safe plain object; callers stringify themselves so they pick formatting. Sections absent from the input are **omitted** from the output, so `{}` produces `{}` rather than a noisy stub with empty arrays for every section.

### Round-trip guarantee

`parseConfig(JSON.parse(JSON.stringify(serializeConfig(c))))` returns `{ config: c, errors: [], dropped: 0 }` for any valid config. Pinned by tests.

### Note on consumers

`requirements` and `settings.conflictMode` aren't yet consumed by the runtime engine. The types live here so the wizard's output round-trips losslessly when those consumers land.

## Test plan

- [x] `tsc --noEmit` clean
- [x] `vitest run` — 2352 passing, 2 skipped (existing PTO flakes), 0 failures (29 new tests)
- [x] `parseConfig` covers each section: shape rejection, mixed valid/invalid lists, drop counts, top-level shape errors, conflictMode whitelist, type-discriminated requirement slots
- [x] `serializeConfig` covers section omission, every section's output shape, role-vs-pool slot discrimination
- [x] **Full-fixture round-trip** of a populated config (every section, every optional field) yields zero errors and an identical config back

## Out of scope (future slices)

- The wizard UI itself (guided setup flow that emits `CalendarConfig`)
- Runtime consumers for `requirements` (a `requirements` engine that validates each event against its template)
- Cross-section integrity validation (`validateConfig(config, { strict: true })`)
- Industry profile presets that auto-populate `labels` / capability lists / common pools

https://claude.ai/code/session_01XojXzZPdEPuGbX2TyLY1pu

---
_Generated by [Claude Code](https://claude.ai/code/session_01XojXzZPdEPuGbX2TyLY1pu)_