### PR TITLE
core(time): DST-aware wall-clock end-time preservation (#258)

### DIFF
--- a/src/core/engine/__tests__/wallClock.test.ts
+++ b/src/core/engine/__tests__/wallClock.test.ts
@@ -123,3 +123,50 @@ describe('computeOccurrenceEnd — sub-hour and cross-day', () => {
     expect(parts.minute).toBe(30);
   });
 });
+
+describe('computeOccurrenceEnd — Codex P1: fall-back fold-side preservation', () => {
+  // 2026-11-01: 01:30 wall-clock occurs twice in NY:
+  //   first  (DST-active, EDT, offset -240) at 05:30 UTC
+  //   second (standard,    EST, offset -300) at 06:30 UTC
+  // An event whose start lands on the second instance and whose end
+  // stays inside the repeated hour MUST keep the end on the second
+  // (EST) instance — otherwise end ends up earlier than start.
+
+  const startSecondInstance = new Date('2026-11-01T06:30:00Z'); // 01:30 EST
+
+  it('keeps the end on the same fold side as the start', () => {
+    const end = computeOccurrenceEnd(startSecondInstance, 15 * 60_000, NY);
+    // Expected: 01:45 EST = 06:45 UTC, *not* 01:45 EDT = 05:45 UTC.
+    expect(end.toISOString()).toBe('2026-11-01T06:45:00.000Z');
+    expect(end.getTime()).toBeGreaterThan(startSecondInstance.getTime());
+  });
+
+  it('an EDT-side start keeps EDT-side end when both stay within the fold', () => {
+    const startFirstInstance = new Date('2026-11-01T05:30:00Z'); // 01:30 EDT
+    const end = computeOccurrenceEnd(startFirstInstance, 15 * 60_000, NY);
+    // 01:45 EDT = 05:45 UTC.
+    expect(end.toISOString()).toBe('2026-11-01T05:45:00.000Z');
+  });
+});
+
+describe('computeOccurrenceEnd — Codex P2: sub-second precision preservation', () => {
+  it('preserves milliseconds in start through tz-aware math', () => {
+    // tz=UTC, 0ms duration, 500ms in start. Result must be the same instant.
+    const start = new Date('2026-01-15T12:00:00.500Z');
+    const end = computeOccurrenceEnd(start, 0, 'UTC');
+    expect(end.toISOString()).toBe('2026-01-15T12:00:00.500Z');
+  });
+
+  it('preserves milliseconds in durationMs through tz-aware math', () => {
+    const start = new Date('2026-01-15T12:00:00.000Z');
+    const end = computeOccurrenceEnd(start, 250, 'UTC');
+    expect(end.toISOString()).toBe('2026-01-15T12:00:00.250Z');
+  });
+
+  it('preserves milliseconds across a DST tz', () => {
+    const start = new Date('2026-06-15T13:00:00.123Z'); // 09:00:00.123 EDT
+    const end = computeOccurrenceEnd(start, 60 * 60_000 + 7, NY);
+    // Wall-clock: 10:00:00.123 + 7ms = 10:00:00.130 EDT = 14:00:00.130 UTC.
+    expect(end.toISOString()).toBe('2026-06-15T14:00:00.130Z');
+  });
+});

