### PR TITLE
core(requirements): runtime consumer for CalendarConfig templates (#386)

### DIFF
--- a/docs/Requirements.md
+++ b/docs/Requirements.md
@@ -1,0 +1,135 @@
+# Requirements engine
+
+The requirements engine is the runtime consumer for the
+`CalendarConfig.requirements` templates. Given an event plus the
+usual resource / assignment / pool maps, `evaluateRequirements`
+returns whether the event is fully staffed and — when it isn't — a
+trail of shortfalls naming each unmet slot.
+
+## What a requirement template looks like
+
+```ts
+{
+  "eventType": "load",
+  "requires": [
+    { "role": "driver",         "count": 1 },
+    { "pool": "nearby_reefers", "count": 1 }
+  ]
+}
+```
+
+A `load` event needs at least one driver and one reefer truck
+assigned to it. Slots are independent: a single resource that's
+tagged with multiple roles **and** lives in the right pool can
+satisfy multiple slots at once, which matches the natural reading
+of "this event needs a driver and a truck."
+
+## Evaluating an event
+
+```ts
+import { evaluateRequirements } from 'works-calendar';
+
+const result = evaluateRequirements({
+  event,                    // Pick<EngineEvent, 'id' | 'category'>
+  requirements,             // ConfigRequirement[]
+  resources,                // ReadonlyMap<id, EngineResource>
+  assignments,              // ReadonlyMap<id, Assignment>
+  pools,                    // ReadonlyMap<id, ResourcePool>
+  proposedLocation,         // optional; required for within(proposed) pools
+});
+
+if (!result.satisfied) {
+  for (const m of result.missing) {
+    if (m.kind === 'role') {
+      console.warn(`Need ${m.missing} more ${m.role}(s) — have ${m.assigned}/${m.required}`);
+    } else {
+      console.warn(`Need ${m.missing} more from pool "${m.pool}" — have ${m.assigned}/${m.required}`);
+    }
+  }
+}
+```
+
+`event.category` is the match key. If no template matches the
+category (or the event has none), the result is
+`{ satisfied: true, missing: [], noTemplate: true }`. Hosts that
+want to *enforce* templating ("every event must declare a type
+that's in the catalog") can read `noTemplate` and react.
+
+## Role tagging
+
+Role membership lives on the resource side, not on `Assignment`.
+A resource declares which roles it can fulfill via `meta.roles`:
+
+```ts
+const alice: EngineResource = {
+  id: 'alice',
+  name: 'Alice Rivera',
+  meta: { roles: ['driver', 'dispatcher'] },
+};
+```
+
+The engine counts every assignment whose resource is tagged with
+the slot's role. This is the v1 contract: it captures static role
+membership and works for the wizard's needs. A future slice may
+add an optional per-assignment `roleId` for "Alice is acting as
+dispatcher *on this event*" semantics; that's additive when it
+lands.
+
+## Pool slots
+
+For each pool slot, the engine computes the pool's effective
+member set:
+
+| Type     | Effective members                                       |
+|----------|---------------------------------------------------------|
+| `manual` | `pool.memberIds`                                        |
+| `query`  | `evaluateQuery(pool.query, resources, ctx).matched`     |
+| `hybrid` | intersection of `pool.memberIds` and the query result   |
+
+…then counts how many assignments to the event reference a
+resource in that set. The same memoization table is reused across
+slots in the same evaluation, so a requirement that names the
+same pool twice ("2 trucks") only runs the query once.
+
+### Distance-based pools
+
+When a pool's `query` uses `from: { kind: 'proposed' }` (the
+common shape for "within N miles of the event"), pass the event's
+location as `proposedLocation`:
+
+```ts
+evaluateRequirements({ event, ..., proposedLocation: event.meta.location });
+```
+
+Without it, the `within(proposed)` clause fails-closed for every
+resource, and the slot's effective member set will be empty — so
+even a perfectly-staffed event will report a shortfall. This is
+documented behavior; tests pin it.
+
+## Defensive contract
+
+`evaluateRequirements` never throws.
+
+- Pool slots that reference a pool id not in the `pools` map
+  surface as a shortfall with `poolUnknown: true` and `assigned: 0`.
+- Query/hybrid pools with no `query` field (which `parseConfig`
+  drops at load time, but hosts may still construct directly)
+  resolve to zero members rather than crashing.
+- Assignments whose `resourceId` isn't in the registry don't
+  contribute to any role or pool slot.
+- Slots are independent — a single assignment satisfies any slot
+  whose criteria it meets, including multiple at once.
+
+## Out of scope (future slices)
+
+- **Engine integration** — auto-rejecting submits with unmet
+  requirements at the operation level. This evaluator is currently
+  a standalone read; hosts decide whether to gate.
+- **Per-assignment `roleId`** — assignments declaring "this resource
+  is acting as role X *on this event*" rather than relying on the
+  resource's static role list.
+- **Soft requirements** — slots that warn but don't block (the v1
+  contract treats every unmet slot as a hard shortfall).
+- **`validateConfig`** — cross-section integrity checks
+  (`requirement.role` ∈ `roles[]`, `requirement.pool` ∈ `pools[]`)
+  still need to land separately.

