### PR TITLE
core(config): industry profile presets for the wizard (#386)

### DIFF
--- a/docs/CalendarConfig.md
+++ b/docs/CalendarConfig.md
@@ -146,6 +146,42 @@ returns `{ config, errors: [], dropped: 0 }` for any valid
 | `events`         | `{ id, title, start, end, eventType?, resourceId?, resourcePoolId?, meta? }[]` | Seed events for demos / config-driven setup. ISO 8601 strings on the wire; the runtime parses them when loading. |
 | `settings`       | `{ conflictMode?, timezone? }`              | `conflictMode` is whitelisted to `block` / `soft` / `off`. Not yet enforced at runtime. |
 
+## Industry profile presets
+
+Four presets ship as starting points for the wizard's first step:
+
+| Profile     | Labels                | Catalogs                                                    |
+|-------------|-----------------------|--------------------------------------------------------------|
+| `trucking`  | Truck / Load / Depot   | `vehicle`, `trailer`, `person` — `driver`, `dispatcher`      |
+| `aviation`  | Aircraft / Flight / Airport | `aircraft`, `pilot` — `pilot-in-command`, `second-in-command`, `dispatcher` |
+| `scheduling`| Room / Booking / Building   | `room`, `equipment`, `person` — `organizer`, `attendee`     |
+| `custom`    | (none)                | (none)                                                       |
+
+```ts
+import { applyProfilePreset, listProfilePresets } from 'works-calendar';
+
+// Wizard first-step picker:
+const presets = listProfilePresets();   // ProfilePreset[]
+
+// User picks "trucking" then starts editing:
+let config = applyProfilePreset('trucking');
+
+// User adds a custom role later. Switching profiles preserves
+// their additions; the new preset's entries are appended for any
+// id not already in the catalog.
+config = applyProfilePreset('aviation', config);
+```
+
+Merge rules:
+
+- **`profile`** — preset always wins (switching profiles updates the field).
+- **`labels`** — per-key. Base wins where set; preset fills gaps.
+- **`resourceTypes` / `roles`** — base entries kept in order; preset entries appended for any id not already present.
+- **`settings`** — per-key, base wins.
+- **`resources`, `pools`, `requirements`, `events`** — never touched by presets. Those stay the user's job.
+
+`applyProfilePreset` is pure — it never mutates the input.
+
 ## Wizard
 
 The `CalendarConfig` shape is the wizard's output target. The

--- a/src/core/config/__tests__/profilePresets.test.ts
+++ b/src/core/config/__tests__/profilePresets.test.ts
@@ -1,0 +1,138 @@
+/**
+ * Profile preset tests (#386 wizard).
+ */
+import { describe, it, expect } from 'vitest'
+import { PROFILE_PRESETS, applyProfilePreset, listProfilePresets } from '../profilePresets'
+import type { CalendarConfig } from '../calendarConfig'
+
+describe('PROFILE_PRESETS — shape', () => {
+  it('ships exactly four presets with stable ids and labels', () => {
+    expect(Object.keys(PROFILE_PRESETS).sort())
+      .toEqual(['aviation', 'custom', 'scheduling', 'trucking'])
+    for (const preset of Object.values(PROFILE_PRESETS)) {
+      expect(preset.id).toBeTruthy()
+      expect(preset.label).toBeTruthy()
+      expect(preset.description.length).toBeGreaterThan(0)
+    }
+  })
+
+  it('listProfilePresets returns the same set in a stable order', () => {
+    const ids = listProfilePresets().map(p => p.id)
+    expect(ids).toEqual(['trucking', 'aviation', 'scheduling', 'custom'])
+  })
+
+  it('every preset carries a `profile` field that matches its id', () => {
+    for (const preset of Object.values(PROFILE_PRESETS)) {
+      expect(preset.config.profile).toBe(preset.id)
+    }
+  })
+})
+
+describe('applyProfilePreset — fresh start', () => {
+  it('seeds a brand-new config from the trucking preset', () => {
+    const out = applyProfilePreset('trucking')
+    expect(out.profile).toBe('trucking')
+    expect(out.labels?.resource).toBe('Truck')
+    expect(out.resourceTypes?.map(t => t.id)).toEqual(['vehicle', 'trailer', 'person'])
+    expect(out.roles?.map(r => r.id)).toEqual(['driver', 'dispatcher'])
+  })
+
+  it('aviation seeds aircraft + pilot + dispatcher roles', () => {
+    const out = applyProfilePreset('aviation')
+    expect(out.labels?.resource).toBe('Aircraft')
+    expect(out.resourceTypes?.map(t => t.id)).toEqual(['aircraft', 'pilot'])
+    expect(out.roles?.map(r => r.id))
+      .toEqual(['pilot-in-command', 'second-in-command', 'dispatcher'])
+  })
+
+  it('scheduling preset uses Room labels + organizer/attendee roles', () => {
+    const out = applyProfilePreset('scheduling')
+    expect(out.labels?.resource).toBe('Room')
+    expect(out.labels?.event).toBe('Booking')
+    expect(out.roles?.map(r => r.id)).toEqual(['organizer', 'attendee'])
+  })
+
+  it('custom preset returns a near-empty config (just the profile id)', () => {
+    const out = applyProfilePreset('custom')
+    expect(out).toEqual({ profile: 'custom' })
+  })
+})
+
+describe('applyProfilePreset — merging into an existing config', () => {
+  it('keeps user-supplied label keys; preset fills only the gaps', () => {
+    const base: CalendarConfig = {
+      labels: { resource: 'Rig', event: 'Run' },
+    }
+    const out = applyProfilePreset('trucking', base)
+    expect(out.labels?.resource).toBe('Rig')   // user wins
+    expect(out.labels?.event).toBe('Run')      // user wins
+    expect(out.labels?.location).toBe('Depot') // preset fills
+  })
+
+  it('appends preset catalog entries without dropping the user\'s existing ones', () => {
+    const base: CalendarConfig = {
+      roles: [{ id: 'safety-officer', label: 'Safety Officer' }],
+    }
+    const out = applyProfilePreset('trucking', base)
+    expect(out.roles!.map(r => r.id))
+      .toEqual(['safety-officer', 'driver', 'dispatcher'])
+  })
+
+  it('skips preset entries whose ids already exist in the base', () => {
+    const base: CalendarConfig = {
+      // User already added a "driver" role with their own label.
+      roles: [{ id: 'driver', label: 'Truck Driver' }],
+    }
+    const out = applyProfilePreset('trucking', base)
+    const driver = out.roles!.find(r => r.id === 'driver')!
+    expect(driver.label).toBe('Truck Driver')   // user's label preserved
+    expect(out.roles!.length).toBe(2)            // preset's dispatcher appended
+  })
+
+  it('preserves user-owned sections the preset does not touch', () => {
+    const base: CalendarConfig = {
+      resources: [{ id: 't1', name: 'Truck 1' }],
+      pools: [{ id: 'fleet', name: 'Fleet', memberIds: [], strategy: 'first-available' }],
+    }
+    const out = applyProfilePreset('trucking', base)
+    expect(out.resources).toBe(base.resources)   // same reference, not rewritten
+    expect(out.pools).toBe(base.pools)
+  })
+
+  it('user-supplied profile is overwritten when a different preset is applied', () => {
+    const base: CalendarConfig = { profile: 'trucking' }
+    const out = applyProfilePreset('aviation', base)
+    expect(out.profile).toBe('aviation')
+  })
+
+  it('per-key settings merge: base wins where set, preset fills gaps', () => {
+    const base: CalendarConfig = { settings: { timezone: 'America/Denver' } }
+    const out = applyProfilePreset('trucking', base)
+    expect(out.settings).toEqual({
+      timezone: 'America/Denver',
+      conflictMode: 'block',
+    })
+  })
+
+  it('does not mutate the input config', () => {
+    const base: CalendarConfig = { roles: [{ id: 'x', label: 'X' }] }
+    const before = JSON.parse(JSON.stringify(base))
+    applyProfilePreset('trucking', base)
+    expect(base).toEqual(before)
+  })
+})
+
+describe('applyProfilePreset — defensive', () => {
+  it('returns a copy of the base when the profile id is unknown', () => {
+    // Cast through unknown — types prevent this at compile-time but
+    // hosts can still pass a string from a URL / JSON file at runtime.
+    const out = applyProfilePreset('nonexistent' as unknown as 'trucking', { profile: 'kept' })
+    expect(out).toEqual({ profile: 'kept' })
+  })
+
+  it('omits empty sections rather than emitting noisy stubs', () => {
+    const out = applyProfilePreset('custom')
+    // `custom` ships only `profile`; no labels / catalogs should appear.
+    expect(Object.keys(out)).toEqual(['profile'])
+  })
+})

--- a/src/core/config/__tests__/profilePresets.test.ts
+++ b/src/core/config/__tests__/profilePresets.test.ts
@@ -123,6 +123,19 @@ describe('applyProfilePreset — merging into an existing config', () => {
 })
 
 describe('applyProfilePreset — defensive', () => {
+  it('does not share array references with the static PROFILE_PRESETS map (#386 P1)', () => {
+    // Hand-out preset-backed catalogs would let downstream mutations
+    // corrupt the module-level default. Apply twice; mutate the first
+    // result; the second should be unaffected.
+    const first = applyProfilePreset('trucking');
+    (first.roles as Array<{ id: string; label: string }>).push({ id: 'rogue', label: 'Rogue' })
+
+    const second = applyProfilePreset('trucking')
+    expect(second.roles!.map(r => r.id)).not.toContain('rogue')
+    // And the static preset itself is untouched.
+    expect(PROFILE_PRESETS.trucking.config.roles!.map(r => r.id)).toEqual(['driver', 'dispatcher'])
+  })
+
   it('returns a copy of the base when the profile id is unknown', () => {
     // Cast through unknown — types prevent this at compile-time but
     // hosts can still pass a string from a URL / JSON file at runtime.

--- a/src/core/config/profilePresets.ts
+++ b/src/core/config/profilePresets.ts
@@ -1,0 +1,211 @@
+/**
+ * Industry profile presets for `CalendarConfig` (issue #386 wizard).
+ *
+ * Tiny data layer — each preset ships labels, a baseline
+ * `resourceTypes` catalog, a baseline `roles` catalog, and (when
+ * useful) a starter pool. Hosts pick a profile in the wizard's
+ * first step; `applyProfilePreset` merges the preset into the
+ * user's working config without overwriting any field they've
+ * already touched.
+ *
+ * Pure / sync. The presets are static data structures, not
+ * functions, so they're cheap to import from a wizard component
+ * tree without any runtime cost.
+ *
+ * Out of scope for this slice (each warrants its own follow-up):
+ *   - Industry-specific capability catalogs (numeric ranges,
+ *     boolean chips). The presets only seed the basics; the
+ *     `PoolBuilder` already auto-derives capabilities from the
+ *     live registry.
+ *   - Sample resources / events. Presets seed metadata only;
+ *     concrete resources stay the host's job.
+ *   - i18n. Labels here are English-only for v1.
+ */
+import type { CalendarConfig } from './calendarConfig'
+
+/** Stable id under which a preset is registered. */
+export type ProfileId = 'trucking' | 'aviation' | 'scheduling' | 'custom'
+
+export interface ProfilePreset {
+  readonly id: ProfileId
+  readonly label: string
+  readonly description: string
+  /**
+   * The actual preset payload — every section is optional so a
+   * preset can ship just labels (e.g. the `custom` preset) or a
+   * full starter kit. `applyProfilePreset` merges this into the
+   * user's working config.
+   */
+  readonly config: Partial<CalendarConfig>
+}
+
+export const PROFILE_PRESETS: Readonly<Record<ProfileId, ProfilePreset>> = {
+  trucking: {
+    id: 'trucking',
+    label: 'Trucking',
+    description: 'Loads, drivers, trucks, and trailers. Defaults that suit fleet dispatch.',
+    config: {
+      profile: 'trucking',
+      labels: {
+        resource: 'Truck',
+        event:    'Load',
+        location: 'Depot',
+      },
+      resourceTypes: [
+        { id: 'vehicle', label: 'Truck' },
+        { id: 'trailer', label: 'Trailer' },
+        { id: 'person',  label: 'Driver' },
+      ],
+      roles: [
+        { id: 'driver',     label: 'Driver' },
+        { id: 'dispatcher', label: 'Dispatcher' },
+      ],
+      settings: { conflictMode: 'block' },
+    },
+  },
+
+  aviation: {
+    id: 'aviation',
+    label: 'Aviation',
+    description: 'Aircraft, pilots, charter flights. Fits charter / part-91 / fractional ops.',
+    config: {
+      profile: 'aviation',
+      labels: {
+        resource: 'Aircraft',
+        event:    'Flight',
+        location: 'Airport',
+      },
+      resourceTypes: [
+        { id: 'aircraft', label: 'Aircraft' },
+        { id: 'pilot',    label: 'Pilot' },
+      ],
+      roles: [
+        { id: 'pilot-in-command', label: 'Pilot in Command' },
+        { id: 'second-in-command', label: 'Second in Command' },
+        { id: 'dispatcher',        label: 'Dispatcher' },
+      ],
+      settings: { conflictMode: 'block' },
+    },
+  },
+
+  scheduling: {
+    id: 'scheduling',
+    label: 'Scheduling',
+    description: 'Rooms, equipment, and people. The general-purpose preset for shared resources.',
+    config: {
+      profile: 'scheduling',
+      labels: {
+        resource: 'Room',
+        event:    'Booking',
+        location: 'Building',
+      },
+      resourceTypes: [
+        { id: 'room',      label: 'Room' },
+        { id: 'equipment', label: 'Equipment' },
+        { id: 'person',    label: 'Person' },
+      ],
+      roles: [
+        { id: 'organizer', label: 'Organizer' },
+        { id: 'attendee',  label: 'Attendee' },
+      ],
+      settings: { conflictMode: 'block' },
+    },
+  },
+
+  custom: {
+    id: 'custom',
+    label: 'Custom',
+    description: 'Start from a blank config. Use when no preset fits or for full control.',
+    config: {
+      profile: 'custom',
+    },
+  },
+}
+
+/**
+ * Convenience for the wizard's profile picker — returns the preset
+ * descriptors in a stable order. Hosts can also iterate
+ * `Object.values(PROFILE_PRESETS)` directly; this helper exists so
+ * the wizard's first step doesn't need to know the underlying map
+ * shape.
+ */
+export function listProfilePresets(): readonly ProfilePreset[] {
+  return [
+    PROFILE_PRESETS.trucking,
+    PROFILE_PRESETS.aviation,
+    PROFILE_PRESETS.scheduling,
+    PROFILE_PRESETS.custom,
+  ]
+}
+
+/**
+ * Merge a preset into a working config. The user's existing fields
+ * always win — applying a preset *adds* sections the user hasn't
+ * touched, it never overwrites in-progress edits.
+ *
+ * Catalog merging (resourceTypes, roles): the preset's entries are
+ * appended after the user's, with duplicate ids dropped. This
+ * makes "I already added a custom role; switching to the trucking
+ * preset shouldn't lose it" the natural outcome.
+ *
+ * Label merging: per-key — preset fills the keys the user hasn't set.
+ *
+ * Pure: returns a new config; never mutates inputs.
+ */
+export function applyProfilePreset(
+  profileId: ProfileId,
+  base: Readonly<CalendarConfig> = {},
+): CalendarConfig {
+  const preset = PROFILE_PRESETS[profileId]
+  if (!preset) return { ...base }
+
+  const merged: { -readonly [K in keyof CalendarConfig]: CalendarConfig[K] } = { ...base }
+  // profile: presets always win — switching profiles should update
+  // this field even if the base already had a different value.
+  if (preset.config.profile !== undefined) merged.profile = preset.config.profile
+
+  // labels: per-key, base wins; preset fills the gaps.
+  if (preset.config.labels || base.labels) {
+    merged.labels = { ...preset.config.labels, ...base.labels }
+  }
+
+  // catalog sections: base first (so its ordering is preserved),
+  // preset entries appended for any id not already present. Skip
+  // assignment when both sides are undefined so the saved object
+  // doesn't carry an explicit `undefined` field (exactOptionalProperties).
+  const types = mergeById(base.resourceTypes, preset.config.resourceTypes)
+  if (types) merged.resourceTypes = types
+  const roles = mergeById(base.roles, preset.config.roles)
+  if (roles) merged.roles = roles
+
+  // settings: per-key, base wins.
+  if (preset.config.settings || base.settings) {
+    merged.settings = { ...preset.config.settings, ...base.settings }
+  }
+
+  // Sections we don't touch (resources, pools, requirements,
+  // events) — the user owns them; presets only seed catalog data.
+  return cleanUndefined(merged)
+}
+
+// ─── Internals ──────────────────────────────────────────────────────────────
+
+function mergeById<T extends { id: string }>(
+  base: readonly T[] | undefined,
+  preset: readonly T[] | undefined,
+): readonly T[] | undefined {
+  if (!base && !preset) return undefined
+  if (!preset) return base
+  if (!base)   return preset
+  const seen = new Set(base.map(x => x.id))
+  const additions = preset.filter(x => !seen.has(x.id))
+  return additions.length > 0 ? [...base, ...additions] : base
+}
+
+function cleanUndefined(o: { [k: string]: unknown }): CalendarConfig {
+  const out: { [k: string]: unknown } = {}
+  for (const k of Object.keys(o)) {
+    if (o[k] !== undefined) out[k] = o[k]
+  }
+  return out as CalendarConfig
+}

--- a/src/core/config/profilePresets.ts
+++ b/src/core/config/profilePresets.ts
@@ -194,12 +194,17 @@ function mergeById<T extends { id: string }>(
   base: readonly T[] | undefined,
   preset: readonly T[] | undefined,
 ): readonly T[] | undefined {
+  // Always emit a fresh array — the preset map is shipped as
+  // module-level static data, so handing back its reference would
+  // let callers mutate a shared default in place. (The merge path
+  // below already produces a new array; the early-return shortcuts
+  // were the leaks Codex flagged on #446.)
   if (!base && !preset) return undefined
-  if (!preset) return base
-  if (!base)   return preset
+  if (!preset) return [...base!]
+  if (!base)   return [...preset]
   const seen = new Set(base.map(x => x.id))
   const additions = preset.filter(x => !seen.has(x.id))
-  return additions.length > 0 ? [...base, ...additions] : base
+  return additions.length > 0 ? [...base, ...additions] : [...base]
 }
 
 function cleanUndefined(o: { [k: string]: unknown }): CalendarConfig {

--- a/src/index.ts
+++ b/src/index.ts
@@ -211,6 +211,10 @@ export { validateConfig } from './core/config/validateConfig';
 export type {
   ValidateConfigResult, ConfigIssue, ConfigIssueSeverity,
 } from './core/config/validateConfig';
+export {
+  PROFILE_PRESETS, listProfilePresets, applyProfilePreset,
+} from './core/config/profilePresets';
+export type { ProfileId, ProfilePreset } from './core/config/profilePresets';
 // ── Requirements engine — runtime consumer for the templates (#386) ──────
 export { evaluateRequirements } from './core/requirements/evaluateRequirements';
 export type {


### PR DESCRIPTION
## Summary

Tiny data layer the wizard's first step picks from. Each preset
seeds **labels**, a baseline **`resourceTypes`** catalog, a
baseline **`roles`** catalog, and (when sensible) **`settings`**.
Resources / pools / requirements / events stay the user's job —
presets only seed catalog data.

### The four presets

| Profile     | Labels                      | `resourceTypes`                | `roles`                                                |
|-------------|-----------------------------|--------------------------------|--------------------------------------------------------|
| `trucking`  | Truck / Load / Depot        | `vehicle`, `trailer`, `person` | `driver`, `dispatcher`                                 |
| `aviation`  | Aircraft / Flight / Airport | `aircraft`, `pilot`            | `pilot-in-command`, `second-in-command`, `dispatcher`  |
| `scheduling`| Room / Booking / Building   | `room`, `equipment`, `person`  | `organizer`, `attendee`                                |
| `custom`    | (none)                      | (none)                         | (none — near-empty starting point)                     |

### `applyProfilePreset(profileId, base?)`

Merges a preset into a working config:

| Section                     | Merge rule                                                                                    |
|-----------------------------|-----------------------------------------------------------------------------------------------|
| `profile`                   | Preset always wins (switching profiles updates the field)                                     |
| `labels`                    | Per-key — base wins where set; preset fills gaps                                              |
| `resourceTypes` / `roles`   | Base kept in order; preset entries appended for any id not already present                    |
| `settings`                  | Per-key — base wins                                                                            |
| `resources` / `pools` / `requirements` / `events` | **Never touched** — the user owns these                                |

Pure — never mutates the input. Switching profiles preserves a
user's added roles / catalog entries; only fields they haven't
filled in get seeded.

### `listProfilePresets()`

Returns the preset descriptors in a stable order so the wizard's
picker doesn't need to know the underlying map shape.

## Test plan

- [x] `tsc --noEmit` clean
- [x] `vitest run` — 2406 passing, 2 skipped (existing PTO flakes), 0 failures (16 new tests)
- [x] Shape: every preset has `id`/`label`/`description`, `profile` field matches `id`
- [x] Fresh-start seeding for each of the four presets
- [x] Merge: label gap-fill, catalog dedup-by-id, preserved untouched sections, profile-switch overwrites
- [x] Defensive: unknown profile id returns the base unchanged

## Out of scope (called out in docs)

- Industry-specific capability catalogs (numeric ranges / boolean chips). `PoolBuilder` already auto-derives capabilities from the live registry; curated catalogs are a follow-up.
- Sample resources / events. Concrete data stays the host's job.
- i18n. Labels are English-only for v1.

## Wizard runway

This + #443 (requirements) + #445 (validateConfig) close the data /
engine half of the wizard runway. Next up is the **wizard UI itself**.

https://claude.ai/code/session_01XojXzZPdEPuGbX2TyLY1pu

---
_Generated by [Claude Code](https://claude.ai/code/session_01XojXzZPdEPuGbX2TyLY1pu)_