### PR TITLE
core(validation): full schema-driven validateEvent with sourcePolicy + onError (#259)

### DIFF
--- a/src/core/engine/engineTypes.ts
+++ b/src/core/engine/engineTypes.ts
@@ -78,6 +78,8 @@ export type {
   EventValidationCode,
   EventValidationIssue,
   EventValidationResult,
+  EventIssueAction,
+  EventIssueSeverity,
   ValidateEventOptions,
 } from './validation/validateEvent';
 

--- a/src/core/engine/validation/__tests__/validateEvent.test.ts
+++ b/src/core/engine/validation/__tests__/validateEvent.test.ts
@@ -193,6 +193,42 @@ describe('validateEvent — sourcePolicy (#259 prod overrides)', () => {
     expect(r.ok).toBe(false);
     expect(r.issues.some(i => i.code === 'INVALID_TITLE')).toBe(true);
   });
+
+  it('honors sourcePolicy on the INVALID_EVENT non-object fast path (Codex P2)', () => {
+    // Pre-fix, the non-object fast path hardcoded INVALID_EVENT as
+    // an error and returned before resolveAction could downgrade it.
+    const onError = vi.fn() as unknown as OnError;
+
+    const warned = validateEvent(null, {
+      mode: 'prod',
+      sourcePolicy: { INVALID_EVENT: 'warn' },
+      onError,
+    });
+    expect(warned.ok).toBe(true);
+    expect(warned.issues[0]?.code).toBe('INVALID_EVENT');
+    expect(warned.issues[0]?.severity).toBe('warn');
+    // Warn-severity must not ping onError.
+    expect(onError).not.toHaveBeenCalled();
+
+    const ignored = validateEvent('not an object', {
+      mode: 'prod',
+      sourcePolicy: { INVALID_EVENT: 'ignore' },
+      onError,
+    });
+    expect(ignored.ok).toBe(true);
+    expect(ignored.issues).toEqual([]);
+    expect(onError).not.toHaveBeenCalled();
+  });
+
+  it('strict mode still hard-errors INVALID_EVENT regardless of sourcePolicy', () => {
+    const r = validateEvent(null, {
+      mode: 'strict',
+      sourcePolicy: { INVALID_EVENT: 'ignore' },
+    });
+    expect(r.ok).toBe(false);
+    expect(r.issues[0]?.code).toBe('INVALID_EVENT');
+    expect(r.issues[0]?.severity).toBe('error');
+  });
 });
 
 describe('validateEvent — onError wiring (#259)', () => {

--- a/src/core/engine/validation/__tests__/validateEvent.test.ts
+++ b/src/core/engine/validation/__tests__/validateEvent.test.ts
@@ -1,0 +1,231 @@
+/**
+ * `validateEvent` — schema-driven event validator (#259).
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { validateEvent } from '../validateEvent';
+import { makeEvent } from '../../schema/eventSchema';
+import type { OnError } from '../../errors/onError';
+
+const baseEvent = () => makeEvent('e1', {
+  title: 'Title',
+  start: new Date('2026-04-28T10:00:00Z'),
+  end: new Date('2026-04-28T11:00:00Z'),
+});
+
+describe('validateEvent — top-level shape', () => {
+  it('rejects non-objects', () => {
+    expect(validateEvent(null).ok).toBe(false);
+    expect(validateEvent('hello').ok).toBe(false);
+    expect(validateEvent(42).ok).toBe(false);
+    expect(validateEvent(undefined).ok).toBe(false);
+  });
+
+  it('a fully valid event passes', () => {
+    expect(validateEvent(baseEvent()).ok).toBe(true);
+  });
+});
+
+describe('validateEvent — id / title / time', () => {
+  it('flags an empty id', () => {
+    const ev = { ...baseEvent(), id: '   ' };
+    const r = validateEvent(ev);
+    expect(r.ok).toBe(false);
+    expect(r.issues.some(i => i.code === 'INVALID_ID')).toBe(true);
+  });
+
+  it('flags an empty title in strict mode', () => {
+    const ev = { ...baseEvent(), title: '' };
+    const r = validateEvent(ev, { mode: 'strict' });
+    expect(r.ok).toBe(false);
+    expect(r.issues.some(i => i.code === 'INVALID_TITLE')).toBe(true);
+  });
+
+  it('allows an empty title in prod mode', () => {
+    const ev = { ...baseEvent(), title: '' };
+    const r = validateEvent(ev, { mode: 'prod' });
+    expect(r.ok).toBe(true);
+    expect(r.issues.some(i => i.code === 'INVALID_TITLE')).toBe(false);
+  });
+
+  it('flags non-string title in either mode', () => {
+    const ev = { ...baseEvent(), title: 42 as unknown as string };
+    expect(validateEvent(ev, { mode: 'strict' }).ok).toBe(false);
+    expect(validateEvent(ev, { mode: 'prod' }).ok).toBe(false);
+  });
+
+  it('flags invalid start / end dates', () => {
+    const bad = { ...baseEvent(), start: new Date('nope'), end: new Date('also-nope') };
+    const r = validateEvent(bad);
+    expect(r.issues.some(i => i.code === 'INVALID_START')).toBe(true);
+    expect(r.issues.some(i => i.code === 'INVALID_END')).toBe(true);
+  });
+
+  it('flags reversed range', () => {
+    const ev = {
+      ...baseEvent(),
+      start: new Date('2026-04-28T11:00:00Z'),
+      end:   new Date('2026-04-28T10:00:00Z'),
+    };
+    const r = validateEvent(ev);
+    expect(r.ok).toBe(false);
+    expect(r.issues.some(i => i.code === 'INVALID_RANGE')).toBe(true);
+  });
+});
+
+describe('validateEvent — exdates', () => {
+  it('passes when exdates is absent or an empty array', () => {
+    expect(validateEvent({ ...baseEvent(), exdates: [] }).ok).toBe(true);
+  });
+
+  it('flags non-array exdates', () => {
+    const ev = { ...baseEvent(), exdates: 'oops' as unknown as readonly Date[] };
+    const r = validateEvent(ev);
+    expect(r.issues.some(i => i.code === 'INVALID_EXDATES')).toBe(true);
+  });
+
+  it('flags an array containing a bad date', () => {
+    const ev = {
+      ...baseEvent(),
+      exdates: [new Date('2026-04-28T00:00:00Z'), new Date('nope')],
+    };
+    const r = validateEvent(ev);
+    const ex = r.issues.find(i => i.code === 'INVALID_EXDATES');
+    expect(ex?.details?.['index']).toBe(1);
+  });
+});
+
+describe('validateEvent — rrule', () => {
+  it('accepts well-formed RRULE strings', () => {
+    expect(validateEvent({ ...baseEvent(), rrule: 'FREQ=WEEKLY;BYDAY=MO' }).ok).toBe(true);
+    expect(validateEvent({ ...baseEvent(), rrule: 'RRULE:FREQ=DAILY' }).ok).toBe(true);
+  });
+
+  it('rejects malformed RRULE strings', () => {
+    expect(validateEvent({ ...baseEvent(), rrule: 'rrule' }).issues.some(i => i.code === 'INVALID_RRULE')).toBe(true);
+    expect(validateEvent({ ...baseEvent(), rrule: 'FREQ=' }).issues.some(i => i.code === 'INVALID_RRULE')).toBe(true);
+    expect(validateEvent({ ...baseEvent(), rrule: 'BYDAY=MO' }).issues.some(i => i.code === 'INVALID_RRULE')).toBe(true);
+    expect(validateEvent({ ...baseEvent(), rrule: 'FREQ=BLARGH' }).issues.some(i => i.code === 'INVALID_RRULE')).toBe(true);
+  });
+
+  it('skips the check when rrule is null/undefined', () => {
+    expect(validateEvent({ ...baseEvent(), rrule: null }).ok).toBe(true);
+    const noRrule = { ...baseEvent() };
+    delete (noRrule as { rrule?: unknown }).rrule;
+    expect(validateEvent(noRrule).ok).toBe(true);
+  });
+});
+
+describe('validateEvent — timezone', () => {
+  it('accepts known IANA zones', () => {
+    expect(validateEvent({ ...baseEvent(), timezone: 'America/New_York' }).ok).toBe(true);
+    expect(validateEvent({ ...baseEvent(), timezone: 'UTC' }).ok).toBe(true);
+  });
+
+  it('flags bogus zones', () => {
+    const r = validateEvent({ ...baseEvent(), timezone: 'Mars/Olympus_Mons' });
+    expect(r.issues.some(i => i.code === 'INVALID_TIMEZONE')).toBe(true);
+  });
+});
+
+describe('validateEvent — resourceId', () => {
+  it('accepts a string', () => {
+    expect(validateEvent({ ...baseEvent(), resourceId: 'truck-1' }).ok).toBe(true);
+  });
+
+  it('accepts null', () => {
+    expect(validateEvent({ ...baseEvent(), resourceId: null }).ok).toBe(true);
+  });
+
+  it('flags non-string resourceId', () => {
+    const ev = { ...baseEvent(), resourceId: 42 as unknown as string };
+    expect(validateEvent(ev).issues.some(i => i.code === 'INVALID_RESOURCE_ID')).toBe(true);
+  });
+});
+
+describe('validateEvent — color (strict only)', () => {
+  it('accepts hex, function, and named colors in strict mode', () => {
+    expect(validateEvent({ ...baseEvent(), color: '#ff8800' }).ok).toBe(true);
+    expect(validateEvent({ ...baseEvent(), color: 'rgb(255, 128, 0)' }).ok).toBe(true);
+    expect(validateEvent({ ...baseEvent(), color: 'tomato' }).ok).toBe(true);
+  });
+
+  it('flags garbage colors in strict mode', () => {
+    const r = validateEvent({ ...baseEvent(), color: 'not a color' });
+    expect(r.issues.some(i => i.code === 'INVALID_COLOR')).toBe(true);
+  });
+
+  it('skips the color check entirely in prod mode', () => {
+    const ev = { ...baseEvent(), color: 'not a color' };
+    const r = validateEvent(ev, { mode: 'prod' });
+    expect(r.issues.some(i => i.code === 'INVALID_COLOR')).toBe(false);
+    expect(r.ok).toBe(true);
+  });
+});
+
+describe('validateEvent — sourcePolicy (#259 prod overrides)', () => {
+  it('downgrades a code to warn in prod', () => {
+    const ev = { ...baseEvent(), title: 42 as unknown as string };
+    const r = validateEvent(ev, {
+      mode: 'prod',
+      sourcePolicy: { INVALID_TITLE: 'warn' },
+    });
+    expect(r.ok).toBe(true);
+    const issue = r.issues.find(i => i.code === 'INVALID_TITLE');
+    expect(issue?.severity).toBe('warn');
+  });
+
+  it('ignores a code entirely in prod', () => {
+    const ev = { ...baseEvent(), timezone: 'Bogus/Zone' };
+    const r = validateEvent(ev, {
+      mode: 'prod',
+      sourcePolicy: { INVALID_TIMEZONE: 'ignore' },
+    });
+    expect(r.ok).toBe(true);
+    expect(r.issues.some(i => i.code === 'INVALID_TIMEZONE')).toBe(false);
+  });
+
+  it('strict mode ignores sourcePolicy', () => {
+    const ev = { ...baseEvent(), title: '' };
+    const r = validateEvent(ev, {
+      mode: 'strict',
+      sourcePolicy: { INVALID_TITLE: 'ignore' },
+    });
+    expect(r.ok).toBe(false);
+    expect(r.issues.some(i => i.code === 'INVALID_TITLE')).toBe(true);
+  });
+});
+
+describe('validateEvent — onError wiring (#259)', () => {
+  it('fires onError once per error-severity issue with phase + sourceId meta', () => {
+    const onError = vi.fn() as unknown as OnError;
+    const ev = {
+      ...baseEvent(),
+      id: '',                 // → INVALID_ID
+      end: new Date('nope'),  // → INVALID_END
+    };
+    validateEvent(ev, { onError, sourceId: 'feed-7' });
+    expect(onError).toHaveBeenCalledTimes(2);
+    const firstCall = (onError as unknown as { mock: { calls: unknown[][] } }).mock.calls[0];
+    const meta = firstCall![1] as { phase: string; sourceId: string };
+    expect(meta.phase).toBe('validate');
+    expect(meta.sourceId).toBe('feed-7');
+  });
+
+  it('does not fire for warn-only issues', () => {
+    const onError = vi.fn() as unknown as OnError;
+    const ev = { ...baseEvent(), title: 42 as unknown as string };
+    validateEvent(ev, {
+      mode: 'prod',
+      sourcePolicy: { INVALID_TITLE: 'warn' },
+      onError,
+    });
+    expect(onError).not.toHaveBeenCalled();
+  });
+
+  it('passes the eventId through when one is available', () => {
+    const onError = vi.fn() as unknown as OnError;
+    validateEvent({ ...baseEvent(), end: new Date('nope') }, { onError });
+    const meta = (onError as unknown as { mock: { calls: unknown[][] } }).mock.calls[0]![1] as { eventId: string };
+    expect(meta.eventId).toBe('e1');
+  });
+});

--- a/src/core/engine/validation/validateEvent.ts
+++ b/src/core/engine/validation/validateEvent.ts
@@ -89,31 +89,37 @@ export function validateEvent(
   opts: ValidateEventOptions = {},
 ): EventValidationResult {
   const mode = opts.mode ?? 'strict';
-
-  if (!input || typeof input !== 'object') {
-    const issue: EventValidationIssue = {
-      code: 'INVALID_EVENT', field: 'event', severity: 'error',
-      message: 'Event must be an object.',
-    };
-    emit(issue, undefined, opts);
-    return { ok: false, issues: [issue] };
-  }
-
-  const ev = input as Partial<EngineEvent>;
   const collected: EventValidationIssue[] = [];
   const collect = (
     code: EventValidationCode,
     field: EventValidationIssue['field'],
     message: string,
     details?: Readonly<Record<string, unknown>>,
-  ) => {
+  ): boolean => {
     const action = resolveAction(code, mode, opts.sourcePolicy);
-    if (action === 'ignore') return;
+    if (action === 'ignore') return false;
     const issue: EventValidationIssue = details === undefined
       ? { code, field, message, severity: actionToSeverity(action) }
       : { code, field, message, severity: actionToSeverity(action), details };
     collected.push(issue);
+    return true;
   };
+
+  // Non-object payload — route through the same policy machinery so
+  // `sourcePolicy: { INVALID_EVENT: 'warn' | 'ignore' }` is honored
+  // (Codex P2 on #259). Bail before touching `ev.<field>` accessors.
+  if (!input || typeof input !== 'object') {
+    collect('INVALID_EVENT', 'event', 'Event must be an object.');
+    for (const issue of collected) {
+      if (issue.severity === 'error') emit(issue, undefined, opts);
+    }
+    return {
+      ok: !collected.some(i => i.severity === 'error'),
+      issues: collected,
+    };
+  }
+
+  const ev = input as Partial<EngineEvent>;
 
   // ── id ────────────────────────────────────────────────────────────────────
   if (typeof ev.id !== 'string' || ev.id.trim().length === 0) {

--- a/src/core/engine/validation/validateEvent.ts
+++ b/src/core/engine/validation/validateEvent.ts
@@ -1,4 +1,7 @@
 import type { EngineEvent } from '../schema/eventSchema';
+import type { OnError } from '../errors/onError';
+import { toStructuredError } from '../errors/onError';
+import { isValidTimezone } from '../time/timezone';
 
 export type ValidationMode = 'strict' | 'prod';
 
@@ -9,90 +12,277 @@ export type EventValidationCode =
   | 'INVALID_START'
   | 'INVALID_END'
   | 'INVALID_RANGE'
-  | 'INVALID_EXDATES';
+  | 'INVALID_EXDATES'
+  | 'INVALID_RRULE'
+  | 'INVALID_TIMEZONE'
+  | 'INVALID_RESOURCE_ID'
+  | 'INVALID_COLOR';
+
+/**
+ * Per-source policy override for an issue code. Used in prod mode
+ * (#259) so a single misbehaving feed can downgrade or ignore a
+ * specific class of issue without blocking the rest of the data.
+ *
+ *   - 'error'  — surface as an error (default, blocks `ok`)
+ *   - 'warn'   — surface but don't block `ok`
+ *   - 'ignore' — drop the issue entirely
+ */
+export type EventIssueAction = 'error' | 'warn' | 'ignore';
+export type EventIssueSeverity = 'error' | 'warn';
 
 export interface EventValidationIssue {
   readonly code: EventValidationCode;
   readonly field: keyof EngineEvent | 'event';
   readonly message: string;
+  readonly severity: EventIssueSeverity;
   readonly details?: Readonly<Record<string, unknown>>;
 }
 
 export interface EventValidationResult {
+  /** True when no `error`-severity issues remain after policy. */
   readonly ok: boolean;
   readonly issues: readonly EventValidationIssue[];
 }
 
 export interface ValidateEventOptions {
   /**
-   * strict: fail on schema/shape drift and questionable values.
-   * prod: best-effort validation; allows callers to log+continue where possible.
+   * strict: every check is enforced; empty titles, unknown timezones,
+   *         malformed colors, and unparseable RRULEs all surface as
+   *         hard errors.
+   * prod:   best-effort; titles may be empty without an error,
+   *         color is not checked (presentation is the host's concern),
+   *         and `sourcePolicy` can downgrade individual codes.
    */
   readonly mode?: ValidationMode;
+  /**
+   * In prod mode, override how specific codes are handled. Codes
+   * not listed keep their default severity. Hosts use this when a
+   * single feed has known dirty data that shouldn't block render.
+   */
+  readonly sourcePolicy?: Partial<Record<EventValidationCode, EventIssueAction>>;
+  /**
+   * When provided, called once per `error`-severity issue with a
+   * structured error and `{ phase: 'validate', sourceId?, eventId? }`
+   * meta. Mirrors the contract used by `expandRecurrenceSafe`.
+   */
+  readonly onError?: OnError;
+  /** Optional source identifier — passed through to `onError` meta. */
+  readonly sourceId?: string;
 }
 
 /**
- * Drop-in skeleton validator for event payloads.
+ * Schema-driven event validator (#259).
  *
- * TODO(team):
- * - Expand this to full schema-driven validation (zod/io-ts/custom rules).
- * - Add per-source policy overrides in prod mode.
- * - Wire to onError contract for centralized telemetry.
+ * Walks the entire `EngineEvent` shape rather than just the few fields
+ * checked by the original skeleton: shapes for id / title / start /
+ * end / range / exdates plus best-effort schema checks for rrule,
+ * timezone, resourceId, and color (color is strict-only).
+ *
+ * No external runtime deps — the existing `EventValidationCode` union
+ * is the schema.
+ *
+ * Returns `{ ok, issues }`. `ok` reflects only `error`-severity
+ * issues; `warn`-severity issues stay in `issues` but don't fail.
  */
 export function validateEvent(
   input: unknown,
   opts: ValidateEventOptions = {},
 ): EventValidationResult {
   const mode = opts.mode ?? 'strict';
-  const issues: EventValidationIssue[] = [];
 
   if (!input || typeof input !== 'object') {
-    return {
-      ok: false,
-      issues: [{ code: 'INVALID_EVENT', field: 'event', message: 'Event must be an object.' }],
+    const issue: EventValidationIssue = {
+      code: 'INVALID_EVENT', field: 'event', severity: 'error',
+      message: 'Event must be an object.',
     };
+    emit(issue, undefined, opts);
+    return { ok: false, issues: [issue] };
   }
 
   const ev = input as Partial<EngineEvent>;
+  const collected: EventValidationIssue[] = [];
+  const collect = (
+    code: EventValidationCode,
+    field: EventValidationIssue['field'],
+    message: string,
+    details?: Readonly<Record<string, unknown>>,
+  ) => {
+    const action = resolveAction(code, mode, opts.sourcePolicy);
+    if (action === 'ignore') return;
+    const issue: EventValidationIssue = details === undefined
+      ? { code, field, message, severity: actionToSeverity(action) }
+      : { code, field, message, severity: actionToSeverity(action), details };
+    collected.push(issue);
+  };
 
+  // ── id ────────────────────────────────────────────────────────────────────
   if (typeof ev.id !== 'string' || ev.id.trim().length === 0) {
-    issues.push({ code: 'INVALID_ID', field: 'id', message: 'Event id must be a non-empty string.' });
+    collect('INVALID_ID', 'id', 'Event id must be a non-empty string.');
   }
 
-  if (typeof ev.title !== 'string' || ev.title.trim().length === 0) {
-    issues.push({ code: 'INVALID_TITLE', field: 'title', message: 'Event title must be a non-empty string.' });
+  // ── title ────────────────────────────────────────────────────────────────
+  if (typeof ev.title !== 'string') {
+    collect('INVALID_TITLE', 'title', 'Event title must be a string.');
+  } else if (ev.title.trim().length === 0 && mode === 'strict') {
+    collect('INVALID_TITLE', 'title', 'Event title must be non-empty in strict mode.');
   }
 
-  if (!(ev.start instanceof Date) || Number.isNaN(ev.start.getTime())) {
-    issues.push({ code: 'INVALID_START', field: 'start', message: 'Event start must be a valid Date.' });
+  // ── start ────────────────────────────────────────────────────────────────
+  if (!isFiniteDate(ev.start)) {
+    collect('INVALID_START', 'start', 'Event start must be a finite Date.');
   }
 
-  if (!(ev.end instanceof Date) || Number.isNaN(ev.end.getTime())) {
-    issues.push({ code: 'INVALID_END', field: 'end', message: 'Event end must be a valid Date.' });
+  // ── end + range ──────────────────────────────────────────────────────────
+  if (!isFiniteDate(ev.end)) {
+    collect('INVALID_END', 'end', 'Event end must be a finite Date.');
+  } else if (isFiniteDate(ev.start) && (ev.end as Date) <= (ev.start as Date)) {
+    collect(
+      'INVALID_RANGE', 'end', 'Event end must be after start.',
+      { start: (ev.start as Date).toISOString(), end: (ev.end as Date).toISOString() },
+    );
   }
 
-  if (ev.start instanceof Date && ev.end instanceof Date && ev.end <= ev.start) {
-    issues.push({
-      code: 'INVALID_RANGE',
-      field: 'end',
-      message: 'Event end must be after start.',
-      details: { start: ev.start.toISOString(), end: ev.end.toISOString() },
-    });
+  // ── exdates ──────────────────────────────────────────────────────────────
+  if (ev.exdates !== undefined) {
+    if (!Array.isArray(ev.exdates)) {
+      collect('INVALID_EXDATES', 'exdates', 'exdates must be an array of Date values.');
+    } else {
+      const badIndex = ev.exdates.findIndex(d => !isFiniteDate(d));
+      if (badIndex !== -1) {
+        collect(
+          'INVALID_EXDATES', 'exdates',
+          `exdates[${badIndex}] is not a valid Date.`,
+          { index: badIndex },
+        );
+      }
+    }
   }
 
-  if (ev.exdates && !Array.isArray(ev.exdates)) {
-    issues.push({
-      code: 'INVALID_EXDATES',
-      field: 'exdates',
-      message: 'exdates must be an array of Date values.',
-    });
+  // ── rrule ────────────────────────────────────────────────────────────────
+  if (ev.rrule !== undefined && ev.rrule !== null) {
+    if (typeof ev.rrule !== 'string' || !looksLikeRrule(ev.rrule)) {
+      collect('INVALID_RRULE', 'rrule', 'rrule must be a parseable RRULE string.');
+    }
   }
 
-  // In prod mode, callers may choose to continue with warnings; we still return
-  // all issues so policy can be decided at integration boundaries.
-  if (mode === 'prod') {
-    return { ok: issues.length === 0, issues };
+  // ── timezone ─────────────────────────────────────────────────────────────
+  if (ev.timezone !== undefined && ev.timezone !== null) {
+    if (typeof ev.timezone !== 'string' || !isValidTimezone(ev.timezone)) {
+      collect(
+        'INVALID_TIMEZONE', 'timezone',
+        `timezone "${String(ev.timezone)}" is not a recognised IANA identifier.`,
+      );
+    }
   }
 
-  return { ok: issues.length === 0, issues };
+  // ── resourceId ───────────────────────────────────────────────────────────
+  if (ev.resourceId !== undefined && ev.resourceId !== null) {
+    if (typeof ev.resourceId !== 'string') {
+      collect('INVALID_RESOURCE_ID', 'resourceId', 'resourceId must be a string when present.');
+    }
+  }
+
+  // ── color (strict-only) ──────────────────────────────────────────────────
+  if (mode === 'strict' && ev.color !== undefined && ev.color !== null) {
+    if (typeof ev.color !== 'string' || !looksLikeCssColor(ev.color)) {
+      collect('INVALID_COLOR', 'color', `color "${String(ev.color)}" is not a recognised CSS color.`);
+    }
+  }
+
+  // Fan out errors to onError. Soft / warn-severity issues stay in
+  // the result for callers but don't ping telemetry.
+  const eventId = typeof ev.id === 'string' ? ev.id : undefined;
+  for (const issue of collected) {
+    if (issue.severity === 'error') emit(issue, eventId, opts);
+  }
+
+  return {
+    ok: !collected.some(i => i.severity === 'error'),
+    issues: collected,
+  };
+}
+
+// ─── Internals ────────────────────────────────────────────────────────────────
+
+function isFiniteDate(d: unknown): d is Date {
+  return d instanceof Date && Number.isFinite(d.getTime());
+}
+
+function actionToSeverity(action: Exclude<EventIssueAction, 'ignore'>): EventIssueSeverity {
+  return action;
+}
+
+function resolveAction(
+  code: EventValidationCode,
+  mode: ValidationMode,
+  policy: ValidateEventOptions['sourcePolicy'],
+): EventIssueAction {
+  // Strict mode ignores sourcePolicy — every issue is an error.
+  if (mode === 'strict') return 'error';
+  return policy?.[code] ?? 'error';
+}
+
+function emit(
+  issue: EventValidationIssue,
+  eventId: string | undefined,
+  opts: ValidateEventOptions,
+): void {
+  if (!opts.onError) return;
+  const meta: { phase: 'validate'; sourceId?: string; eventId?: string } = { phase: 'validate' };
+  if (opts.sourceId !== undefined) meta.sourceId = opts.sourceId;
+  if (eventId !== undefined) meta.eventId = eventId;
+  opts.onError(
+    toStructuredError({
+      code: issue.code,
+      message: issue.message,
+      domain: 'validation',
+      severity: 'error',
+      recoverable: true,
+      ...(issue.details !== undefined ? { context: issue.details } : {}),
+    }),
+    meta,
+  );
+}
+
+/**
+ * Permissive RRULE shape check. We don't fully parse the rule —
+ * `expandRRule` does that lazily and survives malformed input — but
+ * we do require at least one `KEY=VALUE` pair and a recognised FREQ
+ * so blatantly broken strings (e.g. "rrule"") don't pass validation.
+ */
+function looksLikeRrule(s: string): boolean {
+  const trimmed = s.trim();
+  if (trimmed.length === 0) return false;
+  // Strip the optional "RRULE:" prefix that some feeds include.
+  const body = trimmed.replace(/^RRULE:/i, '');
+  const parts = body.split(';').filter(Boolean);
+  if (parts.length === 0) return false;
+  let freq: string | null = null;
+  for (const p of parts) {
+    const eq = p.indexOf('=');
+    if (eq <= 0) return false;
+    const key = p.slice(0, eq).toUpperCase();
+    const value = p.slice(eq + 1);
+    if (value.length === 0) return false;
+    if (key === 'FREQ') freq = value.toUpperCase();
+  }
+  if (freq === null) return false;
+  return ['SECONDLY', 'MINUTELY', 'HOURLY', 'DAILY', 'WEEKLY', 'MONTHLY', 'YEARLY'].includes(freq);
+}
+
+/**
+ * Approximate CSS color check. Covers the cases hosts actually use
+ * (hex, named colors, rgb()/rgba()/hsl()/hsla()/oklch()/color())
+ * without pulling in a full CSS parser. False positives are rare and
+ * non-fatal — color is purely presentational.
+ */
+function looksLikeCssColor(s: string): boolean {
+  const v = s.trim();
+  if (v.length === 0) return false;
+  if (/^#([0-9a-f]{3}|[0-9a-f]{4}|[0-9a-f]{6}|[0-9a-f]{8})$/i.test(v)) return true;
+  if (/^(rgb|rgba|hsl|hsla|hwb|lab|lch|oklab|oklch|color)\s*\(.+\)$/i.test(v)) return true;
+  // Named colors — accept any plain ASCII identifier; the browser
+  // does the final resolution.
+  if (/^[a-z]+$/i.test(v)) return true;
+  return false;
 }


### PR DESCRIPTION
## Summary

Closes #259. Replaces the skeleton validator with a full schema-driven walk of the `EngineEvent` shape, plus prod-mode policy overrides and `onError` telemetry wiring.

### What's new

- **Field coverage:** `rrule` (FREQ + recognised frequency), `timezone` (Intl IANA validity), `resourceId` (string when present), `color` (hex / CSS function / named — strict-only), `exdates` (array of finite Dates with bad-index reporting). Existing id / title / start / end / range / exdates checks preserved.
- **`sourcePolicy` (prod overrides):** new `EventIssueAction = 'error' | 'warn' | 'ignore'`. Hosts downgrade specific codes for one feed without blocking render. Strict mode ignores `sourcePolicy` by design.
- **Severity field on issues.** `ok` reflects only error-severity issues; warn-severity issues stay in `issues` for the host to log.
- **`onError` wiring:** optional `onError` (with optional `sourceId`) fires once per error-severity issue with `{ phase: 'validate', sourceId?, eventId? }` meta. Mirrors the contract used by `expandRecurrenceSafe`.
- **Title-empty special case:** strict mode → error, prod mode → no issue (matches the issue spec).
- **No new external runtime deps** — the existing `EventValidationCode` union is the schema.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `vitest run` — 2527 passed
- [x] 28 new tests covering: top-level shape; id / title / start / end / range; exdates with bad-index reporting; rrule (well-formed, malformed, null skips); timezone (real + bogus); resourceId; color (strict + prod); `sourcePolicy` warn / ignore (with strict-ignores-policy guard); `onError` invocation count + meta passthrough + warn-only silence.
- [x] `npm run build` clean


---
_Generated by [Claude Code](https://claude.ai/code/session_01XojXzZPdEPuGbX2TyLY1pu)_