### PR TITLE
core(requirements): engine-shaped gate for unmet hard requirements (#…

### DIFF
--- a/src/core/requirements/__tests__/gateEventRequirements.test.ts
+++ b/src/core/requirements/__tests__/gateEventRequirements.test.ts
@@ -1,0 +1,172 @@
+/**
+ * `gateEventRequirements` — engine-shaped gate over evaluateRequirements (#448).
+ */
+import { describe, it, expect } from 'vitest'
+import { gateEventRequirements } from '../gateEventRequirements'
+import type { ConfigRequirement } from '../../config/calendarConfig'
+import type { Assignment } from '../../engine/schema/assignmentSchema'
+import type { EngineEvent } from '../../engine/schema/eventSchema'
+import type { EngineResource } from '../../engine/schema/resourceSchema'
+import type { ResourcePool } from '../../pools/resourcePoolSchema'
+
+const r = (id: string, meta: Record<string, unknown> = {}): EngineResource =>
+  ({ id, name: id.toUpperCase(), meta } as EngineResource)
+
+const a = (id: string, eventId: string, resourceId: string): Assignment =>
+  ({ id, eventId, resourceId, units: 100 })
+
+const mapBy = <T extends { id: string }>(items: readonly T[]): ReadonlyMap<string, T> =>
+  new Map(items.map(x => [x.id, x] as const))
+
+const event = (id: string, category: string | null): Pick<EngineEvent, 'id' | 'category'> => ({ id, category })
+
+describe('gateEventRequirements — no template', () => {
+  it('returns the engine VALID shape when there is no matching template', () => {
+    const out = gateEventRequirements({
+      event: event('e1', 'unknown'),
+      requirements: [{ eventType: 'load', requires: [{ role: 'driver', count: 1 }] }],
+      resources: new Map(),
+      assignments: new Map(),
+    })
+    expect(out).toEqual({
+      allowed: true, severity: 'none', violations: [], suggestedPatch: null,
+    })
+  })
+
+  it('returns the engine VALID shape when the event has no category', () => {
+    const out = gateEventRequirements({
+      event: event('e1', null),
+      requirements: [{ eventType: 'load', requires: [{ role: 'driver', count: 1 }] }],
+      resources: new Map(),
+      assignments: new Map(),
+    })
+    expect(out.allowed).toBe(true)
+    expect(out.violations).toEqual([])
+  })
+})
+
+describe('gateEventRequirements — role shortfalls', () => {
+  const requirements: ConfigRequirement[] = [
+    { eventType: 'load', requires: [{ role: 'driver', count: 2 }] },
+  ]
+  const resources = mapBy([
+    r('alice', { roles: ['driver'] }),
+    r('bob',   { roles: ['dispatcher'] }),
+  ])
+
+  it('emits a hard violation when a hard role slot is unmet (default severity)', () => {
+    const out = gateEventRequirements({
+      event: event('e1', 'load'),
+      requirements,
+      resources,
+      assignments: mapBy([a('a1', 'e1', 'alice')]),
+    })
+    expect(out.allowed).toBe(false)
+    expect(out.severity).toBe('hard')
+    expect(out.violations).toEqual([{
+      rule: 'requirements.role',
+      severity: 'hard',
+      message: 'Missing 1 assignment for role "driver" (have 1 of 2).',
+      details: { kind: 'role', role: 'driver', required: 2, assigned: 1, missing: 1 },
+    }])
+  })
+
+  it('pluralises the message when missing >1', () => {
+    const out = gateEventRequirements({
+      event: event('e1', 'load'),
+      requirements: [{ eventType: 'load', requires: [{ role: 'driver', count: 3 }] }],
+      resources,
+      assignments: new Map(),
+    })
+    expect(out.violations[0]?.message).toBe('Missing 3 assignments for role "driver" (have 0 of 3).')
+  })
+})
+
+describe('gateEventRequirements — soft severity stays warn-only', () => {
+  it('soft shortfall → soft violation, allowed stays true', () => {
+    const out = gateEventRequirements({
+      event: event('e1', 'load'),
+      requirements: [{
+        eventType: 'load',
+        requires: [{ role: 'driver', count: 1, severity: 'soft' }],
+      }],
+      resources: new Map(),
+      assignments: new Map(),
+    })
+    expect(out.allowed).toBe(true)
+    expect(out.severity).toBe('soft')
+    expect(out.violations[0]?.severity).toBe('soft')
+  })
+
+  it('mixed hard + soft shortfalls — allowed=false, both surface', () => {
+    const out = gateEventRequirements({
+      event: event('e1', 'load'),
+      requirements: [{
+        eventType: 'load',
+        requires: [
+          { role: 'driver', count: 1 },                    // hard
+          { role: 'helper', count: 1, severity: 'soft' },  // soft
+        ],
+      }],
+      resources: new Map(),
+      assignments: new Map(),
+    })
+    expect(out.allowed).toBe(false)
+    expect(out.severity).toBe('hard')
+    expect(out.violations.length).toBe(2)
+    expect(out.violations.find(v => v.rule === 'requirements.role' && v.details?.['role'] === 'driver')?.severity).toBe('hard')
+    expect(out.violations.find(v => v.rule === 'requirements.role' && v.details?.['role'] === 'helper')?.severity).toBe('soft')
+  })
+})
+
+describe('gateEventRequirements — pool slots', () => {
+  const trucksPool: ResourcePool = {
+    id: 'trucks', name: 'Trucks', type: 'manual',
+    strategy: 'first-available', memberIds: ['t1', 't2'],
+  }
+  const requirements: ConfigRequirement[] = [
+    { eventType: 'load', requires: [{ pool: 'trucks', count: 1 }] },
+  ]
+  const resources = mapBy([r('t1'), r('t2')])
+
+  it('hard pool slot unmet → hard violation', () => {
+    const out = gateEventRequirements({
+      event: event('e1', 'load'),
+      requirements,
+      resources,
+      assignments: new Map(),
+      pools: mapBy([trucksPool]),
+    })
+    expect(out.allowed).toBe(false)
+    expect(out.violations[0]).toEqual({
+      rule: 'requirements.pool',
+      severity: 'hard',
+      message: 'Missing 1 assignment from pool "trucks" (have 0 of 1).',
+      details: { kind: 'pool', pool: 'trucks', required: 1, assigned: 0, missing: 1 },
+    })
+  })
+
+  it('unknown pool reference → distinct rule id + poolUnknown detail', () => {
+    const out = gateEventRequirements({
+      event: event('e1', 'load'),
+      requirements: [{ eventType: 'load', requires: [{ pool: 'ghosts', count: 1 }] }],
+      resources,
+      assignments: new Map(),
+      pools: mapBy([trucksPool]),
+    })
+    expect(out.violations[0]?.rule).toBe('requirements.pool-unknown')
+    expect(out.violations[0]?.details?.['poolUnknown']).toBe(true)
+  })
+
+  it('satisfied pool slot → no violation', () => {
+    const out = gateEventRequirements({
+      event: event('e1', 'load'),
+      requirements,
+      resources,
+      assignments: mapBy([a('a1', 'e1', 't1')]),
+      pools: mapBy([trucksPool]),
+    })
+    expect(out.allowed).toBe(true)
+    expect(out.violations).toEqual([])
+  })
+})

--- a/src/core/requirements/gateEventRequirements.ts
+++ b/src/core/requirements/gateEventRequirements.ts
@@ -1,0 +1,101 @@
+/**
+ * `gateEventRequirements` — engine-shaped gate on top of
+ * `evaluateRequirements` (issue #448).
+ *
+ * `evaluateRequirements` is the pure source-of-truth: it tells you
+ * which slots aren't filled. This helper wraps it in the engine's
+ * standard `ValidationResult` shape so hosts can plug requirement
+ * gating into the same UI / commit pipeline that handles overlap
+ * and working-hours violations.
+ *
+ *   Hard shortfall → `severity: 'hard'` violation. `allowed: false`
+ *                    when any hard shortfall exists.
+ *   Soft shortfall → `severity: 'soft'` violation. Stays warn-only.
+ *   No template     → no violations (matches `evaluateRequirements`'s
+ *                    "no template = no requirement to fail" rule).
+ *
+ * Pure / sync. Doesn't mutate the engine state.
+ */
+import type { ValidationResult, Violation } from '../engine/validation/validationTypes'
+import {
+  evaluateRequirements,
+  type EvaluateRequirementsInput,
+  type RequirementShortfall,
+} from './evaluateRequirements'
+
+export type GateEventRequirementsInput = EvaluateRequirementsInput
+
+export function gateEventRequirements(
+  input: GateEventRequirementsInput,
+): ValidationResult {
+  const evaluation = evaluateRequirements(input)
+
+  if (evaluation.missing.length === 0) {
+    return {
+      allowed: true,
+      severity: 'none',
+      violations: [],
+      suggestedPatch: null,
+    }
+  }
+
+  const violations: Violation[] = evaluation.missing.map(toViolation)
+  const hasHard = violations.some(v => v.severity === 'hard')
+  const hasSoft = violations.some(v => v.severity === 'soft')
+
+  return {
+    allowed: !hasHard,
+    severity: hasHard ? 'hard' : hasSoft ? 'soft' : 'none',
+    violations,
+    suggestedPatch: null,
+  }
+}
+
+function toViolation(s: RequirementShortfall): Violation {
+  if (s.kind === 'role') {
+    return {
+      rule: 'requirements.role',
+      severity: s.severity,
+      message: `Missing ${s.missing} ${plural(s.missing, 'assignment')} for role "${s.role}" (have ${s.assigned} of ${s.required}).`,
+      details: {
+        kind: 'role',
+        role: s.role,
+        required: s.required,
+        assigned: s.assigned,
+        missing: s.missing,
+      },
+    }
+  }
+  // pool
+  if (s.poolUnknown) {
+    return {
+      rule: 'requirements.pool-unknown',
+      severity: s.severity,
+      message: `Pool "${s.pool}" referenced by requirement is not registered.`,
+      details: {
+        kind: 'pool',
+        pool: s.pool,
+        required: s.required,
+        assigned: 0,
+        missing: s.required,
+        poolUnknown: true,
+      },
+    }
+  }
+  return {
+    rule: 'requirements.pool',
+    severity: s.severity,
+    message: `Missing ${s.missing} ${plural(s.missing, 'assignment')} from pool "${s.pool}" (have ${s.assigned} of ${s.required}).`,
+    details: {
+      kind: 'pool',
+      pool: s.pool,
+      required: s.required,
+      assigned: s.assigned,
+      missing: s.missing,
+    },
+  }
+}
+
+function plural(n: number, word: string): string {
+  return n === 1 ? word : `${word}s`
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -223,6 +223,8 @@ export { evaluateRequirements } from './core/requirements/evaluateRequirements';
 export type {
   EvaluateRequirementsInput, RequirementsEvaluation, RequirementShortfall,
 } from './core/requirements/evaluateRequirements';
+export { gateEventRequirements } from './core/requirements/gateEventRequirements';
+export type { GateEventRequirementsInput } from './core/requirements/gateEventRequirements';
 
 // ── Lifecycle event bus (#216) ──────────────────────────────────────────────
 export { EventBus, channelForApprovalTransition } from './core/engine/eventBus';


### PR DESCRIPTION
…448)

Adds `gateEventRequirements(input)` — a thin adapter over `evaluateRequirements` that returns the engine's standard `ValidationResult` shape so requirement gating drops into the same violation-rendering pipeline that handles overlap, working hours, and blocked windows.

- Hard role/pool shortfalls → `severity: 'hard'` violations, `allowed: false`. Hosts can block commit on any of these.
- Soft shortfalls → `severity: 'soft'` violations, `allowed: true`. Stays warn-only (matches `evaluateRequirements`'s soft-severity semantics).
- Unknown pool reference gets a distinct `requirements.pool-unknown` rule id + `poolUnknown: true` detail so hosts can call out the config bug without UX-special-casing.
- Exported from `src/index.ts`.

Closes #448.

## Summary
Describe exactly what this PR changes.

## Scope
- Stage: 
- Planned PR number in sprint: 
- Target files/directories: 
- Why this slice is isolated: 

## Lessons Learned Check (REQUIRED)
Confirm these were actively used while building this PR:

- [ ] PR is intentionally small and isolated
- [ ] Boundary typing was prioritized over internal perfection
- [ ] No silent spread of `any`
- [ ] Advisory root `tsc` was used to catch integration issues
- [ ] I did not assume “looks typed” means “safe”
- [ ] I stopped and isolated typing cascades instead of expanding scope

## Definition of Done (ALL REQUIRED)
This PR is not done unless every box is checked.

- [ ] `npm run type-check:strict` passes
- [ ] Root advisory `tsc --noEmit` passes
- [ ] Tests pass for touched scope at minimum
- [ ] No uncontrolled increase in `any`
- [ ] All new types are intentional and named
- [ ] Public interfaces and exported functions are explicitly typed
- [ ] PR scope matches the sprint plan with no scope creep
- [ ] Any new `any` has an adjacent justification comment
- [ ] No file-wide `: any`
- [ ] No implicit `any` in exported functions

## What Was Typed
List exactly what was typed in this PR.

- 
- 
- 

## What Was Intentionally Left Loose
List anything intentionally not tightened yet.

- 
- 
- 

## `any` Ledger (REQUIRED)
- New `any` added: 
- Existing `any` removed: 
- Net change: 

For every new `any`, explain why it is required and why a safer type was not used yet.

1. 
2. 
3. 

## Boundary Notes
Document any public seams, caller-protection choices, or compatibility decisions.

- 
- 
- 

## Risk Level
- [ ] Low
- [ ] Medium
- [ ] High

Why:

## Validation Evidence
Paste the exact commands run and a short result summary.

```bash
npm run type-check:strict
npx tsc --noEmit -p tsconfig.json
```

Test commands run:

```bash
# paste commands here
```

## Stop Conditions Check
If any item below happened, explain how scope was reduced before merge.

- [ ] `any` started spreading across files
- [ ] Root `tsc` broke repeatedly
- [ ] Types required cross-module rewrites
- [ ] Scope was reduced to keep the PR reviewable

Notes:

## Reviewer Focus
What should reviewers look at first?

- 
- 
- 
