### PR TITLE
demo: add framed Landing layout (desktop chrome + mobile showcase)

### DIFF
--- a/demo/App.tsx
+++ b/demo/App.tsx
@@ -25,6 +25,7 @@ import {
 import MissionHoverCard, { allRequirementsMet } from './MissionHoverCard';
 import missionStyles from './MissionHoverCard.module.css';
 import { makeDispatchEvaluator } from './dispatchEvaluator';
+import Landing from './Landing';
 
 /* ─── Demo identity ─────────────────────────────────────────────── */
 // Air EMS demo: new calendar id so the IHC Fleet localStorage doesn't bleed
@@ -498,53 +499,42 @@ function App() {
   }, [missionAssignments]);
 
   return (
-    <div style={{ height: '100vh', display: 'flex', flexDirection: 'column', background: '#060d1a' }}>
-      <div style={{ flex: 1, padding: 0, minHeight: 0 }}>
-        <div style={{ height: '100%', width: '100%' }}>
-          <WorksCalendar
-            events={events}
-            employees={employees}
-            assets={AIRCRAFT_RESOURCES}
-            pools={pools}
-            onPoolsChange={handlePoolsChange}
-            strictAssetFiltering={true}
-            assetRequestCategories={['maintenance', 'aircraft-request', 'asset-request', 'training', 'mission-assignment']}
-            onEmployeeAdd={handleEmployeeAdd}
-            onEmployeeDelete={handleEmployeeDelete}
-            calendarId={DEMO_CALENDAR_ID}
-            ownerPassword="demo1234"
-            showSetupLanding
-            onConfigSave={handleConfigSave}
-            notes={notes}
-            onNoteSave={handleNoteSave}
-            onNoteDelete={handleNoteDelete}
-            onEventSave={handleEventSave}
-            onEventDelete={handleEventDelete}
-            onScheduleSave={handleEventSave}
-            onAvailabilitySave={handleEventSave}
-            onApprovalAction={handleApprovalAction}
-            onEventClick={handleEventClick}
-            renderEvent={renderEvent}
-            theme={theme}
-            showAddButton={true}
-            categoriesConfig={UNIFIED_CATEGORIES_CONFIG}
-            locationProvider={assetLocationProvider}
-            filterSchema={DEMO_FILTER_SCHEMA}
-            dispatchMissions={dispatchMissions}
-            dispatchEvaluator={dispatchEvaluator}
-          />
-        </div>
-      </div>
+    <>
+      <Landing>
+        <WorksCalendar
+          events={events}
+          employees={employees}
+          assets={AIRCRAFT_RESOURCES}
+          pools={pools}
+          onPoolsChange={handlePoolsChange}
+          strictAssetFiltering={true}
+          assetRequestCategories={['maintenance', 'aircraft-request', 'asset-request', 'training', 'mission-assignment']}
+          onEmployeeAdd={handleEmployeeAdd}
+          onEmployeeDelete={handleEmployeeDelete}
+          calendarId={DEMO_CALENDAR_ID}
+          ownerPassword="demo1234"
+          showSetupLanding
+          onConfigSave={handleConfigSave}
+          notes={notes}
+          onNoteSave={handleNoteSave}
+          onNoteDelete={handleNoteDelete}
+          onEventSave={handleEventSave}
+          onEventDelete={handleEventDelete}
+          onScheduleSave={handleEventSave}
+          onAvailabilitySave={handleEventSave}
+          onApprovalAction={handleApprovalAction}
+          onEventClick={handleEventClick}
+          renderEvent={renderEvent}
+          theme={theme}
+          showAddButton={true}
+          categoriesConfig={UNIFIED_CATEGORIES_CONFIG}
+          locationProvider={assetLocationProvider}
+          filterSchema={DEMO_FILTER_SCHEMA}
+          dispatchMissions={dispatchMissions}
+          dispatchEvaluator={dispatchEvaluator}
+        />
+      </Landing>
 
-      {/* Demo hint: owner password floats below the gear icon */}
-      <div style={{
-        position: 'fixed', top: 56, right: 12, zIndex: 50,
-        fontSize: 10, color: '#94a3b8', pointerEvents: 'none', userSelect: 'none',
-      }}>
-        pw: <code style={{ background: 'rgba(0,0,0,.06)', padding: '1px 4px', borderRadius: 3 }}>demo1234</code>
-      </div>
-
-      {/* Mission workflow modal — shown when a mission-assignment or aircraft-request is clicked */}
       {missionOpen && (
         <MissionHoverCard
           mission={mission}
@@ -562,7 +552,7 @@ function App() {
           onDismiss={() => setNeedsRefresh(false)}
         />
       )}
-    </div>
+    </>
   );
 }
 

