### PR TITLE
core(requirements): guard pool counts against phantom + malformed inputs

### DIFF
--- a/src/core/requirements/__tests__/evaluateRequirements.test.ts
+++ b/src/core/requirements/__tests__/evaluateRequirements.test.ts
@@ -203,6 +203,57 @@ describe('evaluateRequirements — pool slots', () => {
     expect(out.missing[0]).toMatchObject({ kind: 'pool', pool: 'ghost', poolUnknown: true, assigned: 0 })
   })
 
+  it('ignores assignments to resources not in the registry (#386 P1)', () => {
+    // Manual pool's memberIds include a stale id whose resource was
+    // deleted. An assignment still references the deleted id — without
+    // the registry check, that phantom assignment would falsely
+    // satisfy the slot.
+    const stalePool: ResourcePool = {
+      id: 'fleet', name: 'Fleet',
+      memberIds: ['t1', 'gone'],   // 'gone' isn't in resources
+      strategy: 'first-available',
+    }
+    const out = evaluateRequirements({
+      event: event('e1', 'load'),
+      requirements: [{ eventType: 'load', requires: [{ pool: 'fleet', count: 1 }] }],
+      resources,                                          // does NOT include 'gone'
+      pools: mapBy([stalePool]),
+      assignments: mapBy([a('a1', 'e1', 'gone')]),        // assignment to deleted resource
+    })
+    expect(out.satisfied).toBe(false)
+    expect(out.missing[0]?.assigned).toBe(0)
+  })
+
+  it('treats a malformed query as zero members instead of throwing (#386 P2)', () => {
+    // A pool's `query` field is loosely validated by parseConfig as
+    // "any object" — a malformed `{}` can survive parsing and would
+    // crash evaluateQuery (path.startsWith on undefined). The
+    // evaluator's documented "never throws" contract requires a
+    // graceful zero-members fallback.
+    const broken: ResourcePool = {
+      id: 'broken', name: 'Broken',
+      type: 'query', memberIds: [],
+      query: {} as never,                     // malformed by design
+      strategy: 'first-available',
+    }
+    expect(() => evaluateRequirements({
+      event: event('e1', 'load'),
+      requirements: [{ eventType: 'load', requires: [{ pool: 'broken', count: 1 }] }],
+      resources,
+      pools: mapBy([broken]),
+      assignments: mapBy([a('a1', 'e1', 't1')]),
+    })).not.toThrow()
+    const out = evaluateRequirements({
+      event: event('e1', 'load'),
+      requirements: [{ eventType: 'load', requires: [{ pool: 'broken', count: 1 }] }],
+      resources,
+      pools: mapBy([broken]),
+      assignments: mapBy([a('a1', 'e1', 't1')]),
+    })
+    expect(out.satisfied).toBe(false)
+    expect(out.missing[0]?.assigned).toBe(0)
+  })
+
   it('treats a query/hybrid pool with no query as zero members (defensive)', () => {
     const broken: ResourcePool = {
       id: 'broken', name: 'Broken',

--- a/src/core/requirements/evaluateRequirements.ts
+++ b/src/core/requirements/evaluateRequirements.ts
@@ -182,6 +182,14 @@ function countRoleAssignments(roleId: string, ctx: SlotContext): number {
 function countPoolAssignments(members: ReadonlySet<string>, ctx: SlotContext): number {
   let count = 0
   for (const a of ctx.eventAssignments) {
+    // Phantom guard: a manual pool's `memberIds` can carry stale ids
+    // that point at deleted resources. Without checking the registry,
+    // an assignment to a non-existent resource would still match
+    // `members.has(...)` (the id is in the pool list) and falsely
+    // satisfy a slot. The role path is already safe — it reads the
+    // resource's `meta.roles`, which is `undefined` when the resource
+    // is gone — but pool counts need an explicit registry check.
+    if (!ctx.resources.has(a.resourceId)) continue
     if (members.has(a.resourceId)) count++
   }
   return count
@@ -213,7 +221,18 @@ function computePoolMembers(pool: ResourcePool, ctx: SlotContext): ReadonlySet<s
   const queryContext = ctx.proposedLocation
     ? { proposedLocation: ctx.proposedLocation }
     : {}
-  const result = evaluateQuery(pool.query, ctx.resources, queryContext)
+  // Catch any throw from evaluateQuery — a malformed query (e.g. an
+  // empty object that passed parseConfig's loose object check)
+  // breaks the documented "never throws" contract otherwise. The
+  // safe default is "zero effective members"; the slot will surface
+  // as a shortfall, which mirrors how the rest of the evaluator
+  // handles broken pools.
+  let result
+  try {
+    result = evaluateQuery(pool.query, ctx.resources, queryContext)
+  } catch {
+    return new Set()
+  }
   if (type === 'query') return new Set(result.matched)
   // hybrid — intersection of memberIds and query result
   const allowed = new Set(result.matched)


### PR DESCRIPTION
## Summary

Two Codex P-tier follow-ups on the now-merged **#443** (requirements engine).

### P1 — phantom assignments could satisfy a pool slot

`countPoolAssignments` incremented for any assignment whose
`resourceId` was in the pool's member set, but didn't verify the
resource actually exists in the registry. For manual pools, stale
`memberIds` referencing deleted resources let a phantom assignment
falsely satisfy a required slot. Added an explicit
`ctx.resources.has` guard so only assignments to **live** resources
count toward pool slots.

The role path was already safe because `countRoleAssignments` reads
`resource.meta.roles`, which is `undefined` for missing resources.

### P2 — malformed pool queries crashed the evaluator

`computePoolMembers` called `evaluateQuery` directly on `pool.query`,
but `parseConfig` only validates that `query` is *an object* — a
malformed shape like `{}` survives parsing and crashes
`evaluateQuery` (`path.startsWith` on `undefined`). That breaks the
documented **"never throws"** contract for `evaluateRequirements`.

Wrapped the call in try/catch; on throw the pool resolves to zero
effective members, which mirrors how the no-`query` case is handled
and surfaces the slot as a normal shortfall.

## Test plan

- [x] `tsc --noEmit` clean
- [x] `vitest run src/core/requirements` — 17 passing (2 new regression tests)
- [x] Phantom assignment to a deleted resource doesn't satisfy a slot (asserted both `satisfied: false` and `assigned: 0`)
- [x] Malformed `query: {}` doesn't throw and the slot reports as missing
- [x] Full suite still green

https://claude.ai/code/session_01XojXzZPdEPuGbX2TyLY1pu

---
_Generated by [Claude Code](https://claude.ai/code/session_01XojXzZPdEPuGbX2TyLY1pu)_