### PR TITLE
demo: 4-bug polish batch (calendar size, cascade pills, mission stack…

### DIFF
--- a/demo/App.tsx
+++ b/demo/App.tsx
@@ -227,12 +227,18 @@ function scheduleKindFor(category) {
 }
 
 const INITIAL_EVENTS = allEvents.map(e => {
-  const kind = scheduleKindFor(e.category);
+  // Source events (e.g. mission crew assignments in emsData) may already carry
+  // their own meta.kind. Don't override it — derive a kind from category only
+  // when the source didn't pre-tag the event.
+  const sourceMeta = (e as { meta?: Record<string, unknown> }).meta ?? null;
+  const kind = (sourceMeta && typeof sourceMeta['kind'] === 'string')
+    ? (sourceMeta['kind'] as string)
+    : scheduleKindFor(e.category);
   const approvalMeta = APPROVAL_CATS.has(e.category)
     ? { approvalStage: { stage: e.visualPriority === 'high' ? 'requested' : 'approved', updatedAt: e.start } }
     : null;
-  const meta = (kind || approvalMeta)
-    ? { ...(kind ? { kind } : {}), ...(approvalMeta ?? {}) }
+  const meta = (sourceMeta || kind || approvalMeta)
+    ? { ...(sourceMeta ?? {}), ...(kind ? { kind } : {}), ...(approvalMeta ?? {}) }
     : null;
   return {
     id: e.id, title: e.title, start: e.start, end: e.end,
@@ -824,6 +830,7 @@ function App() {
         <Landing
           activeProfile={activeProfile}
           onProfileChange={setActiveProfileId}
+          events={events}
         >
           {calendar}
         </Landing>

--- a/demo/Landing.module.css
+++ b/demo/Landing.module.css
@@ -41,7 +41,7 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 14px 32px;
+  padding: 8px 20px;
   border-bottom: 1px solid var(--border);
   background: rgba(255, 255, 255, 0.55);
   backdrop-filter: saturate(140%) blur(8px);
@@ -87,9 +87,12 @@
 
 .main {
   display: grid;
-  grid-template-columns: minmax(280px, 24%) 1fr;
-  gap: 20px;
-  padding: 16px 16px 16px 24px;
+  /* Fixed chrome width so it doesn't grow on wide viewports — earlier 24%
+     was eating ~460px on a 1920 monitor. The calendar gets every pixel
+     beyond the 300px sidebar plus a tight gutter. */
+  grid-template-columns: 300px 1fr;
+  gap: 16px;
+  padding: 12px 16px 12px 16px;
   min-height: 0;
   overflow: hidden;
 }
@@ -99,7 +102,7 @@
 .chrome {
   display: flex;
   flex-direction: column;
-  gap: 18px;
+  gap: 12px;
   overflow-y: auto;
   padding-right: 4px;
 }
@@ -107,8 +110,8 @@
 .hero {
   display: flex;
   flex-direction: column;
-  gap: 12px;
-  padding-bottom: 6px;
+  gap: 8px;
+  padding-bottom: 2px;
 }
 
 .heroEyebrow {
@@ -121,17 +124,17 @@
 
 .heroTitle {
   margin: 0;
-  font-size: 38px;
-  line-height: 1.05;
-  letter-spacing: -0.025em;
+  font-size: 24px;
+  line-height: 1.15;
+  letter-spacing: -0.02em;
   font-weight: 700;
   color: var(--text);
 }
 
 .heroSub {
   margin: 0;
-  font-size: 15px;
-  line-height: 1.55;
+  font-size: 13px;
+  line-height: 1.5;
   color: var(--text-muted);
   max-width: 44ch;
 }

--- a/demo/Landing.module.css
+++ b/demo/Landing.module.css
@@ -579,16 +579,28 @@
   box-shadow: var(--shadow-lg);
   overflow: hidden;
   position: relative;
+}
+
+/* The stage runs at a virtual size larger than the window, then gets
+   transform: scaled back down so the whole calendar (its own sidebars,
+   toolbar, grid) shrinks together as a single unit — like looking at a
+   smaller monitor. Inline width/height/transform are set by JS based on
+   the live frame size. */
+.calendarStage {
+  position: absolute;
+  top: 0;
+  left: 0;
   display: flex;
   flex-direction: column;
 }
 
 /* The WorksCalendar renders its own border-radius/border in some themes;
    the wrapper window is the visual frame, so suppress the inner one. */
-.calendarWindow > div,
-.calendarWindow [data-testid='works-calendar'] {
+.calendarStage > div,
+.calendarStage [data-testid='works-calendar'] {
   border-radius: 0 !important;
   border: none !important;
+  width: 100% !important;
   height: 100% !important;
   flex: 1;
   min-height: 0;

--- a/demo/Landing.module.css
+++ b/demo/Landing.module.css
@@ -87,9 +87,9 @@
 
 .main {
   display: grid;
-  grid-template-columns: minmax(320px, 36%) 1fr;
-  gap: 32px;
-  padding: 32px 32px 32px 32px;
+  grid-template-columns: minmax(280px, 24%) 1fr;
+  gap: 20px;
+  padding: 16px 16px 16px 24px;
   min-height: 0;
   overflow: hidden;
 }
@@ -318,6 +318,146 @@
   flex-shrink: 0;
 }
 
+/* ─── Approval queue cards ───────────────────────────────────────── */
+
+.queueHeader {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  width: 100%;
+  background: none;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+  text-align: left;
+}
+
+.queueIcon {
+  width: 26px;
+  height: 26px;
+  border-radius: 7px;
+  background: var(--accent-soft);
+  color: var(--accent-deep);
+  display: grid;
+  place-items: center;
+  flex-shrink: 0;
+}
+
+.queueTitle {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text);
+  flex: 1;
+  letter-spacing: -0.005em;
+}
+
+.queueBadge {
+  background: var(--accent);
+  color: #fff;
+  font-size: 11px;
+  font-weight: 700;
+  min-width: 22px;
+  height: 22px;
+  border-radius: 999px;
+  display: grid;
+  place-items: center;
+  padding: 0 7px;
+}
+
+.queueBadgeEmpty {
+  background: var(--bg-card-soft);
+  color: var(--text-faint);
+  border: 1px solid var(--border);
+}
+
+.queueChevron {
+  color: var(--text-faint);
+  transition: transform 150ms ease;
+  flex-shrink: 0;
+}
+
+.queueChevronOpen {
+  transform: rotate(180deg);
+}
+
+.queueBody {
+  display: flex;
+  flex-direction: column;
+  padding-top: 10px;
+  border-top: 1px dashed var(--border);
+}
+
+.queueEmpty {
+  margin: 0;
+  font-size: 12px;
+  line-height: 1.5;
+  color: var(--text-muted);
+}
+
+.queueList {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.queueRow {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+  padding: 6px 8px;
+  background: var(--bg-card-soft);
+  border-radius: 8px;
+  border: 1px solid var(--border);
+}
+
+.queueRowTitle {
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--text);
+  line-height: 1.35;
+  word-break: break-word;
+}
+
+.queueStage {
+  align-self: flex-start;
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  padding: 2px 6px;
+  border-radius: 4px;
+  background: var(--bg-card);
+  color: var(--text-muted);
+  border: 1px solid var(--border);
+}
+
+.queueStageRequested {
+  background: #fef3c7;
+  color: #92400e;
+  border-color: #fde68a;
+}
+
+.queueStageApproved {
+  background: #dbeafe;
+  color: #1e40af;
+  border-color: #bfdbfe;
+}
+
+.queueStageFinalized {
+  background: #dcfce7;
+  color: #15803d;
+  border-color: #bbf7d0;
+}
+
+.queueStageDenied {
+  background: #fee2e2;
+  color: #991b1b;
+  border-color: #fecaca;
+}
+
 /* ─── Permission list ────────────────────────────────────────────── */
 
 .permissionList {
@@ -429,8 +569,7 @@
 
 .calendarWindow {
   width: 100%;
-  height: 92%;
-  max-height: 100%;
+  height: 100%;
   background: var(--bg-card);
   border: 1px solid var(--border-strong);
   border-radius: var(--radius-window);

--- a/demo/Landing.tsx
+++ b/demo/Landing.tsx
@@ -233,11 +233,21 @@ function ApprovalQueueCard({
   defaultOpen: boolean;
 }) {
   const [open, setOpen] = useState(defaultOpen);
-  // Re-sync when the count changes meaningfully (e.g. a new event arrives
-  // for the active profile while the card was collapsed).
+  // Track the previous item count so we can detect a 0 → N transition (e.g.
+  // switching from Dispatcher with no queue to Ops Manager with five waiting
+  // items) and auto-open the card. The earlier `items.length > 0 && !open`
+  // bail meant the card stayed collapsed forever once closed, even when the
+  // queue subsequently filled.
+  const prevCountRef = useRef(items.length);
   useEffect(() => {
-    if (items.length > 0 && !open) return; // don't auto-open if user collapsed it
-    if (items.length === 0 && open) setOpen(false);
+    const prev = prevCountRef.current;
+    const curr = items.length;
+    if (prev === 0 && curr > 0) {
+      setOpen(true);
+    } else if (curr === 0 && open) {
+      setOpen(false);
+    }
+    prevCountRef.current = curr;
   }, [items.length, open]);
 
   return (

--- a/demo/Landing.tsx
+++ b/demo/Landing.tsx
@@ -151,9 +151,58 @@ function DesktopFrame({
         </aside>
 
         <section className={styles.calendarFrame}>
-          <div className={styles.calendarWindow}>{children}</div>
+          <ScaledMonitor>{children}</ScaledMonitor>
         </section>
       </main>
+    </div>
+  );
+}
+
+/* ─── Scaled monitor frame ───────────────────────────────────────── */
+// Renders the calendar inside a transform: scale wrapper so the whole UI
+// (its own internal sidebars, toolbar, grid) shrinks together — the framed
+// window reads like a smaller monitor showing a real desktop calendar
+// instead of a cramped responsive layout. The inner stage is sized at
+// `frame / SCALE`, so after the visual scale-down it exactly fills the
+// frame (no whitespace, no cropping).
+const MONITOR_SCALE = 0.78;
+
+function ScaledMonitor({ children }: { children: ReactNode }) {
+  const frameRef = useRef<HTMLDivElement | null>(null);
+  // Sane defaults so the calendar mounts at a reasonable virtual size on
+  // first paint, before ResizeObserver fires.
+  const [stage, setStage] = useState({ w: 1280, h: 800 });
+
+  useEffect(() => {
+    const node = frameRef.current;
+    if (!node) return;
+    const update = () => {
+      const rect = node.getBoundingClientRect();
+      if (rect.width === 0 || rect.height === 0) return;
+      setStage({
+        w: Math.round(rect.width / MONITOR_SCALE),
+        h: Math.round(rect.height / MONITOR_SCALE),
+      });
+    };
+    update();
+    const ro = new ResizeObserver(update);
+    ro.observe(node);
+    return () => ro.disconnect();
+  }, []);
+
+  return (
+    <div className={styles.calendarWindow} ref={frameRef}>
+      <div
+        className={styles.calendarStage}
+        style={{
+          width: stage.w,
+          height: stage.h,
+          transform: `scale(${MONITOR_SCALE})`,
+          transformOrigin: 'top left',
+        }}
+      >
+        {children}
+      </div>
     </div>
   );
 }

--- a/demo/Landing.tsx
+++ b/demo/Landing.tsx
@@ -1,11 +1,21 @@
 // @ts-nocheck — demo wrapper, follows App.tsx convention
-import { useEffect, useRef, useState, type ReactNode } from 'react';
-import { Check, ChevronDown, X as XIcon } from 'lucide-react';
+import { useEffect, useMemo, useRef, useState, type ReactNode } from 'react';
+import { Check, ChevronDown, ChevronRight, Inbox, Send, X as XIcon } from 'lucide-react';
 import styles from './Landing.module.css';
 import {
   USER_PROFILES,
+  isAwaitingProfile,
+  simulatedRequesterIdFor,
   type DemoProfile,
 } from './profiles';
+
+interface ApprovalEvent {
+  id: string;
+  title: string;
+  start: string;
+  category: string;
+  meta?: { approvalStage?: { stage?: string; updatedAt?: string } };
+}
 
 const MOBILE_BREAKPOINT_PX = 1100;
 
@@ -34,16 +44,27 @@ interface LandingProps {
   children: ReactNode;
   activeProfile: DemoProfile;
   onProfileChange: (profileId: string) => void;
+  /** Live calendar events — drives the approval-queue counts in the chrome. */
+  events?: ApprovalEvent[];
 }
 
-export default function Landing({ children, activeProfile, onProfileChange }: LandingProps) {
+export default function Landing({
+  children,
+  activeProfile,
+  onProfileChange,
+  events = [],
+}: LandingProps) {
   const isMobile = useIsMobile();
   return (
     <div className={styles.root}>
       {isMobile ? (
         <MobileShowcase activeProfile={activeProfile} />
       ) : (
-        <DesktopFrame activeProfile={activeProfile} onProfileChange={onProfileChange}>
+        <DesktopFrame
+          activeProfile={activeProfile}
+          onProfileChange={onProfileChange}
+          events={events}
+        >
           {children}
         </DesktopFrame>
       )}
@@ -76,11 +97,18 @@ function DesktopFrame({
   children,
   activeProfile,
   onProfileChange,
+  events,
 }: {
   children: ReactNode;
   activeProfile: DemoProfile;
   onProfileChange: (id: string) => void;
+  events: ApprovalEvent[];
 }) {
+  const { myRequests, awaiting } = useMemo(
+    () => splitApprovalQueues(events, activeProfile),
+    [events, activeProfile],
+  );
+
   return (
     <div className={styles.desktop}>
       <HeaderBar />
@@ -100,6 +128,20 @@ function DesktopFrame({
             activeProfile={activeProfile}
             onProfileChange={onProfileChange}
           />
+          <ApprovalQueueCard
+            title="Awaiting your approval"
+            icon={<Inbox size={14} aria-hidden="true" />}
+            items={awaiting}
+            emptyState={awaitingEmptyText(activeProfile)}
+            defaultOpen={awaiting.length > 0}
+          />
+          <ApprovalQueueCard
+            title="My requests"
+            icon={<Send size={14} aria-hidden="true" />}
+            items={myRequests}
+            emptyState={`${activeProfile.role} hasn't submitted any open requests in this demo.`}
+            defaultOpen={false}
+          />
           <FeaturesCard />
           <StatusCard />
 
@@ -112,6 +154,149 @@ function DesktopFrame({
           <div className={styles.calendarWindow}>{children}</div>
         </section>
       </main>
+    </div>
+  );
+}
+
+/* ─── Approval queue plumbing ────────────────────────────────────── */
+
+interface ApprovalQueueItem {
+  id: string;
+  title: string;
+  stage: string;
+  start: string;
+  category: string;
+}
+
+function splitApprovalQueues(
+  events: ApprovalEvent[],
+  profile: DemoProfile,
+): { myRequests: ApprovalQueueItem[]; awaiting: ApprovalQueueItem[] } {
+  const myRequests: ApprovalQueueItem[] = [];
+  const awaiting: ApprovalQueueItem[] = [];
+  for (const ev of events) {
+    const stage = ev.meta?.approvalStage?.stage;
+    if (!stage) continue;
+    const item: ApprovalQueueItem = {
+      id: ev.id,
+      title: ev.title,
+      stage,
+      start: ev.start,
+      category: ev.category,
+    };
+    // Awaiting your action: stage matches the profile's open capability.
+    if (isAwaitingProfile(stage, profile)) {
+      awaiting.push(item);
+    }
+    // My requests: simulated submitter matches active profile, and the
+    // request is still open (i.e. not finalized or denied).
+    if (
+      simulatedRequesterIdFor(ev.category) === profile.id &&
+      stage !== 'finalized' &&
+      stage !== 'denied'
+    ) {
+      myRequests.push(item);
+    }
+  }
+  // Most recent first.
+  awaiting.sort((a, b) => b.start.localeCompare(a.start));
+  myRequests.sort((a, b) => b.start.localeCompare(a.start));
+  return { myRequests, awaiting };
+}
+
+function awaitingEmptyText(profile: DemoProfile): string {
+  const { canApprove, canFinalize } = profile.approval;
+  if (!canApprove && !canFinalize) {
+    return `${profile.role} can't act on requests — switch to a role with approval rights to see the queue.`;
+  }
+  return 'Nothing waiting on you right now.';
+}
+
+const STAGE_LABEL: Record<string, string> = {
+  requested: 'Requested',
+  approved:  'Approved · awaiting finalize',
+  finalized: 'Finalized',
+  denied:    'Denied',
+};
+
+function ApprovalQueueCard({
+  title,
+  icon,
+  items,
+  emptyState,
+  defaultOpen,
+}: {
+  title: string;
+  icon: ReactNode;
+  items: ApprovalQueueItem[];
+  emptyState: string;
+  defaultOpen: boolean;
+}) {
+  const [open, setOpen] = useState(defaultOpen);
+  // Re-sync when the count changes meaningfully (e.g. a new event arrives
+  // for the active profile while the card was collapsed).
+  useEffect(() => {
+    if (items.length > 0 && !open) return; // don't auto-open if user collapsed it
+    if (items.length === 0 && open) setOpen(false);
+  }, [items.length, open]);
+
+  return (
+    <div className={styles.card}>
+      <button
+        type="button"
+        className={styles.queueHeader}
+        onClick={() => setOpen(v => !v)}
+        aria-expanded={open}
+      >
+        <span className={styles.queueIcon}>{icon}</span>
+        <span className={styles.queueTitle}>{title}</span>
+        <span
+          className={[
+            styles.queueBadge,
+            items.length === 0 && styles.queueBadgeEmpty,
+          ]
+            .filter(Boolean)
+            .join(' ')}
+        >
+          {items.length}
+        </span>
+        <ChevronDown
+          size={14}
+          className={[styles.queueChevron, open && styles.queueChevronOpen]
+            .filter(Boolean)
+            .join(' ')}
+          aria-hidden="true"
+        />
+      </button>
+
+      {open && (
+        <div className={styles.queueBody}>
+          {items.length === 0 ? (
+            <p className={styles.queueEmpty}>{emptyState}</p>
+          ) : (
+            <ul className={styles.queueList}>
+              {items.map(it => (
+                <li key={it.id} className={styles.queueRow}>
+                  <span className={styles.queueRowTitle}>{it.title}</span>
+                  <span
+                    className={[
+                      styles.queueStage,
+                      it.stage === 'requested' && styles.queueStageRequested,
+                      it.stage === 'approved' && styles.queueStageApproved,
+                      it.stage === 'finalized' && styles.queueStageFinalized,
+                      it.stage === 'denied' && styles.queueStageDenied,
+                    ]
+                      .filter(Boolean)
+                      .join(' ')}
+                  >
+                    {STAGE_LABEL[it.stage] ?? it.stage}
+                  </span>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+      )}
     </div>
   );
 }

--- a/demo/emsData.ts
+++ b/demo/emsData.ts
@@ -295,9 +295,12 @@ export const mission: DemoMissionRequest = {
 };
 
 // Mission calendar events — one aircraft event covering the full mission
-// window plus full-window crew events. Per-leg detail lives on `mission.legs`
-// and surfaces through MissionHoverCard, so the calendar pill renders as a
-// single multi-day bar in Month/Week instead of four short per-leg slivers.
+// window plus full-window crew "shift-kind" events. The aircraft event has
+// no meta.kind, so it surfaces in Month/Week as one continuous mission bar.
+// Crew events are tagged kind: 'shift' so the library's viewScope filters
+// them out of Month/Week (they'd otherwise stack as 6 overlapping multi-day
+// pills) — they still appear in Schedule and the Crew-on-shift surfaces
+// because the kind correctly marks them as active staffing.
 export const missionEvents: DemoEvent[] = [
   // Aircraft — single span for the whole mission window
   {
@@ -308,7 +311,8 @@ export const missionEvents: DemoEvent[] = [
     start: mission.start, end: mission.end,
     assignedTo: 'ac-n803lj', basedAt: 'b-seattle',
   },
-  // Assigned crew covering the full mission window
+  // Assigned crew covering the full mission window. `meta.kind: 'shift'`
+  // hides them from Month/Week noise but keeps them visible in Schedule.
   ...mission.assignments.pilots.map(p => ({
     id: `mission-pilot-${p.resourceId}`,
     title: MISSION_TITLE,
@@ -316,6 +320,7 @@ export const missionEvents: DemoEvent[] = [
     visualPriority: 'high' as const,
     start: mission.start, end: mission.end,
     assignedTo: p.resourceId, basedAt: 'b-seattle',
+    meta: { kind: 'shift' as const },
   })),
   ...mission.assignments.medical.map(m => ({
     id: `mission-med-${m.resourceId}`,
@@ -324,6 +329,7 @@ export const missionEvents: DemoEvent[] = [
     visualPriority: 'high' as const,
     start: mission.start, end: mission.end,
     assignedTo: m.resourceId, basedAt: 'b-seattle',
+    meta: { kind: 'shift' as const },
   })),
 ];
 

--- a/demo/profiles.ts
+++ b/demo/profiles.ts
@@ -125,6 +125,35 @@ export function findProfile(id: string): DemoProfile {
 }
 
 /**
+ * Demo simulation: pretend a request was submitted by whichever profile id
+ * "would" submit that category. Drives the "My requests" card so each role
+ * sees a relevant queue without needing real per-event submitter tracking.
+ *
+ *   aircraft-request, asset-request → dispatcher
+ *   maintenance                     → base-supervisor (mechanic lives here)
+ *   anything else                   → dispatcher (safe default)
+ */
+export function simulatedRequesterIdFor(category: string): string {
+  if (category === 'maintenance') return 'base-supervisor';
+  return 'dispatcher';
+}
+
+/**
+ * Given an event's approval stage and the active profile, return whether
+ * that event is currently waiting on the profile to take an action.
+ *
+ *   requested  →  someone with canApprove
+ *   approved   →  someone with canFinalize
+ *   finalized  →  nobody (terminal)
+ *   denied     →  nobody (terminal)
+ */
+export function isAwaitingProfile(stage: string | null | undefined, profile: DemoProfile): boolean {
+  if (stage === 'requested') return profile.approval.canApprove;
+  if (stage === 'approved')  return profile.approval.canFinalize;
+  return false;
+}
+
+/**
  * Approval action -> required capability key. Used by the demo's
  * onApprovalAction handler to gate transitions on the active profile.
  */

--- a/src/ui/CascadePanel.module.css
+++ b/src/ui/CascadePanel.module.css
@@ -63,8 +63,13 @@
   gap: 5px;
   padding: 5px 10px;
   border-radius: 999px;
-  border: 1px solid var(--wc-border, rgba(60, 35, 10, 0.14));
-  background: var(--wc-bg-card, #fff);
+  /* Sidebar canonical theme vars — `--wc-surface` for the pill body and
+     `--wc-text` for the label both resolve correctly in light AND dark
+     themes. Earlier this used `--wc-bg-card` which isn't a theme var, so
+     it fell back to #fff while text resolved to white in dark themes,
+     making unselected pills invisible. */
+  border: 1px solid var(--wc-border-dark, rgba(0, 0, 0, 0.18));
+  background: var(--wc-surface, #fff);
   color: var(--wc-text, #2d1f0e);
   font-size: 12px;
   font-weight: 500;
@@ -75,8 +80,8 @@
 }
 
 .pill:hover {
-  background: var(--wc-bg-card-hover, #fdfaf4);
-  border-color: var(--wc-border-strong, rgba(60, 35, 10, 0.22));
+  background: var(--wc-surface-2, rgba(0, 0, 0, 0.04));
+  border-color: var(--wc-accent, #c2410c);
 }
 
 .pillSelected {
@@ -86,8 +91,10 @@
 }
 
 .pillSelected:hover {
-  background: var(--wc-accent-deep, #9a3412);
-  border-color: var(--wc-accent-deep, #9a3412);
+  background: var(--wc-accent, #c2410c);
+  border-color: var(--wc-accent, #c2410c);
+  color: #fff;
+  filter: brightness(1.08);
 }
 
 .pillAll {
@@ -185,12 +192,12 @@
 
 .btnGhost {
   background: transparent;
-  border-color: var(--wc-border-strong, rgba(60, 35, 10, 0.18));
+  border-color: var(--wc-border-dark, rgba(0, 0, 0, 0.18));
   color: var(--wc-text-muted, #6b5a44);
 }
 
 .btnGhost:hover:not(:disabled) {
-  background: var(--wc-bg-card-hover, #fdfaf4);
+  background: var(--wc-surface-2, rgba(0, 0, 0, 0.04));
   color: var(--wc-text, #2d1f0e);
 }
 
@@ -201,8 +208,8 @@
 }
 
 .btnPrimary:hover:not(:disabled) {
-  background: var(--wc-accent-deep, #9a3412);
-  border-color: var(--wc-accent-deep, #9a3412);
+  background: var(--wc-accent-dim, #9a3412);
+  border-color: var(--wc-accent-dim, #9a3412);
 }
 
 .btnPrimary:disabled,


### PR DESCRIPTION
…, approval queue)

Four bugs reported from the live demo:

1. Desktop calendar squeezed too small. The framing chrome was eating 36% of the viewport; reduced to 24%, tightened the surrounding padding/gap, and let the calendar window fill 100% of the right column instead of 92%. Frees up real space for the actual product.

2. Cascade pills invisible (white text on white). The pill CSS used `--wc-bg-card` and `--wc-bg-card-hover` which aren't real theme vars (the calendar's themes define `--wc-surface`, `--wc-surface-2`, `--wc-border-dark`, `--wc-accent-dim`). The fallback was always #fff while `--wc-text` correctly resolved to white in dark themes — resulting in unselected pills with no visible label. Switched all pill color refs to the canonical theme vars so contrast is correct in both light and dark themes.

3. São Paulo mission stacked 7 multi-day pills. The earlier fix consolidated the aircraft per-leg events into a single window event, but the 6 crew assignments still each emitted their own full-window mission-assignment event, stacking visually in Month/Week. Tag the crew mission events with `meta.kind: 'shift'` so the library's viewScope filters them out of Month/Week (same mechanism shifts already use), leaving only the aircraft pill as the single mission bar. Crew remain visible in Schedule and the Crew-on-shift surfaces — `kind: 'shift'` correctly marks them as active staffing. Also updated INITIAL_EVENTS to preserve source `meta` instead of discarding it, so future emsData entries can carry their own meta without being clobbered.

4. No approval visibility per role. Profile switching changed gating but offered no surface to see *what* needed doing. Added two collapsible cards to the desktop chrome:
   - Awaiting your approval — events the active profile can act on right now (requested → approve, or approved → finalize). Auto-opens when there's a queue; live count badge.
   - My requests — events the active profile would have submitted (simulated by category: aircraft/asset → dispatcher, maintenance → base supervisor) that aren't finalized/denied. Each row shows title + stage chip (color-coded per stage). When the active role can't act on anything the empty state explains why — switching to Ops Manager or Base Supervisor visibly fills the queue.

Other touches:
- New `simulatedRequesterIdFor` and `isAwaitingProfile` helpers in demo/profiles.ts so the queue logic stays out of the UI layer.
- Landing now takes an `events` prop (defaults to []) and threads it to DesktopFrame; mobile showcase ignores it.

Verified: typecheck clean, demo build, 10/10 happy-paths + regressions e2e pass.

https://claude.ai/code/session_01CZZfrd8wWfSFPwyEZ1YZQT

## Summary
Describe exactly what this PR changes.

## Scope
- Stage: 
- Planned PR number in sprint: 
- Target files/directories: 
- Why this slice is isolated: 

## Lessons Learned Check (REQUIRED)
Confirm these were actively used while building this PR:

- [ ] PR is intentionally small and isolated
- [ ] Boundary typing was prioritized over internal perfection
- [ ] No silent spread of `any`
- [ ] Advisory root `tsc` was used to catch integration issues
- [ ] I did not assume “looks typed” means “safe”
- [ ] I stopped and isolated typing cascades instead of expanding scope

## Definition of Done (ALL REQUIRED)
This PR is not done unless every box is checked.

- [ ] `npm run type-check:strict` passes
- [ ] Root advisory `tsc --noEmit` passes
- [ ] Tests pass for touched scope at minimum
- [ ] No uncontrolled increase in `any`
- [ ] All new types are intentional and named
- [ ] Public interfaces and exported functions are explicitly typed
- [ ] PR scope matches the sprint plan with no scope creep
- [ ] Any new `any` has an adjacent justification comment
- [ ] No file-wide `: any`
- [ ] No implicit `any` in exported functions

## What Was Typed
List exactly what was typed in this PR.

- 
- 
- 

## What Was Intentionally Left Loose
List anything intentionally not tightened yet.

- 
- 
- 

## `any` Ledger (REQUIRED)
- New `any` added: 
- Existing `any` removed: 
- Net change: 

For every new `any`, explain why it is required and why a safer type was not used yet.

1. 
2. 
3. 

## Boundary Notes
Document any public seams, caller-protection choices, or compatibility decisions.

- 
- 
- 

## Risk Level
- [ ] Low
- [ ] Medium
- [ ] High

Why:

## Validation Evidence
Paste the exact commands run and a short result summary.

```bash
npm run type-check:strict
npx tsc --noEmit -p tsconfig.json
```

Test commands run:

```bash
# paste commands here
```

## Stop Conditions Check
If any item below happened, explain how scope was reduced before merge.

- [ ] `any` started spreading across files
- [ ] Root `tsc` broke repeatedly
- [ ] Types required cross-module rewrites
- [ ] Scope was reduced to keep the PR reviewable

Notes:

## Reviewer Focus
What should reviewers look at first?

- 
- 
- 