--- a/demo/Landing.module.css
+++ b/demo/Landing.module.css
@@ -1,0 +1,404 @@
+/* ─── Tokens ─────────────────────────────────────────────────────── */
+
+.root {
+  --bg-base:        #f7f1e8;
+  --bg-base-deep:   #ede4d4;
+  --bg-card:        #ffffff;
+  --bg-card-soft:   #fdfaf4;
+  --border:         rgba(60, 35, 10, 0.08);
+  --border-strong:  rgba(60, 35, 10, 0.14);
+  --text:           #2d1f0e;
+  --text-muted:     #6b5a44;
+  --text-faint:     #9a8a73;
+  --accent:         #c2410c;
+  --accent-soft:    #fed7aa;
+  --accent-deep:    #9a3412;
+  --shadow-sm:      0 1px 2px rgba(45, 31, 14, 0.04), 0 1px 3px rgba(45, 31, 14, 0.06);
+  --shadow-md:      0 4px 12px rgba(45, 31, 14, 0.06), 0 2px 6px rgba(45, 31, 14, 0.04);
+  --shadow-lg:      0 24px 48px -12px rgba(45, 31, 14, 0.18), 0 8px 16px rgba(45, 31, 14, 0.06);
+  --radius-card:    14px;
+  --radius-window:  18px;
+
+  background:
+    radial-gradient(1200px 600px at 85% 0%, #fff7eb 0%, transparent 60%),
+    radial-gradient(900px 500px at 0% 100%, #f3e7d2 0%, transparent 55%),
+    var(--bg-base);
+  color: var(--text);
+  min-height: 100vh;
+  font-family: 'Inter', system-ui, sans-serif;
+}
+
+/* ─── Desktop layout ─────────────────────────────────────────────── */
+
+.desktop {
+  display: grid;
+  grid-template-rows: auto 1fr;
+  height: 100vh;
+  width: 100%;
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 14px 32px;
+  border-bottom: 1px solid var(--border);
+  background: rgba(255, 255, 255, 0.55);
+  backdrop-filter: saturate(140%) blur(8px);
+  -webkit-backdrop-filter: saturate(140%) blur(8px);
+}
+
+.brand {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+}
+
+.logo {
+  width: 28px;
+  height: 28px;
+  border-radius: 8px;
+  background: linear-gradient(135deg, var(--accent) 0%, var(--accent-deep) 100%);
+  color: #fff;
+  font-size: 11px;
+  font-weight: 700;
+  display: grid;
+  place-items: center;
+  letter-spacing: 0.04em;
+}
+
+.nav {
+  display: flex;
+  gap: 24px;
+  align-items: center;
+  font-size: 13px;
+  color: var(--text-muted);
+}
+.nav a {
+  color: inherit;
+  text-decoration: none;
+  transition: color 120ms ease;
+}
+.nav a:hover {
+  color: var(--accent);
+}
+
+.main {
+  display: grid;
+  grid-template-columns: minmax(320px, 36%) 1fr;
+  gap: 32px;
+  padding: 32px 32px 32px 32px;
+  min-height: 0;
+  overflow: hidden;
+}
+
+/* ─── Left chrome ────────────────────────────────────────────────── */
+
+.chrome {
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+  overflow-y: auto;
+  padding-right: 4px;
+}
+
+.hero {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding-bottom: 6px;
+}
+
+.heroEyebrow {
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--accent);
+}
+
+.heroTitle {
+  margin: 0;
+  font-size: 38px;
+  line-height: 1.05;
+  letter-spacing: -0.025em;
+  font-weight: 700;
+  color: var(--text);
+}
+
+.heroSub {
+  margin: 0;
+  font-size: 15px;
+  line-height: 1.55;
+  color: var(--text-muted);
+  max-width: 44ch;
+}
+
+.card {
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-card);
+  padding: 16px 18px;
+  box-shadow: var(--shadow-sm);
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.cardLabel {
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--text-faint);
+}
+
+.profile {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.avatar {
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  background: linear-gradient(135deg, #fdba74, #c2410c);
+  color: #fff;
+  display: grid;
+  place-items: center;
+  font-weight: 600;
+  font-size: 14px;
+  letter-spacing: 0.02em;
+  flex-shrink: 0;
+}
+
+.profileName {
+  font-weight: 600;
+  font-size: 14px;
+  color: var(--text);
+}
+
+.profileRole {
+  font-size: 12px;
+  color: var(--text-muted);
+}
+
+.profileMeta {
+  font-size: 12px;
+  line-height: 1.5;
+  color: var(--text-muted);
+  padding-top: 2px;
+  border-top: 1px dashed var(--border);
+}
+
+.featureRow {
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+}
+
+.featureDot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--accent);
+  margin-top: 7px;
+  flex-shrink: 0;
+  box-shadow: 0 0 0 4px var(--accent-soft);
+}
+
+.featureTitle {
+  font-weight: 600;
+  font-size: 14px;
+  color: var(--text);
+  margin-bottom: 2px;
+}
+
+.featureDesc {
+  font-size: 12.5px;
+  line-height: 1.55;
+  color: var(--text-muted);
+}
+
+.statusGrid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 10px;
+}
+
+.statusItem {
+  background: var(--bg-card-soft);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  padding: 10px 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.statusValue {
+  font-size: 22px;
+  font-weight: 700;
+  color: var(--text);
+  letter-spacing: -0.02em;
+}
+
+.statusLabel {
+  font-size: 11px;
+  color: var(--text-muted);
+  letter-spacing: 0.02em;
+}
+
+.footnote {
+  font-size: 11px;
+  color: var(--text-faint);
+  padding: 4px 4px 12px;
+  line-height: 1.5;
+}
+.footnote code {
+  background: rgba(60, 35, 10, 0.06);
+  padding: 1px 5px;
+  border-radius: 4px;
+  font-size: 10.5px;
+}
+
+/* ─── Calendar window (right side) ───────────────────────────────── */
+
+.calendarFrame {
+  display: flex;
+  align-items: flex-end;
+  justify-content: flex-end;
+  min-width: 0;
+  min-height: 0;
+}
+
+.calendarWindow {
+  width: 100%;
+  height: 92%;
+  max-height: 100%;
+  background: var(--bg-card);
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius-window);
+  box-shadow: var(--shadow-lg);
+  overflow: hidden;
+  position: relative;
+  display: flex;
+  flex-direction: column;
+}
+
+/* The WorksCalendar renders its own border-radius/border in some themes;
+   the wrapper window is the visual frame, so suppress the inner one. */
+.calendarWindow > div,
+.calendarWindow [data-testid='works-calendar'] {
+  border-radius: 0 !important;
+  border: none !important;
+  height: 100% !important;
+  flex: 1;
+  min-height: 0;
+}
+
+/* ─── Mobile showcase ────────────────────────────────────────────── */
+
+.mobile {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+  padding: 24px 20px 48px;
+  min-height: 100vh;
+}
+
+.mobileHeader {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding-bottom: 4px;
+}
+
+.mobileHero {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 8px 0 16px;
+}
+
+.mobileHeroTitle {
+  margin: 0;
+  font-size: 32px;
+  line-height: 1.08;
+  letter-spacing: -0.025em;
+  font-weight: 700;
+}
+
+.mobileHeroSub {
+  margin: 0;
+  font-size: 15px;
+  line-height: 1.55;
+  color: var(--text-muted);
+}
+
+.mobileNotice {
+  background: var(--accent-soft);
+  border: 1px solid #fdba74;
+  border-radius: 10px;
+  padding: 12px 14px;
+  font-size: 13px;
+  line-height: 1.5;
+  color: var(--accent-deep);
+}
+
+.featureCards {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.featureCard {
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-card);
+  padding: 18px 18px 20px;
+  box-shadow: var(--shadow-sm);
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.featureCardEyebrow {
+  font-size: 10.5px;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--accent);
+}
+
+.featureCardTitle {
+  margin: 0;
+  font-size: 18px;
+  line-height: 1.25;
+  font-weight: 600;
+  color: var(--text);
+  letter-spacing: -0.01em;
+}
+
+.featureCardDesc {
+  margin: 0;
+  font-size: 13.5px;
+  line-height: 1.55;
+  color: var(--text-muted);
+}
+
+.featureCardPlaceholder {
+  background: var(--bg-card-soft);
+  border: 1px dashed var(--border-strong);
+  border-radius: 10px;
+  padding: 18px;
+  display: grid;
+  place-items: center;
+  font-size: 12px;
+  color: var(--text-faint);
+  min-height: 96px;
+  margin-top: 4px;
+}

