### PR TITLE
sprint #424 week 6: turnkey UX + README alignment

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,19 +1,53 @@
 # WorksCalendar
 
-WorksCalendar is an embeddable React calendar focused on **real scheduling workflows** (team coverage, PTO handling, saved filtered views) instead of a single static calendar screen.
+**Embeddable scheduling engine for teams, assets, and operations.** Drop it into a React app and get a working calendar, dispatch board, request queue, and approval pipeline — all driven by one config object.
 
 **Website:** [workscalendar.com](https://workscalendar.com) · **Repository:** [github.com/workscalendar/calendarthatworks](https://github.com/workscalendar/calendarthatworks)
 
-## Highlights
+WorksCalendar provides the building blocks for advanced scheduling. Applications are expected to configure and extend these systems to fit their workflow.
+
+## Core features (fully working)
 
 - Multiple calendar modes: month, week, day, agenda, schedule, timeline
-- Schema-driven filtering and saved views
-- Team scheduling workflow (PTO/unavailable → uncovered shift → coverage)
-- External intake form component (`CalendarExternalForm`)
-- Themeable UI with optional packaged themes
+- Event lifecycle states (draft → pending → approved → scheduled → completed) surfaced everywhere
+- Conflict engine with hard-block / soft-warning modes, live inline feedback in the editor, and conflict highlights on the calendar
+- Request queue with approve / deny / finalize / revoke actions wired to a tamper-evident audit chain
+- Dispatch readiness board with per-row "Why?" breakdown — driver / pilot / pool shortfalls explained in plain English
+- Schema-driven filtering, saved views, themeable UI with packaged themes
 - Data adapter pattern for backend-agnostic integrations
-- Declarative approval workflows with a sandboxed expression language — multi-tier approvals, SLA timers + escalation, parallel branches with quorum joins (`requireAll` / `requireAny` / `requireN`), and pluggable notification channels (Slack, email, webhook, or your own adapter)
 - **Written in strict TypeScript**; ships with generated `.d.ts` so consumer types stay in lockstep with the implementation
+
+## Extensible systems (configurable)
+
+- Approval workflow DSL — multi-tier approvals, SLA timers + escalation, parallel branches with quorum joins (`requireAll` / `requireAny` / `requireN`), and pluggable notification channels (Slack, email, webhook, or your own adapter)
+- Resource pools with a query DSL (capability + distance filters), pool resolution strategies, and per-pool readiness evaluation
+- Requirement templates — declare per-event-type role / pool needs and let `evaluateRequirements` gate the booking
+- Custom resource types, roles, labels, and capability schemas
+
+## Profiles
+
+WorksCalendar ships starter profiles so the same engine fits multiple industries via configuration:
+
+| Profile             | Resource label | Event label | Default roles                                                |
+| ------------------- | -------------- | ----------- | ------------------------------------------------------------ |
+| `air_medical`       | Aircraft       | Mission     | Pilot in Command, Flight Paramedic, Flight Nurse, Dispatcher |
+| `aviation`          | Aircraft       | Flight      | Pilot in Command, Second in Command, Dispatcher              |
+| `trucking`          | Truck          | Load        | Driver, Dispatcher                                           |
+| `equipment_rental`  | Equipment      | Rental      | Yard Attendant, Delivery Driver, Dispatcher                  |
+| `scheduling`        | Room           | Booking     | Organizer, Attendee                                          |
+| `custom`            | Resource       | Event       | (none)                                                       |
+
+Apply a profile via the setup wizard's "What are you scheduling?" step or programmatically:
+
+```ts
+import { applyProfilePreset } from 'works-calendar';
+
+const config = applyProfilePreset('air_medical');
+// config.labels.resource === 'Aircraft'
+// config.roles → [pilot-in-command, flight-paramedic, flight-nurse, …]
+```
+
+Switching profiles changes terminology and defaults without changing logic — the conflict engine, requirement evaluator, and approval reducer all read off the same config.
 
 ## New here? Start with the [Setup guide](./docs/Setup.md)
 

--- a/src/WorksCalendar.module.css
+++ b/src/WorksCalendar.module.css
@@ -402,6 +402,16 @@
   color: #fff !important;
 }
 
