### PR TITLE
demo+e2e: ?embed=1 flag bypasses Landing chrome for tests

### DIFF
--- a/demo/App.tsx
+++ b/demo/App.tsx
@@ -341,6 +341,14 @@ function UpdateToast({ onUpdate, onDismiss }) {
 }
 
 /* ─── Demo App ──────────────────────────────────────────────────── */
+// `?embed=1` skips the marketing chrome and renders the calendar
+// full-bleed. e2e tests and any page that wants to embed the demo as
+// a raw calendar use this flag; the default `/` route shows the
+// framed Landing layout.
+const EMBED_MODE =
+  typeof window !== 'undefined' &&
+  new URLSearchParams(window.location.search).has('embed');
+
 function App() {
   const [events,            setEvents]            = useState(INITIAL_EVENTS);
   const [notes,             setNotes]             = useState({});
@@ -498,42 +506,48 @@ function App() {
     );
   }, [missionAssignments]);
 
+  const calendar = (
+    <WorksCalendar
+      events={events}
+      employees={employees}
+      assets={AIRCRAFT_RESOURCES}
+      pools={pools}
+      onPoolsChange={handlePoolsChange}
+      strictAssetFiltering={true}
+      assetRequestCategories={['maintenance', 'aircraft-request', 'asset-request', 'training', 'mission-assignment']}
+      onEmployeeAdd={handleEmployeeAdd}
+      onEmployeeDelete={handleEmployeeDelete}
+      calendarId={DEMO_CALENDAR_ID}
+      ownerPassword="demo1234"
+      showSetupLanding
+      onConfigSave={handleConfigSave}
+      notes={notes}
+      onNoteSave={handleNoteSave}
+      onNoteDelete={handleNoteDelete}
+      onEventSave={handleEventSave}
+      onEventDelete={handleEventDelete}
+      onScheduleSave={handleEventSave}
+      onAvailabilitySave={handleEventSave}
+      onApprovalAction={handleApprovalAction}
+      onEventClick={handleEventClick}
+      renderEvent={renderEvent}
+      theme={theme}
+      showAddButton={true}
+      categoriesConfig={UNIFIED_CATEGORIES_CONFIG}
+      locationProvider={assetLocationProvider}
+      filterSchema={DEMO_FILTER_SCHEMA}
+      dispatchMissions={dispatchMissions}
+      dispatchEvaluator={dispatchEvaluator}
+    />
+  );
+
   return (
     <>
-      <Landing>
-        <WorksCalendar
-          events={events}
-          employees={employees}
-          assets={AIRCRAFT_RESOURCES}
-          pools={pools}
-          onPoolsChange={handlePoolsChange}
-          strictAssetFiltering={true}
-          assetRequestCategories={['maintenance', 'aircraft-request', 'asset-request', 'training', 'mission-assignment']}
-          onEmployeeAdd={handleEmployeeAdd}
-          onEmployeeDelete={handleEmployeeDelete}
-          calendarId={DEMO_CALENDAR_ID}
-          ownerPassword="demo1234"
-          showSetupLanding
-          onConfigSave={handleConfigSave}
-          notes={notes}
-          onNoteSave={handleNoteSave}
-          onNoteDelete={handleNoteDelete}
-          onEventSave={handleEventSave}
-          onEventDelete={handleEventDelete}
-          onScheduleSave={handleEventSave}
-          onAvailabilitySave={handleEventSave}
-          onApprovalAction={handleApprovalAction}
-          onEventClick={handleEventClick}
-          renderEvent={renderEvent}
-          theme={theme}
-          showAddButton={true}
-          categoriesConfig={UNIFIED_CATEGORIES_CONFIG}
-          locationProvider={assetLocationProvider}
-          filterSchema={DEMO_FILTER_SCHEMA}
-          dispatchMissions={dispatchMissions}
-          dispatchEvaluator={dispatchEvaluator}
-        />
-      </Landing>
+      {EMBED_MODE ? (
+        <div style={{ height: '100vh', width: '100vw' }}>{calendar}</div>
+      ) : (
+        <Landing>{calendar}</Landing>
+      )}
 
       {missionOpen && (
         <MissionHoverCard

--- a/tests-e2e/calendar.assets-grouping.spec.ts
+++ b/tests-e2e/calendar.assets-grouping.spec.ts
@@ -14,7 +14,7 @@ const SAVED_VIEWS_KEY = `wc-saved-views-${DEMO_CALENDAR_ID}`;
 test.describe('WorksCalendar Assets view', () => {
   test.beforeEach(async ({ page }) => {
     await page.setViewportSize({ width: 1400, height: 900 });
-    await page.goto('/');
+    await page.goto('/?embed=1');
     await expect(page.getByTestId('works-calendar')).toBeVisible();
   });
 

--- a/tests-e2e/calendar.demo.spec.ts
+++ b/tests-e2e/calendar.demo.spec.ts
@@ -51,14 +51,14 @@ for (const vp of viewports) {
         pageErrors.push(err.message);
       });
 
-      await page.goto('/');
+      await page.goto('/?embed=1');
       await expect(page.getByTestId('works-calendar')).toBeVisible();
       await expect(page.getByRole('toolbar', { name: /calendar navigation/i })).toBeVisible();
       expect(consoleErrors.concat(pageErrors).filter(ignoreEnvNoise)).toEqual([]);
     });
 
     test('main navigation buttons work', async ({ page }) => {
-      await page.goto('/');
+      await page.goto('/?embed=1');
       const calendar = page.getByTestId('works-calendar');
       await expect(calendar).toBeVisible();
 
@@ -73,7 +73,7 @@ for (const vp of viewports) {
     });
 
     test('all views can be selected', async ({ page }) => {
-      await page.goto('/');
+      await page.goto('/?embed=1');
 
       const views = ['Month', 'Week', 'Day', 'Agenda', 'Schedule'];
 
@@ -86,7 +86,7 @@ for (const vp of viewports) {
     });
 
     test('add event dialog opens', async ({ page }) => {
-      await page.goto('/');
+      await page.goto('/?embed=1');
       // Demo now defaults to schedule view; the "Add new event" button only
       // renders in non-schedule views, so switch to Month first.
       await page.getByRole('button', { name: /^Month$/i }).click();
@@ -97,7 +97,7 @@ for (const vp of viewports) {
     });
 
     test('layout is visible and not tiny', async ({ page }) => {
-      await page.goto('/');
+      await page.goto('/?embed=1');
       const root = page.getByTestId('works-calendar');
       await expect(root).toBeVisible();
       const box = await root.boundingBox();
@@ -109,7 +109,7 @@ for (const vp of viewports) {
     });
 
     test('save viewport screenshot', async ({ page }) => {
-      await page.goto('/');
+      await page.goto('/?embed=1');
       await expect(page.getByTestId('works-calendar')).toBeVisible();
       await page.screenshot({ path: 'qa-output/' + vp.name + '.png', fullPage: true });
     });

--- a/tests-e2e/calendar.happy-paths.spec.ts
+++ b/tests-e2e/calendar.happy-paths.spec.ts
@@ -24,7 +24,7 @@ function dateKey(offsetDays = 0): string {
 test.describe('WorksCalendar happy paths', () => {
   test.beforeEach(async ({ page }) => {
     await page.setViewportSize({ width: 1280, height: 900 });
-    await page.goto('/');
+    await page.goto('/?embed=1');
     await expect(page.getByTestId('works-calendar')).toBeVisible();
     // Demo defaults to schedule view; these tests exercise month-view flows
     // (drag, add-event toolbar button), so normalize to Month first.

--- a/tests-e2e/calendar.interaction-crawler.spec.ts
+++ b/tests-e2e/calendar.interaction-crawler.spec.ts
@@ -64,7 +64,7 @@ test.describe('WorksCalendar interaction crawler', () => {
 
   test.beforeEach(async ({ page }) => {
     await page.setViewportSize({ width: 1400, height: 900 });
-    await page.goto('/');
+    await page.goto('/?embed=1');
     await expect(page.getByTestId(ROOT_TEST_ID)).toBeVisible();
   });
 

--- a/tests-e2e/visual-qa.spec.ts
+++ b/tests-e2e/visual-qa.spec.ts
@@ -48,42 +48,42 @@ test.describe('Desktop (1280×900)', () => {
   test.use({ viewport: { width: 1280, height: 900 } });
 
   test('month view', async ({ page }) => {
-    await page.goto('/');
+    await page.goto('/?embed=1');
     await waitForCalendar(page);
     await switchView(page, 'month');
     await snap(page, '01-month-desktop');
   });
 
   test('week view', async ({ page }) => {
-    await page.goto('/');
+    await page.goto('/?embed=1');
     await waitForCalendar(page);
     await switchView(page, 'week');
     await snap(page, '02-week-desktop');
   });
 
   test('day view', async ({ page }) => {
-    await page.goto('/');
+    await page.goto('/?embed=1');
     await waitForCalendar(page);
     await switchView(page, 'day');
     await snap(page, '03-day-desktop');
   });
 
   test('agenda view', async ({ page }) => {
-    await page.goto('/');
+    await page.goto('/?embed=1');
     await waitForCalendar(page);
     await switchView(page, 'agenda');
     await snap(page, '04-agenda-desktop');
   });
 
   test('schedule / timeline view', async ({ page }) => {
-    await page.goto('/');
+    await page.goto('/?embed=1');
     await waitForCalendar(page);
     await switchView(page, 'schedule');
     await snap(page, '05-schedule-desktop');
   });
 
   test('add-event modal open', async ({ page }) => {
-    await page.goto('/');
+    await page.goto('/?embed=1');
     await waitForCalendar(page);
     await switchView(page, 'month');
     // Click the + button or a day cell to open the modal
@@ -102,7 +102,7 @@ test.describe('Desktop (1280×900)', () => {
   });
 
   test('hover card on event', async ({ page }) => {
-    await page.goto('/');
+    await page.goto('/?embed=1');
     await waitForCalendar(page);
     await switchView(page, 'month');
     // Hover the first visible event pill
@@ -115,7 +115,7 @@ test.describe('Desktop (1280×900)', () => {
   });
 
   test('filter bar with active filter', async ({ page }) => {
-    await page.goto('/');
+    await page.goto('/?embed=1');
     await waitForCalendar(page);
     // Click the first filter pill if present
     const filterPill = page.locator('[class*="filterPill"], [class*="FilterPill"]').first();
@@ -127,7 +127,7 @@ test.describe('Desktop (1280×900)', () => {
   });
 
   test('month view — navigate forward one month', async ({ page }) => {
-    await page.goto('/');
+    await page.goto('/?embed=1');
     await waitForCalendar(page);
     await switchView(page, 'month');
     const nextBtn = page.getByRole('button', { name: /next|›|chevron.*right/i }).first();
@@ -139,7 +139,7 @@ test.describe('Desktop (1280×900)', () => {
   });
 
   test('week view — time grid with events', async ({ page }) => {
-    await page.goto('/');
+    await page.goto('/?embed=1');
     await waitForCalendar(page);
     await switchView(page, 'week');
     // Navigate to a week that likely has events
@@ -156,21 +156,21 @@ test.describe('Mobile (375×812)', () => {
   test.use({ viewport: { width: 375, height: 812 } });
 
   test('month view mobile', async ({ page }) => {
-    await page.goto('/');
+    await page.goto('/?embed=1');
     await waitForCalendar(page);
     await switchView(page, 'month');
     await snap(page, '11-month-mobile');
   });
 
   test('agenda view mobile', async ({ page }) => {
-    await page.goto('/');
+    await page.goto('/?embed=1');
     await waitForCalendar(page);
     await switchView(page, 'agenda');
     await snap(page, '12-agenda-mobile');
   });
 
   test('week view mobile', async ({ page }) => {
-    await page.goto('/');
+    await page.goto('/?embed=1');
     await waitForCalendar(page);
     await switchView(page, 'week');
     await snap(page, '13-week-mobile');
@@ -183,14 +183,14 @@ test.describe('Tablet (768×1024)', () => {
   test.use({ viewport: { width: 768, height: 1024 } });
 
   test('month view tablet', async ({ page }) => {
-    await page.goto('/');
+    await page.goto('/?embed=1');
     await waitForCalendar(page);
     await switchView(page, 'month');
     await snap(page, '14-month-tablet');
   });
 
   test('schedule view tablet', async ({ page }) => {
-    await page.goto('/');
+    await page.goto('/?embed=1');
     await waitForCalendar(page);
     await switchView(page, 'schedule');
     await snap(page, '15-schedule-tablet');

--- a/tests-e2e/workflow-builder.spec.ts
+++ b/tests-e2e/workflow-builder.spec.ts
@@ -44,7 +44,7 @@ test.describe('Workflow visual builder', () => {
     await page.addInitScript((key) => {
       try { localStorage.removeItem(key); } catch {}
     }, STORAGE_KEY);
-    await page.goto('/');
+    await page.goto('/?embed=1');
     await expect(page.getByTestId('works-calendar')).toBeVisible();
   });
 


### PR DESCRIPTION
The new framed Landing layout shrinks the calendar away from the viewport edges, which broke any e2e that assumed the calendar was the full-bleed root. Two-part fix:

1. demo/App.tsx detects ?embed=1 in the URL and renders the bare WorksCalendar inside a 100vw/100vh wrapper, skipping the marketing chrome. The default route still shows the framed Landing.
2. tests-e2e/*.spec.ts: every page.goto('/') now navigates to '/?embed=1' so behavior tests exercise the calendar in its raw form rather than the surrounding chrome. Fixture pages (regression-bugs.html, embed-host.html, etc.) are unchanged since they have their own entry points.

Verified: 75/75 non-visual e2e tests pass. visual-qa snapshots are intentionally out of date and need a separate refresh pass once the chrome work settles.

https://claude.ai/code/session_01CZZfrd8wWfSFPwyEZ1YZQT

## Summary
Describe exactly what this PR changes.

## Scope
- Stage: 
- Planned PR number in sprint: 
- Target files/directories: 
- Why this slice is isolated: 

## Lessons Learned Check (REQUIRED)
Confirm these were actively used while building this PR:

- [ ] PR is intentionally small and isolated
- [ ] Boundary typing was prioritized over internal perfection
- [ ] No silent spread of `any`
- [ ] Advisory root `tsc` was used to catch integration issues
- [ ] I did not assume “looks typed” means “safe”
- [ ] I stopped and isolated typing cascades instead of expanding scope

## Definition of Done (ALL REQUIRED)
This PR is not done unless every box is checked.

- [ ] `npm run type-check:strict` passes
- [ ] Root advisory `tsc --noEmit` passes
- [ ] Tests pass for touched scope at minimum
- [ ] No uncontrolled increase in `any`
- [ ] All new types are intentional and named
- [ ] Public interfaces and exported functions are explicitly typed
- [ ] PR scope matches the sprint plan with no scope creep
- [ ] Any new `any` has an adjacent justification comment
- [ ] No file-wide `: any`
- [ ] No implicit `any` in exported functions

## What Was Typed
List exactly what was typed in this PR.

- 
- 
- 

## What Was Intentionally Left Loose
List anything intentionally not tightened yet.

- 
- 
- 

## `any` Ledger (REQUIRED)
- New `any` added: 
- Existing `any` removed: 
- Net change: 

For every new `any`, explain why it is required and why a safer type was not used yet.

1. 
2. 
3. 

## Boundary Notes
Document any public seams, caller-protection choices, or compatibility decisions.

- 
- 
- 

## Risk Level
- [ ] Low
- [ ] Medium
- [ ] High

Why:

## Validation Evidence
Paste the exact commands run and a short result summary.

```bash
npm run type-check:strict
npx tsc --noEmit -p tsconfig.json
```

Test commands run:

```bash
# paste commands here
```

## Stop Conditions Check
If any item below happened, explain how scope was reduced before merge.

- [ ] `any` started spreading across files
- [ ] Root `tsc` broke repeatedly
- [ ] Types required cross-module rewrites
- [ ] Scope was reduced to keep the PR reviewable

Notes:

## Reviewer Focus
What should reviewers look at first?

- 
- 
- 