--- a/demo/Landing.tsx
+++ b/demo/Landing.tsx
@@ -1,0 +1,248 @@
+// @ts-nocheck — demo wrapper, follows App.tsx convention
+import { useEffect, useState, type ReactNode } from 'react';
+import styles from './Landing.module.css';
+
+const MOBILE_BREAKPOINT_PX = 1100;
+
+function useIsMobile(): boolean {
+  const [isMobile, setIsMobile] = useState(() =>
+    typeof window !== 'undefined' ? window.innerWidth < MOBILE_BREAKPOINT_PX : false,
+  );
+  useEffect(() => {
+    const mq = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT_PX - 1}px)`);
+    const handler = (e: MediaQueryListEvent) => setIsMobile(e.matches);
+    setIsMobile(mq.matches);
+    mq.addEventListener('change', handler);
+    return () => mq.removeEventListener('change', handler);
+  }, []);
+  return isMobile;
+}
+
+interface LandingProps {
+  children: ReactNode;
+}
+
+export default function Landing({ children }: LandingProps) {
+  const isMobile = useIsMobile();
+  return (
+    <div className={styles.root}>
+      {isMobile ? <MobileShowcase /> : <DesktopFrame>{children}</DesktopFrame>}
+    </div>
+  );
+}
+
+function HeaderBar() {
+  return (
+    <header className={styles.header}>
+      <div className={styles.brand}>
+        <span className={styles.logo}>WC</span>
+        <span>WorksCalendar</span>
+      </div>
+      <nav className={styles.nav}>
+        <a href="#features">Features</a>
+        <a
+          href="https://github.com/workscalendar/calendarthatworks"
+          target="_blank"
+          rel="noreferrer"
+        >
+          GitHub
+        </a>
+      </nav>
+    </header>
+  );
+}
+
+function DesktopFrame({ children }: { children: ReactNode }) {
+  return (
+    <div className={styles.desktop}>
+      <HeaderBar />
+      <main className={styles.main}>
+        <aside className={styles.chrome}>
+          <section className={styles.hero}>
+            <span className={styles.heroEyebrow}>Operations scheduling</span>
+            <h1 className={styles.heroTitle}>Calendar that actually works.</h1>
+            <p className={styles.heroSub}>
+              Shifts, on-call rotations, multi-leg missions, approvals, and
+              resource pools — across regions, bases, and crews. Try the live
+              demo on the right.
+            </p>
+          </section>
+
+          <ProfileCard />
+          <FeaturesCard />
+          <StatusCard />
+
+          <p className={styles.footnote}>
+            Owner password for settings: <code>demo1234</code>
+          </p>
+        </aside>
+
+        <section className={styles.calendarFrame}>
+          <div className={styles.calendarWindow}>{children}</div>
+        </section>
+      </main>
+    </div>
+  );
+}
+
+function ProfileCard() {
+  return (
+    <div className={styles.card}>
+      <div className={styles.cardLabel}>Logged in as</div>
+      <div className={styles.profile}>
+        <div className={styles.avatar}>SF</div>
+        <div>
+          <div className={styles.profileName}>Sarah Foster</div>
+          <div className={styles.profileRole}>Ops Manager · Seattle (Hub)</div>
+        </div>
+      </div>
+      <div className={styles.profileMeta}>
+        Role-switching to demo the approval hierarchy is wired in next — for now
+        you're seeing the manager view (full approval rights).
+      </div>
+    </div>
+  );
+}
+
+function FeaturesCard() {
+  return (
+    <div className={styles.card} id="features">
+      <div className={styles.cardLabel}>What to try</div>
+      <FeatureRow
+        title="Conflict engine"
+        desc="Drag a shift onto an already-booked resource — the calendar surfaces the overlap and resolution options."
+      />
+      <FeatureRow
+        title="Resource pools"
+        desc="Book against a pool (e.g. PNW Fleet) instead of a tail number. The resolver picks an available aircraft by strategy."
+      />
+      <FeatureRow
+        title="Multi-leg missions"
+        desc="Click the São Paulo → Munich pill to open the mission workflow: requirements, assignments, compliance."
+      />
+      <FeatureRow
+        title="Approval workflow"
+        desc="Aircraft requests, maintenance, and asset bookings flow through a request → approve → finalize state machine."
+      />
+    </div>
+  );
+}
+
+function FeatureRow({ title, desc }: { title: string; desc: string }) {
+  return (
+    <div className={styles.featureRow}>
+      <span className={styles.featureDot} aria-hidden="true" />
+      <div>
+        <div className={styles.featureTitle}>{title}</div>
+        <div className={styles.featureDesc}>{desc}</div>
+      </div>
+    </div>
+  );
+}
+
+function StatusCard() {
+  return (
+    <div className={styles.card}>
+      <div className={styles.cardLabel}>Operations snapshot</div>
+      <div className={styles.statusGrid}>
+        <StatusItem value="5" label="Active bases" />
+        <StatusItem value="6" label="Aircraft" />
+        <StatusItem value="22" label="Personnel" />
+        <StatusItem value="1" label="Live mission" />
+      </div>
+    </div>
+  );
+}
+
+function StatusItem({ value, label }: { value: string; label: string }) {
+  return (
+    <div className={styles.statusItem}>
+      <span className={styles.statusValue}>{value}</span>
+      <span className={styles.statusLabel}>{label}</span>
+    </div>
+  );
+}
+
+function MobileShowcase() {
+  return (
+    <div className={styles.mobile}>
+      <div className={styles.mobileHeader}>
+        <div className={styles.brand}>
+          <span className={styles.logo}>WC</span>
+          <span>WorksCalendar</span>
+        </div>
+        <a
+          href="https://github.com/workscalendar/calendarthatworks"
+          target="_blank"
+          rel="noreferrer"
+          style={{ fontSize: 13, color: '#6b5a44', textDecoration: 'none' }}
+        >
+          GitHub
+        </a>
+      </div>
+
+      <div className={styles.mobileHero}>
+        <span className={styles.heroEyebrow}>Operations scheduling</span>
+        <h1 className={styles.mobileHeroTitle}>Calendar that actually works.</h1>
+        <p className={styles.mobileHeroSub}>
+          Shifts, on-call, missions, approvals, and resource pools — built for
+          teams that operate around the clock.
+        </p>
+      </div>
+
+      <div className={styles.mobileNotice}>
+        The interactive calendar demo is desktop-only — open this page on a
+        larger screen to try it. Below is a tour of what's inside.
+      </div>
+
+      <div className={styles.featureCards}>
+        <MobileFeatureCard
+          eyebrow="Scheduling core"
+          title="Conflict engine"
+          desc="Detects double-bookings, cert mismatches, and pool unavailability the moment you drag a shift into place."
+        />
+        <MobileFeatureCard
+          eyebrow="Allocation"
+          title="Resource pools"
+          desc="Book against a pool (any PNW aircraft, any 8-seat room) and let the resolver pick by round-robin, least-loaded, or proximity."
+        />
+        <MobileFeatureCard
+          eyebrow="Workflow"
+          title="Multi-leg missions"
+          desc="Mission requirements, crew assignments, aircraft selection, and compliance checks — in one workflow card per mission."
+        />
+        <MobileFeatureCard
+          eyebrow="Governance"
+          title="Approval hierarchy"
+          desc="Aircraft requests, maintenance, and asset bookings flow through request → approve → finalize, with role-aware permissions."
+        />
+        <MobileFeatureCard
+          eyebrow="Visibility"
+          title="Filter cascade"
+          desc="Narrow by region → base → crew type → role. Save the result as a one-tap saved view chip."
+        />
+      </div>
+    </div>
+  );
+}
+
+function MobileFeatureCard({
+  eyebrow,
+  title,
+  desc,
+}: {
+  eyebrow: string;
+  title: string;
+  desc: string;
+}) {
+  return (
+    <div className={styles.featureCard}>
+      <span className={styles.featureCardEyebrow}>{eyebrow}</span>
+      <h3 className={styles.featureCardTitle}>{title}</h3>
+      <p className={styles.featureCardDesc}>{desc}</p>
+      <div className={styles.featureCardPlaceholder}>
+        Visual to come — placeholder
+      </div>
+    </div>
+  );
+}

--- a/demo/Landing.tsx
+++ b/demo/Landing.tsx
@@ -12,8 +12,15 @@ function useIsMobile(): boolean {
     const mq = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT_PX - 1}px)`);
     const handler = (e: MediaQueryListEvent) => setIsMobile(e.matches);
     setIsMobile(mq.matches);
