### PR TITLE
core(requirements): soft requirements (warn instead of block) (#450)

### DIFF
--- a/docs/Requirements.md
+++ b/docs/Requirements.md
@@ -120,16 +120,33 @@ documented behavior; tests pin it.
 - Slots are independent — a single assignment satisfies any slot
   whose criteria it meets, including multiple at once.
 
+## Severity: hard vs soft
+
+Each slot can be marked `severity: 'soft'` to declare a *preference*
+rather than a hard requirement. When a soft slot goes unmet, the
+shortfall still surfaces in `missing[]` (so hosts can render
+"this load doesn't have a co-driver" as a warning), but
+`satisfied` stays `true` if every *hard* slot is filled.
+
+```ts
+{
+  "eventType": "load",
+  "requires": [
+    { "role": "driver",     "count": 1, "severity": "hard" },  // blocks
+    { "role": "note-taker", "count": 1, "severity": "soft" },  // warns only
+  ]
+}
+```
+
+`severity` defaults to `'hard'` when omitted, preserving the v1
+contract for existing templates. Engine integration (auto-reject
+gating) reads this to decide whether to block.
+
 ## Out of scope (future slices)
 
-- **Engine integration** — auto-rejecting submits with unmet
+- **Engine integration** — auto-rejecting submits with unmet hard
   requirements at the operation level. This evaluator is currently
   a standalone read; hosts decide whether to gate.
-- **Per-assignment `roleId`** — assignments declaring "this resource
-  is acting as role X *on this event*" rather than relying on the
-  resource's static role list.
-- **Soft requirements** — slots that warn but don't block (the v1
-  contract treats every unmet slot as a hard shortfall).
 - **`validateConfig`** — cross-section integrity checks
   (`requirement.role` ∈ `roles[]`, `requirement.pool` ∈ `pools[]`)
   still need to land separately.

--- a/src/core/config/__tests__/parseConfig.test.ts
+++ b/src/core/config/__tests__/parseConfig.test.ts
@@ -208,6 +208,36 @@ describe('parseConfig — requirements', () => {
     expect(r.config.requirements![0]!.requires).toEqual([{ role: 'driver', count: 1 }])
     expect(r.errors.some(e => e.includes('requires[1]'))).toBe(true)
   })
