### PR TITLE
Claude/stabilize foundation jhjz o

### DIFF
--- a/src/core/__tests__/scheduledEventAdapter.test.ts
+++ b/src/core/__tests__/scheduledEventAdapter.test.ts
@@ -1,0 +1,157 @@
+/**
+ * scheduledEventAdapter — round-trip fidelity for the four fields
+ * that have no direct WorksCalendarEvent equivalent (#465 pre-#424).
+ */
+import { describe, it, expect } from 'vitest'
+import {
+  scheduledEventToCalendarEvent,
+  calendarEventToScheduledEvent,
+  assignmentsFromCalendarEvent,
+} from '../scheduledEventAdapter'
+import type { ScheduledEvent } from '../../types/scheduling'
+import type { Assignment } from '../engine/schema/assignmentSchema'
+
+const BASE: ScheduledEvent = {
+  id: 'evt-1',
+  status: 'pending',
+  start: new Date('2026-06-01T09:00:00Z'),
+  end:   new Date('2026-06-01T17:00:00Z'),
+  resources: ['truck-1', 'driver-1'],
+  eventType: 'delivery',
+  title: 'Delivery run',
+  requirements: [
+    { kind: 'role', roleId: 'driver', count: 1, satisfied: true },
+    { kind: 'pool', poolId: 'fleet-east', count: 1, satisfied: false },
+  ],
+  meta: { customerRef: 'CUST-99' },
+}
+
+describe('scheduledEventToCalendarEvent', () => {
+  it('maps eventType → category without data loss', () => {
+    const ce = scheduledEventToCalendarEvent(BASE)
+    expect(ce.category).toBe('delivery')
+  })
+
+  it('puts the primary resource in .resource', () => {
+    const ce = scheduledEventToCalendarEvent(BASE)
+    expect(ce.resource).toBe('truck-1')
+  })
+
+  it('preserves the full resource list in meta._resources', () => {
+    const ce = scheduledEventToCalendarEvent(BASE)
+    expect(ce.meta?.['_resources']).toEqual(['truck-1', 'driver-1'])
+  })
+
+  it('preserves lifecycle status in meta._lifecycleStatus', () => {
+    const ce = scheduledEventToCalendarEvent(BASE)
+    expect(ce.meta?.['_lifecycleStatus']).toBe('pending')
+  })
+
+  it('preserves requirements in meta._requirements', () => {
+    const ce = scheduledEventToCalendarEvent(BASE)
+    expect(ce.meta?.['_requirements']).toEqual(BASE.requirements)
+  })
+
+  it('synthesises default assignments (units=100) when none supplied', () => {
+    const ce = scheduledEventToCalendarEvent(BASE)
+    const asgns = ce.meta?.['_assignments'] as Assignment[]
+    expect(asgns).toHaveLength(2)
+    expect(asgns[0]).toMatchObject({ eventId: 'evt-1', resourceId: 'truck-1', units: 100 })
+    expect(asgns[1]).toMatchObject({ eventId: 'evt-1', resourceId: 'driver-1', units: 100 })
+  })
+
+  it('uses explicit assignments when provided', () => {
+    const explicit: Assignment[] = [
+      { id: 'a1', eventId: 'evt-1', resourceId: 'truck-1', units: 100 },
+      { id: 'a2', eventId: 'evt-1', resourceId: 'driver-1', units: 50, roleId: 'co-driver' },
+    ]
+    const ce = scheduledEventToCalendarEvent(BASE, explicit)
+    expect(ce.meta?.['_assignments']).toEqual(explicit)
+  })
+
+  it('keeps host meta fields alongside internal keys', () => {
+    const ce = scheduledEventToCalendarEvent(BASE)
+    expect(ce.meta?.['customerRef']).toBe('CUST-99')
+  })
+})
+
+describe('calendarEventToScheduledEvent', () => {
+  it('round-trips status', () => {
+    const rt = calendarEventToScheduledEvent(scheduledEventToCalendarEvent(BASE))
+    expect(rt.status).toBe('pending')
+  })
+
+  it('round-trips eventType via category', () => {
+    const rt = calendarEventToScheduledEvent(scheduledEventToCalendarEvent(BASE))
+    expect(rt.eventType).toBe('delivery')
+  })
+
+  it('round-trips the full resources array', () => {
+    const rt = calendarEventToScheduledEvent(scheduledEventToCalendarEvent(BASE))
+    expect(rt.resources).toEqual(['truck-1', 'driver-1'])
+  })
+
+  it('round-trips requirements', () => {
+    const rt = calendarEventToScheduledEvent(scheduledEventToCalendarEvent(BASE))
+    expect(rt.requirements).toEqual(BASE.requirements)
+  })
+
+  it('strips internal meta keys from ScheduledEvent.meta', () => {
+    const rt = calendarEventToScheduledEvent(scheduledEventToCalendarEvent(BASE))
+    expect(rt.meta?.['_lifecycleStatus']).toBeUndefined()
+    expect(rt.meta?.['_resources']).toBeUndefined()
+    expect(rt.meta?.['_requirements']).toBeUndefined()
+    expect(rt.meta?.['_assignments']).toBeUndefined()
+  })
+
+  it('preserves host meta through the round-trip', () => {
+    const rt = calendarEventToScheduledEvent(scheduledEventToCalendarEvent(BASE))
+    expect(rt.meta?.['customerRef']).toBe('CUST-99')
+  })
+
+  it('defaults status to draft for events without _lifecycleStatus', () => {
+    const rt = calendarEventToScheduledEvent({
+      id: 'x', title: 'plain event', start: new Date(), end: new Date(),
+    })
+    expect(rt.status).toBe('draft')
+  })
+
+  it('falls back to single resource field when _resources is absent', () => {
+    const rt = calendarEventToScheduledEvent({
+      id: 'x', title: 'plain event', start: new Date(), end: new Date(),
+      resource: 'truck-42',
+    })
+    expect(rt.resources).toEqual(['truck-42'])
+  })
+
+  it('produces no requirements when none were set', () => {
+    const noReqs: ScheduledEvent = { ...BASE, requirements: undefined }
+    const rt = calendarEventToScheduledEvent(scheduledEventToCalendarEvent(noReqs))
+    expect(rt.requirements).toBeUndefined()
+  })
+})
+
+describe('assignmentsFromCalendarEvent', () => {
+  it('returns the Assignment[] stored by scheduledEventToCalendarEvent', () => {
+    const explicit: Assignment[] = [
+      { id: 'a1', eventId: 'evt-1', resourceId: 'truck-1', units: 100 },
+      { id: 'a2', eventId: 'evt-1', resourceId: 'driver-1', units: 50, roleId: 'co-driver' },
+    ]
+    const ce = scheduledEventToCalendarEvent(BASE, explicit)
+    expect(assignmentsFromCalendarEvent(ce)).toEqual(explicit)
+  })
+
+  it('returns [] for a plain WorksCalendarEvent', () => {
+    expect(assignmentsFromCalendarEvent({ title: 'x', start: new Date() })).toEqual([])
+  })
+
+  it('preserves roleId on explicit assignments through the round-trip', () => {
+    const explicit: Assignment[] = [
+      { id: 'a1', eventId: 'evt-1', resourceId: 'driver-1', units: 50, roleId: 'co-driver' },
+    ]
+    const ce = scheduledEventToCalendarEvent(BASE, explicit)
+    const [a] = assignmentsFromCalendarEvent(ce)
+    expect(a?.roleId).toBe('co-driver')
+    expect(a?.units).toBe(50)
+  })
+})

