### PR TITLE
ui(wizard): ConfigWizard — guided CalendarConfig editor (#386 capstone)

### DIFF
--- a/docs/ConfigWizard.md
+++ b/docs/ConfigWizard.md
@@ -1,0 +1,79 @@
+# ConfigWizard
+
+The `ConfigWizard` is the capstone UI for issue #386 — a guided
+five-step modal that walks a host (or end user) through producing
+a complete `CalendarConfig`. It composes every primitive that
+landed earlier in the v2 work: profile presets, the resource +
+pool catalogs, `PoolBuilder` for individual pool authoring,
+`validateConfig` for the review step, and `serializeConfig` for
+the JSON output.
+
+> Distinct from the existing `SetupWizardModal` (the first-time
+> owner setup flow documented in `docs/SetupWizard.md`).
+> `ConfigWizard` is specifically for editing the standard
+> `CalendarConfig` shape introduced in #440.
+
+## Mounting
+
+```tsx
+import { ConfigWizard } from 'works-calendar';
+import { useState } from 'react';
+
+function OnboardingButton() {
+  const [open, setOpen] = useState(false);
+  return (
+    <>
+      <button onClick={() => setOpen(true)}>Set up calendar</button>
+      {open && (
+        <ConfigWizard
+          onComplete={(config) => {
+            persist(config);
+            setOpen(false);
+          }}
+          onCancel={() => setOpen(false)}
+        />
+      )}
+    </>
+  );
+}
+```
+
+Pass `initialConfig` to edit an existing setup; the wizard seeds
+every step from it. Round-trip is total — opening, walking
+through, and finishing without changes returns the config
+unchanged.
+
+## Steps
+
+| # | Step              | What it does                                                                                          |
+|---|-------------------|--------------------------------------------------------------------------------------------------------|
+| 1 | Profile           | Pick a starter preset (Trucking / Aviation / Scheduling / Custom). Uses `applyProfilePreset` so seeding never overwrites edits the user already made. |
+| 2 | Types & roles     | Edit the `resourceTypes` and `roles` catalogs. Add / remove / rename inline.                           |
+| 3 | Resources         | Edit the resource registry. Each row captures id, name, type (dropdown sourced from step 2), and lat/lon. |
+| 4 | Pools             | List of `PoolCard`s with edit / disable / delete affordances. "+ Add pool" opens the existing `PoolBuilder` modal. The wizard adapts the config's resources to the engine shape so the live preview / capability discovery work normally. |
+| 5 | Review            | Settings (`conflictMode`, `timezone`), live `validateConfig` results with paths, and the serialized JSON. The "Finish" button hands the final config to `onComplete`. |
+
+The breadcrumbs are clickable — users can jump to any step at any
+time. The wizard never blocks navigation on the current step's
+state; the Review step's validation pane is the single source of
+truth for "is this config OK to ship?".
+
+## Composition with existing primitives
+
+The wizard intentionally re-uses what's already in the library:
+
+- **Profile picker** → `applyProfilePreset` / `listProfilePresets`
+- **Pools step** → `PoolCard` + `PoolBuilder` (live preview, advanced rules editor, range pickers, path autocomplete — all of it)
+- **Review step** → `validateConfig` + `serializeConfig`
+
+Anything those components already do (capability discovery,
+preserved-clause round-trip, distance pools, etc.) just works
+inside the wizard for free.
+
+## Out of scope
+
+- **Sample data generation** — the user fills the registry; the wizard doesn't seed concrete resources.
+- **Industry-specific capability lists** — `PoolBuilder` already auto-derives capabilities from the live registry, so the wizard doesn't curate.
+- **Per-resource `meta.roles` editor** — hosts wire role tags via JSON for now; a chip picker is a follow-up.
+- **File-system download** — the Review step exposes a JSON code block users can copy. No `<a download>` plumbing.
+- **i18n** — labels are English-only for v1.

--- a/src/index.ts
+++ b/src/index.ts
@@ -215,6 +215,8 @@ export {
   PROFILE_PRESETS, listProfilePresets, applyProfilePreset,
 } from './core/config/profilePresets';
 export type { ProfileId, ProfilePreset } from './core/config/profilePresets';
+export { default as ConfigWizard } from './ui/wizard/ConfigWizard';
+export type { ConfigWizardProps, ConfigWizardStepId } from './ui/wizard/ConfigWizard';
 // ── Requirements engine — runtime consumer for the templates (#386) ──────
 export { evaluateRequirements } from './core/requirements/evaluateRequirements';
 export type {

--- a/src/ui/wizard/ConfigWizard.module.css
+++ b/src/ui/wizard/ConfigWizard.module.css
@@ -1,0 +1,409 @@
+.overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 110;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 24px;
+  background: color-mix(in srgb, #111827 65%, transparent);
+}
+
+.panel {
+  display: flex;
+  flex-direction: column;
+  width: min(100%, 880px);
+  height: min(calc(100vh - 48px), 760px);
+  background: var(--wc-bg, #ffffff);
+  border-radius: 12px;
+  box-shadow: 0 20px 60px color-mix(in srgb, #111827 35%, transparent);
+  overflow: hidden;
+}
+
+.head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 14px 22px;
+  border-bottom: 1px solid var(--wc-border, #e5e7eb);
+}
+
+.title {
+  margin: 0;
+  font-size: 16px;
+  font-weight: 600;
+  color: var(--wc-text, #111827);
+}
+
+.closeBtn {
+  font-size: 22px;
+  width: 28px;
+  height: 28px;
+  border: none;
+  background: transparent;
+  cursor: pointer;
+  color: var(--wc-text-muted, #6b7280);
+}
+
+.closeBtn:hover { color: var(--wc-text, #111827); }
+
+.breadcrumbs {
+  display: flex;
+  list-style: none;
+  margin: 0;
+  padding: 10px 22px;
+  gap: 4px;
+  border-bottom: 1px solid var(--wc-border, #e5e7eb);
+  background: var(--wc-bg-muted, #f9fafb);
+  overflow-x: auto;
+}
+
+.crumb {
+  flex-shrink: 0;
+}
+
+.crumbBtn {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 12px;
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--wc-text-muted, #6b7280);
+  background: transparent;
+  border: 1px solid transparent;
+  border-radius: 6px;
+  cursor: pointer;
+}
+
+.crumbBtn:hover {
+  background: var(--wc-bg, #ffffff);
+}
+
+.crumb[data-active='true'] .crumbBtn {
+  color: var(--wc-text, #111827);
+  background: var(--wc-bg, #ffffff);
+  border-color: var(--wc-border, #e5e7eb);
+  box-shadow: 0 1px 2px color-mix(in srgb, #111827 8%, transparent);
+}
+
+.crumb[data-done='true'] .crumbBtn {
+  color: #2563eb;
+}
+
+.crumbIndex {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 18px;
+  height: 18px;
+  font-size: 11px;
+  font-weight: 600;
+  border-radius: 999px;
+  background: color-mix(in srgb, currentColor 12%, transparent);
+}
+
+.crumbLabel {
+  white-space: nowrap;
+}
+
+.body {
+  flex: 1;
+  overflow-y: auto;
+  padding: 18px 22px;
+}
+
+.stepInner {
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+
+.hint {
+  margin: 0;
+  font-size: 13px;
+  color: var(--wc-text-muted, #6b7280);
+}
+
+.empty {
+  margin: 0;
+  font-size: 13px;
+  font-style: italic;
+  color: var(--wc-text-muted, #6b7280);
+}
+
+.fieldset {
+  border: 1px solid var(--wc-border, #e5e7eb);
+  border-radius: 8px;
+  padding: 14px 16px;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.legend {
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--wc-text-muted, #6b7280);
+  padding: 0 6px;
+}
+
+/* Step 1 — profile cards */
+.profileGrid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 10px;
+}
+
+.profileCard {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding: 14px 16px;
+  border: 1px solid var(--wc-border, #e5e7eb);
+  border-radius: 10px;
+  background: var(--wc-bg, #ffffff);
+  cursor: pointer;
+  text-align: left;
+}
+
+.profileCard[data-selected='true'] {
+  border-color: #2563eb;
+  background: color-mix(in srgb, #2563eb 8%, var(--wc-bg, #ffffff));
+}
+
+.profileLabel {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--wc-text, #111827);
+}
+
+.profileDesc {
+  font-size: 12px;
+  color: var(--wc-text-muted, #6b7280);
+}
+
+/* Inputs */
+.input,
+.select,
+.inputNarrow {
+  padding: 6px 10px;
+  font-size: 13px;
+  border: 1px solid var(--wc-border, #e5e7eb);
+  border-radius: 6px;
+  background: var(--wc-bg, #ffffff);
+}
+
+.inputNarrow {
+  width: 90px;
+}
+
+/* Row lists for catalogs / resources */
+.rowList,
+.resourceList {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.row {
+  display: grid;
+  grid-template-columns: 1fr 1fr auto;
+  gap: 8px;
+  align-items: center;
+}
+
+.resourceRow {
+  display: grid;
+  grid-template-columns: 1fr 1fr auto auto auto auto;
+  gap: 8px;
+  align-items: center;
+}
+
+.removeBtn {
+  font-size: 14px;
+  width: 26px;
+  height: 26px;
+  padding: 0;
+  border: 1px solid var(--wc-border, #e5e7eb);
+  background: var(--wc-bg, #ffffff);
+  color: var(--wc-text-muted, #6b7280);
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.removeBtn:hover {
+  color: #dc2626;
+  border-color: #dc2626;
+}
+
+.addBtn {
+  align-self: flex-start;
+  padding: 6px 14px;
+  font-size: 13px;
+  border: 1px dashed var(--wc-border, #d1d5db);
+  background: transparent;
+  border-radius: 6px;
+  cursor: pointer;
+  color: var(--wc-text-muted, #6b7280);
+}
+
+.addBtn:hover {
+  border-color: #2563eb;
+  color: #2563eb;
+}
+
+/* Pools list */
+.poolList {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.rowBtn {
+  padding: 4px 10px;
+  font-size: 12px;
+  border: 1px solid var(--wc-border, #e5e7eb);
+  background: var(--wc-bg, #ffffff);
+  color: var(--wc-text-muted, #6b7280);
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.rowBtn:hover {
+  color: #dc2626;
+  border-color: #dc2626;
+}
+
+/* Review step */
+.settingRow {
+  display: grid;
+  grid-template-columns: 140px 1fr;
+  gap: 10px;
+  align-items: center;
+}
+
+.settingLabel {
+  font-size: 13px;
+  color: var(--wc-text-muted, #6b7280);
+}
+
+.okPill,
+.errPill {
+  display: inline-block;
+  margin-left: 6px;
+  padding: 2px 8px;
+  font-size: 11px;
+  border-radius: 999px;
+  text-transform: none;
+  letter-spacing: 0;
+}
+
+.okPill {
+  background: color-mix(in srgb, #16a34a 14%, transparent);
+  color: #15803d;
+}
+
+.errPill {
+  background: color-mix(in srgb, #dc2626 14%, transparent);
+  color: #b91c1c;
+}
+
+.issueList {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.issueRow {
+  display: flex;
+  gap: 10px;
+  align-items: center;
+  padding: 6px 10px;
+  background: color-mix(in srgb, #dc2626 6%, transparent);
+  border: 1px solid color-mix(in srgb, #dc2626 25%, transparent);
+  border-radius: 6px;
+}
+
+.issuePath {
+  font-family: var(--wc-font-mono, ui-monospace, monospace);
+  font-size: 12px;
+  color: var(--wc-text, #111827);
+  flex: 1;
+}
+
+.issueKind {
+  font-size: 11px;
+  color: var(--wc-text-muted, #6b7280);
+  font-style: italic;
+}
+
+.json {
+  margin: 0;
+  padding: 12px;
+  font-family: var(--wc-font-mono, ui-monospace, monospace);
+  font-size: 12px;
+  color: var(--wc-text, #111827);
+  background: var(--wc-bg-muted, #f3f4f6);
+  border-radius: 6px;
+  max-height: 240px;
+  overflow: auto;
+  white-space: pre;
+}
+
+/* Footer */
+.foot {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 12px 22px;
+  border-top: 1px solid var(--wc-border, #e5e7eb);
+}
+
+.footSpacer {
+  flex: 1;
+}
+
+.btnSecondary,
+.btnPrimary {
+  padding: 8px 18px;
+  font-size: 13px;
+  font-weight: 600;
+  border-radius: 6px;
+  border: 1px solid var(--wc-border, #e5e7eb);
+  cursor: pointer;
+}
+
+.btnSecondary {
+  background: var(--wc-bg, #ffffff);
+  color: var(--wc-text, #111827);
+}
+
+.btnSecondary:hover {
+  background: var(--wc-bg-muted, #f3f4f6);
+}
+
+.btnSecondary:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.btnPrimary {
+  background: #2563eb;
+  border-color: #2563eb;
+  color: #ffffff;
+}
+
+.btnPrimary:hover {
+  background: #1d4ed8;
+  border-color: #1d4ed8;
+}

--- a/src/ui/wizard/ConfigWizard.tsx
+++ b/src/ui/wizard/ConfigWizard.tsx
@@ -24,7 +24,7 @@
  *   - File-system download. The Review step exposes a JSON code
  *     block users can copy; no `<a download>` plumbing.
  */
-import { useCallback, useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useState } from 'react'
 import type { ChangeEvent, MouseEvent } from 'react'
 import { useFocusTrap } from '../../hooks/useFocusTrap'
 import {
@@ -64,7 +64,13 @@ type StepId = typeof STEPS[number]['id']
 export default function ConfigWizard({
   initialConfig, onComplete, onCancel,
 }: ConfigWizardProps): JSX.Element {
-  const trapRef = useFocusTrap<HTMLDivElement>(onCancel)
+  // Track when a step has a nested modal open (currently only the
+  // pools step's PoolBuilder). While the child modal is mounted we
+  // disable the wizard-level focus trap's Escape callback so a single
+  // Escape doesn't cascade through both shells and drop the user's
+  // in-progress edits.
+  const [childModalOpen, setChildModalOpen] = useState(false)
+  const trapRef = useFocusTrap<HTMLDivElement>(childModalOpen ? null : onCancel)
   const [config, setConfig] = useState<CalendarConfig>(initialConfig ?? {})
   const [step, setStep] = useState<number>(0)
 
@@ -125,7 +131,7 @@ export default function ConfigWizard({
           {stepId === 'profile'   && <ProfileStep   config={config} setConfig={update} />}
           {stepId === 'catalogs'  && <CatalogsStep  config={config} setConfig={update} />}
           {stepId === 'resources' && <ResourcesStep config={config} setConfig={update} />}
-          {stepId === 'pools'     && <PoolsStep     config={config} setConfig={update} />}
+          {stepId === 'pools'     && <PoolsStep     config={config} setConfig={update} onChildModalOpen={setChildModalOpen} />}
           {stepId === 'review'    && <ReviewStep    config={config} setConfig={update} />}
         </section>
 
@@ -286,6 +292,44 @@ function ResourcesStep({ config, setConfig }: StepProps): JSX.Element {
     setResources(resources.map((r, j) => j === i ? cleanResource(mut(r)) : r))
   }
   const types = config.resourceTypes ?? []
+
+  // Track in-progress lat/lon strings per row so a half-typed
+  // coordinate (lat first, lon still empty) doesn't fabricate a
+  // synthetic 0 for the missing side. Commit `location` to the
+  // config only when both fields are finite numbers; clear it when
+  // both are empty; leave it untouched in between so the user sees
+  // their typed value mid-edit without poisoning distance pools.
+  const [coords, setCoords] = useState<Map<number, { lat: string; lon: string }>>(new Map())
+  const coordValue = (i: number, which: 'lat' | 'lon'): string => {
+    const draft = coords.get(i)
+    if (draft && draft[which] !== undefined) return draft[which]
+    const r = resources[i]
+    return r?.location ? String(r.location[which]) : ''
+  }
+  const setCoord = (i: number, which: 'lat' | 'lon', raw: string) => {
+    setCoords(prev => {
+      const existing = prev.get(i) ?? {
+        lat: resources[i]?.location ? String(resources[i]!.location!.lat) : '',
+        lon: resources[i]?.location ? String(resources[i]!.location!.lon) : '',
+      }
+      const next = { ...existing, [which]: raw }
+      const out = new Map(prev)
+      out.set(i, next)
+      // Decide whether to commit the parsed pair to the config.
+      const lat = next.lat === '' ? null : Number(next.lat)
+      const lon = next.lon === '' ? null : Number(next.lon)
+      const bothFinite = lat !== null && lon !== null && Number.isFinite(lat) && Number.isFinite(lon)
+      const bothCleared = next.lat === '' && next.lon === ''
+      if (bothFinite) {
+        updateAt(i, prev => withOptional(prev, 'location', { lat: lat as number, lon: lon as number }))
+      } else if (bothCleared) {
+        updateAt(i, prev => withOptional(prev, 'location', undefined))
+      }
+      // Otherwise: partial entry — config.location is left exactly as
+      // it was. The local draft keeps the user's typed value visible.
+      return out
+    })
+  }
   return (
     <div className={styles['stepInner']}>
       <p className={styles['hint']}>
@@ -331,25 +375,19 @@ function ResourcesStep({ config, setConfig }: StepProps): JSX.Element {
               type="number"
               step="any"
               className={styles['inputNarrow']}
-              value={r.location?.lat ?? ''}
+              value={coordValue(i, 'lat')}
               placeholder="lat"
               aria-label={`Resource ${i + 1} latitude`}
-              onChange={(e: ChangeEvent<HTMLInputElement>) => updateAt(i, prev =>
-                withOptional(prev, 'location', e.target.value === ''
-                  ? undefined
-                  : { lat: Number(e.target.value), lon: prev.location?.lon ?? 0 }))}
+              onChange={(e: ChangeEvent<HTMLInputElement>) => setCoord(i, 'lat', e.target.value)}
             />
             <input
               type="number"
               step="any"
               className={styles['inputNarrow']}
-              value={r.location?.lon ?? ''}
+              value={coordValue(i, 'lon')}
               placeholder="lon"
               aria-label={`Resource ${i + 1} longitude`}
-              onChange={(e: ChangeEvent<HTMLInputElement>) => updateAt(i, prev =>
-                withOptional(prev, 'location', e.target.value === ''
-                  ? undefined
-                  : { lat: prev.location?.lat ?? 0, lon: Number(e.target.value) }))}
+              onChange={(e: ChangeEvent<HTMLInputElement>) => setCoord(i, 'lon', e.target.value)}
             />
             <button
               type="button"
@@ -401,9 +439,18 @@ function cleanResource(r: ConfigResource): ConfigResource {
 
 // ─── Step 4 — pools (list + PoolBuilder modal) ─────────────────────────────
 
-function PoolsStep({ config, setConfig }: StepProps): JSX.Element {
+function PoolsStep({
+  config, setConfig, onChildModalOpen,
+}: StepProps & { readonly onChildModalOpen?: (open: boolean) => void }): JSX.Element {
   const pools = config.pools ?? []
   const [editingIndex, setEditingIndex] = useState<number | null>(null)
+  // Mirror the modal's open/closed state up to the wizard root so the
+  // outer focus trap's Escape callback can step aside while the
+  // inner PoolBuilder is mounted.
+  useEffect(() => {
+    onChildModalOpen?.(editingIndex !== null)
+    return () => onChildModalOpen?.(false)
+  }, [editingIndex, onChildModalOpen])
   // Adapt ConfigResource[] → ReadonlyMap<id, EngineResource> for PoolBuilder.
   const resourceMap = useMemo(() => {
     const m = new Map<string, EngineResource>()

--- a/src/ui/wizard/ConfigWizard.tsx
+++ b/src/ui/wizard/ConfigWizard.tsx
@@ -1,0 +1,572 @@
+/**
+ * ConfigWizard — the capstone of the v2 wizard slice (issue #386).
+ *
+ * Walks a host through five steps to produce a `CalendarConfig`:
+ *
+ *   1. Profile      — pick a starter preset (uses `applyProfilePreset`)
+ *   2. Catalogs     — resourceTypes + roles editors
+ *   3. Resources    — registry editor (id, name, type, location)
+ *   4. Pools        — list of `PoolCard`s + an "Add pool" button that
+ *                     opens the existing `PoolBuilder` modal
+ *   5. Review       — settings + `validateConfig` results + JSON output
+ *
+ * The wizard owns its draft `CalendarConfig` state. Hosts mount it
+ * from their settings / onboarding flow, pass an optional
+ * `initialConfig` to edit, and receive the finished config via
+ * `onComplete`.
+ *
+ * Out of scope deliberately:
+ *   - Sample data generation. The user fills the registry.
+ *   - Industry-specific capability lists. PoolBuilder auto-derives
+ *     them from the live registry; the wizard doesn't curate.
+ *   - Per-resource `meta.roles` editor. Hosts wire that via JSON
+ *     for now; a follow-up can add a chip picker.
+ *   - File-system download. The Review step exposes a JSON code
+ *     block users can copy; no `<a download>` plumbing.
+ */
+import { useCallback, useMemo, useState } from 'react'
+import type { ChangeEvent, MouseEvent } from 'react'
+import { useFocusTrap } from '../../hooks/useFocusTrap'
+import {
+  applyProfilePreset, listProfilePresets, PROFILE_PRESETS,
+} from '../../core/config/profilePresets'
+import type { ProfileId } from '../../core/config/profilePresets'
+import { validateConfig } from '../../core/config/validateConfig'
+import { serializeConfig } from '../../core/config/serializeConfig'
+import type {
+  CalendarConfig, ConfigResource, ConfigResourceType, ConfigRole,
+  ConfigSettings,
+} from '../../core/config/calendarConfig'
+import type { ResourcePool } from '../../core/pools/resourcePoolSchema'
+import type { EngineResource } from '../../core/engine/schema/resourceSchema'
+import PoolCard from '../pools/PoolCard'
+import PoolBuilder from '../pools/PoolBuilder'
+import styles from './ConfigWizard.module.css'
+
+export interface ConfigWizardProps {
+  /** Optional starting config — pass to edit an existing setup. */
+  readonly initialConfig?: CalendarConfig
+  /** Fired when the user clicks "Finish" on the Review step. */
+  readonly onComplete: (config: CalendarConfig) => void
+  /** Fired when the user dismisses the wizard. */
+  readonly onCancel: () => void
+}
+
+const STEPS = [
+  { id: 'profile',   label: 'Profile' },
+  { id: 'catalogs',  label: 'Types & roles' },
+  { id: 'resources', label: 'Resources' },
+  { id: 'pools',     label: 'Pools' },
+  { id: 'review',    label: 'Review' },
+] as const
+type StepId = typeof STEPS[number]['id']
+
+export default function ConfigWizard({
+  initialConfig, onComplete, onCancel,
+}: ConfigWizardProps): JSX.Element {
+  const trapRef = useFocusTrap<HTMLDivElement>(onCancel)
+  const [config, setConfig] = useState<CalendarConfig>(initialConfig ?? {})
+  const [step, setStep] = useState<number>(0)
+
+  const update = useCallback((updater: (c: CalendarConfig) => CalendarConfig) => {
+    setConfig(updater)
+  }, [])
+  const goto = useCallback((target: number) => {
+    setStep(Math.max(0, Math.min(STEPS.length - 1, target)))
+  }, [])
+
+  const stepId: StepId = STEPS[step]!.id
+  const isLast = step === STEPS.length - 1
+
+  return (
+    <div
+      className={styles['overlay']}
+      onClick={(e: MouseEvent<HTMLDivElement>) => e.target === e.currentTarget && onCancel()}
+    >
+      <div
+        ref={trapRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="wizard-title"
+        className={styles['panel']}
+      >
+        <header className={styles['head']}>
+          <h2 id="wizard-title" className={styles['title']}>Set up calendar</h2>
+          <button
+            type="button"
+            className={styles['closeBtn']}
+            onClick={onCancel}
+            aria-label="Close wizard"
+          >×</button>
+        </header>
+
+        <ol className={styles['breadcrumbs']} aria-label="Wizard steps">
+          {STEPS.map((s, i) => (
+            <li
+              key={s.id}
+              className={styles['crumb']}
+              data-active={i === step}
+              data-done={i < step}
+            >
+              <button
+                type="button"
+                className={styles['crumbBtn']}
+                onClick={() => goto(i)}
+                aria-current={i === step ? 'step' : undefined}
+              >
+                <span className={styles['crumbIndex']}>{i + 1}</span>
+                <span className={styles['crumbLabel']}>{s.label}</span>
+              </button>
+            </li>
+          ))}
+        </ol>
+
+        <section className={styles['body']} aria-live="polite">
+          {stepId === 'profile'   && <ProfileStep   config={config} setConfig={update} />}
+          {stepId === 'catalogs'  && <CatalogsStep  config={config} setConfig={update} />}
+          {stepId === 'resources' && <ResourcesStep config={config} setConfig={update} />}
+          {stepId === 'pools'     && <PoolsStep     config={config} setConfig={update} />}
+          {stepId === 'review'    && <ReviewStep    config={config} setConfig={update} />}
+        </section>
+
+        <footer className={styles['foot']}>
+          <button type="button" className={styles['btnSecondary']} onClick={onCancel}>
+            Cancel
+          </button>
+          <span className={styles['footSpacer']} />
+          <button
+            type="button"
+            className={styles['btnSecondary']}
+            disabled={step === 0}
+            onClick={() => goto(step - 1)}
+          >
+            Back
+          </button>
+          {!isLast && (
+            <button
+              type="button"
+              className={styles['btnPrimary']}
+              onClick={() => goto(step + 1)}
+            >
+              Next
+            </button>
+          )}
+          {isLast && (
+            <button
+              type="button"
+              className={styles['btnPrimary']}
+              onClick={() => onComplete(config)}
+            >
+              Finish
+            </button>
+          )}
+        </footer>
+      </div>
+    </div>
+  )
+}
+
+// ─── Step 1 — profile picker ───────────────────────────────────────────────
+
+interface StepProps {
+  readonly config: CalendarConfig
+  readonly setConfig: (updater: (c: CalendarConfig) => CalendarConfig) => void
+}
+
+function ProfileStep({ config, setConfig }: StepProps): JSX.Element {
+  return (
+    <div className={styles['stepInner']}>
+      <p className={styles['hint']}>
+        Pick a starter preset. We'll seed your labels, resource types, and
+        roles based on the industry. You can edit anything afterward.
+      </p>
+      <div className={styles['profileGrid']}>
+        {listProfilePresets().map(p => (
+          <button
+            key={p.id}
+            type="button"
+            className={styles['profileCard']}
+            data-selected={config.profile === p.id}
+            onClick={() => setConfig(c => applyProfilePreset(p.id, c))}
+            aria-pressed={config.profile === p.id}
+          >
+            <span className={styles['profileLabel']}>{p.label}</span>
+            <span className={styles['profileDesc']}>{p.description}</span>
+          </button>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+// ─── Step 2 — catalogs (resourceTypes + roles) ─────────────────────────────
+
+function CatalogsStep({ config, setConfig }: StepProps): JSX.Element {
+  return (
+    <div className={styles['stepInner']}>
+      <IdLabelEditor
+        label="Resource types"
+        hint="What kinds of resources can be booked? (e.g. Truck, Person, Room)"
+        items={config.resourceTypes ?? []}
+        onChange={(next) => setConfig(c => ({ ...c, resourceTypes: next }))}
+      />
+      <IdLabelEditor
+        label="Roles"
+        hint="What roles do people / resources fulfill on events? (e.g. Driver, Organizer)"
+        items={config.roles ?? []}
+        onChange={(next) => setConfig(c => ({ ...c, roles: next }))}
+      />
+    </div>
+  )
+}
+
+function IdLabelEditor({
+  label, hint, items, onChange,
+}: {
+  label: string
+  hint: string
+  items: readonly { id: string; label: string }[]
+  onChange: (next: readonly { id: string; label: string }[]) => void
+}): JSX.Element {
+  return (
+    <fieldset className={styles['fieldset']}>
+      <legend className={styles['legend']}>{label}</legend>
+      <p className={styles['hint']}>{hint}</p>
+      <ul className={styles['rowList']}>
+        {items.map((it, i) => (
+          <li key={i} className={styles['row']}>
+            <input
+              type="text"
+              className={styles['input']}
+              value={it.id}
+              placeholder="id (e.g. driver)"
+              aria-label={`${label} ${i + 1} id`}
+              onChange={(e: ChangeEvent<HTMLInputElement>) =>
+                onChange(items.map((x, j) => j === i ? { ...x, id: e.target.value } : x))
+              }
+            />
+            <input
+              type="text"
+              className={styles['input']}
+              value={it.label}
+              placeholder="label (e.g. Driver)"
+              aria-label={`${label} ${i + 1} label`}
+              onChange={(e: ChangeEvent<HTMLInputElement>) =>
+                onChange(items.map((x, j) => j === i ? { ...x, label: e.target.value } : x))
+              }
+            />
+            <button
+              type="button"
+              className={styles['removeBtn']}
+              aria-label={`Remove ${label.toLowerCase()} ${i + 1}`}
+              onClick={() => onChange(items.filter((_, j) => j !== i))}
+            >×</button>
+          </li>
+        ))}
+      </ul>
+      <button
+        type="button"
+        className={styles['addBtn']}
+        onClick={() => onChange([...items, { id: '', label: '' }])}
+      >+ Add {label.toLowerCase().replace(/s$/, '')}</button>
+    </fieldset>
+  )
+}
+
+// ─── Step 3 — resources registry editor ────────────────────────────────────
+
+function ResourcesStep({ config, setConfig }: StepProps): JSX.Element {
+  const resources = config.resources ?? []
+  const setResources = (next: readonly ConfigResource[]) =>
+    setConfig(c => ({ ...c, resources: next }))
+  // Builder form keeps callers free to omit (rather than set to
+  // undefined) optional fields — exactOptionalPropertyTypes draws
+  // a hard line between the two.
+  const updateAt = (i: number, mut: (prev: ConfigResource) => ConfigResource) => {
+    setResources(resources.map((r, j) => j === i ? cleanResource(mut(r)) : r))
+  }
+  const types = config.resourceTypes ?? []
+  return (
+    <div className={styles['stepInner']}>
+      <p className={styles['hint']}>
+        Register the concrete resources hosts will book. Add capabilities
+        and locations later — they're optional, but the v2 query DSL
+        reads them when present.
+      </p>
+      {resources.length === 0 && (
+        <p className={styles['empty']}>No resources yet.</p>
+      )}
+      <ul className={styles['resourceList']}>
+        {resources.map((r, i) => (
+          <li key={i} className={styles['resourceRow']}>
+            <input
+              type="text"
+              className={styles['input']}
+              value={r.id}
+              placeholder="id"
+              aria-label={`Resource ${i + 1} id`}
+              onChange={(e: ChangeEvent<HTMLInputElement>) =>
+                updateAt(i, prev => ({ ...prev, id: e.target.value }))}
+            />
+            <input
+              type="text"
+              className={styles['input']}
+              value={r.name}
+              placeholder="name"
+              aria-label={`Resource ${i + 1} name`}
+              onChange={(e: ChangeEvent<HTMLInputElement>) =>
+                updateAt(i, prev => ({ ...prev, name: e.target.value }))}
+            />
+            <select
+              className={styles['select']}
+              value={r.type ?? ''}
+              aria-label={`Resource ${i + 1} type`}
+              onChange={(e: ChangeEvent<HTMLSelectElement>) =>
+                updateAt(i, prev => withOptional(prev, 'type', e.target.value || undefined))}
+            >
+              <option value="">— type —</option>
+              {types.map(t => <option key={t.id} value={t.id}>{t.label}</option>)}
+            </select>
+            <input
+              type="number"
+              step="any"
+              className={styles['inputNarrow']}
+              value={r.location?.lat ?? ''}
+              placeholder="lat"
+              aria-label={`Resource ${i + 1} latitude`}
+              onChange={(e: ChangeEvent<HTMLInputElement>) => updateAt(i, prev =>
+                withOptional(prev, 'location', e.target.value === ''
+                  ? undefined
+                  : { lat: Number(e.target.value), lon: prev.location?.lon ?? 0 }))}
+            />
+            <input
+              type="number"
+              step="any"
+              className={styles['inputNarrow']}
+              value={r.location?.lon ?? ''}
+              placeholder="lon"
+              aria-label={`Resource ${i + 1} longitude`}
+              onChange={(e: ChangeEvent<HTMLInputElement>) => updateAt(i, prev =>
+                withOptional(prev, 'location', e.target.value === ''
+                  ? undefined
+                  : { lat: prev.location?.lat ?? 0, lon: Number(e.target.value) }))}
+            />
+            <button
+              type="button"
+              className={styles['removeBtn']}
+              aria-label={`Remove resource ${i + 1}`}
+              onClick={() => setResources(resources.filter((_, j) => j !== i))}
+            >×</button>
+          </li>
+        ))}
+      </ul>
+      <button
+        type="button"
+        className={styles['addBtn']}
+        onClick={() => setResources([...resources, { id: '', name: '' }])}
+      >+ Add resource</button>
+    </div>
+  )
+}
+
+/**
+ * Set or remove an optional field on a record without leaking an
+ * explicit `undefined` into the result. With
+ * `exactOptionalPropertyTypes: true`, `{ foo: undefined }` is a
+ * different shape from `{}`, and the latter is what we want when
+ * the field is meant to be absent. Used by the resources-step
+ * inputs and the review-step settings handlers.
+ */
+function withOptional<T extends object, K extends keyof T>(
+  obj: T,
+  key: K,
+  value: T[K] | undefined,
+): T {
+  if (value === undefined) {
+    const { [key]: _drop, ...rest } = obj as Record<K, unknown> & Partial<T>
+    return rest as unknown as T
+  }
+  return { ...obj, [key]: value } as T
+}
+
+function cleanResource(r: ConfigResource): ConfigResource {
+  // Drop a partial location (only one of lat/lon set) so the saved
+  // config doesn't carry malformed coordinates downstream.
+  if (r.location && (!Number.isFinite(r.location.lat) || !Number.isFinite(r.location.lon))) {
+    const { location: _drop, ...rest } = r
+    return rest
+  }
+  return r
+}
+
+// ─── Step 4 — pools (list + PoolBuilder modal) ─────────────────────────────
+
+function PoolsStep({ config, setConfig }: StepProps): JSX.Element {
+  const pools = config.pools ?? []
+  const [editingIndex, setEditingIndex] = useState<number | null>(null)
+  // Adapt ConfigResource[] → ReadonlyMap<id, EngineResource> for PoolBuilder.
+  const resourceMap = useMemo(() => {
+    const m = new Map<string, EngineResource>()
+    for (const r of config.resources ?? []) {
+      m.set(r.id, asEngineResource(r))
+    }
+    return m
+  }, [config.resources])
+  const isCreate = editingIndex === pools.length
+
+  return (
+    <div className={styles['stepInner']}>
+      <p className={styles['hint']}>
+        Pools group resources by membership or query. The v2 engine resolves
+        the concrete member at submit time.
+      </p>
+      {pools.length === 0 && <p className={styles['empty']}>No pools yet.</p>}
+      <div className={styles['poolList']}>
+        {pools.map((p, i) => (
+          <PoolCard
+            key={p.id || i}
+            pool={p}
+            resources={resourceMap}
+            onEdit={() => setEditingIndex(i)}
+            onToggleDisabled={() => setConfig(c => ({
+              ...c,
+              pools: pools.map((x, j) => j === i ? { ...x, disabled: !x.disabled } : x),
+            }))}
+            actions={(
+              <button
+                type="button"
+                className={styles['rowBtn']}
+                onClick={() => setConfig(c => ({ ...c, pools: pools.filter((_, j) => j !== i) }))}
+                aria-label={`Delete pool ${p.name}`}
+              >Delete</button>
+            )}
+          />
+        ))}
+      </div>
+      <button
+        type="button"
+        className={styles['addBtn']}
+        onClick={() => setEditingIndex(pools.length)}
+      >+ Add pool</button>
+
+      {editingIndex !== null && (
+        <PoolBuilder
+          pool={isCreate ? null : pools[editingIndex] ?? null}
+          resources={resourceMap}
+          onCancel={() => setEditingIndex(null)}
+          onSave={(saved) => {
+            setConfig(c => ({
+              ...c,
+              pools: isCreate
+                ? [...pools, saved]
+                : pools.map((p, j) => j === editingIndex ? saved : p),
+            }))
+            setEditingIndex(null)
+          }}
+        />
+      )}
+    </div>
+  )
+}
+
+/**
+ * Lift a `ConfigResource` to the runtime `EngineResource` shape so
+ * `PoolBuilder` (and the live preview) can score against it. Just a
+ * field rename; capabilities + location land under `meta` where the
+ * resolver expects them.
+ */
+function asEngineResource(r: ConfigResource): EngineResource {
+  const meta: Record<string, unknown> = { ...(r.meta ?? {}) }
+  if (r.capabilities) meta['capabilities'] = r.capabilities
+  if (r.location)     meta['location'] = r.location
+  return {
+    id: r.id, name: r.name, meta,
+  } as EngineResource
+}
+
+// ─── Step 5 — review (settings + validation + JSON) ────────────────────────
+
+function ReviewStep({ config, setConfig }: StepProps): JSX.Element {
+  const validation = useMemo(() => validateConfig(config), [config])
+  const json = useMemo(
+    () => JSON.stringify(serializeConfig(config), null, 2),
+    [config],
+  )
+  const settings = config.settings ?? {}
+  const setSettings = (next: ConfigSettings) =>
+    setConfig(c => ({ ...c, settings: next }))
+
+  return (
+    <div className={styles['stepInner']}>
+      <fieldset className={styles['fieldset']}>
+        <legend className={styles['legend']}>Settings</legend>
+        <label className={styles['settingRow']}>
+          <span className={styles['settingLabel']}>Conflict mode</span>
+          <select
+            className={styles['select']}
+            value={settings.conflictMode ?? ''}
+            onChange={(e: ChangeEvent<HTMLSelectElement>) => setSettings(
+              withOptional(settings, 'conflictMode', (e.target.value || undefined) as ConfigSettings['conflictMode']),
+            )}
+          >
+            <option value="">(default)</option>
+            <option value="block">block</option>
+            <option value="soft">soft</option>
+            <option value="off">off</option>
+          </select>
+        </label>
+        <label className={styles['settingRow']}>
+          <span className={styles['settingLabel']}>Timezone</span>
+          <input
+            type="text"
+            className={styles['input']}
+            value={settings.timezone ?? ''}
+            placeholder="America/Denver"
+            onChange={(e: ChangeEvent<HTMLInputElement>) => setSettings(
+              withOptional(settings, 'timezone', e.target.value || undefined),
+            )}
+          />
+        </label>
+      </fieldset>
+
+      <fieldset className={styles['fieldset']} data-testid="wizard-validation">
+        <legend className={styles['legend']}>
+          Validation {validation.ok ? <span className={styles['okPill']}>OK</span> : <span className={styles['errPill']}>{validation.issues.length} issue{validation.issues.length === 1 ? '' : 's'}</span>}
+        </legend>
+        {validation.ok && <p className={styles['hint']}>No issues found. Ready to finish.</p>}
+        {!validation.ok && (
+          <ul className={styles['issueList']}>
+            {validation.issues.map((issue, i) => (
+              <li key={i} className={styles['issueRow']}>
+                <code className={styles['issuePath']}>{issue.path}</code>
+                <span className={styles['issueKind']}>{issue.kind}</span>
+              </li>
+            ))}
+          </ul>
+        )}
+      </fieldset>
+
+      <fieldset className={styles['fieldset']}>
+        <legend className={styles['legend']}>Generated config.json</legend>
+        <pre className={styles['json']} data-testid="wizard-json">{json}</pre>
+      </fieldset>
+    </div>
+  )
+}
+
+function cleanSettings(s: ConfigSettings): ConfigSettings {
+  const out: { -readonly [K in keyof ConfigSettings]: ConfigSettings[K] } = {}
+  if (s.conflictMode) out.conflictMode = s.conflictMode
+  if (s.timezone)     out.timezone     = s.timezone
+  return out
+}
+
+// Hint to the bundler/test that PROFILE_PRESETS is referenced for type
+// imports above; otherwise tree-shakers might prune it from the
+// dts bundle when no consumer uses it. Cheap no-op.
+void PROFILE_PRESETS
+
+// Re-export step state types for callers that want to drive their
+// own wizard variant. Concrete types declared above stay closed.
+export type ConfigWizardStepId = StepId
+export type { ConfigResource, ConfigResourceType, ConfigRole, ConfigSettings }

--- a/src/ui/wizard/__tests__/ConfigWizard.test.tsx
+++ b/src/ui/wizard/__tests__/ConfigWizard.test.tsx
@@ -103,6 +103,53 @@ describe('ConfigWizard — Resources step', () => {
     }])
   })
 
+  it('does not commit a half-typed coordinate (#386 P2)', () => {
+    // Typing only the latitude must not fabricate a longitude:0 in
+    // the saved config — that would drop the resource off the
+    // coast of Africa for distance-pool math.
+    const onComplete = vi.fn()
+    render(<ConfigWizard
+      initialConfig={{ resources: [{ id: 't1', name: 'Truck' }] }}
+      onComplete={onComplete} onCancel={vi.fn()}
+    />)
+    fireEvent.click(screen.getByRole('button', { name: /3.+Resources/ }))
+    fireEvent.change(screen.getByLabelText('Resource 1 latitude'), { target: { value: '40.76' } })
+    fireEvent.click(screen.getByRole('button', { name: /5.+Review/ }))
+    fireEvent.click(screen.getByRole('button', { name: 'Finish' }))
+    const saved = onComplete.mock.calls[0]![0] as CalendarConfig
+    expect(saved.resources![0]!.location).toBeUndefined()
+  })
+
+  it('commits the coordinate only when both lat and lon are typed (#386 P2)', () => {
+    const onComplete = vi.fn()
+    render(<ConfigWizard
+      initialConfig={{ resources: [{ id: 't1', name: 'Truck' }] }}
+      onComplete={onComplete} onCancel={vi.fn()}
+    />)
+    fireEvent.click(screen.getByRole('button', { name: /3.+Resources/ }))
+    fireEvent.change(screen.getByLabelText('Resource 1 latitude'),  { target: { value: '40.76' } })
+    fireEvent.change(screen.getByLabelText('Resource 1 longitude'), { target: { value: '-111.89' } })
+    fireEvent.click(screen.getByRole('button', { name: /5.+Review/ }))
+    fireEvent.click(screen.getByRole('button', { name: 'Finish' }))
+    const saved = onComplete.mock.calls[0]![0] as CalendarConfig
+    expect(saved.resources![0]!.location).toEqual({ lat: 40.76, lon: -111.89 })
+  })
+
+  it('clears the coordinate when both fields are emptied', () => {
+    const onComplete = vi.fn()
+    render(<ConfigWizard
+      initialConfig={{ resources: [{ id: 't1', name: 'Truck', location: { lat: 40, lon: -111 } }] }}
+      onComplete={onComplete} onCancel={vi.fn()}
+    />)
+    fireEvent.click(screen.getByRole('button', { name: /3.+Resources/ }))
+    fireEvent.change(screen.getByLabelText('Resource 1 latitude'),  { target: { value: '' } })
+    fireEvent.change(screen.getByLabelText('Resource 1 longitude'), { target: { value: '' } })
+    fireEvent.click(screen.getByRole('button', { name: /5.+Review/ }))
+    fireEvent.click(screen.getByRole('button', { name: 'Finish' }))
+    const saved = onComplete.mock.calls[0]![0] as CalendarConfig
+    expect(saved.resources![0]!.location).toBeUndefined()
+  })
+
   it('removes a resource when × is clicked', () => {
     const onComplete = vi.fn()
     render(<ConfigWizard
@@ -141,6 +188,24 @@ describe('ConfigWizard — Pools step', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Finish' }))
     const saved = onComplete.mock.calls[0]![0] as CalendarConfig
     expect(saved.pools?.map(p => p.id)).toEqual(['fleet-east'])
+  })
+
+  it('Escape inside the PoolBuilder modal does not cancel the wizard (#386 P1)', () => {
+    // Both shells use a focus trap that listens for Escape. Without
+    // gating, a single Escape inside PoolBuilder fires both
+    // `onCancel` callbacks and drops the wizard's draft. The wizard
+    // disables its outer trap while the inner modal is mounted.
+    const onCancel = vi.fn()
+    render(<ConfigWizard
+      initialConfig={{ resources: [{ id: 't1', name: 'T1' }] }}
+      onComplete={vi.fn()} onCancel={onCancel}
+    />)
+    fireEvent.click(screen.getByRole('button', { name: /4.+Pools/ }))
+    fireEvent.click(screen.getByRole('button', { name: '+ Add pool' }))
+    // PoolBuilder mounts a `dialog` named "Create pool".
+    const builder = screen.getByRole('dialog', { name: 'Create pool' })
+    fireEvent.keyDown(builder, { key: 'Escape' })
+    expect(onCancel).not.toHaveBeenCalled()
   })
 })
 

--- a/src/ui/wizard/__tests__/ConfigWizard.test.tsx
+++ b/src/ui/wizard/__tests__/ConfigWizard.test.tsx
@@ -1,0 +1,209 @@
+// @vitest-environment happy-dom
+/**
+ * ConfigWizard — guided CalendarConfig editor (#386 capstone).
+ */
+import { render, screen, fireEvent, within } from '@testing-library/react'
+import { describe, it, expect, vi } from 'vitest'
+import '@testing-library/jest-dom'
+import React from 'react'
+
+import ConfigWizard from '../ConfigWizard'
+import type { CalendarConfig } from '../../../core/config/calendarConfig'
+
+describe('ConfigWizard — shell', () => {
+  it('renders all five steps in the breadcrumbs', () => {
+    render(<ConfigWizard onComplete={vi.fn()} onCancel={vi.fn()} />)
+    expect(screen.getByRole('button', { name: /1.+Profile/ })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /2.+Types & roles/ })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /3.+Resources/ })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /4.+Pools/ })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /5.+Review/ })).toBeInTheDocument()
+  })
+
+  it('starts on the Profile step (Back disabled, Next active)', () => {
+    render(<ConfigWizard onComplete={vi.fn()} onCancel={vi.fn()} />)
+    expect(screen.getByRole('button', { name: 'Back' })).toBeDisabled()
+    expect(screen.getByRole('button', { name: 'Next' })).toBeEnabled()
+  })
+
+  it('Cancel and the close button both fire onCancel', () => {
+    const onCancel = vi.fn()
+    render(<ConfigWizard onComplete={vi.fn()} onCancel={onCancel} />)
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Close wizard' }))
+    expect(onCancel).toHaveBeenCalledTimes(2)
+  })
+
+  it('clicking a breadcrumb jumps directly to that step', () => {
+    render(<ConfigWizard onComplete={vi.fn()} onCancel={vi.fn()} />)
+    fireEvent.click(screen.getByRole('button', { name: /5.+Review/ }))
+    expect(screen.getByRole('button', { name: 'Finish' })).toBeInTheDocument()
+  })
+})
+
+describe('ConfigWizard — Profile step', () => {
+  it('seeds the config when a preset is picked', () => {
+    const onComplete = vi.fn()
+    render(<ConfigWizard onComplete={onComplete} onCancel={vi.fn()} />)
+    fireEvent.click(screen.getByRole('button', { name: /Trucking/ }))
+    // Jump to review and finish to see the resulting config.
+    fireEvent.click(screen.getByRole('button', { name: /5.+Review/ }))
+    fireEvent.click(screen.getByRole('button', { name: 'Finish' }))
+    const saved = onComplete.mock.calls[0]![0] as CalendarConfig
+    expect(saved.profile).toBe('trucking')
+    expect(saved.labels?.resource).toBe('Truck')
+    expect(saved.roles?.map(r => r.id)).toEqual(['driver', 'dispatcher'])
+  })
+})
+
+describe('ConfigWizard — Catalogs step', () => {
+  it('lets users add and remove resourceTypes / roles', () => {
+    const onComplete = vi.fn()
+    render(<ConfigWizard onComplete={onComplete} onCancel={vi.fn()} />)
+    fireEvent.click(screen.getByRole('button', { name: /2.+Types & roles/ }))
+
+    fireEvent.click(screen.getByRole('button', { name: '+ Add resource type' }))
+    fireEvent.change(screen.getByLabelText('Resource types 1 id'),    { target: { value: 'vehicle' } })
+    fireEvent.change(screen.getByLabelText('Resource types 1 label'), { target: { value: 'Truck' } })
+
+    fireEvent.click(screen.getByRole('button', { name: '+ Add role' }))
+    fireEvent.change(screen.getByLabelText('Roles 1 id'),    { target: { value: 'driver' } })
+    fireEvent.change(screen.getByLabelText('Roles 1 label'), { target: { value: 'Driver' } })
+
+    fireEvent.click(screen.getByRole('button', { name: /5.+Review/ }))
+    fireEvent.click(screen.getByRole('button', { name: 'Finish' }))
+    const saved = onComplete.mock.calls[0]![0] as CalendarConfig
+    expect(saved.resourceTypes).toEqual([{ id: 'vehicle', label: 'Truck' }])
+    expect(saved.roles).toEqual([{ id: 'driver', label: 'Driver' }])
+  })
+})
+
+describe('ConfigWizard — Resources step', () => {
+  it('captures id / name / type / location for each resource', () => {
+    const onComplete = vi.fn()
+    render(<ConfigWizard
+      initialConfig={{ resourceTypes: [{ id: 'vehicle', label: 'Truck' }] }}
+      onComplete={onComplete} onCancel={vi.fn()}
+    />)
+    fireEvent.click(screen.getByRole('button', { name: /3.+Resources/ }))
+    fireEvent.click(screen.getByRole('button', { name: '+ Add resource' }))
+
+    fireEvent.change(screen.getByLabelText('Resource 1 id'),   { target: { value: 't1' } })
+    fireEvent.change(screen.getByLabelText('Resource 1 name'), { target: { value: 'Truck 101' } })
+    fireEvent.change(screen.getByLabelText('Resource 1 type'), { target: { value: 'vehicle' } })
+    fireEvent.change(screen.getByLabelText('Resource 1 latitude'),  { target: { value: '40.76' } })
+    fireEvent.change(screen.getByLabelText('Resource 1 longitude'), { target: { value: '-111.89' } })
+
+    fireEvent.click(screen.getByRole('button', { name: /5.+Review/ }))
+    fireEvent.click(screen.getByRole('button', { name: 'Finish' }))
+    const saved = onComplete.mock.calls[0]![0] as CalendarConfig
+    expect(saved.resources).toEqual([{
+      id: 't1', name: 'Truck 101', type: 'vehicle',
+      location: { lat: 40.76, lon: -111.89 },
+    }])
+  })
+
+  it('removes a resource when × is clicked', () => {
+    const onComplete = vi.fn()
+    render(<ConfigWizard
+      initialConfig={{
+        resources: [{ id: 't1', name: 'A' }, { id: 't2', name: 'B' }],
+      }}
+      onComplete={onComplete} onCancel={vi.fn()}
+    />)
+    fireEvent.click(screen.getByRole('button', { name: /3.+Resources/ }))
+    fireEvent.click(screen.getByRole('button', { name: 'Remove resource 1' }))
+    fireEvent.click(screen.getByRole('button', { name: /5.+Review/ }))
+    fireEvent.click(screen.getByRole('button', { name: 'Finish' }))
+    const saved = onComplete.mock.calls[0]![0] as CalendarConfig
+    expect(saved.resources?.map(r => r.id)).toEqual(['t2'])
+  })
+})
+
+describe('ConfigWizard — Pools step', () => {
+  it('lists existing pools as cards and lets users delete them', () => {
+    const onComplete = vi.fn()
+    render(<ConfigWizard
+      initialConfig={{
+        resources: [{ id: 't1', name: 'T1' }],
+        pools: [
+          { id: 'fleet-east', name: 'East Fleet', memberIds: ['t1'], strategy: 'first-available' },
+          { id: 'fleet-west', name: 'West Fleet', memberIds: [],     strategy: 'first-available' },
+        ],
+      }}
+      onComplete={onComplete} onCancel={vi.fn()}
+    />)
+    fireEvent.click(screen.getByRole('button', { name: /4.+Pools/ }))
+    expect(screen.getAllByRole('article').length).toBe(2)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Delete pool West Fleet' }))
+    fireEvent.click(screen.getByRole('button', { name: /5.+Review/ }))
+    fireEvent.click(screen.getByRole('button', { name: 'Finish' }))
+    const saved = onComplete.mock.calls[0]![0] as CalendarConfig
+    expect(saved.pools?.map(p => p.id)).toEqual(['fleet-east'])
+  })
+})
+
+describe('ConfigWizard — Review step', () => {
+  it('shows OK when there are no validation issues', () => {
+    render(<ConfigWizard
+      initialConfig={{ profile: 'custom' }}
+      onComplete={vi.fn()} onCancel={vi.fn()}
+    />)
+    fireEvent.click(screen.getByRole('button', { name: /5.+Review/ }))
+    expect(within(screen.getByTestId('wizard-validation')).getByText('OK')).toBeInTheDocument()
+  })
+
+  it('surfaces validateConfig issues with their paths', () => {
+    render(<ConfigWizard
+      initialConfig={{
+        // requirement.role doesn't exist in roles[] — validateConfig will flag it.
+        requirements: [{ eventType: 'load', requires: [{ role: 'ghost', count: 1 }] }],
+      }}
+      onComplete={vi.fn()} onCancel={vi.fn()}
+    />)
+    fireEvent.click(screen.getByRole('button', { name: /5.+Review/ }))
+    const validation = screen.getByTestId('wizard-validation')
+    expect(within(validation).getByText('1 issue')).toBeInTheDocument()
+    expect(within(validation).getByText('requirements[0].requires[0].role')).toBeInTheDocument()
+  })
+
+  it('renders the serialized config as JSON', () => {
+    render(<ConfigWizard
+      initialConfig={{ profile: 'aviation' }}
+      onComplete={vi.fn()} onCancel={vi.fn()}
+    />)
+    fireEvent.click(screen.getByRole('button', { name: /5.+Review/ }))
+    expect(screen.getByTestId('wizard-json').textContent).toContain('"profile": "aviation"')
+  })
+
+  it('Finish button hands the final config to onComplete', () => {
+    const onComplete = vi.fn()
+    render(<ConfigWizard
+      initialConfig={{ profile: 'scheduling' }}
+      onComplete={onComplete} onCancel={vi.fn()}
+    />)
+    fireEvent.click(screen.getByRole('button', { name: /5.+Review/ }))
+    fireEvent.click(screen.getByRole('button', { name: 'Finish' }))
+    expect(onComplete).toHaveBeenCalledWith({ profile: 'scheduling' })
+  })
+})
+
+describe('ConfigWizard — initialConfig editing', () => {
+  it('round-trips a fully populated config without losing fields', () => {
+    const initial: CalendarConfig = {
+      profile: 'trucking',
+      labels: { resource: 'Truck', event: 'Load', location: 'Depot' },
+      resourceTypes: [{ id: 'vehicle', label: 'Truck' }],
+      roles: [{ id: 'driver', label: 'Driver' }],
+      resources: [{ id: 't1', name: 'Truck 1', type: 'vehicle' }],
+      pools: [{ id: 'fleet', name: 'Fleet', memberIds: ['t1'], strategy: 'first-available' }],
+      settings: { conflictMode: 'block', timezone: 'America/Denver' },
+    }
+    const onComplete = vi.fn()
+    render(<ConfigWizard initialConfig={initial} onComplete={onComplete} onCancel={vi.fn()} />)
+    fireEvent.click(screen.getByRole('button', { name: /5.+Review/ }))
+    fireEvent.click(screen.getByRole('button', { name: 'Finish' }))
+    expect(onComplete).toHaveBeenCalledWith(initial)
+  })
+})


### PR DESCRIPTION
## Summary

**The capstone of the v2 wizard slice.** Five-step modal that walks
hosts (or end users) through producing a complete `CalendarConfig`.
Composes every primitive that landed earlier — profile presets,
catalogs, `PoolBuilder`, `validateConfig`, `serializeConfig` — so
anything those components already do (live preview, advanced rules
editor, range pickers, path autocomplete, distance pools, …) just
works inside the wizard for free.

> Named `ConfigWizard` to disambiguate from the existing
> `SetupWizardModal` (first-time owner setup, documented at
> `docs/SetupWizard.md`). The new doc is `docs/ConfigWizard.md`.

### Steps

| # | Step              | What it does                                                                                          |
|---|-------------------|--------------------------------------------------------------------------------------------------------|
| 1 | Profile           | Pick a starter preset (uses `applyProfilePreset`)                                                      |
| 2 | Types & roles     | `resourceTypes` + `roles` editors (add / remove / rename inline)                                       |
| 3 | Resources         | Registry editor — id, name, type dropdown (sourced from step 2), lat/lon                               |
| 4 | Pools             | List of `PoolCard`s with edit / disable / delete; "+ Add pool" opens the existing `PoolBuilder`. `ConfigResource → EngineResource` adapter so capabilities + location land under `meta` where the resolver expects them. |
| 5 | Review            | Settings (`conflictMode`, `timezone`), live `validateConfig` results with paths, and the serialized JSON in a code block. |

The wizard owns its draft `CalendarConfig` state. Hosts pass an
optional `initialConfig` to edit; the wizard seeds every step from
it. Round-trip is total — opening, walking through, and finishing
without changes returns the config unchanged.

Breadcrumbs are clickable (free navigation). Cancel / close-button
/ overlay-click all fire `onCancel`; Finish hands the final config
to `onComplete`.

A small `withOptional(obj, key, value)` helper keeps the inputs
honest under `exactOptionalPropertyTypes` — clearing an optional
field removes the key entirely rather than setting it to
`undefined`.

## Test plan

- [x] `tsc --noEmit` clean
- [x] `vitest run` — 2436 passing, 2 skipped (existing PTO flakes), 0 failures (14 new tests)
- [x] **Shell** — every step renders in the breadcrumbs; Back disabled at start; Cancel + close-button both fire `onCancel`; clicking a breadcrumb jumps directly
- [x] **Profile step** — picking a preset seeds the config and survives to Finish
- [x] **Catalogs step** — add / remove `resourceTypes` and `roles`; finish picks them up
- [x] **Resources step** — captures id / name / type / lat-lon; remove-row drops the right entry
- [x] **Pools step** — lists existing pools as cards; delete drops the right pool
- [x] **Review step** — OK pill when valid; issue-list rendering with `path` for invalid configs; serialized JSON in a `<pre data-testid="wizard-json">` block; Finish hands the final config to `onComplete`
- [x] **`initialConfig`** — fully populated config round-trips through the wizard with every section preserved

## Out of scope (future polish)

- Sample data generation
- Industry-specific capability lists (PoolBuilder auto-derives, so the wizard doesn't curate)
- Per-resource `meta.roles` editor (JSON-only for v1)
- File-system download (JSON code block instead of `<a download>`)
- i18n (English-only labels for v1)

## v2 ladder for issue #386 — complete

The wizard sits on top of:

- **#440** — `CalendarConfig` schema + `parseConfig` / `serializeConfig`
- **#443**/**#444** — requirements runtime + the phantom-pool / malformed-query guards
- **#445** — `validateConfig` cross-section integrity
- **#446** — industry profile presets

After this lands, every item from the issue thread's *"Wizard
Output: Standard config.json Structure"* comment has a runtime
home + a UI path. Issue #386 stays open for the v3-ish ideas
called out as out-of-scope here (sample data, role chip picker,
file download, i18n).

https://claude.ai/code/session_01XojXzZPdEPuGbX2TyLY1pu

---
_Generated by [Claude Code](https://claude.ai/code/session_01XojXzZPdEPuGbX2TyLY1pu)_