### PR TITLE
core(requirements): per-assignment `roleId` for "acting as" semantics (#449)

### DIFF
--- a/docs/Requirements.md
+++ b/docs/Requirements.md
@@ -57,8 +57,23 @@ that's in the catalog") can read `noTemplate` and react.
 
 ## Role tagging
 
-Role membership lives on the resource side, not on `Assignment`.
-A resource declares which roles it can fulfill via `meta.roles`:
+Role membership has two layers, in priority order:
+
+**1. Per-assignment `roleId` ("acting as"). Wins when set.**
+
+```ts
+const a: Assignment = {
+  id: 'a1', eventId: 'e1', resourceId: 'alice', units: 100,
+  roleId: 'dispatcher',   // Alice is acting as dispatcher *on this event*
+};
+```
+
+Lets a person who's statically both driver and dispatcher be
+booked as one role on Monday and the other on Tuesday without
+re-tagging the underlying resource. When `assignment.roleId` is
+set, the engine ignores `meta.roles` for the slot match.
+
+**2. Static `meta.roles` on the resource (fallback).**
 
 ```ts
 const alice: EngineResource = {
@@ -68,12 +83,10 @@ const alice: EngineResource = {
 };
 ```
 
-The engine counts every assignment whose resource is tagged with
-the slot's role. This is the v1 contract: it captures static role
-membership and works for the wizard's needs. A future slice may
-add an optional per-assignment `roleId` for "Alice is acting as
-dispatcher *on this event*" semantics; that's additive when it
-lands.
+When `assignment.roleId` is unset, the engine counts every
+assignment whose resource is tagged with the slot's role. This is
+the v1 contract — additive: existing assignments keep working
+exactly as before.
 
 ## Pool slots
 

--- a/src/core/engine/schema/assignmentSchema.ts
+++ b/src/core/engine/schema/assignmentSchema.ts
@@ -29,6 +29,21 @@ export interface Assignment {
    * inherits the tenant of the joined event/resource.
    */
   readonly tenantId?: string;
+  /**
+   * "Acting as" role override for this specific event (#449).
+   *
+   * When set, the requirements engine uses this id as the role the
+   * assignment fulfills, ignoring the resource's static
+   * `meta.roles` for the slot match. Lets a person who's both a
+   * driver and a dispatcher be booked as one role on Monday and
+   * the other on Tuesday without re-tagging the underlying
+   * resource.
+   *
+   * When unset, role membership falls back to the resource's
+   * static `meta.roles: string[]` — the v1 contract — so existing
+   * assignments behave exactly as before.
+   */
+  readonly roleId?: string;
 }
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────

--- a/src/core/requirements/__tests__/evaluateRequirements.test.ts
+++ b/src/core/requirements/__tests__/evaluateRequirements.test.ts
@@ -108,6 +108,74 @@ describe('evaluateRequirements — role slots', () => {
   })
 })
 