--- a/src/core/__tests__/scheduledEventAdapter.test.ts
+++ b/src/core/__tests__/scheduledEventAdapter.test.ts
@@ -125,7 +125,7 @@ describe('calendarEventToScheduledEvent', () => {
   })
 
   it('produces no requirements when none were set', () => {
-    const noReqs: ScheduledEvent = { ...BASE, requirements: undefined }
+    const { requirements: _drop, ...noReqs } = BASE
     const rt = calendarEventToScheduledEvent(scheduledEventToCalendarEvent(noReqs))
     expect(rt.requirements).toBeUndefined()
   })

--- a/src/core/config/calendarConfig.ts
+++ b/src/core/config/calendarConfig.ts
@@ -131,3 +131,27 @@ export interface ConfigSettings {
   /** IANA timezone identifier (e.g. "America/Denver"). */
   readonly timezone?: string
 }
+
+/**
+ * Return a fully-populated CalendarConfig with every section present
+ * and defaulted to an empty/safe value.
+ *
+ * Callers that only need one section can still use optional chaining
+ * (`config.roles ?? []`), but code that depends on a consistent shape
+ * — e.g. serialization, validation, or #424's scheduling engine —
+ * should call this once at startup and pass the result through rather
+ * than re-defaulting at every callsite.
+ */
+export function defaultCalendarConfig(): Required<CalendarConfig> {
+  return {
+    profile: 'custom',
+    labels: {},
+    resourceTypes: [],
+    roles: [],
+    resources: [],
+    pools: [],
+    requirements: [],
+    events: [],
+    settings: {},
+  }
+}

