### PR TITLE
ui(wizard): polish bundle — sample data, role chips, JSON download (#…

### DIFF
--- a/src/core/config/__tests__/profilePresets.test.ts
+++ b/src/core/config/__tests__/profilePresets.test.ts
@@ -2,7 +2,10 @@
  * Profile preset tests (#386 wizard).
  */
 import { describe, it, expect } from 'vitest'
-import { PROFILE_PRESETS, applyProfilePreset, listProfilePresets } from '../profilePresets'
+import {
+  PROFILE_PRESETS, applyProfilePreset, listProfilePresets,
+  getProfileSampleData, applyProfileSampleData,
+} from '../profilePresets'
 import type { CalendarConfig } from '../calendarConfig'
 
 describe('PROFILE_PRESETS — shape', () => {
@@ -147,5 +150,61 @@ describe('applyProfilePreset — defensive', () => {
     const out = applyProfilePreset('custom')
     // `custom` ships only `profile`; no labels / catalogs should appear.
     expect(Object.keys(out)).toEqual(['profile'])
+  })
+})
+
+describe('getProfileSampleData (#451)', () => {
+  it('returns null for the custom preset (no sample data)', () => {
+    expect(getProfileSampleData('custom')).toBeNull()
+  })
+
+  it('returns a fresh copy for trucking with at least one resource and one pool', () => {
+    const sample = getProfileSampleData('trucking')!
+    expect(sample.resources.length).toBeGreaterThan(0)
+    expect(sample.pools.length).toBeGreaterThan(0)
+    // Mutating the returned arrays must not bleed into the next caller.
+    ;(sample.resources as unknown as unknown[]).pop()
+    expect(getProfileSampleData('trucking')!.resources.length).toBeGreaterThan(0)
+  })
+
+  it('aviation + scheduling also ship sample data', () => {
+    expect(getProfileSampleData('aviation')!.resources.length).toBeGreaterThan(0)
+    expect(getProfileSampleData('scheduling')!.resources.length).toBeGreaterThan(0)
+  })
+})
+
+describe('applyProfileSampleData (#451)', () => {
+  it('seeds resources + pools when the working config is empty', () => {
+    const out = applyProfileSampleData('trucking', {})
+    expect(out.resources?.length).toBeGreaterThan(0)
+    expect(out.pools?.length).toBeGreaterThan(0)
+  })
+
+  it('skips ids that already exist in the working config', () => {
+    const sample = getProfileSampleData('trucking')!
+    const firstId = sample.resources[0]!.id
+    const base: CalendarConfig = {
+      resources: [{ id: firstId, name: 'I was here first' }],
+    }
+    const out = applyProfileSampleData('trucking', base)
+    // The original entry survives; only the non-conflicting samples are appended.
+    expect(out.resources?.[0]).toEqual({ id: firstId, name: 'I was here first' })
+    expect(out.resources?.length).toBe(sample.resources.length)
+  })
+
+  it('no-ops cleanly for the custom preset', () => {
+    const base: CalendarConfig = { profile: 'custom' }
+    const out = applyProfileSampleData('custom', base)
+    expect(out).toEqual({ profile: 'custom' })
+  })
+
+  it('preserves user-set fields the sample doesn\'t touch', () => {
+    const base: CalendarConfig = {
+      profile: 'trucking',
+      labels: { resource: 'My Truck' },
+    }
+    const out = applyProfileSampleData('trucking', base)
+    expect(out.labels?.resource).toBe('My Truck')
+    expect(out.profile).toBe('trucking')
   })
 })

--- a/src/core/config/__tests__/profilePresets.test.ts
+++ b/src/core/config/__tests__/profilePresets.test.ts
@@ -167,6 +167,21 @@ describe('getProfileSampleData (#451)', () => {
     expect(getProfileSampleData('trucking')!.resources.length).toBeGreaterThan(0)
   })
 
+  it('deep-clones the payload so mutating a nested object stays local', () => {
+    // Codex flagged that shallow [...arr] still aliased the static
+    // preset entries — editing `.name` would leak across sessions.
+    const first = getProfileSampleData('trucking')!
+    const original = first.resources[0]!.name
+    ;(first.resources[0] as { name: string }).name = 'mutated by caller'
+    // Capability bag is nested two levels deep; mutating it must
+    // also stay local to this caller's copy.
+    const caps = (first.resources[0] as { capabilities?: Record<string, unknown> }).capabilities
+    if (caps) caps['injected'] = true
+    const second = getProfileSampleData('trucking')!
+    expect(second.resources[0]!.name).toBe(original)
+    expect((second.resources[0] as { capabilities?: Record<string, unknown> }).capabilities?.['injected']).toBeUndefined()
+  })
+
   it('aviation + scheduling also ship sample data', () => {
     expect(getProfileSampleData('aviation')!.resources.length).toBeGreaterThan(0)
     expect(getProfileSampleData('scheduling')!.resources.length).toBeGreaterThan(0)

--- a/src/core/config/profilePresets.ts
+++ b/src/core/config/profilePresets.ts
@@ -17,11 +17,18 @@
  *     boolean chips). The presets only seed the basics; the
  *     `PoolBuilder` already auto-derives capabilities from the
  *     live registry.
- *   - Sample resources / events. Presets seed metadata only;
- *     concrete resources stay the host's job.
  *   - i18n. Labels here are English-only for v1.
+ *
+ * Sample data: each preset may carry a `sample` payload (resources
+ * + pools) the wizard can pour into the working config so users
+ * can poke around a populated registry instead of starting blank.
+ * Opt-in: hosts call `getProfileSampleData(profileId)`; the wizard
+ * surfaces a "Load sample data" button on the Resources step.
  */
-import type { CalendarConfig } from './calendarConfig'
+import type {
+  CalendarConfig, ConfigResource,
+} from './calendarConfig'
+import type { ResourcePool } from '../pools/resourcePoolSchema'
 
 /** Stable id under which a preset is registered. */
 export type ProfileId = 'trucking' | 'aviation' | 'scheduling' | 'custom'
@@ -37,6 +44,16 @@ export interface ProfilePreset {
    * user's working config.
    */
   readonly config: Partial<CalendarConfig>
+  /**
+   * Optional starter data — concrete resources and pools the user
+   * can pour into their working config to play with a populated
+   * registry. Opt-in via `getProfileSampleData(id)`; the wizard
+   * exposes a "Load sample data" button rather than auto-applying.
+   */
+  readonly sample?: {
+    readonly resources: readonly ConfigResource[]
+    readonly pools: readonly ResourcePool[]
+  }
 }
 
 export const PROFILE_PRESETS: Readonly<Record<ProfileId, ProfilePreset>> = {
@@ -62,6 +79,29 @@ export const PROFILE_PRESETS: Readonly<Record<ProfileId, ProfilePreset>> = {
       ],
       settings: { conflictMode: 'block' },
     },
+    sample: {
+      resources: [
+        { id: 't1', name: 'Truck 1', type: 'vehicle',
+          capabilities: { refrigerated: true, capacity_lbs: 80000 },
+          location: { lat: 40.76, lon: -111.89 } },
+        { id: 't2', name: 'Truck 2', type: 'vehicle',
+          capabilities: { refrigerated: false, capacity_lbs: 60000 },
+          location: { lat: 40.76, lon: -111.89 } },
+        { id: 'd1', name: 'Alice',   type: 'person',
+          meta: { roles: ['driver'] } },
+        { id: 'd2', name: 'Bob',     type: 'person',
+          meta: { roles: ['driver', 'dispatcher'] } },
+      ],
+      pools: [
+        { id: 'fleet-reefer', name: 'Reefer fleet',
+          type: 'query', strategy: 'first-available',
+          memberIds: [],
+          query: { op: 'eq', path: 'meta.capabilities.refrigerated', value: true } },
+        { id: 'drivers', name: 'Drivers',
+          type: 'manual', strategy: 'least-loaded',
+          memberIds: ['d1', 'd2'] },
+      ],
+    },
   },
 
   aviation: {
@@ -86,6 +126,27 @@ export const PROFILE_PRESETS: Readonly<Record<ProfileId, ProfilePreset>> = {
       ],
       settings: { conflictMode: 'block' },
     },
+    sample: {
+      resources: [
+        { id: 'n123ab', name: 'King Air 350', type: 'aircraft',
+          capabilities: { seats: 9, range_nm: 1800, pressurized: true } },
+        { id: 'n456cd', name: 'Cessna 172',   type: 'aircraft',
+          capabilities: { seats: 4, range_nm: 700,  pressurized: false } },
+        { id: 'p1', name: 'Pat (Capt)', type: 'pilot',
+          meta: { roles: ['pilot-in-command'] } },
+        { id: 'p2', name: 'Sam (FO)',   type: 'pilot',
+          meta: { roles: ['second-in-command'] } },
+      ],
+      pools: [
+        { id: 'long-haul', name: 'Long-haul aircraft',
+          type: 'query', strategy: 'first-available',
+          memberIds: [],
+          query: { op: 'gte', path: 'meta.capabilities.range_nm', value: 1500 } },
+        { id: 'pilots', name: 'Pilots',
+          type: 'manual', strategy: 'least-loaded',
+          memberIds: ['p1', 'p2'] },
+      ],
+    },
   },
 
   scheduling: {
@@ -109,6 +170,22 @@ export const PROFILE_PRESETS: Readonly<Record<ProfileId, ProfilePreset>> = {
         { id: 'attendee',  label: 'Attendee' },
       ],
       settings: { conflictMode: 'block' },
+    },
+    sample: {
+      resources: [
+        { id: 'rm-101', name: 'Conference 101', type: 'room',
+          capabilities: { capacity: 12, has_av: true } },
+        { id: 'rm-201', name: 'Boardroom',      type: 'room',
+          capabilities: { capacity: 24, has_av: true } },
+        { id: 'proj-1', name: 'Projector cart', type: 'equipment',
+          capabilities: { has_av: true } },
+      ],
+      pools: [
+        { id: 'av-rooms', name: 'Rooms with A/V',
+          type: 'query', strategy: 'first-available',
+          memberIds: [],
+          query: { op: 'eq', path: 'meta.capabilities.has_av', value: true } },
+      ],
     },
   },
 
