### PR TITLE
fix saved view chip: clicking active view doesn't toggle off, Clear d…

### DIFF
--- a/src/WorksCalendar.tsx
+++ b/src/WorksCalendar.tsx
@@ -889,6 +889,12 @@ export const WorksCalendar = forwardRef<CalendarApi, WorksCalendarProps>(functio
   }, [cal.filters, cal.view, activeGroupBy, activeSort, activeShowAllGroups, activeAssetsZoom, activeAssetsCollapsed, selectedBaseIds]); // eslint-disable-line react-hooks/exhaustive-deps
 
   const handleApplyView = useCallback((savedView: LooseValue) => {
+    // Clicking an already-active view deselects it and restores default state.
+    if (savedView.id === savedViewActiveId) {
+      setSavedViewActiveId(null);
+      setSavedViewDirty(false);
+      return;
+    }
     skipDirtyRef.current = true;
     cal.replaceFilters(deserializeFilters(savedView.filters, schema));
     if (savedView.view) cal.setView(savedView.view);
@@ -906,7 +912,15 @@ export const WorksCalendar = forwardRef<CalendarApi, WorksCalendarProps>(functio
     );
     setSavedViewActiveId(savedView.id);
     setSavedViewDirty(false);
-  }, [cal, schema]);
+  }, [cal, schema, savedViewActiveId]);
+
+  // Clearing filters from the UI also deselects the active saved view so
+  // the chip doesn't stay highlighted after the user has moved on.
+  const handleClearFilters = useCallback(() => {
+    cal.clearFilters();
+    setSavedViewActiveId(null);
+    setSavedViewDirty(false);
+  }, [cal]);
 
   const handleDeleteView = useCallback((id: LooseValue) => {
     savedViews.deleteView(id);
@@ -2488,7 +2502,7 @@ export const WorksCalendar = forwardRef<CalendarApi, WorksCalendarProps>(functio
                 onUpdate={savedViews.updateView}
                 onDelete={handleDeleteView}
                 onToggleVisibility={savedViews.toggleStripVisibility}
-                onClearFilters={cal.clearFilters}
+                onClearFilters={handleClearFilters}
                 onEditConditions={ownerCfg.isOwner ? (id: LooseValue) => ownerCfg.openConfigToTab('smartViews', { smartViewEditId: id }) : undefined}
               />
             );
@@ -2564,7 +2578,7 @@ export const WorksCalendar = forwardRef<CalendarApi, WorksCalendarProps>(functio
               schema={schema}
               onChange={(key, value) => cal.setFilter(key, value)}
               onClear={(key) => cal.clearFilter(key)}
-              onClearAll={cal.clearFilters}
+              onClearAll={handleClearFilters}
             />
         {/* ── View area ── */}
         <div


### PR DESCRIPTION
…oesn't deselect

handleApplyView: if the clicked view is already active, deselect it (setSavedViewActiveId(null)) instead of silently re-applying. This fixes both reported symptoms — clicking an active chip again now clears it, and the dirty-state effect no longer fights the toggle because we return early before the skipDirtyRef guard.

handleClearFilters: wrap cal.clearFilters() so clicking the Clear button also clears savedViewActiveId and savedViewDirty. Without this the chip stayed highlighted after the user cleared all filters, making it look like the view was still active. Wired to ProfileBar's onClearFilters and the filter-sidebar's onClearAll; the raw cal.clearFilters is preserved for the public renderFilterBar API which doesn't know about saved view state.

https://claude.ai/code/session_01RDBRkFKsHYr7q2NAGzaGGq

## Summary
Describe exactly what this PR changes.

## Scope
- Stage: 
- Planned PR number in sprint: 
- Target files/directories: 
- Why this slice is isolated: 

## Lessons Learned Check (REQUIRED)
Confirm these were actively used while building this PR:

- [ ] PR is intentionally small and isolated
- [ ] Boundary typing was prioritized over internal perfection
- [ ] No silent spread of `any`
- [ ] Advisory root `tsc` was used to catch integration issues
- [ ] I did not assume “looks typed” means “safe”
- [ ] I stopped and isolated typing cascades instead of expanding scope

## Definition of Done (ALL REQUIRED)
This PR is not done unless every box is checked.

- [ ] `npm run type-check:strict` passes
- [ ] Root advisory `tsc --noEmit` passes
- [ ] Tests pass for touched scope at minimum
- [ ] No uncontrolled increase in `any`
- [ ] All new types are intentional and named
- [ ] Public interfaces and exported functions are explicitly typed
- [ ] PR scope matches the sprint plan with no scope creep
- [ ] Any new `any` has an adjacent justification comment
- [ ] No file-wide `: any`
- [ ] No implicit `any` in exported functions

## What Was Typed
List exactly what was typed in this PR.

- 
- 
- 

## What Was Intentionally Left Loose
List anything intentionally not tightened yet.

- 
- 
- 

## `any` Ledger (REQUIRED)
- New `any` added: 
- Existing `any` removed: 
- Net change: 

For every new `any`, explain why it is required and why a safer type was not used yet.

1. 
2. 
3. 

## Boundary Notes
Document any public seams, caller-protection choices, or compatibility decisions.

- 
- 
- 

## Risk Level
- [ ] Low
- [ ] Medium
- [ ] High

Why:

## Validation Evidence
Paste the exact commands run and a short result summary.

```bash
npm run type-check:strict
npx tsc --noEmit -p tsconfig.json
```

Test commands run:

```bash
# paste commands here
```

## Stop Conditions Check
If any item below happened, explain how scope was reduced before merge.

- [ ] `any` started spreading across files
- [ ] Root `tsc` broke repeatedly
- [ ] Types required cross-module rewrites
- [ ] Scope was reduced to keep the PR reviewable

Notes:

## Reviewer Focus
What should reviewers look at first?

- 
- 
- 