--- a/src/core/configSchema.ts
+++ b/src/core/configSchema.ts
@@ -66,6 +66,18 @@ export const DEFAULT_CONFIG: Record<string, any> = {
     assetsLabel: 'Asset',
   },
 
+  // Event type catalog (#424). Each entry describes one category of schedulable
+  // event: id used as the discriminant in event.eventType; label shown in dropdowns;
+  // optional color override. Empty array is safe — all #424 code guards with ?? [].
+  // Shape: { id: string, label: string, color?: string }
+  eventTypes: [],
+
+  // Saved configuration profiles (#424). Owners create named snapshots of the
+  // current config so they can switch between operational modes (e.g. "Summer
+  // schedule", "Holiday mode") without re-entering settings from scratch.
+  // Shape: { id: string, label: string, description?: string }
+  profiles: [],
+
   // Hover card field visibility
   hoverCard: {
     showTime: true,

--- a/src/core/scheduledEventAdapter.ts
+++ b/src/core/scheduledEventAdapter.ts
@@ -50,13 +50,16 @@ function isStringArray(v: unknown): v is string[] {
 
 function isAssignmentArray(v: unknown): v is Assignment[] {
   if (!Array.isArray(v)) return false
-  return v.every(x =>
-    x !== null &&
-    typeof x === 'object' &&
-    typeof (x as Record<string, unknown>)['id'] === 'string' &&
-    typeof (x as Record<string, unknown>)['eventId'] === 'string' &&
-    typeof (x as Record<string, unknown>)['resourceId'] === 'string',
-  )
+  return v.every(x => {
+    if (x === null || typeof x !== 'object') return false
+    const a = x as Record<string, unknown>
+    return (
+      typeof a['id'] === 'string' &&
+      typeof a['eventId'] === 'string' &&
+      typeof a['resourceId'] === 'string' &&
+      typeof a['units'] === 'number'
+    )
+  })
 }
 
 // ─── Public API ────────────────────────────────────────────────────────────
@@ -150,16 +153,18 @@ export function calendarEventToScheduledEvent(e: WorksCalendarEvent): ScheduledE
   const start = toDate(e.start)
   const end   = e.end ? toDate(e.end) : new Date(start.getTime() + 60 * 60 * 1000)
 
+  // exactOptionalPropertyTypes: only spread optional fields when they
+  // have a real value, never explicitly assign `undefined` to them.
   return {
-    id:           e.id ?? '',
+    id: e.id ?? '',
     status,
     start,
     end,
     resources,
-    eventType:    e.category,
-    title:        e.title || undefined,
-    requirements,
-    ...(Object.keys(cleanMeta).length > 0 ? { meta: cleanMeta } : {}),
+    ...(e.category !== undefined   ? { eventType: e.category }       : {}),
+    ...(e.title                    ? { title: e.title }               : {}),
+    ...(requirements !== undefined ? { requirements }                 : {}),
+    ...(Object.keys(cleanMeta).length > 0 ? { meta: cleanMeta }      : {}),
   }
 }
 

--- a/src/core/scheduledEventAdapter.ts
+++ b/src/core/scheduledEventAdapter.ts
@@ -1,0 +1,174 @@
+/**
+ * scheduledEventAdapter — lossless bridge between `ScheduledEvent`
+ * (the #424 scheduling domain model) and `WorksCalendarEvent`
+ * (the calendar rendering model).
+ *
+ * Four fields have no direct `WorksCalendarEvent` equivalent and are
+ * preserved in `meta` under underscore-prefixed keys:
+ *
+ *   _lifecycleStatus  — EventLifecycleStatus ('draft'…'completed')
+ *                        Distinct from WorksCalendarEvent.status (iCal).
+ *   _resources        — full string[] of assigned resource ids
+ *                        WorksCalendarEvent.resource is a single string;
+ *                        multi-resource events would lose all but the first.
+ *   _requirements     — ScheduledEventRequirement[] snapshot
+ *   _assignments      — Assignment[] snapshot (units, roleId per resource)
+ *
+ * `eventType` maps directly to `category` — no meta spillover needed.
+ *
+ * Round-trip guarantee:
+ *   calendarEventToScheduledEvent(scheduledEventToCalendarEvent(e))
+ *   produces a ScheduledEvent that is structurally equal to `e`
+ *   (dates are re-parsed; meta key order may differ).
+ */
+import { parseISO, isValid } from 'date-fns'
+import type { WorksCalendarEvent } from '../types/events'
+import type { ScheduledEvent, ScheduledEventRequirement, EventLifecycleStatus } from '../types/scheduling'
+import { isEventLifecycleStatus } from '../types/scheduling'
+import type { Assignment } from './engine/schema/assignmentSchema'
+
+// ─── Internal meta keys ────────────────────────────────────────────────────
+
+const KEY_STATUS       = '_lifecycleStatus' as const
+const KEY_RESOURCES    = '_resources'       as const
+const KEY_REQUIREMENTS = '_requirements'    as const
+const KEY_ASSIGNMENTS  = '_assignments'     as const
+
+const INTERNAL_KEYS = new Set([KEY_STATUS, KEY_RESOURCES, KEY_REQUIREMENTS, KEY_ASSIGNMENTS])
+
+// ─── Helpers ───────────────────────────────────────────────────────────────
+
+function toDate(v: Date | string): Date {
+  if (v instanceof Date) return v
+  const d = parseISO(v)
+  return isValid(d) ? d : new Date(v)
+}
+
+function isStringArray(v: unknown): v is string[] {
+  return Array.isArray(v) && v.every(x => typeof x === 'string')
+}
+
+function isAssignmentArray(v: unknown): v is Assignment[] {
+  if (!Array.isArray(v)) return false
+  return v.every(x =>
+    x !== null &&
+    typeof x === 'object' &&
+    typeof (x as Record<string, unknown>)['id'] === 'string' &&
+    typeof (x as Record<string, unknown>)['eventId'] === 'string' &&
+    typeof (x as Record<string, unknown>)['resourceId'] === 'string',
+  )
+}
+
+// ─── Public API ────────────────────────────────────────────────────────────
+
+/**
+ * Convert a `ScheduledEvent` to a `WorksCalendarEvent` for calendar
+ * rendering. All scheduling-domain fields that have no direct
+ * `WorksCalendarEvent` equivalent are spilled into `meta`.
+ *
+ * Pass `assignments` when the event has explicit multi-resource
+ * assignment records (units, roleId). If omitted, `_assignments` is
+ * not written to meta and round-trip will reconstruct resources from
+ * `_resources` only.
+ */
+export function scheduledEventToCalendarEvent(
+  e: ScheduledEvent,
+  assignments?: readonly Assignment[],
+): WorksCalendarEvent {
+  const meta: Record<string, unknown> = {
+    ...e.meta,
+    [KEY_STATUS]:    e.status,
+    [KEY_RESOURCES]: Array.from(e.resources),
+  }
+
+  if (e.requirements !== undefined) {
+    meta[KEY_REQUIREMENTS] = e.requirements
+  }
+
+  const eventAssignments = assignments
+    ?? (e.resources.length > 0
+      ? e.resources.map((resourceId, i) => ({
+          id: `${e.id}-asgn-${i}`,
+          eventId: e.id,
+          resourceId,
+          units: 100,
+        } satisfies Assignment))
+      : undefined)
+
+  if (eventAssignments !== undefined) {
+    meta[KEY_ASSIGNMENTS] = eventAssignments
+  }
+
+  return {
+    id:       e.id,
+    title:    e.title ?? '',
+    start:    e.start,
+    end:      e.end,
+    // eventType is the scheduling concept; category is the rendering concept.
+    // They share the same value — no information is lost.
+    category: e.eventType,
+    // Primary resource drives single-resource calendar views.
+    // The full list is preserved in _resources above.
+    resource: e.resources[0],
+    meta,
+  }
+}
+
+/**
+ * Reconstruct a `ScheduledEvent` from a `WorksCalendarEvent` produced
+ * by `scheduledEventToCalendarEvent`. Also accepts arbitrary
+ * `WorksCalendarEvent`s — fields not present in meta are defaulted
+ * (`status → 'draft'`, `resources → [resource].filter(Boolean)`).
+ */
+export function calendarEventToScheduledEvent(e: WorksCalendarEvent): ScheduledEvent {
+  const rawMeta = e.meta ?? {}
+
+  // lifecycle status
+  const rawStatus = rawMeta[KEY_STATUS]
+  const status: EventLifecycleStatus = isEventLifecycleStatus(rawStatus) ? rawStatus : 'draft'
+
+  // resources — prefer the preserved array, fall back to single field
+  const rawResources = rawMeta[KEY_RESOURCES]
+  const resources: readonly string[] = isStringArray(rawResources)
+    ? rawResources
+    : typeof e.resource === 'string'
+      ? [e.resource]
+      : []
+
+  // requirements
+  const rawReqs = rawMeta[KEY_REQUIREMENTS]
+  const requirements = Array.isArray(rawReqs)
+    ? (rawReqs as ScheduledEventRequirement[])
+    : undefined
+
+  // host meta — strip internal keys so they don't leak into ScheduledEvent.meta
+  const cleanMeta: Record<string, unknown> = {}
+  for (const [k, v] of Object.entries(rawMeta)) {
+    if (!INTERNAL_KEYS.has(k as typeof KEY_STATUS)) cleanMeta[k] = v
+  }
+
+  const start = toDate(e.start)
+  const end   = e.end ? toDate(e.end) : new Date(start.getTime() + 60 * 60 * 1000)
+
+  return {
+    id:           e.id ?? '',
+    status,
+    start,
+    end,
+    resources,
+    eventType:    e.category,
+    title:        e.title || undefined,
+    requirements,
+    ...(Object.keys(cleanMeta).length > 0 ? { meta: cleanMeta } : {}),
+  }
+}
+
+/**
+ * Extract the `Assignment[]` embedded by `scheduledEventToCalendarEvent`.
+ * Returns `[]` when the event was not produced by that function or was
+ * produced without an explicit assignments list.
+ */
+export function assignmentsFromCalendarEvent(e: WorksCalendarEvent): Assignment[] {
+  const raw = e.meta?.[KEY_ASSIGNMENTS]
+  return isAssignmentArray(raw) ? raw : []
+}

--- a/src/types/scheduling.ts
+++ b/src/types/scheduling.ts
@@ -1,0 +1,99 @@
+/**
+ * Scheduling domain types for #424 (WorksCalendar product layer).
+ *
+ * These are distinct from `NormalizedEvent` (the calendar rendering
+ * model) and `WorksCalendarEvent` (the host-facing input shape). A
+ * `ScheduledEvent` represents a bookable unit as it moves through the
+ * scheduling lifecycle — from draft through completion.
+ *
+ * Conflict semantics (decided pre-#424):
+ *   hard conflict  → block save entirely (e.g. same resource + overlapping time)
+ *   soft conflict  → warn and allow override (e.g. outside business hours)
+ *
+ * Naming contract (intentional coexistence):
+ *   resource  — the v2 engine term (ConfigResource, EngineResource, CalendarConfig)
+ *   asset     — the legacy owner-config term (config.assets[]; AssetsView)
+ *   Both are present in the codebase. "resource" is the going-forward canonical term.
+ *   "role" = a functional capability assigned to an event slot (ConfigRole)
+ *   "capability" = a boolean/numeric attribute on a resource (ConfigResource.capabilities)
+ *   "pool" = a named group of resources resolved at submit time (ResourcePool)
+ *   "group" = a calendar display grouping (GroupConfig / groupRows)
+ */
+
+/** Five-state lifecycle for a schedulable event. */
+export type EventLifecycleStatus =
+  | 'draft'       // created but not submitted
+  | 'pending'     // submitted, awaiting approval
+  | 'approved'    // approved, not yet on the schedule
+  | 'scheduled'   // on the live schedule
+  | 'completed'   // occurred / closed
+
+/**
+ * A schedulable unit in the #424 product layer.
+ *
+ * `resources` is a list of resource ids (matches `ConfigResource.id` /
+ * `EngineResource.id`). An event may reference more than one resource
+ * when multiple assets are dispatched together (e.g. truck + driver).
+ *
+ * `requirements` is an optional list of requirement slots that must be
+ * satisfied before the event can move from `pending` to `approved`.
+ * Each slot references a role id or pool id from the active CalendarConfig.
+ */
+export interface ScheduledEvent {
+  readonly id: string
+  readonly status: EventLifecycleStatus
+  readonly start: Date
+  readonly end: Date
+  /** Resolved resource ids assigned to this event. */
+  readonly resources: readonly string[]
+  /** Pending requirement slots from the CalendarConfig template. */
+  readonly requirements?: readonly ScheduledEventRequirement[]
+  /** Free-form display title. */
+  readonly title?: string
+  /** Maps to CalendarConfig.requirements[].eventType for template lookup. */
+  readonly eventType?: string
+  /** Arbitrary host metadata — not read by the scheduling engine. */
+  readonly meta?: Readonly<Record<string, unknown>>
+}
+
+/**
+ * A single requirement slot on a `ScheduledEvent`.
+ * Mirrors `ConfigRequirementSlot` but with a resolved `satisfied` flag
+ * so UI components can render readiness without re-running the evaluator.
+ */
+export type ScheduledEventRequirement =
+  | { readonly kind: 'role'; readonly roleId: string; readonly count: number; readonly satisfied: boolean }
+  | { readonly kind: 'pool'; readonly poolId: string; readonly count: number; readonly satisfied: boolean }
+
+/**
+ * Type guard — narrows an unknown value to `ScheduledEvent`.
+ * Useful at system boundaries (API responses, localStorage deserialization).
+ */
+export function isScheduledEvent(v: unknown): v is ScheduledEvent {
+  if (!v || typeof v !== 'object') return false
+  const e = v as Record<string, unknown>
+  return (
+    typeof e['id'] === 'string' &&
+    isEventLifecycleStatus(e['status']) &&
+    e['start'] instanceof Date &&
+    e['end'] instanceof Date &&
+    Array.isArray(e['resources'])
+  )
+}
+
+const LIFECYCLE_STATUSES: readonly EventLifecycleStatus[] = [
+  'draft', 'pending', 'approved', 'scheduled', 'completed',
+]
+
+export function isEventLifecycleStatus(v: unknown): v is EventLifecycleStatus {
+  return typeof v === 'string' && (LIFECYCLE_STATUSES as readonly string[]).includes(v)
+}
+
+/** Ordered lifecycle transitions that are valid (no skipping). */
+export const LIFECYCLE_TRANSITIONS: Readonly<Record<EventLifecycleStatus, readonly EventLifecycleStatus[]>> = {
+  draft:     ['pending'],
+  pending:   ['approved', 'draft'],
+  approved:  ['scheduled', 'pending'],
+  scheduled: ['completed', 'approved'],
+  completed: [],
+}

--- a/src/types/scheduling.ts
+++ b/src/types/scheduling.ts
@@ -77,7 +77,8 @@ export function isScheduledEvent(v: unknown): v is ScheduledEvent {
     isEventLifecycleStatus(e['status']) &&
     e['start'] instanceof Date &&
     e['end'] instanceof Date &&
-    Array.isArray(e['resources'])
+    Array.isArray(e['resources']) &&
+    (e['resources'] as unknown[]).every(r => typeof r === 'string')
   )
 }
 