--- a/src/core/engine/__tests__/wallClock.test.ts
+++ b/src/core/engine/__tests__/wallClock.test.ts
@@ -1,0 +1,125 @@
+/**
+ * `computeOccurrenceEnd` — DST-aware wall-clock end-time preservation (#258).
+ *
+ * The function preserves the UTC delta when `tz` is unset, and the
+ * wall-clock delta when `tz` is provided. The boundary cases worth
+ * proving are spring-forward (a wall-clock hour disappears) and
+ * fall-back (a wall-clock hour repeats).
+ */
+import { describe, it, expect } from 'vitest';
+import { computeOccurrenceEnd } from '../time/wallClock';
+import { partsInTimezone } from '../time/timezone';
+
+const NY = 'America/New_York';
+const UTC = 'UTC';
+const TOKYO = 'Asia/Tokyo';
+
+const HOUR = 3_600_000;
+
+describe('computeOccurrenceEnd — no timezone (legacy / floating)', () => {
+  it('falls back to UTC addition when tz is undefined', () => {
+    const start = new Date('2026-01-15T12:00:00Z');
+    expect(computeOccurrenceEnd(start, 2 * HOUR).toISOString())
+      .toBe('2026-01-15T14:00:00.000Z');
+  });
+
+  it('falls back to UTC addition when tz is null', () => {
+    const start = new Date('2026-01-15T12:00:00Z');
+    expect(computeOccurrenceEnd(start, 2 * HOUR, null).toISOString())
+      .toBe('2026-01-15T14:00:00.000Z');
+  });
+
+  it('falls back to UTC addition when tz is empty string', () => {
+    const start = new Date('2026-01-15T12:00:00Z');
+    expect(computeOccurrenceEnd(start, 2 * HOUR, '').toISOString())
+      .toBe('2026-01-15T14:00:00.000Z');
+  });
+});
+
+describe('computeOccurrenceEnd — timezones without DST', () => {
+  it('UTC: 2h addition is identical to plain math', () => {
+    const start = new Date('2026-01-15T12:00:00Z');
+    expect(computeOccurrenceEnd(start, 2 * HOUR, UTC).toISOString())
+      .toBe('2026-01-15T14:00:00.000Z');
+  });
+
+  it('Asia/Tokyo (no DST): 2h addition is identical to plain math', () => {
+    const start = new Date('2026-01-15T12:00:00Z'); // 21:00 JST
+    const end = computeOccurrenceEnd(start, 2 * HOUR, TOKYO);
+    expect(end.toISOString()).toBe('2026-01-15T14:00:00.000Z');
+    // Wall-clock end is 23:00 JST.
+    expect(partsInTimezone(end, TOKYO).hour).toBe(23);
+  });
+});
+
+describe('computeOccurrenceEnd — spring-forward', () => {
+  // 2026 US spring-forward: 2026-03-08, clocks jump 02:00 → 03:00.
+  // 01:00 EST is 06:00 UTC. 03:00 EDT is 07:00 UTC.
+  const startEST = new Date('2026-03-08T06:00:00Z'); // 01:00 EST
+
+  it('a 2h event ending past the gap finishes at 03:00 wall-clock, not 04:00', () => {
+    const end = computeOccurrenceEnd(startEST, 2 * HOUR, NY);
+    expect(end.toISOString()).toBe('2026-03-08T07:00:00.000Z');
+    // Wall-clock confirmation.
+    const parts = partsInTimezone(end, NY);
+    expect(parts.hour).toBe(3);
+    expect(parts.minute).toBe(0);
+  });
+
+  it('UTC delta for that event is 1h (the gap eats one hour of UTC time)', () => {
+    const end = computeOccurrenceEnd(startEST, 2 * HOUR, NY);
+    expect(end.getTime() - startEST.getTime()).toBe(1 * HOUR);
+  });
+
+  it('plain UTC math (no tz) keeps a 2h UTC delta and lands at 04:00 EDT (the bug we fix)', () => {
+    const end = computeOccurrenceEnd(startEST, 2 * HOUR);
+    expect(partsInTimezone(end, NY).hour).toBe(4);
+  });
+});
+
+describe('computeOccurrenceEnd — fall-back', () => {
+  // 2026 US fall-back: 2026-11-01, clocks fall 02:00 → 01:00.
+  // 01:00 EDT (the first 1:00) is 05:00 UTC.
+  // Wall-clock 03:00 EST (after fold) is 08:00 UTC.
+  const startEDT = new Date('2026-11-01T05:00:00Z'); // 01:00 EDT (first occurrence)
+
+  it('a 2h event finishes at 03:00 wall-clock (post-fold)', () => {
+    const end = computeOccurrenceEnd(startEDT, 2 * HOUR, NY);
+    expect(end.toISOString()).toBe('2026-11-01T08:00:00.000Z');
+    const parts = partsInTimezone(end, NY);
+    expect(parts.hour).toBe(3);
+  });
+
+  it('UTC delta is 3h (the fold inserts an extra hour of UTC time)', () => {
+    const end = computeOccurrenceEnd(startEDT, 2 * HOUR, NY);
+    expect(end.getTime() - startEDT.getTime()).toBe(3 * HOUR);
+  });
+
+  it('plain UTC math (no tz) keeps a 2h UTC delta and lands at 02:00 EST', () => {
+    const end = computeOccurrenceEnd(startEDT, 2 * HOUR);
+    expect(partsInTimezone(end, NY).hour).toBe(2);
+  });
+});
+
+describe('computeOccurrenceEnd — sub-hour and cross-day', () => {
+  it('preserves a 30-minute wall-clock delta across spring-forward', () => {
+    // Start at 01:30 EST → +30m wall-clock → 02:00 wall-clock,
+    // which is in the gap. wallClockToUtc snaps to post-DST.
+    const start = new Date('2026-03-08T06:30:00Z'); // 01:30 EST
+    const end = computeOccurrenceEnd(start, 30 * 60_000, NY);
+    // Snapped wall-clock is 03:00 EDT = 07:00 UTC.
+    expect(end.toISOString()).toBe('2026-03-08T07:00:00.000Z');
+  });
+
+  it('crossing midnight stays correct on a non-DST day', () => {
+    const start = new Date('2026-01-15T04:30:00Z'); // 23:30 EST (Jan 14)
+    const end = computeOccurrenceEnd(start, 2 * HOUR, NY);
+    // Wall-clock end: 01:30 EST on Jan 15.
+    const parts = partsInTimezone(end, NY);
+    expect(parts.year).toBe(2026);
+    expect(parts.month).toBe(1);
+    expect(parts.day).toBe(15);
+    expect(parts.hour).toBe(1);
+    expect(parts.minute).toBe(30);
+  });
+});

