### PR TITLE
core(config): drop query/hybrid pools that omit a query

### DIFF
--- a/src/core/config/__tests__/parseConfig.test.ts
+++ b/src/core/config/__tests__/parseConfig.test.ts
@@ -147,6 +147,24 @@ describe('parseConfig — pools', () => {
     })
     expect(r.errors.some(e => e.includes('type'))).toBe(true)
   })
+
+  it('drops query/hybrid pools that omit `query` (defensive contract)', () => {
+    // Accepting these would let resolvePool throw at runtime — which
+    // is exactly what the defensive parse contract is meant to prevent.
+    const r = parseConfig({
+      pools: [
+        { id: 'q',  name: 'Q',  memberIds: [],    strategy: 'first-available', type: 'query' },
+        { id: 'h',  name: 'H',  memberIds: ['x'], strategy: 'first-available', type: 'hybrid' },
+        { id: 'ok', name: 'OK', memberIds: [],    strategy: 'first-available',
+          type: 'query',
+          query: { op: 'eq', path: 'meta.capabilities.refrigerated', value: true } },
+      ],
+    })
+    expect(r.config.pools!.map(p => p.id)).toEqual(['ok'])
+    expect(r.dropped).toBe(2)
+    expect(r.errors.some(e => e.includes('type "query" requires a query'))).toBe(true)
+    expect(r.errors.some(e => e.includes('type "hybrid" requires a query'))).toBe(true)
+  })
 })
 
 describe('parseConfig — requirements', () => {

--- a/src/core/config/parseConfig.ts
+++ b/src/core/config/parseConfig.ts
@@ -192,24 +192,41 @@ function parsePool(raw: unknown, path: string, errors: string[]): ResourcePool |
     errors.push(`${path}: invalid strategy "${String(raw['strategy'])}", dropping`)
     return null
   }
+  // Resolve type + query together so we can drop any pool whose
+  // declared type would crash the resolver at runtime. `query` /
+  // `hybrid` types REQUIRE pool.query; accepting one without it
+  // means the runtime engine throws the moment it tries to schedule
+  // against the pool — which contradicts the defensive parse
+  // contract (drop, don't crash).
+  let poolType: PoolType | undefined
+  if (raw['type'] !== undefined) {
+    if (typeof raw['type'] === 'string' && POOL_TYPES.includes(raw['type'] as PoolType)) {
+      poolType = raw['type'] as PoolType
+    } else {
+      errors.push(`${path}.type: invalid value "${String(raw['type'])}", ignoring`)
+    }
+  }
+  let query: NonNullable<ResourcePool['query']> | undefined
+  if (raw['query'] !== undefined) {
+    if (isObject(raw['query'])) {
+      query = raw['query'] as NonNullable<ResourcePool['query']>
+    } else {
+      errors.push(`${path}.query: expected object, ignoring`)
+    }
+  }
+  if ((poolType === 'query' || poolType === 'hybrid') && !query) {
+    errors.push(`${path}: type "${poolType}" requires a query, dropping`)
+    return null
+  }
   const out: { -readonly [K in keyof ResourcePool]: ResourcePool[K] } = {
     id: raw['id'],
     name: raw['name'],
     memberIds: raw['memberIds'] as string[],
     strategy: raw['strategy'] as PoolStrategy,
   }
-  if (raw['type'] !== undefined) {
-    if (typeof raw['type'] === 'string' && POOL_TYPES.includes(raw['type'] as PoolType)) {
-      out.type = raw['type'] as PoolType
-    } else {
-      errors.push(`${path}.type: invalid value "${String(raw['type'])}", ignoring`)
-    }
-  }
-  if (raw['query'] !== undefined) {
-    if (isObject(raw['query'])) out.query = raw['query'] as NonNullable<ResourcePool['query']>
-    else errors.push(`${path}.query: expected object, ignoring`)
-  }
-  if (typeof raw['rrCursor'] === 'number') out.rrCursor = raw['rrCursor']
+  if (poolType) out.type  = poolType
+  if (query)    out.query = query
+  if (typeof raw['rrCursor'] === 'number')  out.rrCursor = raw['rrCursor']
   if (typeof raw['disabled'] === 'boolean') out.disabled = raw['disabled']
   return out
 }


### PR DESCRIPTION
P1 from Codex on PR #440: parseConfig accepted type: 'query' or 'hybrid' as soon as the type string was valid, even when no query was present. The runtime resolver throws at scheduling time for those types without a query, so a single bad pool in hand-authored JSON could crash scheduling instead of being counted as a dropped entry — directly contradicting the defensive parse contract.

Resolve type + query together; drop the pool with an error when a typed pool has no query, surface a normal "ignoring" error when type is unknown (existing behavior).

2 regression tests pin the contract:
  - query without query → dropped + error
  - hybrid without query → dropped + error
  - clean fixture still passes through

https://claude.ai/code/session_01XojXzZPdEPuGbX2TyLY1pu

## Summary
Describe exactly what this PR changes.

## Scope
- Stage: 
- Planned PR number in sprint: 
- Target files/directories: 
- Why this slice is isolated: 

## Lessons Learned Check (REQUIRED)
Confirm these were actively used while building this PR:

- [ ] PR is intentionally small and isolated
- [ ] Boundary typing was prioritized over internal perfection
- [ ] No silent spread of `any`
- [ ] Advisory root `tsc` was used to catch integration issues
- [ ] I did not assume “looks typed” means “safe”
- [ ] I stopped and isolated typing cascades instead of expanding scope

## Definition of Done (ALL REQUIRED)
This PR is not done unless every box is checked.

- [ ] `npm run type-check:strict` passes
- [ ] Root advisory `tsc --noEmit` passes
- [ ] Tests pass for touched scope at minimum
- [ ] No uncontrolled increase in `any`
- [ ] All new types are intentional and named
- [ ] Public interfaces and exported functions are explicitly typed
- [ ] PR scope matches the sprint plan with no scope creep
- [ ] Any new `any` has an adjacent justification comment
- [ ] No file-wide `: any`
- [ ] No implicit `any` in exported functions

## What Was Typed
List exactly what was typed in this PR.

- 
- 
- 

## What Was Intentionally Left Loose
List anything intentionally not tightened yet.

- 
- 
- 

## `any` Ledger (REQUIRED)
- New `any` added: 
- Existing `any` removed: 
- Net change: 

For every new `any`, explain why it is required and why a safer type was not used yet.

1. 
2. 
3. 

## Boundary Notes
Document any public seams, caller-protection choices, or compatibility decisions.

- 
- 
- 

## Risk Level
- [ ] Low
- [ ] Medium
- [ ] High

Why:

## Validation Evidence
Paste the exact commands run and a short result summary.

```bash
npm run type-check:strict
npx tsc --noEmit -p tsconfig.json
```

Test commands run:

```bash
# paste commands here
```

## Stop Conditions Check
If any item below happened, explain how scope was reduced before merge.

- [ ] `any` started spreading across files
- [ ] Root `tsc` broke repeatedly
- [ ] Types required cross-module rewrites
- [ ] Scope was reduced to keep the PR reviewable

Notes:

## Reviewer Focus
What should reviewers look at first?

- 
- 
- 
