### PR TITLE
ui(wizard): polish bundle — finish gating, hybrid count, stable row id (#460)

### DIFF
--- a/src/ui/pools/PoolBuilder.tsx
+++ b/src/ui/pools/PoolBuilder.tsx
@@ -659,9 +659,13 @@ function previewStats(
   if (!pool.query) return { matched: 0, excluded: resources.length }
   const result = evaluateQuery(pool.query, resources)
   if (pool.type === 'hybrid') {
+    // Hybrid = intersection of curated `memberIds` and the query.
+    // The natural denominator is the curated list, not the entire
+    // registry — counting full-registry exclusions made a 2-member
+    // hybrid against a 50-resource fleet look like 48 misses.
     const allowed = new Set(result.matched)
     const matched = pool.memberIds.filter(id => allowed.has(id)).length
-    return { matched, excluded: resources.length - matched }
+    return { matched, excluded: pool.memberIds.length - matched }
   }
   return { matched: result.matched.length, excluded: result.excluded.length }
 }

--- a/src/ui/pools/__tests__/PoolBuilder.test.tsx
+++ b/src/ui/pools/__tests__/PoolBuilder.test.tsx
@@ -141,6 +141,42 @@ describe('PoolBuilder — query pool', () => {
   })
 })
 
+describe('PoolBuilder — hybrid preview count (#460)', () => {
+  it('counts excluded against the curated member list, not the entire registry', () => {
+    // Hybrid pool curating t1 + t3 with a "refrigerated" query.
+    // Only t1 passes the query (t3 is non-refrigerated).
+    // Old (wrong) count: resources.length(3) - matched(1) = 2
+    // New (correct) count: memberIds.length(2) - matched(1) = 1
+    const pool: ResourcePool = {
+      id: 'p', name: 'Curated reefers',
+      type: 'hybrid', memberIds: ['t1', 't3'],
+      query: { op: 'eq', path: 'meta.capabilities.refrigerated', value: true },
+      strategy: 'first-available',
+    }
+    render(<PoolBuilder pool={pool} resources={fleet} onSave={vi.fn()} onCancel={vi.fn()} />)
+    const preview = screen.getByLabelText('Live match preview')
+    expect(preview).toHaveTextContent('1 match')
+    expect(preview).toHaveTextContent('1 excluded')
+    expect(preview).not.toHaveTextContent('2 excluded')
+  })
+
+  it('shows zero excluded when every curated member passes the query', () => {
+    // Curated list is t1 + t2; both refrigerated; query passes both.
+    // Old count: resources.length(3) - 2 = 1 ("excluded" was misleading)
+    // New count: memberIds.length(2) - 2 = 0 (nothing curated got dropped)
+    const pool: ResourcePool = {
+      id: 'p', name: 'All-pass hybrid',
+      type: 'hybrid', memberIds: ['t1', 't2'],
+      query: { op: 'eq', path: 'meta.capabilities.refrigerated', value: true },
+      strategy: 'first-available',
+    }
+    render(<PoolBuilder pool={pool} resources={fleet} onSave={vi.fn()} onCancel={vi.fn()} />)
+    const preview = screen.getByLabelText('Live match preview')
+    expect(preview).toHaveTextContent('2 matches')
+    expect(preview).not.toHaveTextContent('excluded')
+  })
+})
+
 describe('PoolBuilder — editing existing pools', () => {
   it('seeds capability chips and radius from an existing query pool', () => {
     const pool: ResourcePool = {

--- a/src/ui/wizard/ConfigWizard.tsx
+++ b/src/ui/wizard/ConfigWizard.tsx
@@ -22,7 +22,7 @@
  *     hosts wanting localization can fork the component until
  *     a translation layer ships.
  */
-import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import type { ChangeEvent, MouseEvent } from 'react'
 import { useFocusTrap } from '../../hooks/useFocusTrap'
 import {
@@ -43,7 +43,16 @@ import PoolBuilder from '../pools/PoolBuilder'
 import styles from './ConfigWizard.module.css'
 
 export interface ConfigWizardProps {
-  /** Optional starting config — pass to edit an existing setup. */
+  /**
+   * Optional starting config — pass to edit an existing setup.
+   *
+   * Read once at mount: changing this prop while the wizard is
+   * mounted does **not** reset the in-progress draft. Hosts that
+   * need to swap configs (e.g. switching tenants) should remount
+   * the wizard with a fresh React `key` so the draft state is
+   * dropped cleanly and the user's in-progress edits don't get
+   * silently merged into the new starting point.
+   */
   readonly initialConfig?: CalendarConfig
   /** Fired when the user clicks "Finish" on the Review step. */
   readonly onComplete: (config: CalendarConfig) => void
@@ -82,6 +91,12 @@ export default function ConfigWizard({
 
   const stepId: StepId = STEPS[step]!.id
   const isLast = step === STEPS.length - 1
+
+  // Wizard-wide validation — single source of truth shared by the
+  // Review step's pill and the Finish button's disabled state.
+  // validateConfig is pure, so re-running on every config change is
+  // cheap and guarantees the two read the same thing.
+  const validation = useMemo(() => validateConfig(config), [config])
 
   return (
     <div
@@ -131,7 +146,7 @@ export default function ConfigWizard({
           {stepId === 'catalogs'  && <CatalogsStep  config={config} setConfig={update} />}
           {stepId === 'resources' && <ResourcesStep config={config} setConfig={update} />}
           {stepId === 'pools'     && <PoolsStep     config={config} setConfig={update} onChildModalOpen={setChildModalOpen} />}
-          {stepId === 'review'    && <ReviewStep    config={config} setConfig={update} />}
+          {stepId === 'review'    && <ReviewStep    config={config} setConfig={update} validation={validation} />}
         </section>
 
         <footer className={styles['foot']}>
@@ -160,6 +175,11 @@ export default function ConfigWizard({
             <button
               type="button"
               className={styles['btnPrimary']}
+              disabled={!validation.ok}
+              title={validation.ok
+                ? undefined
+                : `Fix ${validation.issues.length} validation issue${validation.issues.length === 1 ? '' : 's'} before finishing.`}
+              aria-describedby={validation.ok ? undefined : 'wizard-validation-summary'}
               onClick={() => onComplete(config)}
             >
               Finish
@@ -298,22 +318,48 @@ function ResourcesStep({ config, setConfig }: StepProps): JSX.Element {
   // config only when both fields are finite numbers; clear it when
   // both are empty; leave it untouched in between so the user sees
   // their typed value mid-edit without poisoning distance pools.
-  const [coords, setCoords] = useState<Map<number, { lat: string; lon: string }>>(new Map())
+  //
+  // Drafts are keyed by a stable per-row id (#460): keying by array
+  // index meant deleting a row above another shifted indices and
+  // re-attached the deleted row's typed coordinate to its neighbour.
+  // The rowKeys array is kept in lock-step with `resources` —
+  // `addResource` / `removeAt` push/splice both at the same index;
+  // a length-mismatch effect catches up on external mutations
+  // (e.g. "Load sample data" or initialConfig editing).
+  const rowKeyCounter = useRef(0)
+  const makeRowKey = useCallback(() => `row-${rowKeyCounter.current++}`, [])
+  const [rowKeys, setRowKeys] = useState<readonly string[]>(
+    () => resources.map(() => `row-${rowKeyCounter.current++}`),
+  )
+  useEffect(() => {
+    if (rowKeys.length === resources.length) return
+    setRowKeys(prev => {
+      if (prev.length > resources.length) return prev.slice(0, resources.length)
+      const padded = [...prev]
+      while (padded.length < resources.length) padded.push(makeRowKey())
+      return padded
+    })
+  }, [resources.length, rowKeys.length, makeRowKey])
+
+  const [coords, setCoords] = useState<Map<string, { lat: string; lon: string }>>(new Map())
   const coordValue = (i: number, which: 'lat' | 'lon'): string => {
-    const draft = coords.get(i)
+    const key = rowKeys[i]
+    const draft = key ? coords.get(key) : undefined
     if (draft && draft[which] !== undefined) return draft[which]
     const r = resources[i]
     return r?.location ? String(r.location[which]) : ''
   }
   const setCoord = (i: number, which: 'lat' | 'lon', raw: string) => {
+    const key = rowKeys[i]
+    if (!key) return
     setCoords(prev => {
-      const existing = prev.get(i) ?? {
+      const existing = prev.get(key) ?? {
         lat: resources[i]?.location ? String(resources[i]!.location!.lat) : '',
         lon: resources[i]?.location ? String(resources[i]!.location!.lon) : '',
       }
       const next = { ...existing, [which]: raw }
       const out = new Map(prev)
-      out.set(i, next)
+      out.set(key, next)
       // Decide whether to commit the parsed pair to the config.
       const lat = next.lat === '' ? null : Number(next.lat)
       const lon = next.lon === '' ? null : Number(next.lon)
@@ -328,6 +374,23 @@ function ResourcesStep({ config, setConfig }: StepProps): JSX.Element {
       // it was. The local draft keeps the user's typed value visible.
       return out
     })
+  }
+  const removeAt = (i: number) => {
+    const droppedKey = rowKeys[i]
+    setResources(resources.filter((_, j) => j !== i))
+    setRowKeys(prev => prev.filter((_, j) => j !== i))
+    if (droppedKey) {
+      setCoords(prev => {
+        if (!prev.has(droppedKey)) return prev
+        const next = new Map(prev)
+        next.delete(droppedKey)
+        return next
+      })
+    }
+  }
+  const addResource = () => {
+    setResources([...resources, { id: '', name: '' }])
+    setRowKeys(prev => [...prev, makeRowKey()])
   }
   const profile = isProfileId(config.profile) ? config.profile : null
   const sample = profile ? getProfileSampleData(profile) : null
@@ -352,7 +415,7 @@ function ResourcesStep({ config, setConfig }: StepProps): JSX.Element {
       )}
       <ul className={styles['resourceList']}>
         {resources.map((r, i) => (
-          <li key={i} className={styles['resourceRow']}>
+          <li key={rowKeys[i] ?? `idx-${i}`} className={styles['resourceRow']}>
             <input
               type="text"
               className={styles['input']}
@@ -403,7 +466,7 @@ function ResourcesStep({ config, setConfig }: StepProps): JSX.Element {
               type="button"
               className={styles['removeBtn']}
               aria-label={`Remove resource ${i + 1}`}
-              onClick={() => setResources(resources.filter((_, j) => j !== i))}
+              onClick={() => removeAt(i)}
             >×</button>
             {(config.roles ?? []).length > 0 && (
               <RoleChips
@@ -419,7 +482,7 @@ function ResourcesStep({ config, setConfig }: StepProps): JSX.Element {
       <button
         type="button"
         className={styles['addBtn']}
-        onClick={() => setResources([...resources, { id: '', name: '' }])}
+        onClick={() => addResource()}
       >+ Add resource</button>
     </div>
   )
@@ -608,8 +671,11 @@ function asEngineResource(r: ConfigResource): EngineResource {
 
 // ─── Step 5 — review (settings + validation + JSON) ────────────────────────
 
-function ReviewStep({ config, setConfig }: StepProps): JSX.Element {
-  const validation = useMemo(() => validateConfig(config), [config])
+type ValidateConfigResult = ReturnType<typeof validateConfig>
+
+function ReviewStep({
+  config, setConfig, validation,
+}: StepProps & { readonly validation: ValidateConfigResult }): JSX.Element {
   const json = useMemo(
     () => JSON.stringify(serializeConfig(config), null, 2),
     [config],
@@ -657,14 +723,19 @@ function ReviewStep({ config, setConfig }: StepProps): JSX.Element {
         </legend>
         {validation.ok && <p className={styles['hint']}>No issues found. Ready to finish.</p>}
         {!validation.ok && (
-          <ul className={styles['issueList']}>
-            {validation.issues.map((issue, i) => (
-              <li key={i} className={styles['issueRow']}>
-                <code className={styles['issuePath']}>{issue.path}</code>
-                <span className={styles['issueKind']}>{issue.kind}</span>
-              </li>
-            ))}
-          </ul>
+          <>
+            <p id="wizard-validation-summary" className={styles['hint']}>
+              Fix these issues to enable Finish.
+            </p>
+            <ul className={styles['issueList']}>
+              {validation.issues.map((issue, i) => (
+                <li key={i} className={styles['issueRow']}>
+                  <code className={styles['issuePath']}>{issue.path}</code>
+                  <span className={styles['issueKind']}>{issue.kind}</span>
+                </li>
+              ))}
+            </ul>
+          </>
         )}
       </fieldset>
 
@@ -687,9 +758,10 @@ function ReviewStep({ config, setConfig }: StepProps): JSX.Element {
  * Trigger a browser download for a JSON string. Uses the
  * `Blob` + `URL.createObjectURL` + invisible `<a download>` dance
  * because that's the only cross-browser way to ship a file from a
- * pure-client wizard. The URL is revoked immediately after the
- * click — modern browsers queue the download synchronously, so
- * revoking on the next tick is safe and avoids leaking object URLs.
+ * pure-client wizard. The URL is revoked on the next tick rather
+ * than synchronously so older Safari and embedded WebViews — which
+ * sometimes process the click out-of-band — can still resolve the
+ * Blob before the URL goes away.
  *
  * No-op when run outside a browser (test environments without
  * `document` or `URL.createObjectURL`); the click would throw and
@@ -705,7 +777,7 @@ function downloadJson(content: string, filename: string): void {
   document.body.appendChild(a)
   a.click()
   document.body.removeChild(a)
-  URL.revokeObjectURL(href)
+  setTimeout(() => URL.revokeObjectURL(href), 0)
 }
 
 function cleanSettings(s: ConfigSettings): ConfigSettings {

--- a/src/ui/wizard/__tests__/ConfigWizard.test.tsx
+++ b/src/ui/wizard/__tests__/ConfigWizard.test.tsx
@@ -9,6 +9,7 @@ import React from 'react'
 
 import ConfigWizard from '../ConfigWizard'
 import type { CalendarConfig } from '../../../core/config/calendarConfig'
+import { applyProfilePreset } from '../../../core/config/profilePresets'
 
 describe('ConfigWizard — shell', () => {
   it('renders all five steps in the breadcrumbs', () => {
@@ -254,6 +255,96 @@ describe('ConfigWizard — Review step', () => {
   })
 })
 
+describe('ConfigWizard — Finish gating (#460)', () => {
+  it('disables Finish when validation fails', () => {
+    const onComplete = vi.fn()
+    render(<ConfigWizard
+      initialConfig={{
+        // role-slot template references a role that's not in roles[].
+        requirements: [{ eventType: 'load', requires: [{ role: 'ghost', count: 1 }] }],
+      }}
+      onComplete={onComplete} onCancel={vi.fn()}
+    />)
+    fireEvent.click(screen.getByRole('button', { name: /5.+Review/ }))
+    const finish = screen.getByRole('button', { name: 'Finish' })
+    expect(finish).toBeDisabled()
+    fireEvent.click(finish)
+    expect(onComplete).not.toHaveBeenCalled()
+  })
+
+  it('shows a hint linking the disabled Finish to the validation block', () => {
+    render(<ConfigWizard
+      initialConfig={{
+        requirements: [{ eventType: 'load', requires: [{ role: 'ghost', count: 1 }] }],
+      }}
+      onComplete={vi.fn()} onCancel={vi.fn()}
+    />)
+    fireEvent.click(screen.getByRole('button', { name: /5.+Review/ }))
+    expect(screen.getByText(/Fix these issues to enable Finish/)).toBeInTheDocument()
+  })
+
+  it('Finish stays enabled (and submits) when validation is clean', () => {
+    const onComplete = vi.fn()
+    render(<ConfigWizard
+      initialConfig={{ profile: 'custom' }}
+      onComplete={onComplete} onCancel={vi.fn()}
+    />)
+    fireEvent.click(screen.getByRole('button', { name: /5.+Review/ }))
+    const finish = screen.getByRole('button', { name: 'Finish' })
+    expect(finish).toBeEnabled()
+    fireEvent.click(finish)
+    expect(onComplete).toHaveBeenCalled()
+  })
+})
+
+describe('ConfigWizard — coordinate drafts keyed by row id (#460)', () => {
+  it('a partial-typed coord follows its row when a sibling above is deleted', () => {
+    // Index-keyed drafts (the pre-fix behavior) lost the typed
+    // value because deleting row 2 shifted row 3 to index 2 but
+    // the draft stayed pinned at index 3.
+    render(<ConfigWizard
+      initialConfig={{
+        resources: [
+          { id: 'a', name: 'A' },
+          { id: 'b', name: 'B' },
+          { id: 'c', name: 'C' },
+        ],
+      }}
+      onComplete={vi.fn()} onCancel={vi.fn()}
+    />)
+    fireEvent.click(screen.getByRole('button', { name: /3.+Resources/ }))
+    // Type into the third row's lat (lon stays empty — the pair
+    // doesn't commit, so the draft only lives in the local map).
+    fireEvent.change(screen.getByLabelText('Resource 3 latitude'), { target: { value: '99' } })
+    // Delete the middle row.
+    fireEvent.click(screen.getByRole('button', { name: 'Remove resource 2' }))
+    // The c row is now Resource 2; its typed lat must still show.
+    expect(screen.getByLabelText('Resource 2 latitude')).toHaveValue(99)
+  })
+
+  it('a deleted row\'s partial draft does not leak onto a freshly-added row', () => {
+    render(<ConfigWizard
+      initialConfig={{
+        resources: [
+          { id: 'a', name: 'A' },
+          { id: 'b', name: 'B' },
+        ],
+      }}
+      onComplete={vi.fn()} onCancel={vi.fn()}
+    />)
+    fireEvent.click(screen.getByRole('button', { name: /3.+Resources/ }))
+    // Half-type a coord on row 1, delete row 1, add a new row at
+    // the end. The new row at the same index must start empty
+    // rather than inheriting row 1's orphan draft.
+    fireEvent.change(screen.getByLabelText('Resource 1 latitude'), { target: { value: '88' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Remove resource 1' }))
+    fireEvent.click(screen.getByRole('button', { name: '+ Add resource' }))
+    // After the delete + add, two rows survive: original b at #1
+    // and a fresh blank at #2. The blank must show no typed lat.
+    expect(screen.getByLabelText('Resource 2 latitude')).toHaveValue(null)
+  })
+})
+
 describe('ConfigWizard — sample data button (#451)', () => {
   it('hides the button for the custom profile (no sample data)', () => {
     const { unmount } = render(<ConfigWizard
@@ -276,8 +367,11 @@ describe('ConfigWizard — sample data button (#451)', () => {
 
   it('clicking Load sample data populates resources + pools', () => {
     const onComplete = vi.fn()
+    // Apply the preset first so the sample data's `type` and role
+    // references resolve cleanly — Finish gating (#460) refuses
+    // configs that fail validateConfig.
     render(<ConfigWizard
-      initialConfig={{ profile: 'trucking' }}
+      initialConfig={applyProfilePreset('trucking', {})}
       onComplete={onComplete} onCancel={vi.fn()}
     />)
     fireEvent.click(screen.getByRole('button', { name: /3.+Resources/ }))
@@ -350,7 +444,7 @@ describe('ConfigWizard — JSON download (#451)', () => {
     expect(screen.getByRole('button', { name: 'Download config.json' })).toBeInTheDocument()
   })
 
-  it('clicking the button creates an object URL and triggers an anchor click', () => {
+  it('clicking the button creates an object URL and triggers an anchor click', async () => {
     const createSpy = vi.fn(() => 'blob:mock')
     const revokeSpy = vi.fn()
     const originalURL = global.URL
@@ -360,6 +454,7 @@ describe('ConfigWizard — JSON download (#451)', () => {
       revokeObjectURL: revokeSpy,
     }) as unknown as typeof URL
     Object.defineProperty(global, 'URL', { value: PatchedURL, writable: true, configurable: true })
+    vi.useFakeTimers()
     try {
       render(<ConfigWizard
         initialConfig={{ profile: 'aviation' }}
@@ -368,8 +463,13 @@ describe('ConfigWizard — JSON download (#451)', () => {
       fireEvent.click(screen.getByRole('button', { name: /5.+Review/ }))
       fireEvent.click(screen.getByRole('button', { name: 'Download config.json' }))
       expect(createSpy).toHaveBeenCalled()
+      // #460: revoke is now deferred via setTimeout(_, 0) so older
+      // browsers can resolve the blob before the URL goes away.
+      expect(revokeSpy).not.toHaveBeenCalled()
+      vi.runAllTimers()
       expect(revokeSpy).toHaveBeenCalledWith('blob:mock')
     } finally {
+      vi.useRealTimers()
       Object.defineProperty(global, 'URL', { value: originalURL, writable: true, configurable: true })
     }
   })


### PR DESCRIPTION
## Summary

Closes #460. Five follow-up items surfaced reviewing #447 (the v2 ConfigWizard capstone):

1. **Finish gating.** Review step computed `validateConfig`, but Finish still called `onComplete` on invalid drafts. Validation is now lifted to the wizard root and wired into Finish's `disabled` state, with a hint linking the disabled state back to the issue list.
2. **Hybrid pool preview count.** PoolBuilder's hybrid path counted `excluded = resources.length - matched`, making a 2-member hybrid against a 50-resource fleet read as 48 misses. Now `memberIds.length - matched` — the denominator matches the curated list.
3. **Coordinate drafts keyed by stable row id.** The `coords` Map was index-keyed, so deleting a row above another shifted indices and dropped or migrated typed-but-uncommitted coords. Added a parallel `rowKeys` array kept in lock-step with `resources` via a length-mismatch effect; the draft Map and `<li key>` route through it.
4. **`initialConfig` resync docs.** Clarified in the prop's JSDoc that the prop is read once at mount; hosts swapping configs while mounted should remount with a `key` to drop stale state cleanly.
5. **Object URL revoke timing.** `downloadJson` revoked synchronously after `a.click()`; wrapped in `setTimeout(_, 0)` so the doc comment matches behavior and older Safari / embedded WebViews can resolve the Blob before the URL goes away.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `vitest run` — 2499 passed (added 6 new tests: 3 for Finish gating, 2 for stable row id, 2 for hybrid count; one Codex-flagged path covered by the previous patch)
- [x] `npm run build` clean
- [ ] Manual: open the wizard, intentionally produce a `validateConfig` issue, confirm Finish disables and the hint appears
- [ ] Manual: edit a hybrid pool and verify the preview count matches the curated member list
- [ ] Manual: type a partial coord on row 3, delete row 2, confirm the typed value follows row 3 to its new index


---
_Generated by [Claude Code](https://claude.ai/code/session_01XojXzZPdEPuGbX2TyLY1pu)_