--- a/src/core/requirements/__tests__/evaluateRequirements.test.ts
+++ b/src/core/requirements/__tests__/evaluateRequirements.test.ts
@@ -1,0 +1,297 @@
+/**
+ * `evaluateRequirements` — runtime consumer for the
+ * `CalendarConfig.requirements` templates (#386).
+ */
+import { describe, it, expect } from 'vitest'
+import { evaluateRequirements } from '../evaluateRequirements'
+import type { ConfigRequirement } from '../../config/calendarConfig'
+import type { Assignment } from '../../engine/schema/assignmentSchema'
+import type { EngineEvent } from '../../engine/schema/eventSchema'
+import type { EngineResource } from '../../engine/schema/resourceSchema'
+import type { ResourcePool } from '../../pools/resourcePoolSchema'
+
+const r = (id: string, meta: Record<string, unknown> = {}): EngineResource =>
+  ({ id, name: id.toUpperCase(), meta } as EngineResource)
+
+const a = (id: string, eventId: string, resourceId: string): Assignment =>
+  ({ id, eventId, resourceId, units: 100 })
+
+const mapBy = <T extends { id: string }>(items: readonly T[]): ReadonlyMap<string, T> =>
+  new Map(items.map(x => [x.id, x] as const))
+
+const event = (id: string, category: string | null): Pick<EngineEvent, 'id' | 'category'> => ({ id, category })
+
+describe('evaluateRequirements — no template / no category', () => {
+  it('reports satisfied + noTemplate when event.category is null', () => {
+    const out = evaluateRequirements({
+      event: event('e1', null),
+      requirements: [],
+      resources: new Map(),
+      assignments: new Map(),
+    })
+    expect(out).toEqual({ satisfied: true, missing: [], noTemplate: true })
+  })
+
+  it('reports satisfied + noTemplate when no template matches the category', () => {
+    const out = evaluateRequirements({
+      event: event('e1', 'load'),
+      requirements: [{ eventType: 'maintenance', requires: [{ role: 'tech', count: 1 }] }],
+      resources: new Map(),
+      assignments: new Map(),
+    })
+    expect(out).toEqual({ satisfied: true, missing: [], noTemplate: true })
+  })
+})
+
+describe('evaluateRequirements — role slots', () => {
+  const requirements: ConfigRequirement[] = [
+    { eventType: 'load', requires: [{ role: 'driver', count: 2 }] },
+  ]
+  const resources = mapBy([
+    r('alice', { roles: ['driver'] }),
+    r('bob',   { roles: ['driver', 'dispatcher'] }),
+    r('carol', { roles: ['dispatcher'] }),
+    r('truck', { /* no roles meta */ }),
+  ])
+
+  it('counts assignments whose resource is tagged with the required role', () => {
+    const assignments = mapBy([a('a1', 'e1', 'alice'), a('a2', 'e1', 'bob')])
+    const out = evaluateRequirements({ event: event('e1', 'load'), requirements, resources, assignments })
+    expect(out.satisfied).toBe(true)
+    expect(out.missing).toEqual([])
+  })
+
+  it('reports a role shortfall with the correct missing count', () => {
+    const assignments = mapBy([a('a1', 'e1', 'alice')])
+    const out = evaluateRequirements({ event: event('e1', 'load'), requirements, resources, assignments })
+    expect(out.satisfied).toBe(false)
+    expect(out.missing).toEqual([{ kind: 'role', role: 'driver', required: 2, assigned: 1, missing: 1 }])
+  })
+
+  it('ignores assignments to other events', () => {
+    const assignments = mapBy([
+      a('a1', 'e1', 'alice'),
+      a('a2', 'e2', 'bob'),     // different event
+    ])
+    const out = evaluateRequirements({ event: event('e1', 'load'), requirements, resources, assignments })
+    expect(out.satisfied).toBe(false)
+    expect(out.missing[0]?.assigned).toBe(1)
+  })
+
+  it('ignores resources without a roles tag (driver requires the meta)', () => {
+    const assignments = mapBy([a('a1', 'e1', 'truck')])  // no roles meta
+    const out = evaluateRequirements({
+      event: event('e1', 'load'),
+      requirements: [{ eventType: 'load', requires: [{ role: 'driver', count: 1 }] }],
+      resources, assignments,
+    })
+    expect(out.satisfied).toBe(false)
+    expect(out.missing[0]?.assigned).toBe(0)
+  })
+
+  it('counts resources tagged with multiple roles toward each matching slot', () => {
+    // Bob is both driver + dispatcher. The event needs 1 of each;
+    // a single Bob assignment satisfies both slots.
+    const assignments = mapBy([a('a1', 'e1', 'bob')])
+    const out = evaluateRequirements({
+      event: event('e1', 'load'),
+      requirements: [{
+        eventType: 'load',
+        requires: [
+          { role: 'driver', count: 1 },
+          { role: 'dispatcher', count: 1 },
+        ],
+      }],
+      resources, assignments,
+    })
+    expect(out.satisfied).toBe(true)
+  })
+})
+
+describe('evaluateRequirements — pool slots', () => {
+  const truck = (id: string, refrigerated = false) =>
+    r(id, { type: 'vehicle', capabilities: { refrigerated } })
+
+  const resources = mapBy([
+    truck('t1'),
+    truck('t2'),
+    truck('reefer-1', true),
+    truck('reefer-2', true),
+  ])
+
+  const fleetPool: ResourcePool = {
+    id: 'fleet', name: 'Fleet',
+    memberIds: ['t1', 't2'],
+    strategy: 'first-available',
+  }
+  const reeferPool: ResourcePool = {
+    id: 'reefers', name: 'Reefers',
+    type: 'query', memberIds: [],
+    query: { op: 'eq', path: 'meta.capabilities.refrigerated', value: true },
+    strategy: 'first-available',
+  }
+
+  it('counts assignments whose resource is in the manual pool', () => {
+    const out = evaluateRequirements({
+      event: event('e1', 'load'),
+      requirements: [{ eventType: 'load', requires: [{ pool: 'fleet', count: 1 }] }],
+      resources,
+      pools: mapBy([fleetPool]),
+      assignments: mapBy([a('a1', 'e1', 't1')]),
+    })
+    expect(out.satisfied).toBe(true)
+  })
+
+  it('reports a shortfall with required / assigned / missing counts', () => {
+    const out = evaluateRequirements({
+      event: event('e1', 'load'),
+      requirements: [{ eventType: 'load', requires: [{ pool: 'fleet', count: 2 }] }],
+      resources,
+      pools: mapBy([fleetPool]),
+      assignments: mapBy([a('a1', 'e1', 't1')]),
+    })
+    expect(out.satisfied).toBe(false)
+    expect(out.missing).toEqual([{ kind: 'pool', pool: 'fleet', required: 2, assigned: 1, missing: 1 }])
+  })
+
+  it('runs the query for query pools', () => {
+    // Two reefer assignments → query pool requirement of 2 is met
+    // even though `memberIds: []` would say "no members" if we only
+    // looked there.
+    const out = evaluateRequirements({
+      event: event('e1', 'load'),
+      requirements: [{ eventType: 'load', requires: [{ pool: 'reefers', count: 2 }] }],
+      resources,
+      pools: mapBy([reeferPool]),
+      assignments: mapBy([
+        a('a1', 'e1', 'reefer-1'),
+        a('a2', 'e1', 'reefer-2'),
+      ]),
+    })
+    expect(out.satisfied).toBe(true)
+  })
+
+  it('intersects memberIds with the query for hybrid pools', () => {
+    const hybrid: ResourcePool = {
+      id: 'curated-reefers', name: 'Curated Reefers',
+      type: 'hybrid', memberIds: ['reefer-1'],     // only one curated
+      query: { op: 'eq', path: 'meta.capabilities.refrigerated', value: true },
+      strategy: 'first-available',
+    }
+    // reefer-2 matches the query but isn't in memberIds → doesn't
+    // count toward the hybrid pool slot.
+    const out = evaluateRequirements({
+      event: event('e1', 'load'),
+      requirements: [{ eventType: 'load', requires: [{ pool: 'curated-reefers', count: 1 }] }],
+      resources,
+      pools: mapBy([hybrid]),
+      assignments: mapBy([a('a1', 'e1', 'reefer-2')]),
+    })
+    expect(out.satisfied).toBe(false)
+    expect(out.missing[0]?.assigned).toBe(0)
+  })
+
+  it('flags poolUnknown when the slot references a pool not in the map', () => {
+    const out = evaluateRequirements({
+      event: event('e1', 'load'),
+      requirements: [{ eventType: 'load', requires: [{ pool: 'ghost', count: 1 }] }],
+      resources,
+      pools: mapBy([fleetPool]),
+      assignments: new Map(),
+    })
+    expect(out.satisfied).toBe(false)
+    expect(out.missing[0]).toMatchObject({ kind: 'pool', pool: 'ghost', poolUnknown: true, assigned: 0 })
+  })
+
+  it('treats a query/hybrid pool with no query as zero members (defensive)', () => {
+    const broken: ResourcePool = {
+      id: 'broken', name: 'Broken',
+      type: 'query', memberIds: [],
+      strategy: 'first-available',
+      // no query — parseConfig drops these at load time, but a host
+      // that constructs runtime pools directly might still hand one in.
+    }
+    const out = evaluateRequirements({
+      event: event('e1', 'load'),
+      requirements: [{ eventType: 'load', requires: [{ pool: 'broken', count: 1 }] }],
+      resources,
+      pools: mapBy([broken]),
+      assignments: mapBy([a('a1', 'e1', 't1')]),  // assignment exists, but pool has no members
+    })
+    expect(out.satisfied).toBe(false)
+    expect(out.missing[0]?.assigned).toBe(0)
+  })
+})
+
+describe('evaluateRequirements — mixed slots', () => {
+  it('reports every shortfall in input order', () => {
+    const resources = mapBy([
+      r('alice', { roles: ['driver'] }),
+      r('truck', {}),
+    ])
+    const pool: ResourcePool = {
+      id: 'fleet', name: 'Fleet', memberIds: ['truck'], strategy: 'first-available',
+    }
+    const out = evaluateRequirements({
+      event: event('e1', 'load'),
+      requirements: [{
+        eventType: 'load',
+        requires: [
+          { role: 'driver', count: 2 },
+          { pool: 'fleet',  count: 2 },
+        ],
+      }],
+      resources,
+      pools: mapBy([pool]),
+      assignments: mapBy([a('a1', 'e1', 'alice'), a('a2', 'e1', 'truck')]),
+    })
+    expect(out.satisfied).toBe(false)
+    expect(out.missing).toEqual([
+      { kind: 'role', role: 'driver', required: 2, assigned: 1, missing: 1 },
+      { kind: 'pool', pool: 'fleet',  required: 2, assigned: 1, missing: 1 },
+    ])
+  })
+})
+
+describe('evaluateRequirements — proposedLocation passthrough', () => {
+  it('feeds proposedLocation into evaluateQuery so distance pools resolve', () => {
+    const SLC = { lat: 40.7608, lon: -111.8910 }
+    const reefer = (id: string, lat: number, lon: number) =>
+      r(id, { capabilities: { refrigerated: true }, location: { lat, lon } })
+    const resources = mapBy([
+      reefer('near', SLC.lat, SLC.lon),
+      reefer('far',  37.6189, -122.3750),  // SFO — ~600 mi away
+    ])
+    const pool: ResourcePool = {
+      id: 'nearby', name: 'Nearby Reefers', type: 'query', memberIds: [],
+      query: {
+        op: 'and',
+        clauses: [
+          { op: 'eq',     path: 'meta.capabilities.refrigerated', value: true },
+          { op: 'within', path: 'meta.location', from: { kind: 'proposed' }, miles: 50 },
+        ],
+      },
+      strategy: 'first-available',
+    }
+    // Without proposedLocation, the within(proposed) clause fails-closed
+    // and no resource matches → assigning 'near' doesn't satisfy the slot.
+    const withoutLoc = evaluateRequirements({
+      event: event('e1', 'load'),
+      requirements: [{ eventType: 'load', requires: [{ pool: 'nearby', count: 1 }] }],
+      resources,
+      pools: mapBy([pool]),
+      assignments: mapBy([a('a1', 'e1', 'near')]),
+    })
+    expect(withoutLoc.satisfied).toBe(false)
+    // With proposedLocation, the same data resolves correctly.
+    const withLoc = evaluateRequirements({
+      event: event('e1', 'load'),
+      requirements: [{ eventType: 'load', requires: [{ pool: 'nearby', count: 1 }] }],
+      resources,
+      pools: mapBy([pool]),
+      assignments: mapBy([a('a1', 'e1', 'near')]),
+      proposedLocation: SLC,
+    })
+    expect(withLoc.satisfied).toBe(true)
+  })
+})