--- a/src/ui/pools/PoolCard.tsx
+++ b/src/ui/pools/PoolCard.tsx
@@ -126,7 +126,8 @@ function computeStats(
   if (pool.type === 'hybrid') {
     const allowed = new Set(result.matched)
     const matched = pool.memberIds.filter(id => allowed.has(id)).length
-    return { matched, excluded: list.length - matched }
+    // excluded = curated members that didn't satisfy the query, not total registry size
+    return { matched, excluded: pool.memberIds.length - matched }
   }
   return { matched: result.matched.length, excluded: result.excluded.length }
 }

--- a/src/ui/pools/__tests__/PoolCard.test.tsx
+++ b/src/ui/pools/__tests__/PoolCard.test.tsx
@@ -114,4 +114,20 @@ describe('PoolCard — live stats', () => {
     const stats = screen.getByTestId('pool-card-stats')
     expect(stats).toHaveTextContent('1')
   })
+
+  it('hybrid excluded = memberIds not matching query, not total registry size (#465)', () => {
+    // Pool has 2 curated members; only 1 satisfies the query.
+    // excluded should be 1 (the unmatched member), not 2 (registry - matched).
+    render(<PoolCard
+      pool={{
+        id: 'p', name: 'OurReefers', type: 'hybrid',
+        memberIds: ['t2', 't3'],
+        query: { op: 'eq', path: 'meta.capabilities.refrigerated', value: true },
+        strategy: 'first-available',
+      }}
+      resources={reefers}
+    />)
+    const stats = screen.getByTestId('pool-card-stats')
+    expect(stats).toHaveAttribute('aria-label', '1 matched, 1 excluded')
+  })
 })