--- a/src/core/engine/time/timezone.ts
+++ b/src/core/engine/time/timezone.ts
@@ -84,23 +84,21 @@ export function utcOffsetMinutes(d: Date, tz: string): number {
  *
  * Example: 9:00 AM in America/Denver → UTC Date
  *
- * DST-aware (#258): a single offset pass picks the wrong side of the
- * transition when the wall-clock target sits across it, so we try
- * both candidate offsets and pick whichever round-trips cleanly via
- * `partsInTimezone`.
+ * DST-aware (#258): collects up to four candidate UTC instants
+ * (the offset-1 anchor, the offset-2 anchor for non-trivial fixups,
+ * and ±1h fold siblings) and returns the one whose `partsInTimezone`
+ * round-trips back to the requested wall-clock target.
  *
  *   - Outside DST transitions: candidate1 round-trips and is returned.
- *   - On the DST-active side of a fall-back: candidate1 lands an hour
- *     off; candidate2 (using the offset at candidate1's instant)
- *     round-trips correctly and is returned.
  *   - Spring-forward gap (a wall-clock time that doesn't exist):
- *     neither candidate round-trips. Default to candidate1 — the
- *     "snap forward" mapping (skip the missing hour) — because a
- *     duration that lands in the gap is almost always meant to extend
- *     past it rather than collapse before it.
+ *     none of the candidates round-trip. Default to the offset-2
+ *     anchor when available, otherwise candidate1 — both represent
+ *     the "snap forward" mapping in the common case.
  *   - Fall-back fold (an ambiguous wall-clock time that repeats):
- *     candidate1's first round-trip wins, which is the earlier (DST-
- *     active) of the two — matches common library convention.
+ *     two candidates round-trip. By default the earlier (DST-active)
+ *     instance wins. Callers can pin a side via `preferOffsetMinutes`
+ *     — typically the offset of a known anchor (e.g. start time) —
+ *     to keep duration math monotonic across the fold.
  */
 export function wallClockToUtc(
   year: number,
@@ -110,22 +108,42 @@ export function wallClockToUtc(
   minute: number,
   second: number,
   tz: string,
+  preferOffsetMinutes?: number,
 ): Date {
   const approxUtc = new Date(Date.UTC(year, month - 1, day, hour, minute, second));
   const target = { year, month, day, hour, minute, second };
 
   const offset1 = utcOffsetMinutes(approxUtc, tz);
   const candidate1 = new Date(approxUtc.getTime() - offset1 * 60_000);
-  if (matchesWallClock(candidate1, tz, target)) return candidate1;
 
+  // Build candidate set: the naive anchor, the re-anchored variant
+  // when offsets disagree (handles spring-forward where offset1 reads
+  // the pre-DST side but the target lives on the post-DST side), and
+  // ±1h fold siblings (handles fall-back ambiguity, where the same
+  // wall-clock minute exists in both the DST-active and standard
+  // periods).
+  const candidates: Date[] = [candidate1];
   const offset2 = utcOffsetMinutes(candidate1, tz);
-  if (offset2 === offset1) return candidate1;
-  const candidate2 = new Date(approxUtc.getTime() - offset2 * 60_000);
-  if (matchesWallClock(candidate2, tz, target)) return candidate2;
+  if (offset2 !== offset1) {
+    candidates.push(new Date(approxUtc.getTime() - offset2 * 60_000));
+  }
+  candidates.push(new Date(candidate1.getTime() + 3_600_000));
+  candidates.push(new Date(candidate1.getTime() - 3_600_000));
 
-  // Wall-clock time doesn't exist in this tz on this date (spring-
-  // forward gap). Default to candidate1 — see fn comment.
-  return candidate1;
+  const matches = candidates.filter(d => matchesWallClock(d, tz, target));
+  if (matches.length === 0) {
+    // Spring-forward gap — `candidate1` is the snap-forward result
+    // (the wall-clock time interpreted with the offset that was in
+    // force just before the transition, which lands one missing
+    // hour past the requested time on the post-DST side).
+    return candidate1;
+  }
+
+  if (preferOffsetMinutes !== undefined) {
+    const hinted = matches.find(d => utcOffsetMinutes(d, tz) === preferOffsetMinutes);
+    if (hinted) return hinted;
+  }
+  return matches[0]!;
 }
 
 function matchesWallClock(

--- a/src/core/engine/time/timezone.ts
+++ b/src/core/engine/time/timezone.ts
@@ -84,8 +84,23 @@ export function utcOffsetMinutes(d: Date, tz: string): number {
  *
  * Example: 9:00 AM in America/Denver → UTC Date
  *
- * This is an approximation that iterates once to handle DST correctly.
- * For precise scheduling use a full timezone library (e.g. date-fns-tz).
+ * DST-aware (#258): a single offset pass picks the wrong side of the
+ * transition when the wall-clock target sits across it, so we try
+ * both candidate offsets and pick whichever round-trips cleanly via
+ * `partsInTimezone`.
+ *
+ *   - Outside DST transitions: candidate1 round-trips and is returned.
+ *   - On the DST-active side of a fall-back: candidate1 lands an hour
+ *     off; candidate2 (using the offset at candidate1's instant)
+ *     round-trips correctly and is returned.
+ *   - Spring-forward gap (a wall-clock time that doesn't exist):
+ *     neither candidate round-trips. Default to candidate1 — the
+ *     "snap forward" mapping (skip the missing hour) — because a
+ *     duration that lands in the gap is almost always meant to extend
+ *     past it rather than collapse before it.
+ *   - Fall-back fold (an ambiguous wall-clock time that repeats):
+ *     candidate1's first round-trip wins, which is the earlier (DST-
+ *     active) of the two — matches common library convention.
  */
 export function wallClockToUtc(
   year: number,
@@ -96,12 +111,31 @@ export function wallClockToUtc(
   second: number,
   tz: string,
 ): Date {
-  // First pass: assume current UTC offset
   const approxUtc = new Date(Date.UTC(year, month - 1, day, hour, minute, second));
-  const offset    = utcOffsetMinutes(approxUtc, tz);
-  // Second pass: correct for offset
-  const corrected = new Date(approxUtc.getTime() - offset * 60_000);
-  return corrected;
+  const target = { year, month, day, hour, minute, second };
+
+  const offset1 = utcOffsetMinutes(approxUtc, tz);
+  const candidate1 = new Date(approxUtc.getTime() - offset1 * 60_000);
+  if (matchesWallClock(candidate1, tz, target)) return candidate1;
+
+  const offset2 = utcOffsetMinutes(candidate1, tz);
+  if (offset2 === offset1) return candidate1;
+  const candidate2 = new Date(approxUtc.getTime() - offset2 * 60_000);
+  if (matchesWallClock(candidate2, tz, target)) return candidate2;
+
+  // Wall-clock time doesn't exist in this tz on this date (spring-
+  // forward gap). Default to candidate1 — see fn comment.
+  return candidate1;
+}
+
+function matchesWallClock(
+  d: Date,
+  tz: string,
+  target: { year: number; month: number; day: number; hour: number; minute: number; second: number },
+): boolean {
+  const p = partsInTimezone(d, tz);
+  return p.year === target.year && p.month === target.month && p.day === target.day
+      && p.hour === target.hour && p.minute === target.minute && p.second === target.second;
 }
 
 /**

--- a/src/core/engine/time/wallClock.ts
+++ b/src/core/engine/time/wallClock.ts
@@ -11,7 +11,7 @@
  * engine can always recover the correct UTC instant for any given date.
  */
 
-import { wallClockToUtc, hoursInTimezone, partsInTimezone } from './timezone';
+import { wallClockToUtc, hoursInTimezone, partsInTimezone, utcOffsetMinutes } from './timezone';
 import { buildOccurrenceDateKey } from '../recurrence/recurrenceMath';
 
 // ─── Wall-clock anchor ────────────────────────────────────────────────────────
@@ -87,11 +87,23 @@ export function computeOccurrenceEnd(
   if (!tz) return new Date(start.getTime() + durationMs);
 
   const startParts = partsInTimezone(start, tz);
+  // Carry the start's offset as a fold-side hint so a fall-back
+  // ambiguous end stays on the same side of the transition as the
+  // start (Codex P1 on #258). Without this, an event whose start is
+  // the second instance of the repeated hour and whose end is still
+  // inside that hour gets re-anchored to the first instance — moving
+  // end *before* start.
+  const startOffsetMinutes = utcOffsetMinutes(start, tz);
+  // Sub-second precision lives outside `partsInTimezone` (integer
+  // seconds only) and outside `wallClockToUtc` (no ms argument), so
+  // we shuttle the millisecond residue through the wall-clock
+  // arithmetic by hand (Codex P2 on #258).
+  const startMsResidue = start.getTime() - Math.floor(start.getTime() / 1000) * 1000;
 
-  // Treat the wall-clock parts as if they were UTC and add `durationMs`
-  // there. This is "clock arithmetic" — the carry rules (60s = 1m,
-  // 60m = 1h, etc.) match what a wall clock does, and the result is
-  // independent of the source/target offsets.
+  // Treat the wall-clock parts as if they were UTC and add the
+  // residue + duration there. This is "clock arithmetic" — the
+  // carry rules (60s = 1m, 60m = 1h, etc.) match what a wall clock
+  // does, and the result is independent of the source/target offsets.
   const wallStartAsUtc = Date.UTC(
     startParts.year,
     startParts.month - 1,
@@ -100,11 +112,13 @@ export function computeOccurrenceEnd(
     startParts.minute,
     startParts.second,
   );
-  const wallEndAsUtc = new Date(wallStartAsUtc + durationMs);
+  const wallEndAsUtc = new Date(wallStartAsUtc + startMsResidue + durationMs);
+  const wallEndMsResidue = wallEndAsUtc.getTime() - Math.floor(wallEndAsUtc.getTime() / 1000) * 1000;
 
   // Read the post-add wall-clock parts back out of the throwaway UTC
-  // moment and re-anchor in the real timezone.
-  return wallClockToUtc(
+  // moment and re-anchor in the real timezone, preferring the start's
+  // DST offset when ambiguous.
+  const baseEnd = wallClockToUtc(
     wallEndAsUtc.getUTCFullYear(),
     wallEndAsUtc.getUTCMonth() + 1,
     wallEndAsUtc.getUTCDate(),
@@ -112,7 +126,9 @@ export function computeOccurrenceEnd(
     wallEndAsUtc.getUTCMinutes(),
     wallEndAsUtc.getUTCSeconds(),
     tz,
+    startOffsetMinutes,
   );
+  return new Date(baseEnd.getTime() + wallEndMsResidue);
 }
 
 // ─── Display helpers ──────────────────────────────────────────────────────────

--- a/src/core/engine/time/wallClock.ts
+++ b/src/core/engine/time/wallClock.ts
@@ -59,17 +59,60 @@ export function applyWallClockAnchor(
  *   - the original event duration in ms
  *   - the event's timezone (for DST-aware duration)
  *
- * In most cases this is just `start + durationMs`.
- * The timezone parameter is reserved for future DST-aware duration math.
+ * When `tz` is null/undefined, this is `start + durationMs` — the
+ * UTC delta is preserved. That matches the "floating event" model
+ * and is the right call when no timezone is known.
+ *
+ * When `tz` is a valid IANA zone, this preserves the **wall-clock**
+ * duration instead. That matters across DST transitions: a 2h
+ * meeting that starts at 1:00 AM the night clocks spring forward
+ * should end at 3:00 AM (wall-clock), not 4:00 AM. UTC-only math
+ * skips an hour by silently keeping a 2h UTC delta even though the
+ * clock itself jumped.
+ *
+ * Algorithm:
+ *   1. Project `start` to wall-clock parts in `tz`.
+ *   2. Add `durationMs` worth of wall-clock time, carrying minutes
+ *      → hours → days the same way regardless of DST (i.e. clock
+ *      arithmetic, not UTC arithmetic).
+ *   3. Convert the new wall-clock parts back to UTC at `tz`. If
+ *      the end lands inside a spring-forward gap (a non-existent
+ *      time), `wallClockToUtc` snaps it to the post-DST equivalent.
  */
 export function computeOccurrenceEnd(
   start: Date,
   durationMs: number,
-  _tz?: string | null,
+  tz?: string | null,
 ): Date {
-  // Currently: simple addition.
-  // TODO: For DST-aware semantics (preserve wall-clock end time), use _tz.
-  return new Date(start.getTime() + durationMs);
+  if (!tz) return new Date(start.getTime() + durationMs);
+
+  const startParts = partsInTimezone(start, tz);
+
+  // Treat the wall-clock parts as if they were UTC and add `durationMs`
+  // there. This is "clock arithmetic" — the carry rules (60s = 1m,
+  // 60m = 1h, etc.) match what a wall clock does, and the result is
+  // independent of the source/target offsets.
+  const wallStartAsUtc = Date.UTC(
+    startParts.year,
+    startParts.month - 1,
+    startParts.day,
+    startParts.hour,
+    startParts.minute,
+    startParts.second,
+  );
+  const wallEndAsUtc = new Date(wallStartAsUtc + durationMs);
+
+  // Read the post-add wall-clock parts back out of the throwaway UTC
+  // moment and re-anchor in the real timezone.
+  return wallClockToUtc(
+    wallEndAsUtc.getUTCFullYear(),
+    wallEndAsUtc.getUTCMonth() + 1,
+    wallEndAsUtc.getUTCDate(),
+    wallEndAsUtc.getUTCHours(),
+    wallEndAsUtc.getUTCMinutes(),
+    wallEndAsUtc.getUTCSeconds(),
+    tz,
+  );
 }
 
 // ─── Display helpers ──────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Closes #258. `computeOccurrenceEnd(start, durationMs, tz)` now preserves **wall-clock** duration when a tz is supplied — the prior simple UTC addition silently swallowed (or fabricated) an hour around DST boundaries.

Examples (`America/New_York`):
- Spring-forward: 1:00 AM + 2h returned 4:00 AM EDT → now correctly 3:00 AM EDT.
- Fall-back: 1:00 AM + 2h returned 2:00 AM EST → now correctly 3:00 AM EST.

When `tz` is `null` / `undefined` / `''`, legacy UTC math is preserved, so floating events stay byte-identical.

The fix also hardens `wallClockToUtc` from a single-pass approximation to a two-candidate verifier (each candidate round-trips through `partsInTimezone` to confirm it represents the requested wall-clock time). Existing `wallClockToUtc` tests use stable-offset dates and are unaffected.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `vitest run` — 2512 passed, 13 new in `wallClock.test.ts` covering: float tz, no-DST zones (UTC, JST), spring-forward (post-gap + UTC delta + the old buggy result as a regression marker), fall-back, sub-hour gap inputs, cross-midnight no-DST
- [x] `wallClockToUtc` regression — pre-existing tests still pass
- [ ] Manual: schedule a 2h event 1:00 AM on a US spring-forward Sunday with tz=`America/New_York`, confirm end is 3:00 AM


---
_Generated by [Claude Code](https://claude.ai/code/session_01XojXzZPdEPuGbX2TyLY1pu)_