--- a/src/core/requirements/evaluateRequirements.ts
+++ b/src/core/requirements/evaluateRequirements.ts
@@ -1,0 +1,221 @@
+/**
+ * `evaluateRequirements` — runtime consumer for the
+ * `CalendarConfig.requirements` templates (issue #386 wizard slice).
+ *
+ * Pure / sync. Given an event, a requirements template list, and the
+ * usual registry + assignment + pool maps, returns whether the event
+ * is fully staffed plus a `missing` trail when it isn't.
+ *
+ * Match key is `event.category` (the engine's existing
+ * "what kind of event is this?" field). The wizard / config layer
+ * uses `eventType` as the same concept; the trip from one to the
+ * other is a string match.
+ *
+ * Slot semantics:
+ *   - `{ role, count }` — at least `count` assignments to this event
+ *     must reference resources whose `meta.roles` includes `role`.
+ *   - `{ pool, count }` — at least `count` assignments to this event
+ *     must reference resources in the pool's effective member set
+ *     (manual: memberIds; query: evaluateQuery; hybrid: intersection).
+ *
+ * Slots are independent — a single assignment can satisfy multiple
+ * slots if its resource is tagged with the right role and is also
+ * in the named pool. That matches the natural reading of "this
+ * event needs a driver and a truck"; an Alice tagged as both is
+ * still one body filling both.
+ */
+import type { EngineEvent } from '../engine/schema/eventSchema'
+import type { EngineResource } from '../engine/schema/resourceSchema'
+import type { Assignment } from '../engine/schema/assignmentSchema'
+import type { ResourcePool } from '../pools/resourcePoolSchema'
+import type { LatLon } from '../pools/geo'
+import type { ConfigRequirement, ConfigRequirementSlot } from '../config/calendarConfig'
+import { evaluateQuery } from '../pools/evaluateQuery'
+
+export interface EvaluateRequirementsInput {
+  /**
+   * Minimal event shape — we only need the id (to match assignments)
+   * and the category (to match a requirement template). Pass an
+   * EngineEvent or a lighter fixture; both work.
+   */
+  readonly event: Pick<EngineEvent, 'id' | 'category'>
+  readonly requirements: readonly ConfigRequirement[]
+  readonly resources: ReadonlyMap<string, EngineResource>
+  readonly assignments: ReadonlyMap<string, Assignment>
+  readonly pools?: ReadonlyMap<string, ResourcePool>
+  /**
+   * Reference point for query/hybrid pools that use
+   * `from: { kind: 'proposed' }`. Typically the event's pickup /
+   * origin location. Passing it lets distance-based pools resolve
+   * their member set against the event's actual position.
+   */
+  readonly proposedLocation?: LatLon
+}
+
+export type RequirementShortfall =
+  | {
+      readonly kind: 'role'
+      readonly role: string
+      readonly required: number
+      readonly assigned: number
+      readonly missing: number
+    }
+  | {
+      readonly kind: 'pool'
+      readonly pool: string
+      readonly required: number
+      readonly assigned: number
+      readonly missing: number
+      /**
+       * `true` when the slot pointed at a pool id that isn't in the
+       * `pools` map. The shortfall surfaces with `assigned: 0` so
+       * the host can render "pool unknown — fix your config" without
+       * special-casing missing keys.
+       */
+      readonly poolUnknown?: boolean
+    }
+
+export interface RequirementsEvaluation {
+  readonly satisfied: boolean
+  /** Per-slot shortfalls in input order. Empty when satisfied. */
+  readonly missing: readonly RequirementShortfall[]
+  /**
+   * True when no requirement template matched `event.category`.
+   * The evaluation reports `satisfied: true` in that case (no
+   * template = no requirement to fail), but hosts that want to
+   * enforce strict templating use this flag to flag it.
+   */
+  readonly noTemplate: boolean
+}
+
+const SATISFIED_NO_TEMPLATE: RequirementsEvaluation = {
+  satisfied: true, missing: [], noTemplate: true,
+}
+
+export function evaluateRequirements(
+  input: EvaluateRequirementsInput,
+): RequirementsEvaluation {
+  const { event, requirements, resources, assignments } = input
+  const eventType = event.category
+  if (eventType == null) return SATISFIED_NO_TEMPLATE
+
+  const template = requirements.find(r => r.eventType === eventType)
+  if (!template) return SATISFIED_NO_TEMPLATE
+
+  // Pre-compute the assignments for this event — slot evaluators
+  // walk the same set repeatedly so doing it once is the obvious
+  // optimization at zero cost.
+  const eventAssignments: readonly Assignment[] = (() => {
+    const out: Assignment[] = []
+    for (const a of assignments.values()) {
+      if (a.eventId === event.id) out.push(a)
+    }
+    return out
+  })()
+
+  // Memoize each pool's effective member set — a single requirement
+  // may name the same pool twice (e.g. "2 trucks"); evaluating its
+  // query each time would be wasteful.
+  const poolMemberCache = new Map<string, ReadonlySet<string> | null>()
+
+  const missing: RequirementShortfall[] = []
+  for (const slot of template.requires) {
+    const shortfall = checkSlot(slot, {
+      eventAssignments, resources, pools: input.pools,
+      proposedLocation: input.proposedLocation,
+      poolMemberCache,
+    })
+    if (shortfall) missing.push(shortfall)
+  }
+
+  return { satisfied: missing.length === 0, missing, noTemplate: false }
+}
+
+// ─── Internals ──────────────────────────────────────────────────────────────
+
+interface SlotContext {
+  readonly eventAssignments: readonly Assignment[]
+  readonly resources: ReadonlyMap<string, EngineResource>
+  readonly pools?: ReadonlyMap<string, ResourcePool> | undefined
+  readonly proposedLocation?: LatLon | undefined
+  readonly poolMemberCache: Map<string, ReadonlySet<string> | null>
+}
+
+function checkSlot(slot: ConfigRequirementSlot, ctx: SlotContext): RequirementShortfall | null {
+  if ('role' in slot) {
+    const assigned = countRoleAssignments(slot.role, ctx)
+    if (assigned >= slot.count) return null
+    return {
+      kind: 'role', role: slot.role,
+      required: slot.count, assigned,
+      missing: slot.count - assigned,
+    }
+  }
+  // pool slot
+  const members = poolMembers(slot.pool, ctx)
+  if (members === null) {
+    return {
+      kind: 'pool', pool: slot.pool,
+      required: slot.count, assigned: 0,
+      missing: slot.count, poolUnknown: true,
+    }
+  }
+  const assigned = countPoolAssignments(members, ctx)
+  if (assigned >= slot.count) return null
+  return {
+    kind: 'pool', pool: slot.pool,
+    required: slot.count, assigned,
+    missing: slot.count - assigned,
+  }
+}
+
+function countRoleAssignments(roleId: string, ctx: SlotContext): number {
+  let count = 0
+  for (const a of ctx.eventAssignments) {
+    const r = ctx.resources.get(a.resourceId)
+    const roles = (r?.meta?.['roles'] ?? null) as readonly string[] | null
+    if (Array.isArray(roles) && roles.includes(roleId)) count++
+  }
+  return count
+}
+
+function countPoolAssignments(members: ReadonlySet<string>, ctx: SlotContext): number {
+  let count = 0
+  for (const a of ctx.eventAssignments) {
+    if (members.has(a.resourceId)) count++
+  }
+  return count
+}
+
+function poolMembers(poolId: string, ctx: SlotContext): ReadonlySet<string> | null {
+  const cached = ctx.poolMemberCache.get(poolId)
+  if (cached !== undefined) return cached
+  const pool = ctx.pools?.get(poolId) ?? null
+  if (!pool) {
+    ctx.poolMemberCache.set(poolId, null)
+    return null
+  }
+  const members = computePoolMembers(pool, ctx)
+  ctx.poolMemberCache.set(poolId, members)
+  return members
+}
+
+function computePoolMembers(pool: ResourcePool, ctx: SlotContext): ReadonlySet<string> {
+  const type = pool.type ?? 'manual'
+  if (type === 'manual') return new Set(pool.memberIds)
+  if (!pool.query) {
+    // Misconfigured query/hybrid pool — defensive: treat it as
+    // having zero members rather than throwing inside the
+    // requirements evaluator. parseConfig drops these at load
+    // time; this guard handles directly-passed runtime pools.
+    return new Set()
+  }
+  const queryContext = ctx.proposedLocation
+    ? { proposedLocation: ctx.proposedLocation }
+    : {}
+  const result = evaluateQuery(pool.query, ctx.resources, queryContext)
+  if (type === 'query') return new Set(result.matched)
+  // hybrid — intersection of memberIds and query result
+  const allowed = new Set(result.matched)
+  return new Set(pool.memberIds.filter(id => allowed.has(id)))
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -207,6 +207,11 @@ export type {
   ConfigResource, ConfigRequirement, ConfigRequirementSlot,
   ConfigSeedEvent, ConfigSettings,
 } from './core/config/calendarConfig';
+// ── Requirements engine — runtime consumer for the templates (#386) ──────
+export { evaluateRequirements } from './core/requirements/evaluateRequirements';
+export type {
+  EvaluateRequirementsInput, RequirementsEvaluation, RequirementShortfall,
+} from './core/requirements/evaluateRequirements';
 
 // ── Lifecycle event bus (#216) ──────────────────────────────────────────────
 export { EventBus, channelForApprovalTransition } from './core/engine/eventBus';


### PR DESCRIPTION
## Summary

Runtime consumer for the `CalendarConfig.requirements` templates
that landed in #440. Turns the *"this event needs a driver and a
truck"* templates from dead config into real validation. Pure
function — no engine integration yet (gating submits is a
separate UX call); hosts decide when and where to call it.

```ts
evaluateRequirements({
  event, requirements, resources, assignments, pools?, proposedLocation?,
}) → { satisfied, missing[], noTemplate }
```

### Match key

`event.category`. When no template matches (or the event has none),
the result is `{ satisfied: true, missing: [], noTemplate: true }`.
Hosts that want to *enforce* templating ("every event must declare
a type") can react to `noTemplate`.

### Slot semantics

| Slot          | What gets counted                                                                                                                |
|---------------|------------------------------------------------------------------------------------------------------------------------------------|
| `{ role, count }` | Assignments whose resource has `role` in `meta.roles: string[]`. Multi-role resources count toward each slot they qualify for. |
| `{ pool, count }` | Assignments whose resource is in the pool's effective member set (manual: `memberIds`; query: `evaluateQuery`; hybrid: intersection). Pool member sets are memoized per evaluation so a *"2 trucks"* requirement only runs the query once. |

### Defensive contract — never throws

- **Unknown pool id** → shortfall with `poolUnknown: true`, `assigned: 0`
- **Query / hybrid pool with no `query`** (parseConfig drops these,
  but hosts may still construct directly) → 0 effective members
- **Assignments to unknown resources** don't contribute to any slot

### Distance-based pools

For `within(proposed)` clauses, pass the event's location as
`proposedLocation`. Without it the clause fails-closed for every
resource and the slot's effective member set is empty — even a
perfectly-staffed event would report a shortfall. Documented and
pinned by tests.

## Test plan

- [x] `tsc --noEmit` clean
- [x] `vitest run` — 2388 passing, 2 skipped (existing PTO flakes), 0 failures (15 new tests)
- [x] no-template fall-through (null category + no match)
- [x] role counting (satisfied + shortfall + assigned-to-other-event ignored + missing roles meta + multi-role resource satisfies multiple slots)
- [x] pool counting (manual + query + hybrid)
- [x] mixed-slot evaluation reports every shortfall in input order
- [x] unknown pool id surfaces `poolUnknown: true`
- [x] query / hybrid with no query → 0 members (defensive)
- [x] `proposedLocation` passthrough end-to-end (`within(proposed)` resolves correctly with it, fails-closed without)

## Role tagging

Role membership lives on the resource side via `meta.roles`,
not on `Assignment`. A resource declares which roles it can
fulfill:

```ts
const alice: EngineResource = {
  id: 'alice', name: 'Alice Rivera',
  meta: { roles: ['driver', 'dispatcher'] },
};
```

This v1 contract captures static role membership and works for
the wizard's needs. A future slice may add an optional
per-assignment `roleId` for *"Alice is acting as dispatcher on
this event"* semantics; that's additive when it lands.

## Out of scope (still pending v2 follow-ups)

- **Engine integration** — auto-rejecting submits with unmet
  requirements at the operation level
- **Per-assignment `roleId`** (acting-as semantics)
- **Soft requirements** (warn but don't block)
- **`validateConfig`** — cross-section integrity
  (`requirement.role` ∈ `roles[]`, `requirement.pool` ∈ `pools[]`)
- **Industry profile presets**
- **The wizard UI itself** (capstone — lands once these are stable)

https://claude.ai/code/session_01XojXzZPdEPuGbX2TyLY1pu

---
_Generated by [Claude Code](https://claude.ai/code/session_01XojXzZPdEPuGbX2TyLY1pu)_