+  it('round-trips slot severity (#450)', () => {
+    const r = parseConfig({
+      requirements: [{
+        eventType: 'load',
+        requires: [
+          { role: 'driver',     count: 1, severity: 'hard' },
+          { pool: 'note-taker', count: 1, severity: 'soft' },
+        ],
+      }],
+    })
+    expect(r.config.requirements).toEqual([{
+      eventType: 'load',
+      requires: [
+        { role: 'driver',     count: 1, severity: 'hard' },
+        { pool: 'note-taker', count: 1, severity: 'soft' },
+      ],
+    }])
+  })
+
+  it('ignores an unknown severity value while keeping the slot', () => {
+    const r = parseConfig({
+      requirements: [{
+        eventType: 'load',
+        requires: [{ role: 'driver', count: 1, severity: 'maybe' }],
+      }],
+    })
+    // Slot survives; severity is dropped (treated as default 'hard' by the engine).
+    expect(r.config.requirements?.[0]?.requires).toEqual([{ role: 'driver', count: 1 }])
+    expect(r.errors.some(e => e.includes('severity'))).toBe(true)
+  })
 })
 
 describe('parseConfig — events (seed)', () => {

--- a/src/core/config/calendarConfig.ts
+++ b/src/core/config/calendarConfig.ts
@@ -92,9 +92,18 @@ export interface ConfigRequirement {
   readonly requires: readonly ConfigRequirementSlot[]
 }
 
+/**
+ * `hard` (default): unmet → `satisfied: false`, blocks submit
+ * gating when wired. `soft`: unmet → still in `missing[]` with the
+ * severity tag, but `satisfied` ignores it. Lets a template say
+ * "this load *prefers* a co-driver" without rejecting the booking
+ * when no co-driver is available.
+ */
+export type ConfigRequirementSeverity = 'hard' | 'soft'
+
 export type ConfigRequirementSlot =
-  | { readonly role: string; readonly count: number }
-  | { readonly pool: string; readonly count: number }
+  | { readonly role: string; readonly count: number; readonly severity?: ConfigRequirementSeverity }
+  | { readonly pool: string; readonly count: number; readonly severity?: ConfigRequirementSeverity }
 
 export interface ConfigSeedEvent {
   readonly id: string

--- a/src/core/config/parseConfig.ts
+++ b/src/core/config/parseConfig.ts
@@ -248,12 +248,27 @@ function parseRequirement(raw: unknown, path: string, errors: string[]): ConfigR
   let slotsDropped = 0
   raw['requires'].forEach((slot, i) => {
     if (isObject(slot) && typeof slot['count'] === 'number' && slot['count'] >= 0) {
+      // Severity is opt-in; an unknown value is logged + ignored,
+      // and the slot stays valid (treated as the default 'hard').
+      // We never reject the whole slot just for a typo'd severity.
+      let severity: 'hard' | 'soft' | undefined
+      if (slot['severity'] !== undefined) {
+        if (slot['severity'] === 'hard' || slot['severity'] === 'soft') {
+          severity = slot['severity']
+        } else {
+          errors.push(`${path}.requires[${i}].severity: invalid value "${String(slot['severity'])}", ignoring`)
+        }
+      }
       if (typeof slot['role'] === 'string') {
-        requires.push({ role: slot['role'], count: slot['count'] })
+        requires.push(severity
+          ? { role: slot['role'], count: slot['count'], severity }
+          : { role: slot['role'], count: slot['count'] })
         return
       }
       if (typeof slot['pool'] === 'string') {
-        requires.push({ pool: slot['pool'], count: slot['count'] })
+        requires.push(severity
+          ? { pool: slot['pool'], count: slot['count'], severity }
+          : { pool: slot['pool'], count: slot['count'] })
         return
       }
     }

--- a/src/core/config/serializeConfig.ts
+++ b/src/core/config/serializeConfig.ts
@@ -70,10 +70,14 @@ function serializePool(p: ResourcePool): Record<string, unknown> {
 function serializeRequirement(r: ConfigRequirement): Record<string, unknown> {
   return {
     eventType: r.eventType,
-    requires: r.requires.map((slot) =>
-      'role' in slot
+    requires: r.requires.map((slot) => {
+      const base = 'role' in slot
         ? { role: slot.role, count: slot.count }
-        : { pool: slot.pool, count: slot.count }),
+        : { pool: slot.pool, count: slot.count }
+      // Only emit severity when the slot specified one — preserves
+      // the "default hard, omit when implicit" round-trip contract.
+      return slot.severity ? { ...base, severity: slot.severity } : base
+    }),
   }
 }
 

--- a/src/core/requirements/__tests__/evaluateRequirements.test.ts
+++ b/src/core/requirements/__tests__/evaluateRequirements.test.ts
@@ -65,7 +65,7 @@ describe('evaluateRequirements — role slots', () => {
     const assignments = mapBy([a('a1', 'e1', 'alice')])
     const out = evaluateRequirements({ event: event('e1', 'load'), requirements, resources, assignments })
     expect(out.satisfied).toBe(false)
-    expect(out.missing).toEqual([{ kind: 'role', role: 'driver', required: 2, assigned: 1, missing: 1 }])
+    expect(out.missing).toEqual([{ kind: 'role', role: 'driver', required: 2, assigned: 1, missing: 1, severity: 'hard' }])
   })
 
   it('ignores assignments to other events', () => {
@@ -151,7 +151,7 @@ describe('evaluateRequirements — pool slots', () => {
       assignments: mapBy([a('a1', 'e1', 't1')]),
     })
     expect(out.satisfied).toBe(false)
-    expect(out.missing).toEqual([{ kind: 'pool', pool: 'fleet', required: 2, assigned: 1, missing: 1 }])
+    expect(out.missing).toEqual([{ kind: 'pool', pool: 'fleet', required: 2, assigned: 1, missing: 1, severity: 'hard' }])
   })
 
   it('runs the query for query pools', () => {
@@ -274,6 +274,74 @@ describe('evaluateRequirements — pool slots', () => {
   })
 })
 
+describe('evaluateRequirements — soft requirements (#450)', () => {
+  const resources = mapBy([
+    r('alice', { roles: ['driver'] }),
+  ])
+
+  it('a slot defaults to severity:hard when omitted', () => {
+    const out = evaluateRequirements({
+      event: event('e1', 'load'),
+      requirements: [{ eventType: 'load', requires: [{ role: 'note-taker', count: 1 }] }],
+      resources,
+      assignments: new Map(),
+    })
+    expect(out.satisfied).toBe(false)
+    expect(out.missing[0]?.severity).toBe('hard')
+  })
+
+  it('soft shortfalls surface in missing[] but do NOT flip satisfied', () => {
+    // Need a driver (hard, satisfied) + note-taker (soft, unmet).
+    const out = evaluateRequirements({
+      event: event('e1', 'load'),
+      requirements: [{
+        eventType: 'load',
+        requires: [
+          { role: 'driver',     count: 1, severity: 'hard' },
+          { role: 'note-taker', count: 1, severity: 'soft' },
+        ],
+      }],
+      resources,
+      assignments: mapBy([a('a1', 'e1', 'alice')]),
+    })
+    expect(out.satisfied).toBe(true)             // hard requirement met
+    expect(out.missing.length).toBe(1)           // soft shortfall surfaced
+    expect(out.missing[0]?.severity).toBe('soft')
+    expect(out.missing[0]).toMatchObject({ kind: 'role', role: 'note-taker', missing: 1 })
+  })
+
+  it('hard + soft both unmet → satisfied is false (hard drives the gate)', () => {
+    const out = evaluateRequirements({
+      event: event('e1', 'load'),
+      requirements: [{
+        eventType: 'load',
+        requires: [
+          { role: 'driver',     count: 1, severity: 'hard' },
+          { role: 'note-taker', count: 1, severity: 'soft' },
+        ],
+      }],
+      resources,
+      assignments: new Map(),
+    })
+    expect(out.satisfied).toBe(false)
+    expect(out.missing.map(m => m.severity)).toEqual(['hard', 'soft'])
+  })
+
+  it('only-soft requirements never block — satisfied:true even when fully unmet', () => {
+    const out = evaluateRequirements({
+      event: event('e1', 'load'),
+      requirements: [{
+        eventType: 'load',
+        requires: [{ role: 'note-taker', count: 2, severity: 'soft' }],
+      }],
+      resources,
+      assignments: new Map(),
+    })
+    expect(out.satisfied).toBe(true)
+    expect(out.missing[0]?.severity).toBe('soft')
+  })
+})
+
 describe('evaluateRequirements — mixed slots', () => {
   it('reports every shortfall in input order', () => {
     const resources = mapBy([
@@ -298,8 +366,8 @@ describe('evaluateRequirements — mixed slots', () => {
     })
     expect(out.satisfied).toBe(false)
     expect(out.missing).toEqual([
-      { kind: 'role', role: 'driver', required: 2, assigned: 1, missing: 1 },
-      { kind: 'pool', pool: 'fleet',  required: 2, assigned: 1, missing: 1 },
+      { kind: 'role', role: 'driver', required: 2, assigned: 1, missing: 1, severity: 'hard' },
+      { kind: 'pool', pool: 'fleet',  required: 2, assigned: 1, missing: 1, severity: 'hard' },
     ])
   })
 })

--- a/src/core/requirements/evaluateRequirements.ts
+++ b/src/core/requirements/evaluateRequirements.ts
@@ -29,7 +29,9 @@ import type { EngineResource } from '../engine/schema/resourceSchema'
 import type { Assignment } from '../engine/schema/assignmentSchema'
 import type { ResourcePool } from '../pools/resourcePoolSchema'
 import type { LatLon } from '../pools/geo'
-import type { ConfigRequirement, ConfigRequirementSlot } from '../config/calendarConfig'
+import type {
+  ConfigRequirement, ConfigRequirementSlot, ConfigRequirementSeverity,
+} from '../config/calendarConfig'
 import { evaluateQuery } from '../pools/evaluateQuery'
 
 export interface EvaluateRequirementsInput {
@@ -59,6 +61,14 @@ export type RequirementShortfall =
       readonly required: number
       readonly assigned: number
       readonly missing: number
+      /**
+       * Mirrors `ConfigRequirementSlot.severity` — defaults to
+       * `'hard'` when the slot didn't specify one. Only `hard`
+       * shortfalls flip `RequirementsEvaluation.satisfied` to false;
+       * `soft` shortfalls stay in `missing[]` for hosts to render
+       * as warnings.
+       */
+      readonly severity: ConfigRequirementSeverity
     }
   | {
       readonly kind: 'pool'
@@ -66,6 +76,7 @@ export type RequirementShortfall =
       readonly required: number
       readonly assigned: number
       readonly missing: number
+      readonly severity: ConfigRequirementSeverity
       /**
        * `true` when the slot pointed at a pool id that isn't in the
        * `pools` map. The shortfall surfaces with `assigned: 0` so
@@ -128,7 +139,13 @@ export function evaluateRequirements(
     if (shortfall) missing.push(shortfall)
   }
 
-  return { satisfied: missing.length === 0, missing, noTemplate: false }
+  // `satisfied` reflects only HARD shortfalls. Soft shortfalls
+  // surface in `missing[]` with their severity tag so hosts can
+  // render warnings, but they don't fail the evaluation. The empty
+  // hard set short-circuits to `true` even when soft shortfalls
+  // exist — that's exactly what soft means.
+  const satisfied = !missing.some(s => s.severity === 'hard')
+  return { satisfied, missing, noTemplate: false }
 }
 
 // ─── Internals ──────────────────────────────────────────────────────────────
@@ -142,6 +159,7 @@ interface SlotContext {
 }
 
 function checkSlot(slot: ConfigRequirementSlot, ctx: SlotContext): RequirementShortfall | null {
+  const severity: ConfigRequirementSeverity = slot.severity ?? 'hard'
   if ('role' in slot) {
     const assigned = countRoleAssignments(slot.role, ctx)
     if (assigned >= slot.count) return null
@@ -149,6 +167,7 @@ function checkSlot(slot: ConfigRequirementSlot, ctx: SlotContext): RequirementSh
       kind: 'role', role: slot.role,
       required: slot.count, assigned,
       missing: slot.count - assigned,
+      severity,
     }
   }
   // pool slot
@@ -157,7 +176,7 @@ function checkSlot(slot: ConfigRequirementSlot, ctx: SlotContext): RequirementSh
     return {
       kind: 'pool', pool: slot.pool,
       required: slot.count, assigned: 0,
-      missing: slot.count, poolUnknown: true,
+      missing: slot.count, severity, poolUnknown: true,
     }
   }
   const assigned = countPoolAssignments(members, ctx)
@@ -166,6 +185,7 @@ function checkSlot(slot: ConfigRequirementSlot, ctx: SlotContext): RequirementSh
     kind: 'pool', pool: slot.pool,
     required: slot.count, assigned,
     missing: slot.count - assigned,
+    severity,
   }
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -205,6 +205,7 @@ export { serializeConfig } from './core/config/serializeConfig';
 export type {
   CalendarConfig, ConfigLabels, ConfigResourceType, ConfigRole,
   ConfigResource, ConfigRequirement, ConfigRequirementSlot,
+  ConfigRequirementSeverity,
   ConfigSeedEvent, ConfigSettings,
 } from './core/config/calendarConfig';
 export { validateConfig } from './core/config/validateConfig';


### PR DESCRIPTION
Closes #450.

## Summary

Adds an optional `severity: 'hard' | 'soft'` to each `ConfigRequirementSlot` so a template can declare *"this load **prefers** a co-driver"* without rejecting the booking when no co-driver is available.

Fully additive — slots default to `severity: 'hard'` when omitted, and templates that don't mention severity round-trip without surfacing it in their JSON.

## Behavior

| Slot severity | Met? | `missing[]` | `satisfied` |
|---------------|------|-------------|--------------|
| `hard` (default) | yes | (omitted)  | `true` |
| `hard` (default) | no  | shortfall + `severity: 'hard'` | **`false`** |
| `soft`           | yes | (omitted)  | `true` |
| `soft`           | no  | shortfall + `severity: 'soft'` | `true` (warn only) |

`satisfied` reflects only hard shortfalls; soft ones surface in `missing[]` for hosts to render as warnings. Engine integration (the gating PR — #448) reads `severity` to decide whether to block.

## Test plan

- [x] `tsc --noEmit` clean
- [x] `vitest run` — 2446 passing, 2 skipped (pre-existing PTO flakes), 0 failures (5 new tests)
- [x] Omitted severity defaults to `'hard'`
- [x] Soft shortfalls surface but don't flip `satisfied`
- [x] Mixed hard + soft unmet: hard drives the gate
- [x] All-soft unmet: `satisfied: true`, warnings still in `missing[]`
- [x] `parseConfig` round-trip + unknown-severity is logged-and-ignored

## Note on stack

#449 (per-assignment `roleId`) is also in flight on a separate branch. The two PRs touch independent fields (`Assignment.roleId` vs. `ConfigRequirementSlot.severity` + `RequirementShortfall.severity`); they should rebase cleanly past each other in either order.

https://claude.ai/code/session_01XojXzZPdEPuGbX2TyLY1pu

---
_Generated by [Claude Code](https://claude.ai/code/session_01XojXzZPdEPuGbX2TyLY1pu)_