### PR TITLE
core(config): validateConfig — cross-section integrity (#386)

### DIFF
--- a/docs/CalendarConfig.md
+++ b/docs/CalendarConfig.md
@@ -79,6 +79,39 @@ match a `roles[].id`?) is **not** checked — those references
 typically come from external sources and the engine's own runtime
 validators handle them when they fire.
 
+## Validating cross-section integrity
+
+`parseConfig` checks each section's *shape* but deliberately does
+not cross-check references between them. `validateConfig(config)`
+is the opt-in pass that walks the references and surfaces issues:
+
+| Check                                  | Issue kind                  |
+|----------------------------------------|------------------------------|
+| `resource.type` ∈ `resourceTypes[].id` | `unknown-resource-type`     |
+| `pool.memberIds[*]` ∈ `resources[].id` | `unknown-pool-member`       |
+| `requirement.role` ∈ `roles[].id`      | `unknown-requirement-role`  |
+| `requirement.pool` ∈ `pools[].id`      | `unknown-requirement-pool`  |
+| `event.resourceId` ∈ `resources[].id`  | `unknown-event-resource`    |
+| `event.resourcePoolId` ∈ `pools[].id`  | `unknown-event-pool`        |
+| Duplicate ids in any catalog section   | `duplicate-id`              |
+
+```ts
+import { validateConfig } from 'works-calendar';
+
+const { ok, issues } = validateConfig(config);
+if (!ok) {
+  for (const issue of issues) {
+    console.warn(`${issue.path}: ${issue.kind}`);
+  }
+}
+```
+
+Each issue carries enough context to render
+*"requirements[0].requires[1].pool: pool 'aircraft' not found"*
+without stitching strings together. Useful for the wizard's review
+step, CLI tools loading config files, and any consumer that wants
+to fail fast on internal inconsistencies.
+
 ## Writing a config
 
 ```ts

--- a/src/core/config/__tests__/validateConfig.test.ts
+++ b/src/core/config/__tests__/validateConfig.test.ts
@@ -1,0 +1,212 @@
+/**
+ * `validateConfig` — cross-section integrity checks (#386).
+ */
+import { describe, it, expect } from 'vitest'
+import { validateConfig } from '../validateConfig'
+import type { CalendarConfig } from '../calendarConfig'
+
+describe('validateConfig — empty + clean', () => {
+  it('accepts an empty config', () => {
+    expect(validateConfig({})).toEqual({ ok: true, issues: [] })
+  })
+
+  it('accepts a fully-populated, internally-consistent config', () => {
+    const config: CalendarConfig = {
+      profile: 'trucking',
+      labels: { resource: 'Truck' },
+      resourceTypes: [{ id: 'vehicle', label: 'Truck' }],
+      roles:         [{ id: 'driver',  label: 'Driver' }],
+      resources: [
+        { id: 't1', name: 'Truck 1', type: 'vehicle' },
+        { id: 't2', name: 'Truck 2', type: 'vehicle' },
+      ],
+      pools: [{
+        id: 'fleet', name: 'Fleet', memberIds: ['t1', 't2'],
+        strategy: 'first-available',
+      }],
+      requirements: [{
+        eventType: 'load',
+        requires: [
+          { role: 'driver', count: 1 },
+          { pool: 'fleet',  count: 1 },
+        ],
+      }],
+      events: [{
+        id: 'e1', title: 'Run', start: '2026-04-20T09:00:00Z', end: '2026-04-20T18:00:00Z',
+        eventType: 'load',
+        resourcePoolId: 'fleet',
+      }],
+      settings: { conflictMode: 'block', timezone: 'America/Denver' },
+    }
+    expect(validateConfig(config)).toEqual({ ok: true, issues: [] })
+  })
+})
+
+describe('validateConfig — resources', () => {
+  it('flags resources with an unknown type id', () => {
+    const r = validateConfig({
+      resourceTypes: [{ id: 'vehicle', label: 'Truck' }],
+      resources:     [{ id: 't1', name: 'Truck 1', type: 'aircraft' }],
+    })
+    expect(r.ok).toBe(false)
+    expect(r.issues).toEqual([{
+      severity: 'error',
+      kind: 'unknown-resource-type',
+      section: 'resources',
+      path: 'resources[0].type',
+      resourceId: 't1',
+      typeId: 'aircraft',
+    }])
+  })
+
+  it('skips the check when type is omitted', () => {
+    const r = validateConfig({
+      resourceTypes: [{ id: 'vehicle', label: 'Truck' }],
+      resources:     [{ id: 't1', name: 'Truck 1' }],   // no type
+    })
+    expect(r.ok).toBe(true)
+  })
+})
+
+describe('validateConfig — pools', () => {
+  it('flags pool members not in the resource registry', () => {
+    const r = validateConfig({
+      resources: [{ id: 't1', name: 'T1' }],
+      pools: [{ id: 'fleet', name: 'Fleet', memberIds: ['t1', 'ghost'], strategy: 'first-available' }],
+    })
+    expect(r.ok).toBe(false)
+    expect(r.issues).toEqual([{
+      severity: 'error',
+      kind: 'unknown-pool-member',
+      section: 'pools',
+      path: 'pools[0].memberIds[1]',
+      poolId: 'fleet',
+      memberId: 'ghost',
+    }])
+  })
+
+  it('reports each unknown member separately, in order', () => {
+    const r = validateConfig({
+      resources: [{ id: 't1', name: 'T1' }],
+      pools: [{ id: 'fleet', name: 'Fleet', memberIds: ['ghost-a', 't1', 'ghost-b'], strategy: 'first-available' }],
+    })
+    expect(r.issues.map(i => i.kind === 'unknown-pool-member' ? i.memberId : null))
+      .toEqual(['ghost-a', 'ghost-b'])
+  })
+})
+
+describe('validateConfig — requirements', () => {
+  it('flags unknown role references', () => {
+    const r = validateConfig({
+      roles: [{ id: 'driver', label: 'Driver' }],
+      requirements: [{
+        eventType: 'load',
+        requires: [{ role: 'pilot', count: 1 }],
+      }],
+    })
+    expect(r.ok).toBe(false)
+    expect(r.issues[0]).toEqual({
+      severity: 'error',
+      kind: 'unknown-requirement-role',
+      section: 'requirements',
+      path: 'requirements[0].requires[0].role',
+      eventType: 'load',
+      roleId: 'pilot',
+    })
+  })
+
+  it('flags unknown pool references', () => {
+    const r = validateConfig({
+      pools: [{ id: 'fleet', name: 'Fleet', memberIds: [], strategy: 'first-available' }],
+      requirements: [{
+        eventType: 'load',
+        requires: [{ pool: 'aircraft', count: 1 }],
+      }],
+    })
+    expect(r.issues[0]).toMatchObject({
+      kind: 'unknown-requirement-pool',
+      poolId: 'aircraft',
+      eventType: 'load',
+    })
+  })
+
+  it('walks every slot of every requirement (mixed kinds + indices)', () => {
+    const r = validateConfig({
+      roles: [{ id: 'driver', label: 'Driver' }],
+      pools: [{ id: 'fleet',  name: 'Fleet', memberIds: [], strategy: 'first-available' }],
+      requirements: [
+        {
+          eventType: 'load',
+          requires: [
+            { role: 'driver',   count: 1 },   // ok
+            { role: 'pilot',    count: 1 },   // ❌
+            { pool: 'fleet',    count: 1 },   // ok
+            { pool: 'aircraft', count: 1 },   // ❌
+          ],
+        },
+      ],
+    })
+    expect(r.issues.map(i => i.path)).toEqual([
+      'requirements[0].requires[1].role',
+      'requirements[0].requires[3].pool',
+    ])
+  })
+})
+
+describe('validateConfig — events', () => {
+  it('flags events whose resourceId is unknown', () => {
+    const r = validateConfig({
+      resources: [{ id: 't1', name: 'T1' }],
+      events: [{ id: 'e1', title: 'X', start: '2026-04-20T09:00:00Z', end: '2026-04-20T10:00:00Z', resourceId: 'ghost' }],
+    })
+    expect(r.issues[0]).toMatchObject({ kind: 'unknown-event-resource', resourceId: 'ghost', eventId: 'e1' })
+  })
+
+  it('flags events whose resourcePoolId is unknown', () => {
+    const r = validateConfig({
+      pools: [{ id: 'fleet', name: 'Fleet', memberIds: [], strategy: 'first-available' }],
+      events: [{ id: 'e1', title: 'X', start: '2026-04-20T09:00:00Z', end: '2026-04-20T10:00:00Z', resourcePoolId: 'ghost' }],
+    })
+    expect(r.issues[0]).toMatchObject({ kind: 'unknown-event-pool', poolId: 'ghost', eventId: 'e1' })
+  })
+
+  it('does not flag events that omit both resource hooks (drafts are valid)', () => {
+    expect(validateConfig({
+      events: [{ id: 'e1', title: 'X', start: '2026-04-20T09:00:00Z', end: '2026-04-20T10:00:00Z' }],
+    })).toEqual({ ok: true, issues: [] })
+  })
+})
+
+describe('validateConfig — duplicate ids', () => {
+  it('catches duplicates in every catalog section', () => {
+    const r = validateConfig({
+      resourceTypes: [{ id: 'vehicle', label: 'Truck' }, { id: 'vehicle', label: 'Trailer' }],
+      roles:         [{ id: 'driver',  label: 'Driver' }, { id: 'driver',  label: 'Driver II' }],
+      resources:     [{ id: 't1', name: 'A' }, { id: 't1', name: 'B' }],
+      pools:         [{ id: 'p',  name: 'P', memberIds: [], strategy: 'first-available' },
+                      { id: 'p',  name: 'P2', memberIds: [], strategy: 'first-available' }],
+    })
+    const dups = r.issues.filter(i => i.kind === 'duplicate-id').map(i => i.kind === 'duplicate-id' ? `${i.section}/${i.id}` : '')
+    expect(dups).toEqual([
+      'resourceTypes/vehicle',
+      'roles/driver',
+      'resources/t1',
+      'pools/p',
+    ])
+  })
+})
+
+describe('validateConfig — error vs ok summary', () => {
+  it('returns ok:true when there are no error-severity issues', () => {
+    const r = validateConfig({})
+    expect(r.ok).toBe(true)
+  })
+
+  it('returns ok:false when any error is present', () => {
+    const r = validateConfig({
+      requirements: [{ eventType: 'x', requires: [{ role: 'unknown', count: 1 }] }],
+    })
+    expect(r.ok).toBe(false)
+    expect(r.issues.length).toBe(1)
+  })
+})

--- a/src/core/config/validateConfig.ts
+++ b/src/core/config/validateConfig.ts
@@ -1,0 +1,220 @@
+/**
+ * `validateConfig` — cross-section integrity for `CalendarConfig`
+ * (issue #386 wizard slice).
+ *
+ * `parseConfig` from #440 validates each section's *shape* and drops
+ * malformed entries. It deliberately does NOT cross-check references
+ * between sections — those typically come from external sources, and
+ * the runtime validators handle them when they fire.
+ *
+ * `validateConfig` is the opt-in pass that walks the references:
+ *
+ *   - `resource.type`         ∈ `resourceTypes[].id`
+ *   - `pool.memberIds[*]`     ∈ `resources[].id`
+ *   - `requirement.role`      ∈ `roles[].id`
+ *   - `requirement.pool`      ∈ `pools[].id`
+ *   - `event.resourceId`      ∈ `resources[].id`
+ *   - `event.resourcePoolId`  ∈ `pools[].id`
+ *   - duplicate ids inside any section
+ *
+ * Each issue carries enough context for a host to render
+ * "requirement[2].requires[1]: pool 'fleet-east' not found" without
+ * stitching strings together.
+ *
+ * Pure / sync. The wizard's review step calls this; CLIs consuming
+ * config files call this; nothing else has to.
+ */
+import type { CalendarConfig } from './calendarConfig'
+
+export type ConfigIssueSeverity = 'error' | 'warning'
+
+export type ConfigIssue =
+  | {
+      readonly severity: ConfigIssueSeverity
+      readonly kind: 'unknown-resource-type'
+      readonly section: 'resources'
+      /** Human path like `resources[3].type`. */
+      readonly path: string
+      readonly resourceId: string
+      readonly typeId: string
+    }
+  | {
+      readonly severity: ConfigIssueSeverity
+      readonly kind: 'unknown-pool-member'
+      readonly section: 'pools'
+      readonly path: string
+      readonly poolId: string
+      readonly memberId: string
+    }
+  | {
+      readonly severity: ConfigIssueSeverity
+      readonly kind: 'unknown-requirement-role'
+      readonly section: 'requirements'
+      readonly path: string
+      readonly eventType: string
+      readonly roleId: string
+    }
+  | {
+      readonly severity: ConfigIssueSeverity
+      readonly kind: 'unknown-requirement-pool'
+      readonly section: 'requirements'
+      readonly path: string
+      readonly eventType: string
+      readonly poolId: string
+    }
+  | {
+      readonly severity: ConfigIssueSeverity
+      readonly kind: 'unknown-event-resource'
+      readonly section: 'events'
+      readonly path: string
+      readonly eventId: string
+      readonly resourceId: string
+    }
+  | {
+      readonly severity: ConfigIssueSeverity
+      readonly kind: 'unknown-event-pool'
+      readonly section: 'events'
+      readonly path: string
+      readonly eventId: string
+      readonly poolId: string
+    }
+  | {
+      readonly severity: ConfigIssueSeverity
+      readonly kind: 'duplicate-id'
+      readonly section: 'resourceTypes' | 'roles' | 'resources' | 'pools'
+      readonly path: string
+      readonly id: string
+    }
+
+export interface ValidateConfigResult {
+  /** True when no `error`-severity issues were found. */
+  readonly ok: boolean
+  /** Every issue found, in the order the walker discovered them. */
+  readonly issues: readonly ConfigIssue[]
+}
+
+export function validateConfig(config: CalendarConfig): ValidateConfigResult {
+  const issues: ConfigIssue[] = []
+
+  // ── Build id sets for fast lookup ──────────────────────────────────────
+  const typeIds        = new Set<string>()
+  const roleIds        = new Set<string>()
+  const resourceIds    = new Set<string>()
+  const poolIds        = new Set<string>()
+
+  // Duplicate-id guard per section. We collect the id sets here so a
+  // duplicate in (say) `resources` doesn't quietly mask later
+  // membership checks — the second entry still lives in `resources[]`
+  // even if the parser kept the first.
+  collectIdsWithDuplicates(config.resourceTypes, 'resourceTypes', typeIds,     issues)
+  collectIdsWithDuplicates(config.roles,         'roles',         roleIds,    issues)
+  collectIdsWithDuplicates(config.resources,     'resources',     resourceIds, issues)
+  collectIdsWithDuplicates(config.pools,         'pools',         poolIds,    issues)
+
+  // ── resources[].type must match a resourceType id ──────────────────────
+  config.resources?.forEach((r, i) => {
+    if (r.type != null && !typeIds.has(r.type)) {
+      issues.push({
+        severity: 'error',
+        kind: 'unknown-resource-type',
+        section: 'resources',
+        path: `resources[${i}].type`,
+        resourceId: r.id,
+        typeId: r.type,
+      })
+    }
+  })
+
+  // ── pools[].memberIds must match resource ids ─────────────────────────
+  config.pools?.forEach((p, i) => {
+    p.memberIds.forEach((memberId, j) => {
+      if (!resourceIds.has(memberId)) {
+        issues.push({
+          severity: 'error',
+          kind: 'unknown-pool-member',
+          section: 'pools',
+          path: `pools[${i}].memberIds[${j}]`,
+          poolId: p.id,
+          memberId,
+        })
+      }
+    })
+  })
+
+  // ── requirements[].requires[] role / pool refs ────────────────────────
+  config.requirements?.forEach((req, i) => {
+    req.requires.forEach((slot, j) => {
+      if ('role' in slot) {
+        if (!roleIds.has(slot.role)) {
+          issues.push({
+            severity: 'error',
+            kind: 'unknown-requirement-role',
+            section: 'requirements',
+            path: `requirements[${i}].requires[${j}].role`,
+            eventType: req.eventType,
+            roleId: slot.role,
+          })
+        }
+      } else if (!poolIds.has(slot.pool)) {
+        issues.push({
+          severity: 'error',
+          kind: 'unknown-requirement-pool',
+          section: 'requirements',
+          path: `requirements[${i}].requires[${j}].pool`,
+          eventType: req.eventType,
+          poolId: slot.pool,
+        })
+      }
+    })
+  })
+
+  // ── events[].resourceId / resourcePoolId ──────────────────────────────
+  config.events?.forEach((e, i) => {
+    if (e.resourceId != null && !resourceIds.has(e.resourceId)) {
+      issues.push({
+        severity: 'error',
+        kind: 'unknown-event-resource',
+        section: 'events',
+        path: `events[${i}].resourceId`,
+        eventId: e.id,
+        resourceId: e.resourceId,
+      })
+    }
+    if (e.resourcePoolId != null && !poolIds.has(e.resourcePoolId)) {
+      issues.push({
+        severity: 'error',
+        kind: 'unknown-event-pool',
+        section: 'events',
+        path: `events[${i}].resourcePoolId`,
+        eventId: e.id,
+        poolId: e.resourcePoolId,
+      })
+    }
+  })
+
+  return { ok: !issues.some(i => i.severity === 'error'), issues }
+}
+
+// ─── Internals ─────────────────────────────────────────────────────────────
+
+function collectIdsWithDuplicates(
+  items: readonly { id: string }[] | undefined,
+  section: 'resourceTypes' | 'roles' | 'resources' | 'pools',
+  out: Set<string>,
+  issues: ConfigIssue[],
+): void {
+  if (!items) return
+  items.forEach((item, i) => {
+    if (out.has(item.id)) {
+      issues.push({
+        severity: 'error',
+        kind: 'duplicate-id',
+        section,
+        path: `${section}[${i}]`,
+        id: item.id,
+      })
+      return
+    }
+    out.add(item.id)
+  })
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -207,6 +207,10 @@ export type {
   ConfigResource, ConfigRequirement, ConfigRequirementSlot,
   ConfigSeedEvent, ConfigSettings,
 } from './core/config/calendarConfig';
+export { validateConfig } from './core/config/validateConfig';
+export type {
+  ValidateConfigResult, ConfigIssue, ConfigIssueSeverity,
+} from './core/config/validateConfig';
 // ── Requirements engine — runtime consumer for the templates (#386) ──────
 export { evaluateRequirements } from './core/requirements/evaluateRequirements';
 export type {


### PR DESCRIPTION
## Summary

`parseConfig` checks each section's **shape** and drops malformed
entries. It deliberately does *not* cross-check references between
sections — those typically come from external sources, and the
runtime validators handle them when they fire.

`validateConfig` is the **opt-in pass** that walks the references:

| Check                                  | Issue kind                  |
|----------------------------------------|-----------------------------|
| `resource.type` ∈ `resourceTypes[].id` | `unknown-resource-type`     |
| `pool.memberIds[*]` ∈ `resources[].id` | `unknown-pool-member`       |
| `requirement.role` ∈ `roles[].id`      | `unknown-requirement-role`  |
| `requirement.pool` ∈ `pools[].id`      | `unknown-requirement-pool`  |
| `event.resourceId` ∈ `resources[].id`  | `unknown-event-resource`    |
| `event.resourcePoolId` ∈ `pools[].id`  | `unknown-event-pool`        |
| Duplicate ids in any catalog section   | `duplicate-id`              |

Returns `{ ok, issues[] }`. Each `ConfigIssue` carries the path
(`requirements[0].requires[1].pool`) and the specific id that
didn't resolve, so hosts can render *"pool 'aircraft' not found"*
without stitching strings together.

```ts
import { validateConfig } from 'works-calendar';