-    mq.addEventListener('change', handler);
-    return () => mq.removeEventListener('change', handler);
+    // Safari < 14 / older iOS WebViews only expose addListener/removeListener
+    // on MediaQueryList; calling addEventListener throws there. Feature-detect
+    // and fall back so the demo still mounts on legacy clients.
+    if (typeof mq.addEventListener === 'function') {
+      mq.addEventListener('change', handler);
+      return () => mq.removeEventListener('change', handler);
+    }
+    mq.addListener(handler);
+    return () => mq.removeListener(handler);
   }, []);
   return isMobile;
 }


### PR DESCRIPTION
Wrap the full-bleed Air EMS calendar in a new Landing component:
- Desktop: warm-light header + left narrative chrome (hero, profile,
  feature list, ops snapshot) with the calendar pinned to the right in
  a framed window. Drops the floating "pw:" hint into the chrome.
- Mobile (<1100px): pure showcase. Replaces the embedded calendar with
  a hero + feature cards + "desktop only" notice, since the calendar
  was unusable at phone width.

Calendar wiring (events, pools, dispatch, mission modal, PWA toast) is
unchanged — only the layout shell around it is new. First pass of the
demo redesign; cascade Focus rebuild and richer chrome content (live
status counts, profile-switching to demo approval hierarchy, real
feature visuals on mobile) come next.

https://claude.ai/code/session_01CZZfrd8wWfSFPwyEZ1YZQT