+describe('evaluateRequirements — per-assignment roleId (#449)', () => {
+  // Resources tagged with static meta.roles to verify the override
+  // takes precedence; same fixture as the role-slots block.
+  const resources = mapBy([
+    r('alice',   { roles: ['driver'] }),
+    r('bob',     { roles: ['driver', 'dispatcher'] }),
+    r('untagged', {}),
+  ])
+
+  it('an assignment with roleId counts toward that role even when the resource lacks the tag', () => {
+    // 'untagged' has no meta.roles, but the assignment pins it as a
+    // dispatcher for this specific event — should satisfy a 1-dispatcher
+    // requirement.
+    const out = evaluateRequirements({
+      event: event('e1', 'load'),
+      requirements: [{ eventType: 'load', requires: [{ role: 'dispatcher', count: 1 }] }],
+      resources,
+      assignments: mapBy([
+        { id: 'a1', eventId: 'e1', resourceId: 'untagged', units: 100, roleId: 'dispatcher' },
+      ]),
+    })
+    expect(out.satisfied).toBe(true)
+  })
+
+  it('roleId overrides static meta.roles for the slot match', () => {
+    // Bob is statically tagged as both driver + dispatcher. The
+    // assignment pins him as dispatcher this time — he should NOT
+    // count toward a driver requirement, even though meta.roles
+    // includes 'driver'.
+    const out = evaluateRequirements({
+      event: event('e1', 'load'),
+      requirements: [{ eventType: 'load', requires: [{ role: 'driver', count: 1 }] }],
+      resources,
+      assignments: mapBy([
+        { id: 'a1', eventId: 'e1', resourceId: 'bob', units: 100, roleId: 'dispatcher' },
+      ]),
+    })
+    expect(out.satisfied).toBe(false)
+    expect(out.missing[0]?.assigned).toBe(0)
+  })
+
+  it('falls back to static meta.roles when roleId is omitted (v1 contract)', () => {
+    // Alice has no roleId on her assignment, so the resource's
+    // meta.roles drives the count. Should still work like before.
+    const out = evaluateRequirements({
+      event: event('e1', 'load'),
+      requirements: [{ eventType: 'load', requires: [{ role: 'driver', count: 1 }] }],
+      resources,
+      assignments: mapBy([a('a1', 'e1', 'alice')]),
+    })
+    expect(out.satisfied).toBe(true)
+  })
+
+  it('mixed assignments — some with roleId, some without — count correctly', () => {
+    // Need 2 drivers. Alice (static) + bob acting-as driver = 2.
+    const out = evaluateRequirements({
+      event: event('e1', 'load'),
+      requirements: [{ eventType: 'load', requires: [{ role: 'driver', count: 2 }] }],
+      resources,
+      assignments: mapBy([
+        a('a1', 'e1', 'alice'),                                                                // static driver
+        { id: 'a2', eventId: 'e1', resourceId: 'untagged', units: 100, roleId: 'driver' },   // acting-as
+      ]),
+    })
+    expect(out.satisfied).toBe(true)
+  })
+})
+
 describe('evaluateRequirements — pool slots', () => {
   const truck = (id: string, refrigerated = false) =>
     r(id, { type: 'vehicle', capabilities: { refrigerated } })

--- a/src/core/requirements/__tests__/evaluateRequirements.test.ts
+++ b/src/core/requirements/__tests__/evaluateRequirements.test.ts
@@ -161,6 +161,21 @@ describe('evaluateRequirements — per-assignment roleId (#449)', () => {
     expect(out.satisfied).toBe(true)
   })
 
+  it('stale assignment with roleId does not satisfy a slot when the resource is missing', () => {
+    // The resource was deleted but the assignment record was retained.
+    // Even though roleId matches, the phantom resource must not count.
+    const out = evaluateRequirements({
+      event: event('e1', 'load'),
+      requirements: [{ eventType: 'load', requires: [{ role: 'dispatcher', count: 1 }] }],
+      resources,  // 'ghost' is not in this map
+      assignments: mapBy([
+        { id: 'a1', eventId: 'e1', resourceId: 'ghost', units: 100, roleId: 'dispatcher' },
+      ]),
+    })
+    expect(out.satisfied).toBe(false)
+    expect(out.missing[0]?.assigned).toBe(0)
+  })
+
   it('mixed assignments — some with roleId, some without — count correctly', () => {
     // Need 2 drivers. Alice (static) + bob acting-as driver = 2.
     const out = evaluateRequirements({

--- a/src/core/requirements/evaluateRequirements.ts
+++ b/src/core/requirements/evaluateRequirements.ts
@@ -172,6 +172,13 @@ function checkSlot(slot: ConfigRequirementSlot, ctx: SlotContext): RequirementSh
 function countRoleAssignments(roleId: string, ctx: SlotContext): number {
   let count = 0
   for (const a of ctx.eventAssignments) {
+    // Per-assignment "acting as" override wins (#449). When the host
+    // pinned the role on this specific assignment, ignore the
+    // resource's static meta.roles for slot matching.
+    if (a.roleId !== undefined) {
+      if (a.roleId === roleId) count++
+      continue
+    }
     const r = ctx.resources.get(a.resourceId)
     const roles = (r?.meta?.['roles'] ?? null) as readonly string[] | null
     if (Array.isArray(roles) && roles.includes(roleId)) count++

--- a/src/core/requirements/evaluateRequirements.ts
+++ b/src/core/requirements/evaluateRequirements.ts
@@ -176,6 +176,10 @@ function countRoleAssignments(roleId: string, ctx: SlotContext): number {
     // pinned the role on this specific assignment, ignore the
     // resource's static meta.roles for slot matching.
     if (a.roleId !== undefined) {
+      // Phantom guard: a stale assignment (resource deleted, assignment
+      // retained) must not satisfy a slot just because roleId matches.
+      // Mirrors the same check in countPoolAssignments.
+      if (!ctx.resources.has(a.resourceId)) continue
       if (a.roleId === roleId) count++
       continue
     }


### PR DESCRIPTION
Closes #449.

## Summary

Adds an optional `Assignment.roleId` field for "acting as" semantics. Lets a person who's statically tagged as both driver and dispatcher be booked as one role on Monday and the other on Tuesday without re-tagging the underlying resource — the assignment itself carries the role decision for that specific event.

Fully additive: existing assignments keep counting through the static `meta.roles` fallback exactly as before.

## Behavior

| `assignment.roleId` | `resource.meta.roles` | Counts toward role X? |
|---------------------|------------------------|------------------------|
| `'X'`               | (any)                  | Yes — only X           |
| `'Y'`               | `['X', 'Y']`           | **No** — acting as Y, not X |
| unset               | `['X']`                | Yes — falls back to static |
| unset               | `[]` / undefined       | No                     |

The middle row is the meaningful one: the override truly *replaces* the static tags for that event. *"Bob is acting as dispatcher today, so don't also count him as a driver"* is the right reading — and what real fleet ops want.

## Test plan

- [x] `tsc --noEmit` clean
- [x] `vitest run` — 2444 passing, 2 skipped (pre-existing PTO flakes), 0 failures (4 new tests)
- [x] Acting-as adds a role the resource doesn't statically have
- [x] Override hides a role the resource statically has
- [x] Omitting `roleId` falls back to `meta.roles` (v1 contract intact)
- [x] Mixed: one assignment with override + one without, both count correctly

## Out of scope

The other requirements follow-ups land in their own PRs:
- #450 — soft requirements (warn vs block)
- #448 — engine integration (auto-reject submits)

https://claude.ai/code/session_01XojXzZPdEPuGbX2TyLY1pu

---
_Generated by [Claude Code](https://claude.ai/code/session_01XojXzZPdEPuGbX2TyLY1pu)_