const { ok, issues } = validateConfig(config);
if (!ok) {
  for (const issue of issues) {
    console.warn(`${issue.path}: ${issue.kind}`);
  }
}
```

Useful for the wizard's review step, CLI tools loading config
files, and any consumer that wants to fail fast on internal
inconsistencies.

## Test plan

- [x] `tsc --noEmit` clean
- [x] `vitest run` — 2403 passing, 2 skipped (existing PTO flakes), 0 failures (15 new tests)
- [x] Empty + fully-populated clean configs pass
- [x] Each issue kind verified in isolation: unknown resource type, unknown pool member, unknown role / pool requirement reference, unknown event resource / pool, duplicate id per catalog section
- [x] Mixed valid + invalid slots in one requirement report only the invalid paths
- [x] `ok` summary: false when any error issue exists, true otherwise

## Out of scope

- Warning-severity issues (today only `error`s exist; the
  severity field is in place for future warnings like "pool has
  zero effective members")
- Auto-fix / suggested-patch UX
- Validating `event.eventType` against `requirements[].eventType`
  (events without a matching template fall through to
  `evaluateRequirements`'s `noTemplate: true` branch — that's the
  right place to surface it, not parse-time)

## Wizard runway

This + the requirements engine (#443) close the engine half of the
runway. Remaining before the wizard:
1. **Industry profile presets** — data layer
2. **The wizard UI itself** — capstone

https://claude.ai/code/session_01XojXzZPdEPuGbX2TyLY1pu

---
_Generated by [Claude Code](https://claude.ai/code/session_01XojXzZPdEPuGbX2TyLY1pu)_