@@ -186,6 +263,47 @@ export function applyProfilePreset(
   // Sections we don't touch (resources, pools, requirements,
   // events) — the user owns them; presets only seed catalog data.
   return cleanUndefined(merged)
+}
+
+/**
+ * Read-only accessor for a profile's sample payload. Returns
+ * `null` when the profile has no sample data (e.g. `custom`).
+ * Always hands back a fresh object so callers can mutate freely.
+ */
+export function getProfileSampleData(
+  profileId: ProfileId,
+): { resources: readonly ConfigResource[]; pools: readonly ResourcePool[] } | null {
+  const sample = PROFILE_PRESETS[profileId]?.sample
+  if (!sample) return null
+  return {
+    resources: [...sample.resources],
+    pools: [...sample.pools],
+  }
+}
+
+/**
+ * Merge a profile's sample data into a working config. Pours in
+ * new resources and pools, skipping any whose `id` already exists
+ * (the user's edits always win). Pure: returns a new config.
+ */
+export function applyProfileSampleData(
+  profileId: ProfileId,
+  base: Readonly<CalendarConfig>,
+): CalendarConfig {
+  const sample = getProfileSampleData(profileId)
+  if (!sample) return { ...base }
+  const existingResIds = new Set((base.resources ?? []).map(r => r.id))
+  const newResources = sample.resources.filter(r => !existingResIds.has(r.id))
+  const existingPoolIds = new Set((base.pools ?? []).map(p => p.id))
+  const newPools = sample.pools.filter(p => !existingPoolIds.has(p.id))
+  const out: { -readonly [K in keyof CalendarConfig]: CalendarConfig[K] } = { ...base }
+  if (newResources.length > 0) {
+    out.resources = [...(base.resources ?? []), ...newResources]
+  }
+  if (newPools.length > 0) {
+    out.pools = [...(base.pools ?? []), ...newPools]
+  }
+  return out
 }
 
 // ─── Internals ──────────────────────────────────────────────────────────────