+/* Calendar | Operations divider (#424 wk6) — splits the view picker
+   into the two semantic groups so users see scheduling tabs apart
+   from the operational boards. Slightly stronger than the per-button
+   border so the boundary reads as a group seam, not a button edge. */
+.viewGroupDivider {
+  align-self: stretch;
+  width: 2px;
+  background: color-mix(in srgb, var(--wc-border) 70%, var(--wc-text-muted) 30%);
+}
+
 /* Actions */
 .actions {
   display: flex;

--- a/src/WorksCalendar.tsx
+++ b/src/WorksCalendar.tsx
@@ -360,18 +360,19 @@ function opAnnouncement(op: LooseValue) {
   }
 }
 
-type ViewDef = { id: ViewId; label: string; alwaysOn: boolean; hint?: string };
+type ViewGroup = 'calendar' | 'operations';
+type ViewDef = { id: ViewId; label: string; alwaysOn: boolean; hint?: string; group: ViewGroup };
 const ALL_VIEWS: readonly ViewDef[] = [
-  { id: 'month',    label: 'Month',    alwaysOn: true,  hint: 'Scheduled events — appointments, missions, PTO' },
-  { id: 'week',     label: 'Week',     alwaysOn: true,  hint: 'Scheduled events by day — not staffing or on-call' },
-  { id: 'day',      label: 'Day',      alwaysOn: false },
-  { id: 'agenda',   label: 'Agenda',   alwaysOn: false },
-  { id: 'schedule', label: 'Schedule', alwaysOn: false, hint: 'Staffing — day/night shifts, on-call rotation, duty status' },
-  { id: 'base',     label: 'Base',     alwaysOn: false, hint: 'Gantt-style — employees, aircraft, and base events side by side' },
-  { id: 'assets',   label: 'Assets',   alwaysOn: false },
-  { id: 'dispatch', label: 'Dispatch', alwaysOn: false, hint: 'Fleet readiness at a moment in time — what can launch now?' },
-  { id: 'requests', label: 'Requests', alwaysOn: false, hint: 'Pending approval queue — approve, deny, or escalate requests' },
-  { id: 'map',      label: 'Map',      alwaysOn: false, hint: 'Geographic plot of events that carry coordinates (meta.coords)' },
+  { id: 'month',    label: 'Month',    alwaysOn: true,  hint: 'Scheduled events — appointments, missions, PTO',                   group: 'calendar' },
+  { id: 'week',     label: 'Week',     alwaysOn: true,  hint: 'Scheduled events by day — not staffing or on-call',                group: 'calendar' },
+  { id: 'day',      label: 'Day',      alwaysOn: false,                                                                            group: 'calendar' },
+  { id: 'agenda',   label: 'Agenda',   alwaysOn: false,                                                                            group: 'calendar' },
+  { id: 'schedule', label: 'Schedule', alwaysOn: false, hint: 'Staffing — day/night shifts, on-call rotation, duty status',       group: 'calendar' },
+  { id: 'base',     label: 'Base',     alwaysOn: false, hint: 'Gantt-style — employees, aircraft, and base events side by side', group: 'calendar' },
+  { id: 'assets',   label: 'Assets',   alwaysOn: false,                                                                            group: 'operations' },
+  { id: 'dispatch', label: 'Dispatch', alwaysOn: false, hint: 'Fleet readiness at a moment in time — what can launch now?',      group: 'operations' },
+  { id: 'requests', label: 'Requests', alwaysOn: false, hint: 'Pending approval queue — approve, deny, or escalate requests',    group: 'operations' },
+  { id: 'map',      label: 'Map',      alwaysOn: false, hint: 'Geographic plot of events that carry coordinates (meta.coords)',  group: 'operations' },
 ];
 
 const DEFAULT_SCHEDULE_INSTANTIATION_LIMITS = {
@@ -2438,8 +2439,15 @@ export const WorksCalendar = forwardRef<CalendarApi, WorksCalendarProps>(functio
               </div>
             }
             centerSlot={
-              <div className={styles['viewGroup']} role="group" aria-label="Calendar view">
-                {VIEWS.map(v => (
+              // Views are grouped Calendar | Operations (#424 wk6) so a
+              // new user sees scheduling tabs separately from the
+              // operational boards (Assets / Dispatch / Requests / Map).
+              // Both groups share the same buttonGroup styling; the
+              // separator is purely visual.
+              (() => {
+                const calendarViews   = VIEWS.filter(v => v.group === 'calendar');
+                const operationsViews = VIEWS.filter(v => v.group === 'operations');
+                const renderBtn = (v: ViewDef) => (
                   <button
                     key={v.id}
                     className={[styles['viewBtn'], cal.view === v.id && styles['activeView']].filter(Boolean).join(' ')}
@@ -2449,8 +2457,21 @@ export const WorksCalendar = forwardRef<CalendarApi, WorksCalendarProps>(functio
                   >
                     {v.label}
                   </button>
-                ))}
-              </div>
+                );
+                return (
+                  <div className={styles['viewGroup']} role="group" aria-label="Calendar view">
+                    {calendarViews.map(renderBtn)}
+                    {operationsViews.length > 0 && (
+                      <span
+                        className={styles['viewGroupDivider']}
+                        aria-hidden="true"
+                        role="presentation"
+                      />
+                    )}
+                    {operationsViews.map(renderBtn)}
+                  </div>
+                );
+              })()
             }
             rightSlot={
               <div className={styles['actions']}>
@@ -2589,8 +2610,14 @@ export const WorksCalendar = forwardRef<CalendarApi, WorksCalendarProps>(functio
                   groupCount={sidebarGroupLevels.length}
                 />
                 {hasAddButton && cal.view !== 'schedule' && (
-                  <button className={styles['addBtn']} onClick={() => setFormEvent({})} aria-label="Add new event">
-                    <Plus size={14} aria-hidden="true" /><span className={styles['addBtnLabel']}> Add Event</span>
+                  <button
+                    className={styles['addBtn']}
+                    onClick={() => setFormEvent({})}
+                    aria-label={`Add new ${profileLabels.event.toLowerCase()}`}
+                    title={profileLabels.event === 'Event' ? undefined : `Create a new ${profileLabels.event.toLowerCase()}`}
+                  >
+                    <Plus size={14} aria-hidden="true" />
+                    <span className={styles['addBtnLabel']}> New {profileLabels.event}</span>
                   </button>
                 )}
                 {hasAddButton && hasScheduleTemplates && (

--- a/src/core/config/__tests__/resolveLabels.test.ts
+++ b/src/core/config/__tests__/resolveLabels.test.ts
@@ -59,4 +59,49 @@ describe('resolveLabels', () => {
     expect(out['aircraft']).toBe('Rotor');
     expect(out['mission']).toBe('Run');
   });
+
+  /* ── Boundary coercion (Codex feedback on PR #469) ─────────────────────
+     Owner config is loaded from raw JSON without runtime validation, so
+     a stray `labels.event: 42` must NOT crash callers that downstream
+     `.toLowerCase()` the result. Coerce non-strings to fallbacks here. */
+
+  it('coerces non-string canonical labels to the fallback ladder', () => {
+    const out = resolveLabels({
+      profile: 'air_medical',
+      // Intentionally pathological — numbers / nulls / objects.
+      labels: { event: 42, resource: null, location: { x: 1 } } as unknown as Record<string, string>,
+    });
+    // Numeric/null/object overrides discarded → fall through to preset.
+    expect(out.event).toBe('Mission');
+    expect(out.resource).toBe('Aircraft');
+    expect(out.location).toBe('Base');
+    // The downstream `.toLowerCase()` that the toolbar runs must never throw.
+    expect(() => out.event.toLowerCase()).not.toThrow();
+  });
+
+  it('treats empty / whitespace-only overrides as missing', () => {
+    const out = resolveLabels({
+      profile: 'trucking',
+      labels: { event: '   ', resource: '' },
+    });
+    expect(out.event).toBe('Load');
+    expect(out.resource).toBe('Truck');
+  });
+
+  it('drops non-string free-form keys instead of leaking them through', () => {
+    const out = resolveLabels({
+      labels: { aircraft: 42, mission: 'Run' } as unknown as Record<string, string>,
+    });
+    expect(out['mission']).toBe('Run');
+    expect(out['aircraft']).toBeUndefined();
+  });
+
+  it('survives a non-object labels value at the boundary', () => {
+    const out = resolveLabels({
+      profile: 'air_medical',
+      labels: 'not-an-object' as unknown as Record<string, string>,
+    });
+    expect(out.event).toBe('Mission');
+    expect(out.resource).toBe('Aircraft');
+  });
 });

--- a/src/core/config/resolveLabels.ts
+++ b/src/core/config/resolveLabels.ts
@@ -13,9 +13,16 @@
  *   2. Profile preset default (computed from `config.profile`).
  *   3. Built-in fallback (generic word).
  *
+ * Coercion: owner config is loaded from raw JSON (`loadConfig` does no
+ * runtime type validation), so any of these values may arrive as
+ * non-strings (numbers, nulls, objects). Every input runs through
+ * `coerceLabel` which trims and discards anything that isn't a
+ * non-empty string — the fallback ladder takes over instead, and UI
+ * code can call `.toLowerCase()` on the result without crashing the
+ * toolbar on a stray `labels.event: 42`.
+ *
  * Pure / sync. Returns a new object so callers can mutate freely.
  */
-import type { CalendarConfig } from './calendarConfig';
 import { PROFILE_PRESETS, type ProfileId } from './profilePresets';
 
 /**
@@ -46,6 +53,18 @@ const FALLBACK = {
   location: 'Location',
 } as const;
 
+/**
+ * Narrow an arbitrary value to a usable label string. Returns null for
+ * anything that isn't a non-empty trimmed string so the resolver
+ * falls through to its next ladder rung instead of binding a number /
+ * boolean / object to a label slot.
+ */
+function coerceLabel(value: unknown): string | null {
+  if (typeof value !== 'string') return null;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
 function pluralize(word: string): string {
   if (!word) return word;
   // Tiny English pluralizer — covers the every-day cases the four
@@ -56,36 +75,46 @@ function pluralize(word: string): string {
   return `${word}s`;
 }
 
-function presetLabels(profile: string | undefined): Partial<Record<string, string>> {
-  if (!profile) return {};
+function presetLabels(profile: unknown): Partial<Record<string, string>> {
+  if (typeof profile !== 'string') return {};
   const preset = PROFILE_PRESETS[profile as ProfileId];
   return preset?.config.labels ?? {};
 }
 
 export function resolveLabels(
-  config: { profile?: string | undefined; labels?: Partial<Record<string, string>> | undefined } | null | undefined,
+  config: { profile?: unknown; labels?: unknown } | null | undefined,
 ): ResolvedLabels {
-  const profile = config?.profile;
-  const overrides = (config?.labels ?? {}) as Partial<Record<string, string>>;
-  const presets = presetLabels(profile);
+  // Defensive narrowing — config is allowed to be `unknown`-shaped at
+  // the boundary because hosts hand us raw JSON. Anything that isn't
+  // a plain object falls through to fallbacks.
+  const rawLabels = (config && typeof config === 'object' && 'labels' in config)
+    ? (config as { labels?: unknown }).labels
+    : undefined;
+  const overrides: Record<string, unknown> = rawLabels && typeof rawLabels === 'object'
+    ? rawLabels as Record<string, unknown>
+    : {};
+  const presets = presetLabels((config as { profile?: unknown } | null | undefined)?.profile);
 
-  const resource = overrides['resource'] ?? presets['resource'] ?? FALLBACK.resource;
-  const event    = overrides['event']    ?? presets['event']    ?? FALLBACK.event;
-  const location = overrides['location'] ?? presets['location'] ?? FALLBACK.location;
+  const resource = coerceLabel(overrides['resource']) ?? coerceLabel(presets['resource']) ?? FALLBACK.resource;
+  const event    = coerceLabel(overrides['event'])    ?? coerceLabel(presets['event'])    ?? FALLBACK.event;
+  const location = coerceLabel(overrides['location']) ?? coerceLabel(presets['location']) ?? FALLBACK.location;
 
-  const resources = overrides['resources'] ?? pluralize(resource);
-  const events    = overrides['events']    ?? pluralize(event);
-  const locations = overrides['locations'] ?? pluralize(location);
+  const resources = coerceLabel(overrides['resources']) ?? pluralize(resource);
+  const events    = coerceLabel(overrides['events'])    ?? pluralize(event);
+  const locations = coerceLabel(overrides['locations']) ?? pluralize(location);
 
   // Carry through any extra keys the host set (preset extras as well,
   // host wins) so consumers that read `labels.aircraft` or similar
-  // free-form keys still find them.
+  // free-form keys still find them. Non-string values are dropped at
+  // the same boundary so consumers never see a stray number/null.
   const extras: Record<string, string> = {};
   for (const [k, v] of Object.entries(presets)) {
-    if (typeof v === 'string') extras[k] = v;
+    const coerced = coerceLabel(v);
+    if (coerced) extras[k] = coerced;
   }
   for (const [k, v] of Object.entries(overrides)) {
-    if (typeof v === 'string') extras[k] = v;
+    const coerced = coerceLabel(v);
+    if (coerced) extras[k] = coerced;
   }
 
   return {

--- a/src/ui/wizard/ConfigWizard.module.css
+++ b/src/ui/wizard/ConfigWizard.module.css
@@ -125,6 +125,17 @@
   color: var(--wc-text-muted, #6b7280);
 }
 
+/* Profile-step headline (#424 wk6) — frames the wizard's first
+   question so the user sees "what are you scheduling?" before the
+   preset grid, instead of jumping straight into a list of cards. */
+.stepHeadline {
+  margin: 0;
+  font-size: 18px;
+  font-weight: 700;
+  color: var(--wc-text, #111827);
+  letter-spacing: -0.01em;
+}
+
 .empty {
   margin: 0;
   font-size: 13px;

--- a/src/ui/wizard/ConfigWizard.tsx
+++ b/src/ui/wizard/ConfigWizard.tsx
@@ -202,6 +202,7 @@ interface StepProps {
 function ProfileStep({ config, setConfig }: StepProps): JSX.Element {
   return (
     <div className={styles['stepInner']}>
+      <h2 className={styles['stepHeadline']}>What are you scheduling?</h2>
       <p className={styles['hint']}>
         Pick a starter preset. We'll seed your labels, resource types, and
         roles based on the industry. You can edit anything afterward.

--- a/src/ui/wizard/__tests__/ConfigWizard.test.tsx
+++ b/src/ui/wizard/__tests__/ConfigWizard.test.tsx
@@ -513,3 +513,12 @@ describe('ConfigWizard — initialConfig editing', () => {
     expect(onComplete).toHaveBeenCalledWith(initial)
   })
 })
+
+describe('ConfigWizard — profile step framing (#424 wk6)', () => {
+  it('frames the first step with "What are you scheduling?"', () => {
+    render(<ConfigWizard onComplete={vi.fn()} onCancel={vi.fn()} />)
+    expect(
+      screen.getByRole('heading', { name: /What are you scheduling\?/i }),
+    ).toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
Closes the roadmap by making the system usable without explanation and aligning the README with the platform framing.

UX:
- Add Event button now reads "+ New {profile.event}" — "New Mission" on air-medical, "New Rental" on equipment-rental, "New Load" on trucking, etc. Replaces the generic "+ Add Event" with the same vocabulary the rest of the UI uses (sourced from `resolveLabels`, week 5).
- View picker is split into Calendar | Operations groups via a visual divider. Calendar = month / week / day / agenda / schedule / base; Operations = assets / dispatch / requests / map. New users see scheduling tabs apart from the operational boards instead of one undifferentiated row.
- ConfigWizard's profile step now opens with a "What are you scheduling?" headline above the preset grid so the wizard frames its first question in plain English instead of jumping straight into a list of cards.

README:
- New headline: "Embeddable scheduling engine for teams, assets, and operations" — replaces the narrower "real scheduling workflows" line.
- Building-blocks framing: "WorksCalendar provides the building blocks for advanced scheduling. Applications are expected to configure and extend these systems to fit their workflow."
- New "Core features (fully working)" vs "Extensible systems (configurable)" split — distinguishes shipped behaviour from configuration surfaces.
- New "Profiles" section with a table of every shipped profile (air_medical, aviation, trucking, equipment_rental, scheduling, custom) plus an `applyProfilePreset` snippet showing how a profile change rewrites labels + roles without touching engine logic.
- No external-library comparisons in docs (confirmed by grep over README.md + docs/ + src/).

Tests: new ConfigWizard headline assertion. Full suite green (2641 unit + 92 e2e). Type-check clean.

## Summary
Describe exactly what this PR changes.

## Scope
- Stage: 
- Planned PR number in sprint: 
- Target files/directories: 
- Why this slice is isolated: 

## Lessons Learned Check (REQUIRED)
Confirm these were actively used while building this PR:

- [ ] PR is intentionally small and isolated
- [ ] Boundary typing was prioritized over internal perfection
- [ ] No silent spread of `any`
- [ ] Advisory root `tsc` was used to catch integration issues
- [ ] I did not assume “looks typed” means “safe”
- [ ] I stopped and isolated typing cascades instead of expanding scope

## Definition of Done (ALL REQUIRED)
This PR is not done unless every box is checked.

- [ ] `npm run type-check:strict` passes
- [ ] Root advisory `tsc --noEmit` passes
- [ ] Tests pass for touched scope at minimum
- [ ] No uncontrolled increase in `any`
- [ ] All new types are intentional and named
- [ ] Public interfaces and exported functions are explicitly typed
- [ ] PR scope matches the sprint plan with no scope creep
- [ ] Any new `any` has an adjacent justification comment
- [ ] No file-wide `: any`
- [ ] No implicit `any` in exported functions

## What Was Typed
List exactly what was typed in this PR.

- 
- 
- 

## What Was Intentionally Left Loose
List anything intentionally not tightened yet.

- 
- 
- 

## `any` Ledger (REQUIRED)
- New `any` added: 
- Existing `any` removed: 
- Net change: 

For every new `any`, explain why it is required and why a safer type was not used yet.

1. 
2. 
3. 

## Boundary Notes
Document any public seams, caller-protection choices, or compatibility decisions.

- 
- 
- 

## Risk Level
- [ ] Low
- [ ] Medium
- [ ] High

Why:

## Validation Evidence
Paste the exact commands run and a short result summary.

```bash
npm run type-check:strict
npx tsc --noEmit -p tsconfig.json
```

Test commands run:

```bash
# paste commands here
```

## Stop Conditions Check
If any item below happened, explain how scope was reduced before merge.

- [ ] `any` started spreading across files
- [ ] Root `tsc` broke repeatedly
- [ ] Types required cross-module rewrites
- [ ] Scope was reduced to keep the PR reviewable

Notes:

## Reviewer Focus
What should reviewers look at first?

- 
- 
- 