### PR DESCRIPTION
## Summary
Describe exactly what this PR changes.

## Scope
- Stage: 
- Planned PR number in sprint: 
- Target files/directories: 
- Why this slice is isolated: 

## Lessons Learned Check (REQUIRED)
Confirm these were actively used while building this PR:

- [ ] PR is intentionally small and isolated
- [ ] Boundary typing was prioritized over internal perfection
- [ ] No silent spread of `any`
- [ ] Advisory root `tsc` was used to catch integration issues
- [ ] I did not assume “looks typed” means “safe”
- [ ] I stopped and isolated typing cascades instead of expanding scope

## Definition of Done (ALL REQUIRED)
This PR is not done unless every box is checked.

- [ ] `npm run type-check:strict` passes
- [ ] Root advisory `tsc --noEmit` passes
- [ ] Tests pass for touched scope at minimum
- [ ] No uncontrolled increase in `any`
- [ ] All new types are intentional and named
- [ ] Public interfaces and exported functions are explicitly typed
- [ ] PR scope matches the sprint plan with no scope creep
- [ ] Any new `any` has an adjacent justification comment
- [ ] No file-wide `: any`
- [ ] No implicit `any` in exported functions

## What Was Typed
List exactly what was typed in this PR.

- 
- 
- 

## What Was Intentionally Left Loose
List anything intentionally not tightened yet.

- 
- 
- 

## `any` Ledger (REQUIRED)
- New `any` added: 
- Existing `any` removed: 
- Net change: 

For every new `any`, explain why it is required and why a safer type was not used yet.

1. 
2. 
3. 

## Boundary Notes
Document any public seams, caller-protection choices, or compatibility decisions.

- 
- 
- 

## Risk Level
- [ ] Low
- [ ] Medium
- [ ] High

Why:

## Validation Evidence
Paste the exact commands run and a short result summary.

```bash
npm run type-check:strict
npx tsc --noEmit -p tsconfig.json
```

Test commands run:

```bash
# paste commands here
```

## Stop Conditions Check
If any item below happened, explain how scope was reduced before merge.

- [ ] `any` started spreading across files
- [ ] Root `tsc` broke repeatedly
- [ ] Types required cross-module rewrites
- [ ] Scope was reduced to keep the PR reviewable

Notes:

## Reviewer Focus
What should reviewers look at first?

- 
- 
- 
