### PR TITLE
demo(mobile): replace placeholder visuals with per-feature illustrations

### DIFF
--- a/demo/Landing.module.css
+++ b/demo/Landing.module.css
@@ -554,3 +554,391 @@
   min-height: 96px;
   margin-top: 4px;
 }
+
+/* ─── Shared visual frame ────────────────────────────────────────── */
+
+.featureCardVisual {
+  margin-top: 6px;
+}
+
+.visualFrame {
+  background: var(--bg-card-soft);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 14px 14px 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.visualCaption {
+  font-size: 11.5px;
+  line-height: 1.45;
+  color: var(--text-faint);
+  padding-top: 4px;
+  border-top: 1px dashed var(--border);
+}
+
+/* ─── Conflict visual ────────────────────────────────────────────── */
+
+.conflictGrid {
+  display: grid;
+  grid-template-columns: 28px 1fr;
+  gap: 8px;
+  position: relative;
+}
+
+.conflictTimeCol {
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  font-size: 9.5px;
+  color: var(--text-faint);
+  padding: 2px 0;
+  letter-spacing: 0.04em;
+}
+
+.conflictPillCol {
+  position: relative;
+  height: 86px;
+  border-left: 1px dashed var(--border-strong);
+  padding-left: 8px;
+}
+
+.conflictPillMaint,
+.conflictPillMission {
+  position: absolute;
+  left: 8px;
+  right: 4px;
+  border-radius: 6px;
+  padding: 6px 9px;
+  font-size: 11px;
+  font-weight: 600;
+  color: #fff;
+  display: flex;
+  align-items: center;
+  letter-spacing: -0.005em;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.conflictPillMaint {
+  top: 4px;
+  height: 38px;
+  background: linear-gradient(135deg, #f87171, #dc2626);
+  z-index: 1;
+}
+
+.conflictPillMission {
+  top: 32px;
+  height: 38px;
+  background: linear-gradient(135deg, #c084fc, #a855f7);
+  z-index: 2;
+}
+
+.conflictHatch {
+  position: absolute;
+  left: 8px;
+  right: 4px;
+  top: 32px;
+  height: 10px;
+  border-radius: 0;
+  z-index: 3;
+  background-image: repeating-linear-gradient(
+    45deg,
+    rgba(220, 38, 38, 0.85) 0,
+    rgba(220, 38, 38, 0.85) 3px,
+    rgba(254, 226, 226, 0.85) 3px,
+    rgba(254, 226, 226, 0.85) 6px
+  );
+}
+
+.conflictBadge {
+  position: absolute;
+  top: -6px;
+  right: 0;
+  background: #dc2626;
+  color: #fff;
+  font-size: 9px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  padding: 3px 7px;
+  border-radius: 4px;
+  z-index: 4;
+  box-shadow: 0 2px 6px rgba(220, 38, 38, 0.35);
+}
+
+/* ─── Pools visual ───────────────────────────────────────────────── */
+
+.poolsHeader {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.poolsName {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text);
+}
+
+.poolsStrategy {
+  font-size: 10.5px;
+  font-weight: 500;
+  color: var(--accent);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+
+.poolsRow {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 6px;
+}
+
+.poolTile {
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 8px 6px 7px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1px;
+  position: relative;
+  transition: all 100ms ease;
+}
+
+.poolTileSelected {
+  background: linear-gradient(180deg, #fff7eb 0%, #fed7aa 100%);
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px rgba(194, 65, 12, 0.15), 0 4px 12px rgba(194, 65, 12, 0.18);
+  transform: translateY(-2px);
+}
+
+.poolTileTail {
+  font-size: 11px;
+  font-weight: 700;
+  color: var(--text);
+  letter-spacing: 0.01em;
+}
+
+.poolTileModel {
+  font-size: 9.5px;
+  color: var(--text-muted);
+  letter-spacing: 0.02em;
+}
+
+.poolTileBadge {
+  position: absolute;
+  bottom: -8px;
+  left: 50%;
+  transform: translateX(-50%);
+  background: var(--accent);
+  color: #fff;
+  font-size: 8.5px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  padding: 2px 6px;
+  border-radius: 4px;
+  white-space: nowrap;
+}
+
+/* ─── Mission timeline visual ────────────────────────────────────── */
+
+.missionTimeline {
+  display: grid;
+  grid-template-columns: repeat(5, 1fr);
+  gap: 4px;
+}
+
+.missionStop {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 2px;
+  position: relative;
+  min-width: 0;
+}
+
+.missionStopHead {
+  position: relative;
+  height: 14px;
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin-bottom: 4px;
+}
+
+.missionLine {
+  position: absolute;
+  left: -50%;
+  right: 50%;
+  top: 50%;
+  height: 2px;
+  background: linear-gradient(90deg, var(--accent-soft), var(--accent));
+  transform: translateY(-50%);
+}
+
+.missionDot {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background: var(--accent);
+  box-shadow: 0 0 0 3px var(--accent-soft);
+  position: relative;
+  z-index: 1;
+}
+
+.missionCode {
+  font-size: 10.5px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  color: var(--text);
+}
+
+.missionCity {
+  font-size: 9px;
+  color: var(--text-muted);
+  letter-spacing: 0.01em;
+}
+
+.missionTime {
+  font-size: 8.5px;
+  color: var(--text-faint);
+  letter-spacing: 0.01em;
+}
+
+/* ─── Approval stepper visual ────────────────────────────────────── */
+
+.approvalSteps {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 4px;
+}
+
+.approvalStep {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 3px;
+  position: relative;
+  min-width: 0;
+}
+
+.approvalConnector {
+  position: absolute;
+  left: -50%;
+  right: 50%;
+  top: 11px;
+  height: 2px;
+  background: var(--border-strong);
+  z-index: 0;
+}
+
+.approvalConnectorDone {
+  background: #15803d;
+}
+
+.approvalDot {
+  width: 22px;
+  height: 22px;
+  border-radius: 50%;
+  display: grid;
+  place-items: center;
+  background: var(--bg-card);
+  border: 2px solid var(--border-strong);
+  color: var(--text-faint);
+  position: relative;
+  z-index: 1;
+  margin-bottom: 4px;
+}
+
+.approvalDotDone {
+  background: #15803d;
+  border-color: #15803d;
+  color: #fff;
+}
+
+.approvalDotPending {
+  background: var(--bg-card);
+  border-color: var(--accent);
+  color: var(--accent);
+}
+
+.approvalDotInner {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--accent);
+  animation: approvalPulse 1.6s ease-in-out infinite;
+}
+
+@keyframes approvalPulse {
+  0%, 100% { transform: scale(1);   opacity: 1;   }
+  50%      { transform: scale(1.6); opacity: 0.5; }
+}
+
+.approvalLabel {
+  font-size: 10.5px;
+  font-weight: 600;
+  color: var(--text);
+  letter-spacing: 0.01em;
+}
+
+.approvalRole {
+  font-size: 9.5px;
+  color: var(--text-muted);
+  letter-spacing: 0.02em;
+  text-align: center;
+  line-height: 1.3;
+}
+
+/* ─── Cascade visual ─────────────────────────────────────────────── */
+
+.cascadeTiers {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.cascadeTier {
+  display: grid;
+  grid-template-columns: 56px 1fr;
+  align-items: center;
+  gap: 6px;
+}
+
+.cascadeTierLabel {
+  font-size: 10.5px;
+  font-weight: 600;
+  color: var(--text-muted);
+  letter-spacing: 0.02em;
+}
+
+.cascadePills {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+}
+
+.cascadePill {
+  font-size: 10.5px;
+  font-weight: 500;
+  padding: 3px 8px;
+  border-radius: 999px;
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  color: var(--text-muted);
+  white-space: nowrap;
+}
+
+.cascadePillSel {
+  background: var(--accent);
+  border-color: var(--accent);
+  color: #fff;
+}

--- a/demo/Landing.tsx
+++ b/demo/Landing.tsx
@@ -340,26 +340,31 @@ function MobileShowcase({ activeProfile: _activeProfile }: { activeProfile: Demo
           eyebrow="Scheduling core"
           title="Conflict engine"
           desc="Detects double-bookings, cert mismatches, and pool unavailability the moment you drag a shift into place."
+          visual={<ConflictVisual />}
         />
         <MobileFeatureCard
           eyebrow="Allocation"
           title="Resource pools"
           desc="Book against a pool (any PNW aircraft, any 8-seat room) and let the resolver pick by round-robin, least-loaded, or proximity."
+          visual={<PoolsVisual />}
         />
         <MobileFeatureCard
           eyebrow="Workflow"
           title="Multi-leg missions"
           desc="Mission requirements, crew assignments, aircraft selection, and compliance checks — in one workflow card per mission."
+          visual={<MissionVisual />}
         />
         <MobileFeatureCard
           eyebrow="Governance"
           title="Approval hierarchy"
           desc="Aircraft requests, maintenance, and asset bookings flow through request → approve → finalize, with role-aware permissions."
+          visual={<ApprovalVisual />}
         />
         <MobileFeatureCard
           eyebrow="Visibility"
           title="Filter cascade"
           desc="Narrow by region → base → crew type → role. Save the result as a one-tap saved view chip."
+          visual={<CascadeVisual />}
         />
       </div>
     </div>
@@ -370,18 +375,193 @@ function MobileFeatureCard({
   eyebrow,
   title,
   desc,
+  visual,
 }: {
   eyebrow: string;
   title: string;
   desc: string;
+  visual?: ReactNode;
 }) {
   return (
     <div className={styles.featureCard}>
       <span className={styles.featureCardEyebrow}>{eyebrow}</span>
       <h3 className={styles.featureCardTitle}>{title}</h3>
       <p className={styles.featureCardDesc}>{desc}</p>
-      <div className={styles.featureCardPlaceholder}>
-        Visual to come — placeholder
+      {visual && <div className={styles.featureCardVisual}>{visual}</div>}
+    </div>
+  );
+}
+
+/* ─── Visuals ────────────────────────────────────────────────────── */
+
+function ConflictVisual() {
+  return (
+    <div className={styles.visualFrame}>
+      <div className={styles.conflictGrid} aria-hidden="true">
+        <div className={styles.conflictTimeCol}>
+          <span>09</span>
+          <span>10</span>
+          <span>11</span>
+          <span>12</span>
+        </div>
+        <div className={styles.conflictPillCol}>
+          <div className={styles.conflictPillMaint}>
+            Maintenance · N802EC
+          </div>
+          <div className={styles.conflictPillMission}>
+            Mission · N802EC
+          </div>
+          <div className={styles.conflictHatch} />
+          <span className={styles.conflictBadge}>CONFLICT</span>
+        </div>
+      </div>
+      <div className={styles.visualCaption}>
+        Same aircraft can't fly two assignments. The engine flags it as you drop.
+      </div>
+    </div>
+  );
+}
+
+function PoolsVisual() {
+  const tails = [
+    { tail: 'N801AW', model: 'AW139', selected: false },
+    { tail: 'N802EC', model: 'EC135', selected: false },
+    { tail: 'N803LJ', model: 'LJ45',  selected: true  },
+    { tail: 'N804AW', model: 'AW139', selected: false },
+  ];
+  return (
+    <div className={styles.visualFrame}>
+      <div className={styles.poolsHeader}>
+        <span className={styles.poolsName}>PNW Fleet</span>
+        <span className={styles.poolsStrategy}>round-robin</span>
+      </div>
+      <div className={styles.poolsRow}>
+        {tails.map(t => (
+          <div
+            key={t.tail}
+            className={[styles.poolTile, t.selected && styles.poolTileSelected]
+              .filter(Boolean)
+              .join(' ')}
+          >
+            <span className={styles.poolTileTail}>{t.tail}</span>
+            <span className={styles.poolTileModel}>{t.model}</span>
+            {t.selected && <span className={styles.poolTileBadge}>chosen</span>}
+          </div>
+        ))}
+      </div>
+      <div className={styles.visualCaption}>
+        Booking targets the pool. Resolver picks the next available tail.
+      </div>
+    </div>
+  );
+}
+
+function MissionVisual() {
+  const stops = [
+    { code: 'GRU', city: 'São Paulo', t: '06:00 Mon' },
+    { code: 'JFK', city: 'New York',  t: '14:00 Mon' },
+    { code: 'LHR', city: 'London',    t: '06:00 Tue' },
+    { code: 'MUC', city: 'Munich',    t: '11:00 Tue' },
+    { code: 'SEA', city: 'Seattle',   t: '08:00 Thu' },
+  ];
+  return (
+    <div className={styles.visualFrame}>
+      <div className={styles.missionTimeline}>
+        {stops.map((s, i) => (
+          <div key={s.code} className={styles.missionStop}>
+            <div className={styles.missionStopHead}>
+              {i > 0 && <span className={styles.missionLine} aria-hidden="true" />}
+              <span className={styles.missionDot} aria-hidden="true" />
+            </div>
+            <span className={styles.missionCode}>{s.code}</span>
+            <span className={styles.missionCity}>{s.city}</span>
+            <span className={styles.missionTime}>{s.t}</span>
+          </div>
+        ))}
+      </div>
+      <div className={styles.visualCaption}>
+        Four legs across three days. One mission, one workflow card.
+      </div>
+    </div>
+  );
+}
+
+function ApprovalVisual() {
+  const steps = [
+    { label: 'Submitted',   role: 'Dispatcher',     state: 'done'    },
+    { label: 'Approved',    role: 'Base Supervisor', state: 'done'   },
+    { label: 'Finalized',   role: 'Ops Manager',    state: 'pending' },
+  ];
+  return (
+    <div className={styles.visualFrame}>
+      <div className={styles.approvalSteps}>
+        {steps.map((s, i) => (
+          <div key={s.label} className={styles.approvalStep}>
+            {i > 0 && (
+              <span
+                className={[
+                  styles.approvalConnector,
+                  s.state === 'done' && styles.approvalConnectorDone,
+                ]
+                  .filter(Boolean)
+                  .join(' ')}
+                aria-hidden="true"
+              />
+            )}
+            <div
+              className={[
+                styles.approvalDot,
+                s.state === 'done' && styles.approvalDotDone,
+                s.state === 'pending' && styles.approvalDotPending,
+              ]
+                .filter(Boolean)
+                .join(' ')}
+              aria-hidden="true"
+            >
+              {s.state === 'done' ? <Check size={11} /> : <span className={styles.approvalDotInner} />}
+            </div>
+            <span className={styles.approvalLabel}>{s.label}</span>
+            <span className={styles.approvalRole}>{s.role}</span>
+          </div>
+        ))}
+      </div>
+      <div className={styles.visualCaption}>
+        Each role unlocks specific transitions. Switch profiles on desktop to see it.
+      </div>
+    </div>
+  );
+}
+
+function CascadeVisual() {
+  const tiers = [
+    { label: 'Region',  pills: [{ v: 'All' }, { v: 'PNW', sel: true }, { v: 'RM' }] },
+    { label: 'Base',    pills: [{ v: 'All' }, { v: 'Seattle', sel: true }, { v: 'Portland' }] },
+    { label: 'Type',    pills: [{ v: 'All' }, { v: 'Crew', sel: true }, { v: 'Asset' }] },
+    { label: 'Sub-type',pills: [{ v: 'All' }, { v: 'Pilot', sel: true }, { v: 'Medical' }, { v: 'Maint.' }] },
+  ];
+  return (
+    <div className={styles.visualFrame}>
+      <div className={styles.cascadeTiers}>
+        {tiers.map(t => (
+          <div key={t.label} className={styles.cascadeTier}>
+            <span className={styles.cascadeTierLabel}>{t.label}</span>
+            <div className={styles.cascadePills}>
+              {t.pills.map(p => (
+                <span
+                  key={p.v}
+                  className={[styles.cascadePill, p.sel && styles.cascadePillSel]
+                    .filter(Boolean)
+                    .join(' ')}
+                >
+                  {p.v}
+                </span>
+              ))}
+            </div>
+          </div>
+        ))}
+      </div>
+      <div className={styles.visualCaption}>
+        Drill down → narrow what's visible. Save the result as a chip.
       </div>
     </div>
   );


### PR DESCRIPTION
The mobile showcase had five feature cards with identical "Visual to come — placeholder" stubs, since the content was tabled while the desktop framing landed. Replace each with a static, faithful CSS illustration of the feature so the showcase tells a real story.

Conflict engine — calendar-grid mock with two overlapping aircraft
  pills (Maintenance + Mission on the same tail), red diagonal hatch
  on the overlap, "CONFLICT" badge.
Resource pools — "PNW Fleet · round-robin" header above four aircraft
  tiles; the resolver-chosen tile lifted with a glow and "chosen"
  badge.
Multi-leg missions — five-stop horizontal timeline (GRU → JFK → LHR →
  MUC → SEA) with airport codes, cities, and per-leg timestamps.
Approval hierarchy — three-step stepper: Submitted (Dispatcher,
  done), Approved (Base Supervisor, done), Finalized (Ops Manager,
  pending) with a pulsing "in-flight" dot on the open step.
Filter cascade — miniature tier picker with Region / Base / Type /
  Sub-type rows, one pill selected per row to show the drill-down.

Each visual sits in a shared `.visualFrame` (warm-light card surface matching the rest of the chrome) with a one-line caption underneath re-tying the visual back to what it represents. MobileFeatureCard gains a `visual` slot; the placeholder div is gone.

Pure presentation — no data deps, no interactions, safe across viewports. Verified: typecheck clean, demo build, 24/24 demo e2e green.

https://claude.ai/code/session_01CZZfrd8wWfSFPwyEZ1YZQT

## Summary
Describe exactly what this PR changes.

## Scope
- Stage: 
- Planned PR number in sprint: 
- Target files/directories: 
- Why this slice is isolated: 

## Lessons Learned Check (REQUIRED)
Confirm these were actively used while building this PR:

- [ ] PR is intentionally small and isolated
- [ ] Boundary typing was prioritized over internal perfection
- [ ] No silent spread of `any`
- [ ] Advisory root `tsc` was used to catch integration issues
- [ ] I did not assume “looks typed” means “safe”
- [ ] I stopped and isolated typing cascades instead of expanding scope

## Definition of Done (ALL REQUIRED)
This PR is not done unless every box is checked.

- [ ] `npm run type-check:strict` passes
- [ ] Root advisory `tsc --noEmit` passes
- [ ] Tests pass for touched scope at minimum
- [ ] No uncontrolled increase in `any`
- [ ] All new types are intentional and named
- [ ] Public interfaces and exported functions are explicitly typed
- [ ] PR scope matches the sprint plan with no scope creep
- [ ] Any new `any` has an adjacent justification comment
- [ ] No file-wide `: any`
- [ ] No implicit `any` in exported functions

## What Was Typed
List exactly what was typed in this PR.

- 
- 
- 

## What Was Intentionally Left Loose
List anything intentionally not tightened yet.

- 
- 
- 

## `any` Ledger (REQUIRED)
- New `any` added: 
- Existing `any` removed: 
- Net change: 

For every new `any`, explain why it is required and why a safer type was not used yet.

1. 
2. 
3. 

## Boundary Notes
Document any public seams, caller-protection choices, or compatibility decisions.

- 
- 
- 

## Risk Level
- [ ] Low
- [ ] Medium
- [ ] High

Why:

## Validation Evidence
Paste the exact commands run and a short result summary.

```bash
npm run type-check:strict
npx tsc --noEmit -p tsconfig.json
```

Test commands run:

```bash
# paste commands here
```

## Stop Conditions Check
If any item below happened, explain how scope was reduced before merge.

- [ ] `any` started spreading across files
- [ ] Root `tsc` broke repeatedly
- [ ] Types required cross-module rewrites
- [ ] Scope was reduced to keep the PR reviewable

Notes:

## Reviewer Focus
What should reviewers look at first?

- 
- 
- 