--- a/src/core/config/profilePresets.ts
+++ b/src/core/config/profilePresets.ts
@@ -268,7 +268,9 @@ export function applyProfilePreset(
 /**
  * Read-only accessor for a profile's sample payload. Returns
  * `null` when the profile has no sample data (e.g. `custom`).
- * Always hands back a fresh object so callers can mutate freely.
+ * Deep-clones the payload so callers can mutate freely without
+ * leaking into the module-level static preset (which is shared
+ * across every wizard session in the same JS realm).
  */
 export function getProfileSampleData(
   profileId: ProfileId,
@@ -276,8 +278,8 @@ export function getProfileSampleData(
   const sample = PROFILE_PRESETS[profileId]?.sample
   if (!sample) return null
   return {
-    resources: [...sample.resources],
-    pools: [...sample.pools],
+    resources: sample.resources.map(deepClone),
+    pools: sample.pools.map(deepClone),
   }
 }
 
@@ -331,4 +333,17 @@ function cleanUndefined(o: { [k: string]: unknown }): CalendarConfig {
     if (o[k] !== undefined) out[k] = o[k]
   }
   return out as CalendarConfig
+}
+
+/**
+ * Deep-clone a sample-payload entry. The presets are pure JSON-
+ * shaped data (no Dates, Maps, functions), so we prefer the
+ * structured-clone algorithm when available and fall back to a
+ * JSON round-trip — both produce a fully detached copy so callers
+ * can mutate without leaking into the module-level static preset.
+ */
+function deepClone<T>(value: T): T {
+  const sc = (globalThis as { structuredClone?: <U>(v: U) => U }).structuredClone
+  if (typeof sc === 'function') return sc(value)
+  return JSON.parse(JSON.stringify(value)) as T
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -216,6 +216,7 @@ export {
   PROFILE_PRESETS, listProfilePresets, applyProfilePreset,
 } from './core/config/profilePresets';
 export type { ProfileId, ProfilePreset } from './core/config/profilePresets';
+export { getProfileSampleData, applyProfileSampleData } from './core/config/profilePresets';
 export { default as ConfigWizard } from './ui/wizard/ConfigWizard';
 export type { ConfigWizardProps, ConfigWizardStepId } from './ui/wizard/ConfigWizard';
 // ── Requirements engine — runtime consumer for the templates (#386) ──────

--- a/src/ui/wizard/ConfigWizard.module.css
+++ b/src/ui/wizard/ConfigWizard.module.css
@@ -407,3 +407,59 @@
   background: #1d4ed8;
   border-color: #1d4ed8;
 }
+
+/* ── #451 wizard polish: sample data, role chips, JSON download ──────────── */
+
+.sampleBtn {
+  align-self: flex-start;
+  padding: 6px 12px;
+  font-size: 12px;
+  font-weight: 600;
+  background: var(--wc-bg-muted, #f3f4f6);
+  border: 1px dashed var(--wc-border, #d1d5db);
+  border-radius: 6px;
+  cursor: pointer;
+  color: var(--wc-text, #111827);
+}
+
+.sampleBtn:hover {
+  border-color: #2563eb;
+  color: #2563eb;
+}
+
+.roleChips {
+  flex: 1 1 100%;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  margin-top: 6px;
+  padding-left: 4px;
+}
+
+.roleChip {
+  padding: 3px 10px;
+  font-size: 11px;
+  border-radius: 999px;
+  border: 1px solid var(--wc-border, #d1d5db);
+  background: var(--wc-bg, #ffffff);
+  color: var(--wc-text-muted, #6b7280);
+  cursor: pointer;
+}
+
+.roleChip[data-active='true'] {
+  background: color-mix(in srgb, #2563eb 12%, var(--wc-bg, #ffffff));
+  border-color: #2563eb;
+  color: #1d4ed8;
+  font-weight: 600;
+}
+
+.roleChip:hover:not([data-active='true']) {
+  border-color: #2563eb;
+  color: #2563eb;
+}
+
+.jsonActions {
+  display: flex;
+  justify-content: flex-end;
+  margin-bottom: 6px;
+}

--- a/src/ui/wizard/ConfigWizard.tsx
+++ b/src/ui/wizard/ConfigWizard.tsx
@@ -16,19 +16,18 @@
  * `onComplete`.
  *
  * Out of scope deliberately:
- *   - Sample data generation. The user fills the registry.
  *   - Industry-specific capability lists. PoolBuilder auto-derives
  *     them from the live registry; the wizard doesn't curate.
- *   - Per-resource `meta.roles` editor. Hosts wire that via JSON
- *     for now; a follow-up can add a chip picker.
- *   - File-system download. The Review step exposes a JSON code
- *     block users can copy; no `<a download>` plumbing.
+ *   - Full i18n. User-facing strings stay English-only for v1;
+ *     hosts wanting localization can fork the component until
+ *     a translation layer ships.
  */
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import type { ChangeEvent, MouseEvent } from 'react'
 import { useFocusTrap } from '../../hooks/useFocusTrap'
 import {
-  applyProfilePreset, listProfilePresets, PROFILE_PRESETS,
+  applyProfilePreset, applyProfileSampleData, getProfileSampleData,
+  listProfilePresets, PROFILE_PRESETS,
 } from '../../core/config/profilePresets'
 import type { ProfileId } from '../../core/config/profilePresets'
 import { validateConfig } from '../../core/config/validateConfig'
@@ -330,6 +329,9 @@ function ResourcesStep({ config, setConfig }: StepProps): JSX.Element {
       return out
     })
   }
+  const profile = isProfileId(config.profile) ? config.profile : null
+  const sample = profile ? getProfileSampleData(profile) : null
+  const canLoadSample = profile !== null && sample !== null && sample.resources.length > 0
   return (
     <div className={styles['stepInner']}>
       <p className={styles['hint']}>
@@ -337,6 +339,14 @@ function ResourcesStep({ config, setConfig }: StepProps): JSX.Element {
         and locations later — they're optional, but the v2 query DSL
         reads them when present.
       </p>
+      {canLoadSample && (
+        <button
+          type="button"
+          className={styles['sampleBtn']}
+          onClick={() => profile && setConfig(c => applyProfileSampleData(profile, c))}
+          aria-label="Load sample data for this profile"
+        >Load sample data</button>
+      )}
       {resources.length === 0 && (
         <p className={styles['empty']}>No resources yet.</p>
       )}
@@ -395,6 +405,14 @@ function ResourcesStep({ config, setConfig }: StepProps): JSX.Element {
               aria-label={`Remove resource ${i + 1}`}
               onClick={() => setResources(resources.filter((_, j) => j !== i))}
             >×</button>
+            {(config.roles ?? []).length > 0 && (
+              <RoleChips
+                resourceIndex={i}
+                roles={config.roles ?? []}
+                selected={readResourceRoles(r)}
+                onToggle={(roleId) => updateAt(i, prev => toggleResourceRole(prev, roleId))}
+              />
+            )}
           </li>
         ))}
       </ul>
@@ -403,6 +421,63 @@ function ResourcesStep({ config, setConfig }: StepProps): JSX.Element {
         className={styles['addBtn']}
         onClick={() => setResources([...resources, { id: '', name: '' }])}
       >+ Add resource</button>
+    </div>
+  )
+}
+
+const PROFILE_IDS: readonly ProfileId[] = ['trucking', 'aviation', 'scheduling', 'custom']
+function isProfileId(v: unknown): v is ProfileId {
+  return typeof v === 'string' && (PROFILE_IDS as readonly string[]).includes(v)
+}
+
+function readResourceRoles(r: ConfigResource): readonly string[] {
+  const raw = (r.meta as Record<string, unknown> | undefined)?.['roles']
+  return Array.isArray(raw) ? raw.filter((x): x is string => typeof x === 'string') : []
+}
+
+function toggleResourceRole(r: ConfigResource, roleId: string): ConfigResource {
+  const current = readResourceRoles(r)
+  const next = current.includes(roleId)
+    ? current.filter(x => x !== roleId)
+    : [...current, roleId]
+  // Drop the meta.roles key entirely when empty so the saved config
+  // doesn't carry an empty array (cleaner JSON, lossless round-trip).
+  const meta = { ...(r.meta as Record<string, unknown> ?? {}) }
+  if (next.length > 0) {
+    meta['roles'] = next
+  } else {
+    delete meta['roles']
+  }
+  if (Object.keys(meta).length === 0) {
+    const { meta: _drop, ...rest } = r
+    return rest
+  }
+  return { ...r, meta }
+}
+
+function RoleChips({
+  resourceIndex, roles, selected, onToggle,
+}: {
+  resourceIndex: number
+  roles: readonly { id: string; label: string }[]
+  selected: readonly string[]
+  onToggle: (roleId: string) => void
+}): JSX.Element {
+  return (
+    <div className={styles['roleChips']} role="group" aria-label={`Resource ${resourceIndex + 1} roles`}>
+      {roles.map(role => {
+        const active = selected.includes(role.id)
+        return (
+          <button
+            key={role.id}
+            type="button"
+            className={styles['roleChip']}
+            data-active={active}
+            aria-pressed={active}
+            onClick={() => onToggle(role.id)}
+          >{role.label || role.id}</button>
+        )
+      })}
     </div>
   )
 }
@@ -595,10 +670,42 @@ function ReviewStep({ config, setConfig }: StepProps): JSX.Element {
 
       <fieldset className={styles['fieldset']}>
         <legend className={styles['legend']}>Generated config.json</legend>
+        <div className={styles['jsonActions']}>
+          <button
+            type="button"
+            className={styles['btnSecondary']}
+            onClick={() => downloadJson(json, 'config.json')}
+          >Download config.json</button>
+        </div>
         <pre className={styles['json']} data-testid="wizard-json">{json}</pre>
       </fieldset>
     </div>
   )
+}
+
+/**
+ * Trigger a browser download for a JSON string. Uses the
+ * `Blob` + `URL.createObjectURL` + invisible `<a download>` dance
+ * because that's the only cross-browser way to ship a file from a
+ * pure-client wizard. The URL is revoked immediately after the
+ * click — modern browsers queue the download synchronously, so
+ * revoking on the next tick is safe and avoids leaking object URLs.
+ *
+ * No-op when run outside a browser (test environments without
+ * `document` or `URL.createObjectURL`); the click would throw and
+ * we don't want it to.
+ */
+function downloadJson(content: string, filename: string): void {
+  if (typeof document === 'undefined' || typeof URL === 'undefined' || !URL.createObjectURL) return
+  const blob = new Blob([content], { type: 'application/json' })
+  const href = URL.createObjectURL(blob)
+  const a = document.createElement('a')
+  a.href = href
+  a.download = filename
+  document.body.appendChild(a)
+  a.click()
+  document.body.removeChild(a)
+  URL.revokeObjectURL(href)
 }
 
 function cleanSettings(s: ConfigSettings): ConfigSettings {

--- a/src/ui/wizard/__tests__/ConfigWizard.test.tsx
+++ b/src/ui/wizard/__tests__/ConfigWizard.test.tsx
@@ -254,6 +254,127 @@ describe('ConfigWizard — Review step', () => {
   })
 })
 
+describe('ConfigWizard — sample data button (#451)', () => {
+  it('hides the button for the custom profile (no sample data)', () => {
+    const { unmount } = render(<ConfigWizard
+      initialConfig={{ profile: 'custom' }}
+      onComplete={vi.fn()} onCancel={vi.fn()}
+    />)
+    fireEvent.click(screen.getByRole('button', { name: /3.+Resources/ }))
+    expect(screen.queryByRole('button', { name: /Load sample data/ })).toBeNull()
+    unmount()
+  })
+
+  it('shows the button when the chosen profile ships sample data', () => {
+    render(<ConfigWizard
+      initialConfig={{ profile: 'trucking' }}
+      onComplete={vi.fn()} onCancel={vi.fn()}
+    />)
+    fireEvent.click(screen.getByRole('button', { name: /3.+Resources/ }))
+    expect(screen.getByRole('button', { name: /Load sample data/ })).toBeInTheDocument()
+  })
+
+  it('clicking Load sample data populates resources + pools', () => {
+    const onComplete = vi.fn()
+    render(<ConfigWizard
+      initialConfig={{ profile: 'trucking' }}
+      onComplete={onComplete} onCancel={vi.fn()}
+    />)
+    fireEvent.click(screen.getByRole('button', { name: /3.+Resources/ }))
+    fireEvent.click(screen.getByRole('button', { name: /Load sample data/ }))
+    fireEvent.click(screen.getByRole('button', { name: /5.+Review/ }))
+    fireEvent.click(screen.getByRole('button', { name: 'Finish' }))
+    const saved = onComplete.mock.calls[0]![0] as CalendarConfig
+    expect((saved.resources?.length ?? 0)).toBeGreaterThan(0)
+    expect((saved.pools?.length ?? 0)).toBeGreaterThan(0)
+  })
+})
+
+describe('ConfigWizard — role chip picker (#451)', () => {
+  it('renders one chip per configured role beneath each resource', () => {
+    render(<ConfigWizard
+      initialConfig={{
+        roles: [{ id: 'driver', label: 'Driver' }, { id: 'dispatcher', label: 'Dispatcher' }],
+        resources: [{ id: 't1', name: 'Truck' }],
+      }}
+      onComplete={vi.fn()} onCancel={vi.fn()}
+    />)
+    fireEvent.click(screen.getByRole('button', { name: /3.+Resources/ }))
+    const group = screen.getByRole('group', { name: 'Resource 1 roles' })
+    expect(within(group).getByRole('button', { name: 'Driver' })).toBeInTheDocument()
+    expect(within(group).getByRole('button', { name: 'Dispatcher' })).toBeInTheDocument()
+  })
+
+  it('toggling a chip writes to meta.roles and persists through Finish', () => {
+    const onComplete = vi.fn()
+    render(<ConfigWizard
+      initialConfig={{
+        roles: [{ id: 'driver', label: 'Driver' }],
+        resources: [{ id: 't1', name: 'Truck' }],
+      }}
+      onComplete={onComplete} onCancel={vi.fn()}
+    />)
+    fireEvent.click(screen.getByRole('button', { name: /3.+Resources/ }))
+    fireEvent.click(screen.getByRole('button', { name: 'Driver' }))
+    fireEvent.click(screen.getByRole('button', { name: /5.+Review/ }))
+    fireEvent.click(screen.getByRole('button', { name: 'Finish' }))
+    const saved = onComplete.mock.calls[0]![0] as CalendarConfig
+    expect(saved.resources?.[0]?.meta).toEqual({ roles: ['driver'] })
+  })
+
+  it('toggling off a previously-set role drops it (and clears meta when empty)', () => {
+    const onComplete = vi.fn()
+    render(<ConfigWizard
+      initialConfig={{
+        roles: [{ id: 'driver', label: 'Driver' }],
+        resources: [{ id: 't1', name: 'Truck', meta: { roles: ['driver'] } }],
+      }}
+      onComplete={onComplete} onCancel={vi.fn()}
+    />)
+    fireEvent.click(screen.getByRole('button', { name: /3.+Resources/ }))
+    fireEvent.click(screen.getByRole('button', { name: 'Driver' }))
+    fireEvent.click(screen.getByRole('button', { name: /5.+Review/ }))
+    fireEvent.click(screen.getByRole('button', { name: 'Finish' }))
+    const saved = onComplete.mock.calls[0]![0] as CalendarConfig
+    expect(saved.resources?.[0]?.meta).toBeUndefined()
+  })
+})
+
+describe('ConfigWizard — JSON download (#451)', () => {
+  it('renders a Download config.json button on the Review step', () => {
+    render(<ConfigWizard
+      initialConfig={{ profile: 'custom' }}
+      onComplete={vi.fn()} onCancel={vi.fn()}
+    />)
+    fireEvent.click(screen.getByRole('button', { name: /5.+Review/ }))
+    expect(screen.getByRole('button', { name: 'Download config.json' })).toBeInTheDocument()
+  })
+
+  it('clicking the button creates an object URL and triggers an anchor click', () => {
+    const createSpy = vi.fn(() => 'blob:mock')
+    const revokeSpy = vi.fn()
+    const originalURL = global.URL
+    // happy-dom ships URL but not always createObjectURL — patch both.
+    const PatchedURL: typeof URL = Object.assign(function () {}, originalURL, {
+      createObjectURL: createSpy,
+      revokeObjectURL: revokeSpy,
+    }) as unknown as typeof URL
+    Object.defineProperty(global, 'URL', { value: PatchedURL, writable: true, configurable: true })
+    try {
+      render(<ConfigWizard
+        initialConfig={{ profile: 'aviation' }}
+        onComplete={vi.fn()} onCancel={vi.fn()}
+      />)
+      fireEvent.click(screen.getByRole('button', { name: /5.+Review/ }))
+      fireEvent.click(screen.getByRole('button', { name: 'Download config.json' }))
+      expect(createSpy).toHaveBeenCalled()
+      expect(revokeSpy).toHaveBeenCalledWith('blob:mock')
+    } finally {
+      Object.defineProperty(global, 'URL', { value: originalURL, writable: true, configurable: true })
+    }
+  })
+})
+
 describe('ConfigWizard — initialConfig editing', () => {
   it('round-trips a fully populated config without losing fields', () => {
     const initial: CalendarConfig = {


### PR DESCRIPTION
…451)

Closes the three remaining "out of scope" items from the v2 wizard capstone (#386 / #447):

- Sample data: each profile preset now ships an optional `sample` payload (resources + pools). New `getProfileSampleData(id)` and `applyProfileSampleData(id, base)` helpers expose it. The wizard's Resources step renders a "Load sample data" button when the active profile has a payload — clicking pours the samples into the working config, skipping any ids the user already created.
- Role chips: Resources step gains a chip row beneath each resource, showing one toggle per configured role. Toggling writes to `meta.roles` and drops the key entirely when emptied (cleaner JSON, lossless round-trip).
- JSON download: Review step gains a "Download config.json" button next to the rendered code block. Uses Blob + createObjectURL + invisible `<a download>`, with object URL revoked on the next tick. No-ops cleanly when run without a browser DOM.

Closes #451.

## Summary
Describe exactly what this PR changes.

## Scope
- Stage: 
- Planned PR number in sprint: 
- Target files/directories: 
- Why this slice is isolated: 

## Lessons Learned Check (REQUIRED)
Confirm these were actively used while building this PR:

- [ ] PR is intentionally small and isolated
- [ ] Boundary typing was prioritized over internal perfection
- [ ] No silent spread of `any`
- [ ] Advisory root `tsc` was used to catch integration issues
- [ ] I did not assume “looks typed” means “safe”
- [ ] I stopped and isolated typing cascades instead of expanding scope

## Definition of Done (ALL REQUIRED)
This PR is not done unless every box is checked.

- [ ] `npm run type-check:strict` passes
- [ ] Root advisory `tsc --noEmit` passes
- [ ] Tests pass for touched scope at minimum
- [ ] No uncontrolled increase in `any`
- [ ] All new types are intentional and named
- [ ] Public interfaces and exported functions are explicitly typed
- [ ] PR scope matches the sprint plan with no scope creep
- [ ] Any new `any` has an adjacent justification comment
- [ ] No file-wide `: any`
- [ ] No implicit `any` in exported functions

## What Was Typed
List exactly what was typed in this PR.

- 
- 
- 

## What Was Intentionally Left Loose
List anything intentionally not tightened yet.

- 
- 
- 

## `any` Ledger (REQUIRED)
- New `any` added: 
- Existing `any` removed: 
- Net change: 

For every new `any`, explain why it is required and why a safer type was not used yet.

1. 
2. 
3. 

## Boundary Notes
Document any public seams, caller-protection choices, or compatibility decisions.

- 
- 
- 

## Risk Level
- [ ] Low
- [ ] Medium
- [ ] High

Why:

## Validation Evidence
Paste the exact commands run and a short result summary.

```bash
npm run type-check:strict
npx tsc --noEmit -p tsconfig.json
```

Test commands run:

```bash
# paste commands here
```

## Stop Conditions Check
If any item below happened, explain how scope was reduced before merge.

- [ ] `any` started spreading across files
- [ ] Root `tsc` broke repeatedly
- [ ] Types required cross-module rewrites
- [ ] Scope was reduced to keep the PR reviewable

Notes:

## Reviewer Focus
What should reviewers look at first?

- 
- 
- 
