### PR TITLE
ui(pools): depth rails on composite + NOT clauses (#453)

### DIFF
--- a/src/ui/pools/ClauseEditor.module.css
+++ b/src/ui/pools/ClauseEditor.module.css
@@ -43,19 +43,48 @@
   padding: 6px 0 0;
 }
 
+/*
+ * Depth lines — a thin vertical "rail" runs down the gutter of each
+ * composite's child list, with a short horizontal stub branching out
+ * to every child row. The pattern mirrors a tree view so it's clear
+ * at a glance which sub-rules belong to which AND/OR group, even at
+ * deeper nesting levels where the background tint alone gets noisy.
+ */
 .childList {
   list-style: none;
   margin: 0;
-  padding: 0;
+  padding: 0 0 0 16px;
+  position: relative;
   display: flex;
   flex-direction: column;
   gap: 6px;
+}
+
+.childList::before {
+  content: '';
+  position: absolute;
+  left: 6px;
+  top: 0;
+  bottom: 6px;
+  width: 1px;
+  background: var(--wc-border-strong, #cbd5e1);
 }
 
 .child {
   display: flex;
   gap: 6px;
   align-items: flex-start;
+  position: relative;
+}
+
+.child::before {
+  content: '';
+  position: absolute;
+  left: -10px;
+  top: 18px;
+  width: 10px;
+  height: 1px;
+  background: var(--wc-border-strong, #cbd5e1);
 }
 
 .child > .clause {
@@ -64,6 +93,28 @@
 
 .notBody {
   flex: 1;
+  position: relative;
+  padding-left: 16px;
+}
+
+.notBody::before {
+  content: '';
+  position: absolute;
+  left: 6px;
+  top: 0;
+  bottom: 50%;
+  width: 1px;
+  background: var(--wc-border-strong, #cbd5e1);
+}
+
+.notBody::after {
+  content: '';
+  position: absolute;
+  left: 6px;
+  top: 50%;
+  width: 10px;
+  height: 1px;
+  background: var(--wc-border-strong, #cbd5e1);
 }
 
 .leafBody {

--- a/src/ui/pools/ClauseEditor.tsx
+++ b/src/ui/pools/ClauseEditor.tsx
@@ -10,10 +10,9 @@
  * The component owns no state of its own; the parent (typically
  * `AdvancedRulesEditor`) holds the tree.
  *
- * Out of scope deliberately: path autocomplete from live resources,
- * drag-drop reordering of composite children, depth-line nesting
- * visuals. Those land in follow-up slices once this primitive is
- * stable.
+ * Out of scope deliberately: drag-drop reordering of composite
+ * children. Path autocomplete and depth-line nesting visuals land
+ * via opt-in props (`pathSuggestions`) and CSS rails respectively.
  */
 import { useId, type ChangeEvent } from 'react'
 import type {
@@ -190,7 +189,7 @@ function CompositeBody({
           {clause.op === 'and' ? 'No sub-rules (matches everything)' : 'No sub-rules (matches nothing)'}
         </span>
       )}
-      <ul className={styles['childList']}>
+      <ul className={styles['childList']} data-depth-rail="composite">
         {clause.clauses.map((c, i) => (
           <li key={i} className={styles['child']}>
             <ClauseEditor
@@ -259,7 +258,7 @@ function NotBody({
   datalistId?: string | undefined
 }): JSX.Element {
   return (
-    <div className={styles['notBody']}>
+    <div className={styles['notBody']} data-depth-rail="not">
       <ClauseEditor
         clause={clause.clause}
         depth={depth + 1}

--- a/src/ui/pools/__tests__/ClauseEditor.test.tsx
+++ b/src/ui/pools/__tests__/ClauseEditor.test.tsx
@@ -278,3 +278,34 @@ describe('ClauseEditor — not', () => {
     })
   })
 })
+
+describe('ClauseEditor — depth rails (#453)', () => {
+  it('marks every composite child list with data-depth-rail="composite"', () => {
+    const { container } = render(<Harness initial={{
+      op: 'and',
+      clauses: [
+        { op: 'eq', path: 'a', value: 1 },
+        { op: 'or', clauses: [
+          { op: 'eq', path: 'b', value: 2 },
+        ] },
+      ],
+    }} />)
+    // Outer AND + inner OR each render their own rail.
+    expect(container.querySelectorAll('[data-depth-rail="composite"]').length).toBe(2)
+  })
+
+  it('marks the NOT body with data-depth-rail="not"', () => {
+    const { container } = render(<Harness initial={{
+      op: 'not',
+      clause: { op: 'eq', path: 'tenantId', value: 'banned' },
+    }} />)
+    expect(container.querySelector('[data-depth-rail="not"]')).not.toBeNull()
+  })
+
+  it('omits depth rails on plain leaf clauses', () => {
+    const { container } = render(<Harness initial={{
+      op: 'eq', path: 'a', value: 1,
+    }} />)
+    expect(container.querySelector('[data-depth-rail]')).toBeNull()
+  })
+})


### PR DESCRIPTION
Adds visual tree-style depth indicators to ClauseEditor so it's clear which sub-rules belong to which AND/OR/NOT group when nesting gets deep — the background-tint cue alone gets noisy past 2 levels.

- A 1px vertical rail runs down the gutter of every composite child list, with a short horizontal stub branching out to each child row.
- NOT bodies get the same rail pattern adapted for a single child.
- Both rails are tagged with `data-depth-rail` attributes (`composite` / `not`) so consumers can theme or test them.
- Strikes the "depth-line nesting visuals" item from the file's out-of-scope comment now that it's implemented.

Closes #453.

## Summary
Describe exactly what this PR changes.

## Scope
- Stage: 
- Planned PR number in sprint: 
- Target files/directories: 
- Why this slice is isolated: 

## Lessons Learned Check (REQUIRED)
Confirm these were actively used while building this PR:

- [ ] PR is intentionally small and isolated
- [ ] Boundary typing was prioritized over internal perfection
- [ ] No silent spread of `any`
- [ ] Advisory root `tsc` was used to catch integration issues
- [ ] I did not assume “looks typed” means “safe”
- [ ] I stopped and isolated typing cascades instead of expanding scope

## Definition of Done (ALL REQUIRED)
This PR is not done unless every box is checked.

- [ ] `npm run type-check:strict` passes
- [ ] Root advisory `tsc --noEmit` passes
- [ ] Tests pass for touched scope at minimum
- [ ] No uncontrolled increase in `any`
- [ ] All new types are intentional and named
- [ ] Public interfaces and exported functions are explicitly typed
- [ ] PR scope matches the sprint plan with no scope creep
- [ ] Any new `any` has an adjacent justification comment
- [ ] No file-wide `: any`
- [ ] No implicit `any` in exported functions

## What Was Typed
List exactly what was typed in this PR.

- 
- 
- 

## What Was Intentionally Left Loose
List anything intentionally not tightened yet.

- 
- 
- 

## `any` Ledger (REQUIRED)
- New `any` added: 
- Existing `any` removed: 
- Net change: 

For every new `any`, explain why it is required and why a safer type was not used yet.

1. 
2. 
3. 

## Boundary Notes
Document any public seams, caller-protection choices, or compatibility decisions.

- 
- 
- 

## Risk Level
- [ ] Low
- [ ] Medium
- [ ] High

Why:

## Validation Evidence
Paste the exact commands run and a short result summary.

```bash
npm run type-check:strict
npx tsc --noEmit -p tsconfig.json
```

Test commands run:

```bash
# paste commands here
```

## Stop Conditions Check
If any item below happened, explain how scope was reduced before merge.

- [ ] `any` started spreading across files
- [ ] Root `tsc` broke repeatedly
- [ ] Types required cross-module rewrites
- [ ] Scope was reduced to keep the PR reviewable

Notes:

## Reviewer Focus
What should reviewers look at first?

- 
- 
- 
