### PR TITLE
ui(pools): validate clause paths against live registry (#452)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -197,6 +197,8 @@ export type { AdvancedRulesEditorProps } from './ui/pools/AdvancedRulesEditor';
 export { summarizePool, summarizeQuery } from './ui/pools/poolSummary';
 export type { PoolSummary } from './ui/pools/poolSummary';
 export { derivePathSuggestions } from './ui/pools/pathSuggestions';
+export { validateClausePaths } from './ui/pools/validateClausePaths';
+export type { ValidateClausePathsResult, ClausePathIssue } from './ui/pools/validateClausePaths';
 export type { CapabilityRange } from './ui/pools/PoolBuilder';
 // ── CalendarConfig — standard config.json shape (#386 wizard) ─────────────
 export { parseConfig } from './core/config/parseConfig';

--- a/src/ui/pools/AdvancedRulesEditor.module.css
+++ b/src/ui/pools/AdvancedRulesEditor.module.css
@@ -50,6 +50,19 @@
   flex-shrink: 0;
 }
 
+.warningChip {
+  display: inline-block;
+  padding: 2px 8px;
+  font-size: 11px;
+  font-weight: 500;
+  color: #b45309;
+  background: #fef3c7;
+  border: 1px solid #fcd34d;
+  border-radius: 999px;
+  white-space: nowrap;
+  cursor: help;
+}
+
 .rowBtn {
   padding: 3px 9px;
   font-size: 12px;

--- a/src/ui/pools/AdvancedRulesEditor.tsx
+++ b/src/ui/pools/AdvancedRulesEditor.tsx
@@ -10,10 +10,12 @@
  * changes via `onChange`. The parent (`PoolBuilder`) owns the array
  * and AND-merges it with the simple-form clauses on save.
  */
-import { useState } from 'react'
+import { useMemo, useState } from 'react'
 import type { ResourceQuery } from '../../core/pools/poolQuerySchema'
+import type { EngineResource } from '../../core/engine/schema/resourceSchema'
 import ClauseEditor from './ClauseEditor'
 import { summarizeQuery } from './poolSummary'
+import { validateClausePaths } from './validateClausePaths'
 import styles from './AdvancedRulesEditor.module.css'
 
 export interface AdvancedRulesEditorProps {
@@ -25,14 +27,31 @@ export interface AdvancedRulesEditorProps {
    * `derivePathSuggestions(resources)`.
    */
   readonly pathSuggestions?: readonly string[] | undefined
+  /**
+   * Optional live registry. When provided, each row computes
+   * `validateClausePaths` and surfaces a warning chip on the
+   * summary when one or more paths in the clause don't resolve on
+   * any resource. The chip is informational; it never blocks
+   * editing — paths that don't resolve today are sometimes
+   * intentional (forward-looking schemas / optional capabilities).
+   */
+  readonly resources?: ReadonlyMap<string, EngineResource> | readonly EngineResource[] | undefined
 }
 
 const DEFAULT_NEW_CLAUSE: ResourceQuery = { op: 'eq', path: '', value: '' }
 
 export default function AdvancedRulesEditor({
-  clauses, onChange, pathSuggestions,
+  clauses, onChange, pathSuggestions, resources,
 }: AdvancedRulesEditorProps): JSX.Element {
   const [editingIndex, setEditingIndex] = useState<number | null>(null)
+
+  // Per-row path validation against the live registry. Re-runs only
+  // when the clause list or registry changes; cheap enough to do
+  // inline since each clause is small and the registry is bounded.
+  const unresolvedByRow = useMemo(() => {
+    if (!resources) return [] as ReadonlyArray<ReadonlySet<string>>
+    return clauses.map(c => validateClausePaths(c, resources).byPath)
+  }, [clauses, resources])
 
   const updateAt = (index: number, next: ResourceQuery) =>
     onChange(clauses.map((c, i) => i === index ? next : c))
@@ -70,12 +89,24 @@ export default function AdvancedRulesEditor({
         {clauses.map((c, i) => {
           const phrase = summarizeQuery(c).join(' & ') || `${c.op}(...)`
           const isEditing = editingIndex === i
+          const unresolved = unresolvedByRow[i] ?? null
+          const unresolvedCount = unresolved ? unresolved.size : 0
           return (
-            <li key={i} className={styles['row']}>
+            <li key={i} className={styles['row']} data-has-unresolved={unresolvedCount > 0 ? 'true' : undefined}>
               <div className={styles['rowHead']}>
                 <span className={styles['summary']} data-testid={`advanced-rule-summary-${i}`}>
                   {phrase}
                 </span>
+                {unresolvedCount > 0 && (
+                  <span
+                    className={styles['warningChip']}
+                    role="status"
+                    title={`${unresolvedCount} path(s) don't resolve on any live resource: ${[...unresolved!].join(', ')}`}
+                    data-testid={`advanced-rule-warning-${i}`}
+                  >
+                    ⚠ {unresolvedCount} unresolved
+                  </span>
+                )}
                 <span className={styles['rowActions']}>
                   <button
                     type="button"
@@ -115,6 +146,7 @@ export default function AdvancedRulesEditor({
                   <ClauseEditor
                     clause={c}
                     pathSuggestions={pathSuggestions}
+                    unresolvedPaths={unresolved ?? undefined}
                     onChange={(next) => updateAt(i, next)}
                   />
                 </div>

--- a/src/ui/pools/ClauseEditor.module.css
+++ b/src/ui/pools/ClauseEditor.module.css
@@ -74,6 +74,31 @@
   flex: 1;
 }
 
+.pathInputWrap {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  flex: 1;
+  min-width: 160px;
+}
+
+.pathInputWrap .pathInput {
+  flex: 1;
+  min-width: 0;
+}
+
+.pathInput[data-unresolved='true'] {
+  border-color: #f59e0b;
+}
+
+.pathWarning {
+  flex: 0 0 auto;
+  font-size: 14px;
+  color: #b45309;
+  line-height: 1;
+  cursor: help;
+}
+
 .pathInput {
   flex: 1;
   min-width: 160px;

--- a/src/ui/pools/ClauseEditor.tsx
+++ b/src/ui/pools/ClauseEditor.tsx
@@ -41,6 +41,14 @@ export interface ClauseEditorProps {
    */
   readonly pathSuggestions?: readonly string[] | undefined
   /**
+   * Optional set of paths that don't resolve on any live resource —
+   * typically `validateClausePaths(query, resources).byPath`. When a
+   * leaf's `path` is in this set, the editor renders a small ⚠
+   * indicator next to the input. Informational only: the editor
+   * still accepts the path so forward-looking schemas keep working.
+   */
+  readonly unresolvedPaths?: ReadonlySet<string> | undefined
+  /**
    * Internal — the root editor passes its datalist id to every
    * nested clause so every path input references the same
    * `<datalist>` (which only the root renders). Hosts shouldn't
@@ -65,7 +73,7 @@ const ALL_OPS: readonly { value: ResourceQuery['op']; label: string; group: 'log
 ]
 
 export default function ClauseEditor({
-  clause, onChange, hideOpPicker, depth = 0, pathSuggestions,
+  clause, onChange, hideOpPicker, depth = 0, pathSuggestions, unresolvedPaths,
   datalistId: parentDatalistId,
 }: ClauseEditorProps): JSX.Element {
   // Hard cap to keep nesting from spiralling. The user can lift it by
@@ -120,32 +128,33 @@ export default function ClauseEditor({
           depth={depth}
           atCap={atDepthCap}
           pathSuggestions={pathSuggestions}
+          unresolvedPaths={unresolvedPaths}
           datalistId={datalistId}
         />
       )}
 
       {clause.op === 'not' && (
-        <NotBody clause={clause} onChange={onChange} depth={depth} pathSuggestions={pathSuggestions} datalistId={datalistId} />
+        <NotBody clause={clause} onChange={onChange} depth={depth} pathSuggestions={pathSuggestions} unresolvedPaths={unresolvedPaths} datalistId={datalistId} />
       )}
 
       {(clause.op === 'eq' || clause.op === 'neq') && (
-        <EqBody clause={clause} onChange={onChange} datalistId={datalistId} />
+        <EqBody clause={clause} onChange={onChange} datalistId={datalistId} unresolvedPaths={unresolvedPaths} />
       )}
 
       {(clause.op === 'gt' || clause.op === 'gte' || clause.op === 'lt' || clause.op === 'lte') && (
-        <NumericBody clause={clause} onChange={onChange} datalistId={datalistId} />
+        <NumericBody clause={clause} onChange={onChange} datalistId={datalistId} unresolvedPaths={unresolvedPaths} />
       )}
 
       {clause.op === 'in' && (
-        <InBody clause={clause} onChange={onChange} datalistId={datalistId} />
+        <InBody clause={clause} onChange={onChange} datalistId={datalistId} unresolvedPaths={unresolvedPaths} />
       )}
 
       {clause.op === 'exists' && (
-        <ExistsBody clause={clause} onChange={onChange} datalistId={datalistId} />
+        <ExistsBody clause={clause} onChange={onChange} datalistId={datalistId} unresolvedPaths={unresolvedPaths} />
       )}
 
       {clause.op === 'within' && (
-        <WithinBody clause={clause} onChange={onChange} datalistId={datalistId} />
+        <WithinBody clause={clause} onChange={onChange} datalistId={datalistId} unresolvedPaths={unresolvedPaths} />
       )}
 
       {/* The datalist lives on the outer container so every leaf
@@ -163,13 +172,14 @@ export default function ClauseEditor({
 // ─── Bodies ────────────────────────────────────────────────────────────────
 
 function CompositeBody({
-  clause, onChange, depth, atCap, pathSuggestions, datalistId,
+  clause, onChange, depth, atCap, pathSuggestions, unresolvedPaths, datalistId,
 }: {
   clause: Extract<ResourceQuery, { op: 'and' | 'or' }>
   onChange: (next: ResourceQuery) => void
   depth: number
   atCap: boolean
   pathSuggestions?: readonly string[] | undefined
+  unresolvedPaths?: ReadonlySet<string> | undefined
   datalistId: string
 }): JSX.Element {
   // Move helpers — out-of-bounds moves are no-ops so the buttons can
@@ -197,6 +207,7 @@ function CompositeBody({
               clause={c}
               depth={depth + 1}
               pathSuggestions={pathSuggestions}
+              unresolvedPaths={unresolvedPaths}
               datalistId={datalistId}
               onChange={(next) => onChange({
                 ...clause,
@@ -250,12 +261,13 @@ function CompositeBody({
 }
 
 function NotBody({
-  clause, onChange, depth, pathSuggestions, datalistId,
+  clause, onChange, depth, pathSuggestions, unresolvedPaths, datalistId,
 }: {
   clause: Extract<ResourceQuery, { op: 'not' }>
   onChange: (next: ResourceQuery) => void
   depth: number
   pathSuggestions?: readonly string[] | undefined
+  unresolvedPaths?: ReadonlySet<string> | undefined
   datalistId?: string | undefined
 }): JSX.Element {
   return (
@@ -264,6 +276,7 @@ function NotBody({
         clause={clause.clause}
         depth={depth + 1}
         pathSuggestions={pathSuggestions}
+        unresolvedPaths={unresolvedPaths}
         datalistId={datalistId}
         onChange={(inner) => onChange({ ...clause, clause: inner })}
       />
@@ -272,15 +285,16 @@ function NotBody({
 }
 
 function EqBody({
-  clause, onChange, datalistId,
+  clause, onChange, datalistId, unresolvedPaths,
 }: {
   clause: Extract<ResourceQuery, { op: 'eq' | 'neq' }>
   onChange: (next: ResourceQuery) => void
   datalistId?: string | undefined
+  unresolvedPaths?: ReadonlySet<string> | undefined
 }): JSX.Element {
   return (
     <div className={styles['leafBody']}>
-      <PathInput value={clause.path} onChange={(path) => onChange({ ...clause, path })} datalistId={datalistId} />
+      <PathInput value={clause.path} onChange={(path) => onChange({ ...clause, path })} datalistId={datalistId} unresolved={!!(unresolvedPaths && clause.path && unresolvedPaths.has(clause.path))} />
       <ValueInput
         value={clause.value}
         onChange={(value) => onChange({ ...clause, value })}
@@ -290,15 +304,16 @@ function EqBody({
 }
 
 function NumericBody({
-  clause, onChange, datalistId,
+  clause, onChange, datalistId, unresolvedPaths,
 }: {
   clause: Extract<ResourceQuery, { op: 'gt' | 'gte' | 'lt' | 'lte' }>
   onChange: (next: ResourceQuery) => void
   datalistId?: string | undefined
+  unresolvedPaths?: ReadonlySet<string> | undefined
 }): JSX.Element {
   return (
     <div className={styles['leafBody']}>
-      <PathInput value={clause.path} onChange={(path) => onChange({ ...clause, path })} datalistId={datalistId} />
+      <PathInput value={clause.path} onChange={(path) => onChange({ ...clause, path })} datalistId={datalistId} unresolved={!!(unresolvedPaths && clause.path && unresolvedPaths.has(clause.path))} />
       <input
         type="number"
         className={styles['numInput']}
@@ -312,15 +327,16 @@ function NumericBody({
 }
 
 function InBody({
-  clause, onChange, datalistId,
+  clause, onChange, datalistId, unresolvedPaths,
 }: {
   clause: Extract<ResourceQuery, { op: 'in' }>
   onChange: (next: ResourceQuery) => void
   datalistId?: string | undefined
+  unresolvedPaths?: ReadonlySet<string> | undefined
 }): JSX.Element {
   return (
     <div className={styles['leafBody']}>
-      <PathInput value={clause.path} onChange={(path) => onChange({ ...clause, path })} datalistId={datalistId} />
+      <PathInput value={clause.path} onChange={(path) => onChange({ ...clause, path })} datalistId={datalistId} unresolved={!!(unresolvedPaths && clause.path && unresolvedPaths.has(clause.path))} />
       <input
         type="text"
         className={styles['valuesInput']}
@@ -338,31 +354,33 @@ function InBody({
 }
 
 function ExistsBody({
-  clause, onChange, datalistId,
+  clause, onChange, datalistId, unresolvedPaths,
 }: {
   clause: Extract<ResourceQuery, { op: 'exists' }>
   onChange: (next: ResourceQuery) => void
   datalistId?: string | undefined
+  unresolvedPaths?: ReadonlySet<string> | undefined
 }): JSX.Element {
   return (
     <div className={styles['leafBody']}>
-      <PathInput value={clause.path} onChange={(path) => onChange({ ...clause, path })} datalistId={datalistId} />
+      <PathInput value={clause.path} onChange={(path) => onChange({ ...clause, path })} datalistId={datalistId} unresolved={!!(unresolvedPaths && clause.path && unresolvedPaths.has(clause.path))} />
     </div>
   )
 }
 
 function WithinBody({
-  clause, onChange, datalistId,
+  clause, onChange, datalistId, unresolvedPaths,
 }: {
   clause: Extract<ResourceQuery, { op: 'within' }>
   onChange: (next: ResourceQuery) => void
   datalistId?: string | undefined
+  unresolvedPaths?: ReadonlySet<string> | undefined
 }): JSX.Element {
   const fromKind = clause.from.kind
   const usingMiles = clause.km == null
   return (
     <div className={styles['leafBody']}>
-      <PathInput value={clause.path} onChange={(path) => onChange({ ...clause, path })} datalistId={datalistId} />
+      <PathInput value={clause.path} onChange={(path) => onChange({ ...clause, path })} datalistId={datalistId} unresolved={!!(unresolvedPaths && clause.path && unresolvedPaths.has(clause.path))} />
       <select
         className={styles['fromKindPicker']}
         value={fromKind}
@@ -436,22 +454,41 @@ function WithinBody({
 // ─── Shared inputs ─────────────────────────────────────────────────────────
 
 function PathInput({
-  value, onChange, datalistId,
+  value, onChange, datalistId, unresolved,
 }: {
   value: string
   onChange: (v: string) => void
   datalistId?: string | undefined
+  /**
+   * `true` when the parent has determined this path doesn't resolve
+   * on any live resource. Renders a small ⚠ next to the input —
+   * informational; doesn't block input.
+   */
+  unresolved?: boolean
 }): JSX.Element {
   return (
-    <input
-      type="text"
-      className={styles['pathInput']}
-      value={value}
-      placeholder="meta.capabilities.refrigerated"
-      aria-label="Field path"
-      list={datalistId}
-      onChange={(e: ChangeEvent<HTMLInputElement>) => onChange(e.target.value)}
-    />
+    <span className={styles['pathInputWrap']}>
+      <input
+        type="text"
+        className={styles['pathInput']}
+        value={value}
+        placeholder="meta.capabilities.refrigerated"
+        aria-label="Field path"
+        list={datalistId}
+        aria-invalid={unresolved ? 'true' : undefined}
+        data-unresolved={unresolved ? 'true' : undefined}
+        onChange={(e: ChangeEvent<HTMLInputElement>) => onChange(e.target.value)}
+      />
+      {unresolved && (
+        <span
+          className={styles['pathWarning']}
+          role="img"
+          aria-label="Path not found on any resource"
+          title="This path doesn't resolve on any live resource. Could be a typo, or a forward-looking schema."
+          data-testid="clause-path-warning"
+        >⚠</span>
+      )}
+    </span>
   )
 }
 

--- a/src/ui/pools/PoolBuilder.tsx
+++ b/src/ui/pools/PoolBuilder.tsx
@@ -384,7 +384,7 @@ export default function PoolBuilder(props: PoolBuilderProps): JSX.Element {
             <AdvancedRulesEditor
               clauses={draft.preserved}
               pathSuggestions={pathSuggestions}
-              resources={resourceList}
+              resources={resourceList.length > 0 ? resourceList : undefined}
               onChange={(next) => setDraft(d => ({ ...d, preserved: next }))}
             />
           </details>

--- a/src/ui/pools/PoolBuilder.tsx
+++ b/src/ui/pools/PoolBuilder.tsx
@@ -384,6 +384,7 @@ export default function PoolBuilder(props: PoolBuilderProps): JSX.Element {
             <AdvancedRulesEditor
               clauses={draft.preserved}
               pathSuggestions={pathSuggestions}
+              resources={resourceList}
               onChange={(next) => setDraft(d => ({ ...d, preserved: next }))}
             />
           </details>

--- a/src/ui/pools/__tests__/AdvancedRulesEditor.test.tsx
+++ b/src/ui/pools/__tests__/AdvancedRulesEditor.test.tsx
@@ -108,3 +108,65 @@ describe('AdvancedRulesEditor — summaries + edit toggle', () => {
     ])
   })
 })
+
+describe('AdvancedRulesEditor — path validation chip (#452)', () => {
+  const r = (id: string, meta: Record<string, unknown> = {}) =>
+    ({ id, name: id.toUpperCase(), meta }) as unknown as { id: string; name: string; meta: Record<string, unknown> }
+  const fleet = [r('t1', { capabilities: { refrigerated: true } })]
+
+  function ChipHarness({ initial, withResources }: {
+    initial: readonly ResourceQuery[]
+    withResources: boolean
+  }) {
+    const [c, setC] = useState<readonly ResourceQuery[]>(initial)
+    return withResources
+      ? <AdvancedRulesEditor clauses={c} onChange={setC} resources={fleet as never} />
+      : <AdvancedRulesEditor clauses={c} onChange={setC} />
+  }
+
+  it('shows a warning chip when a row has unresolved paths', () => {
+    render(<ChipHarness
+      initial={[
+        { op: 'eq', path: 'meta.capabilities.refridgerated', value: true } as ResourceQuery,
+      ]}
+      withResources
+    />)
+    const chip = screen.getByTestId('advanced-rule-warning-0')
+    expect(chip).toHaveTextContent('1 unresolved')
+    expect(chip.getAttribute('title')).toContain('meta.capabilities.refridgerated')
+  })
+
+  it('omits the chip when every path resolves', () => {
+    render(<ChipHarness
+      initial={[
+        { op: 'eq', path: 'meta.capabilities.refrigerated', value: true } as ResourceQuery,
+      ]}
+      withResources
+    />)
+    expect(screen.queryByTestId('advanced-rule-warning-0')).toBeNull()
+  })
+
+  it('does nothing without resources (validation is opt-in)', () => {
+    render(<ChipHarness
+      initial={[
+        { op: 'eq', path: 'meta.bogus', value: true } as ResourceQuery,
+      ]}
+      withResources={false}
+    />)
+    expect(screen.queryByTestId('advanced-rule-warning-0')).toBeNull()
+  })
+
+  it('opens the row editor and shows the inline ⚠ next to the bad path', () => {
+    render(<ChipHarness
+      initial={[
+        { op: 'eq', path: 'meta.bogus', value: true } as ResourceQuery,
+      ]}
+      withResources
+    />)
+    fireEvent.click(screen.getByRole('button', { name: 'Edit' }))
+    const warning = screen.getByTestId('clause-path-warning')
+    expect(warning).toBeInTheDocument()
+    const pathInput = screen.getByLabelText('Field path')
+    expect(pathInput).toHaveAttribute('aria-invalid', 'true')
+  })
+})

--- a/src/ui/pools/__tests__/validateClausePaths.test.ts
+++ b/src/ui/pools/__tests__/validateClausePaths.test.ts
@@ -1,0 +1,100 @@
+/**
+ * `validateClausePaths` — soft path-existence check (#452).
+ */
+import { describe, it, expect } from 'vitest'
+import { validateClausePaths } from '../validateClausePaths'
+import type { ResourceQuery } from '../../../core/pools/poolQuerySchema'
+import type { EngineResource } from '../../../core/engine/schema/resourceSchema'
+
+const r = (id: string, meta: Record<string, unknown> = {}): EngineResource =>
+  ({ id, name: id.toUpperCase(), meta } as EngineResource)
+
+const fleet: readonly EngineResource[] = [
+  r('t1', { capabilities: { refrigerated: true,  capacity_lbs: 80000 }, location: { lat: 40, lon: -111 } }),
+  r('t2', { capabilities: { refrigerated: false, capacity_lbs: 60000 } }),
+]
+
+describe('validateClausePaths', () => {
+  it('returns ok when every leaf path resolves on at least one resource', () => {
+    const q: ResourceQuery = { op: 'eq', path: 'meta.capabilities.refrigerated', value: true }
+    const r = validateClausePaths(q, fleet)
+    expect(r.ok).toBe(true)
+    expect(r.unresolved).toEqual([])
+    expect(r.byPath.size).toBe(0)
+  })
+
+  it('flags a typo on the leaf path', () => {
+    const q: ResourceQuery = { op: 'eq', path: 'meta.capabilities.refridgerated', value: true }
+    const out = validateClausePaths(q, fleet)
+    expect(out.ok).toBe(false)
+    expect(out.unresolved.map(u => u.path)).toEqual(['meta.capabilities.refridgerated'])
+    expect(out.byPath.has('meta.capabilities.refridgerated')).toBe(true)
+  })
+
+  it('walks AND/OR composites and reports each unresolved leaf', () => {
+    const q: ResourceQuery = {
+      op: 'and',
+      clauses: [
+        { op: 'eq',  path: 'meta.capabilities.refrigerated', value: true },         // resolves
+        { op: 'gte', path: 'meta.capabilities.capacity_kg',  value: 80000 },        // typo (lbs vs kg)
+        { op: 'eq',  path: 'meta.bogus',                     value: 'x' },           // unknown
+      ],
+    }
+    const out = validateClausePaths(q, fleet)
+    expect(out.unresolved.map(u => u.path)).toEqual([
+      'meta.capabilities.capacity_kg',
+      'meta.bogus',
+    ])
+  })
+
+  it('walks NOT to its inner clause', () => {
+    const q: ResourceQuery = {
+      op: 'not',
+      clause: { op: 'eq', path: 'meta.absent', value: 1 },
+    }
+    expect(validateClausePaths(q, fleet).unresolved.map(u => u.path)).toEqual(['meta.absent'])
+  })
+
+  it('counts repeated paths but reports each path once', () => {
+    const q: ResourceQuery = {
+      op: 'and',
+      clauses: [
+        { op: 'gte', path: 'meta.bogus', value: 1 },
+        { op: 'lte', path: 'meta.bogus', value: 5 },
+      ],
+    }
+    const out = validateClausePaths(q, fleet)
+    expect(out.unresolved.length).toBe(1)
+    expect(out.unresolved[0]?.count).toBe(2)
+  })
+
+  it('treats top-level fields (id, name, tenantId, …) as resolvable', () => {
+    const q: ResourceQuery = { op: 'eq', path: 'name', value: 'T1' }
+    expect(validateClausePaths(q, fleet).ok).toBe(true)
+  })
+
+  it('handles the within op (its `path` participates like any leaf)', () => {
+    const q: ResourceQuery = {
+      op: 'within', path: 'meta.location',
+      from: { kind: 'point', lat: 40, lon: -111 }, miles: 50,
+    }
+    expect(validateClausePaths(q, fleet).ok).toBe(true)
+
+    const bad: ResourceQuery = {
+      op: 'within', path: 'meta.absent.location',
+      from: { kind: 'point', lat: 40, lon: -111 }, miles: 50,
+    }
+    expect(validateClausePaths(bad, fleet).ok).toBe(false)
+  })
+
+  it('skips empty path strings (avoid noise on blank leaves)', () => {
+    const q: ResourceQuery = { op: 'eq', path: '', value: '' }
+    expect(validateClausePaths(q, fleet).ok).toBe(true)
+  })
+
+  it('accepts a Map of resources interchangeably with an array', () => {
+    const map = new Map(fleet.map(x => [x.id, x]))
+    const q: ResourceQuery = { op: 'eq', path: 'meta.bogus', value: 1 }
+    expect(validateClausePaths(q, map)).toEqual(validateClausePaths(q, fleet))
+  })
+})

--- a/src/ui/pools/validateClausePaths.ts
+++ b/src/ui/pools/validateClausePaths.ts
@@ -1,0 +1,111 @@
+/**
+ * `validateClausePaths` — soft path-existence check for the
+ * advanced rules editor (#452).
+ *
+ * `ClauseEditor`'s path input accepts any string. With a live
+ * registry to consult, we can flag *"this path resolves on zero
+ * resources"* so users catch typos before saving — without
+ * rejecting the save, since paths that don't currently resolve
+ * are sometimes intentional (forward-looking schemas, optional
+ * capabilities the host hasn't populated yet).
+ *
+ * Pure / sync. Returns the list of unresolved paths in clause
+ * order plus a flat `byPath` set for quick lookup. Composite ops
+ * (and / or / not) walk their children; the `within` op
+ * contributes its `path` like any other leaf.
+ */
+import type { ResourceQuery } from '../../core/pools/poolQuerySchema'
+import type { EngineResource } from '../../core/engine/schema/resourceSchema'
+
+const TOP_LEVEL_KEYS: ReadonlySet<string> = new Set([
+  'id', 'name', 'tenantId', 'capacity', 'color', 'timezone',
+])
+
+export interface ClausePathIssue {
+  /** The literal path string the user typed. */
+  readonly path: string
+  /** How many leaf clauses in the tree referenced this path. */
+  readonly count: number
+}
+
+export interface ValidateClausePathsResult {
+  /** True when every path resolves on at least one resource. */
+  readonly ok: boolean
+  /** Per-unresolved-path issue descriptors, sorted by first occurrence. */
+  readonly unresolved: readonly ClausePathIssue[]
+  /** Quick membership set for "is this specific path unresolved?". */
+  readonly byPath: ReadonlySet<string>
+}
+
+export function validateClausePaths(
+  query: ResourceQuery,
+  resources: ReadonlyMap<string, EngineResource> | readonly EngineResource[],
+): ValidateClausePathsResult {
+  const list = resources instanceof Map
+    ? Array.from(resources.values())
+    : resources as readonly EngineResource[]
+
+  // Walk every leaf clause once, collect distinct paths in order.
+  const seen: string[] = []
+  const counts = new Map<string, number>()
+  collectPaths(query, (p) => {
+    if (!counts.has(p)) seen.push(p)
+    counts.set(p, (counts.get(p) ?? 0) + 1)
+  })
+
+  const unresolvedPaths: string[] = []
+  for (const path of seen) {
+    if (!resolvesOnAny(path, list)) unresolvedPaths.push(path)
+  }
+  const unresolved: ClausePathIssue[] = unresolvedPaths.map(p => ({
+    path: p, count: counts.get(p) ?? 1,
+  }))
+  return {
+    ok: unresolved.length === 0,
+    unresolved,
+    byPath: new Set(unresolvedPaths),
+  }
+}
+
+// ─── Internals ────────────────────────────────────────────────────────────
+
+function collectPaths(q: ResourceQuery, push: (p: string) => void): void {
+  switch (q.op) {
+    case 'and':
+    case 'or':
+      for (const c of q.clauses) collectPaths(c, push)
+      return
+    case 'not':
+      collectPaths(q.clause, push)
+      return
+    default:
+      // Every leaf op (eq / neq / in / gt / gte / lt / lte / exists /
+      // within) carries a `path` field of the same shape.
+      if (typeof q.path === 'string' && q.path.length > 0) push(q.path)
+      return
+  }
+}
+
+function resolvesOnAny(path: string, resources: readonly EngineResource[]): boolean {
+  for (const r of resources) {
+    if (readPath(r, path) !== undefined) return true
+  }
+  return false
+}
+
+function readPath(r: EngineResource, path: string): unknown {
+  if (TOP_LEVEL_KEYS.has(path)) {
+    return (r as unknown as Record<string, unknown>)[path]
+  }
+  // Bare `meta.x` and `x` resolve to `r.meta.x`. Mirrors evaluateQuery's
+  // path semantics so warnings match what the resolver actually checks.
+  const segments = path.startsWith('meta.')
+    ? path.slice(5).split('.')
+    : path.split('.')
+  let cursor: unknown = r.meta
+  for (const seg of segments) {
+    if (cursor == null || typeof cursor !== 'object') return undefined
+    cursor = (cursor as Record<string, unknown>)[seg]
+  }
+  return cursor
+}


### PR DESCRIPTION
Adds soft path-existence checks for ResourceQuery clauses against the live resource fleet — surfaces typos like `refridgerated` without blocking input.

- New `validateClausePaths(query, resources)` walks AND/OR/NOT composites and resolves each leaf path against actual resources; returns `{ ok, unresolved, byPath }`.
- AdvancedRulesEditor: per-row warning chip on collapsed summaries and inline ⚠ next to the offending Field path input when a row is opened. Validation is opt-in (passes through when no `resources` prop is supplied).
- ClauseEditor: PathInput renders ⚠ + `aria-invalid="true"` when the parent flags the path as unresolved. Threaded through composite/leaf bodies via `unresolvedPaths` prop.
- PoolBuilder forwards its `resourceList` to AdvancedRulesEditor.

Closes #452.

## Summary
Describe exactly what this PR changes.

## Scope
- Stage: 
- Planned PR number in sprint: 
- Target files/directories: 
- Why this slice is isolated: 

## Lessons Learned Check (REQUIRED)
Confirm these were actively used while building this PR:

- [ ] PR is intentionally small and isolated
- [ ] Boundary typing was prioritized over internal perfection
- [ ] No silent spread of `any`
- [ ] Advisory root `tsc` was used to catch integration issues
- [ ] I did not assume “looks typed” means “safe”
- [ ] I stopped and isolated typing cascades instead of expanding scope

## Definition of Done (ALL REQUIRED)
This PR is not done unless every box is checked.

- [ ] `npm run type-check:strict` passes
- [ ] Root advisory `tsc --noEmit` passes
- [ ] Tests pass for touched scope at minimum
- [ ] No uncontrolled increase in `any`
- [ ] All new types are intentional and named
- [ ] Public interfaces and exported functions are explicitly typed
- [ ] PR scope matches the sprint plan with no scope creep
- [ ] Any new `any` has an adjacent justification comment
- [ ] No file-wide `: any`
- [ ] No implicit `any` in exported functions

## What Was Typed
List exactly what was typed in this PR.

- 
- 
- 

## What Was Intentionally Left Loose
List anything intentionally not tightened yet.

- 
- 
- 

## `any` Ledger (REQUIRED)
- New `any` added: 
- Existing `any` removed: 
- Net change: 

For every new `any`, explain why it is required and why a safer type was not used yet.

1. 
2. 
3. 

## Boundary Notes
Document any public seams, caller-protection choices, or compatibility decisions.

- 
- 
- 

## Risk Level
- [ ] Low
- [ ] Medium
- [ ] High

Why:

## Validation Evidence
Paste the exact commands run and a short result summary.

```bash
npm run type-check:strict
npx tsc --noEmit -p tsconfig.json
```

Test commands run:

```bash
# paste commands here
```

## Stop Conditions Check
If any item below happened, explain how scope was reduced before merge.

- [ ] `any` started spreading across files
- [ ] Root `tsc` broke repeatedly
- [ ] Types required cross-module rewrites
- [ ] Scope was reduced to keep the PR reviewable

Notes:

## Reviewer Focus
What should reviewers look at first?

- 
- 
- 
