### PR TITLE
Introduce geo types/utilities and refactor asset-tracker integration API

### DIFF
--- a/src/core/conflicts/geoConflictRules.ts
+++ b/src/core/conflicts/geoConflictRules.ts
@@ -1,0 +1,6 @@
+export interface GeoConflictRule {
+  readonly id: string
+  readonly description: string
+}
+
+export const geoConflictRules: readonly GeoConflictRule[] = []

--- a/src/core/geo/geoTypes.ts
+++ b/src/core/geo/geoTypes.ts
@@ -1,0 +1,28 @@
+export interface GeoPoint {
+  readonly lat: number
+  readonly lon: number
+}
+
+export interface ResourceTrackingMeta {
+  readonly location: GeoPoint
+  readonly altitudeFt: number | null
+  readonly heading: number | null
+  readonly speedKt: number | null
+  readonly timestamp: number
+  readonly source: string
+  readonly label: string
+  readonly stale: boolean
+}
+
+export interface AssetTrackerPosition {
+  readonly id: string
+  readonly lat: number
+  readonly lon: number
+  readonly altitude: number | null
+  readonly heading: number | null
+  readonly speed: number | null
+  readonly timestamp: number
+  readonly source: string
+  readonly label: string
+  readonly meta?: Readonly<Record<string, unknown>>
+}

--- a/src/core/geo/haversine.ts
+++ b/src/core/geo/haversine.ts
@@ -1,0 +1,17 @@
+import type { GeoPoint } from './geoTypes'
+
+const EARTH_RADIUS_KM = 6371
+
+const toRadians = (deg: number): number => (deg * Math.PI) / 180
+
+export function haversineDistanceKm(a: GeoPoint, b: GeoPoint): number {
+  const dLat = toRadians(b.lat - a.lat)
+  const dLon = toRadians(b.lon - a.lon)
+  const lat1 = toRadians(a.lat)
+  const lat2 = toRadians(b.lat)
+
+  const sinLat = Math.sin(dLat / 2)
+  const sinLon = Math.sin(dLon / 2)
+  const h = sinLat * sinLat + Math.cos(lat1) * Math.cos(lat2) * sinLon * sinLon
+  return 2 * EARTH_RADIUS_KM * Math.asin(Math.sqrt(h))
+}

--- a/src/core/geo/mapAdapterTypes.ts
+++ b/src/core/geo/mapAdapterTypes.ts
@@ -1,0 +1,8 @@
+import type { AssetTrackerPosition } from './geoTypes'
+
+export interface WorksCalendarMapAdapter {
+  mount(container: HTMLElement): void
+  updatePositions(positions: readonly AssetTrackerPosition[]): void
+  focusPosition(id: string): void
+  destroy(): void
+}

--- a/src/core/geo/positionGuards.ts
+++ b/src/core/geo/positionGuards.ts
@@ -1,0 +1,13 @@
+import type { AssetTrackerPosition } from './geoTypes'
+
+export function isValidPosition(pos: AssetTrackerPosition): boolean {
+  return (
+    Number.isFinite(pos.lat) &&
+    Number.isFinite(pos.lon) &&
+    pos.lat >= -90 &&
+    pos.lat <= 90 &&
+    pos.lon >= -180 &&
+    pos.lon <= 180 &&
+    Number.isFinite(pos.timestamp)
+  )
+}

--- a/src/core/geo/positionToResourceMeta.ts
+++ b/src/core/geo/positionToResourceMeta.ts
@@ -1,0 +1,24 @@
+import type { AssetTrackerPosition, ResourceTrackingMeta } from './geoTypes'
+import { isValidPosition } from './positionGuards'
+
+export function positionToResourceTrackingMeta(
+  pos: AssetTrackerPosition,
+  nowSeconds: number,
+  staleThresholdSeconds: number,
+): ResourceTrackingMeta | null {
+  if (!isValidPosition(pos)) return null
+
+  return {
+    location: {
+      lat: pos.lat,
+      lon: pos.lon,
+    },
+    altitudeFt: pos.altitude,
+    heading: pos.heading,
+    speedKt: pos.speed,
+    timestamp: pos.timestamp,
+    source: pos.source,
+    label: pos.label,
+    stale: nowSeconds - pos.timestamp > staleThresholdSeconds,
+  }
+}

--- a/src/integrations/__tests__/asset-tracker.test.ts
+++ b/src/integrations/__tests__/asset-tracker.test.ts
@@ -1,88 +1,51 @@
-/**
- * asset-tracker bridge — pins the integration with Map_Idea's
- * normalized position schema (issue #386).
- *
- * We don't import the real `asset-tracker` package; the bridge
- * accepts a structural type so any registry that exposes `getById`
- * or `positions()` works. These tests fake a registry to verify
- * both code paths.
- */
-import { describe, it, expect } from 'vitest'
+import { describe, expect, it } from 'vitest'
 import {
-  fromAssetTrackerRegistry,
+  createAssetTrackerIntegration,
+  isValidPosition,
+  mapPositionToResourceMeta,
+  positionToResourceTrackingMeta,
   type AssetTrackerLikeRegistry,
   type AssetTrackerPosition,
 } from '../asset-tracker'
-import { attachLocations } from '../../core/pools/locationAdapters'
-import type { EngineResource } from '../../core/engine/schema/resourceSchema'
-
-const r = (id: string): EngineResource => ({ id, name: id, meta: {} } as EngineResource)
 
 const samplePosition: AssetTrackerPosition = {
   id: 'truck-101',
-  lat: 40.7608, lon: -111.8910,
-  altitude: 1300, heading: 90, speed: 65,
+  lat: 40.7608,
+  lon: -111.891,
+  altitude: 1300,
+  heading: 90,
+  speed: 65,
   timestamp: 1714329600,
   source: 'samsara',
   label: 'Truck 101',
-  meta: { vin: 'XYZ' },
 }
 
-describe('fromAssetTrackerRegistry', () => {
-  it('uses getById when available (preferred O(1) path)', () => {
-    const registry: AssetTrackerLikeRegistry = {
-      getById: (id) => id === 'truck-101' ? samplePosition : null,
-    }
-    const adapter = fromAssetTrackerRegistry(registry)
-    expect(adapter.id).toBe('asset-tracker')
-
-    const resolved = adapter.resolve(r('truck-101'))
-    expect(resolved).toMatchObject({
-      lat: 40.7608, lon: -111.8910, altitude: 1300, heading: 90,
-      speed: 65, source: 'samsara', timestamp: 1714329600,
-      meta: { vin: 'XYZ' },
-    })
-
-    expect(adapter.resolve(r('truck-999'))).toBeNull()
+describe('asset-tracker integration subpath', () => {
+  it('validates normalized positions', () => {
+    expect(isValidPosition(samplePosition)).toBe(true)
+    expect(isValidPosition({ ...samplePosition, lat: 120 })).toBe(false)
   })
 
-  it('falls back to positions() iteration when getById is absent', () => {
-    const registry: AssetTrackerLikeRegistry = {
-      positions: () => [samplePosition],
-    }
-    const adapter = fromAssetTrackerRegistry(registry)
-    const resolved = adapter.resolve(r('truck-101'))
-    expect(resolved).toMatchObject({ lat: 40.7608, lon: -111.8910 })
-    expect(adapter.resolve(r('truck-999'))).toBeNull()
+  it('maps position to tracking meta through both APIs', () => {
+    const direct = positionToResourceTrackingMeta(samplePosition, 1714329660, 120)
+    const alias = mapPositionToResourceMeta(samplePosition, 1714329660, 120)
+    expect(alias).toEqual(direct)
   })
 
-  it('honors a custom adapter id when multiple feeds are wired', () => {
-    const adapter = fromAssetTrackerRegistry(
-      { positions: () => [] },
-      { id: 'fleet-east' },
-    )
-    expect(adapter.id).toBe('fleet-east')
+  it('creates location adapter from registry getById()', () => {
+    const registry: AssetTrackerLikeRegistry = {
+      getById: (id) => (id === 'truck-101' ? samplePosition : null),
+    }
+    const integration = createAssetTrackerIntegration(registry, { nowSeconds: () => 1714329660 })
+    const loc = integration.locationAdapter.resolve({ id: 'truck-101', name: 'Truck 101' })
+    expect(loc).toMatchObject({ lat: 40.7608, lon: -111.891, altitude: 1300, speed: 65 })
+    expect((loc?.meta as any).tracking.stale).toBe(false)
   })
 
-  it('omits optional fields when the upstream position omits them', () => {
-    const registry: AssetTrackerLikeRegistry = {
-      getById: () => ({ id: 'minimal', lat: 0, lon: 0 }),
-    }
-    const resolved = fromAssetTrackerRegistry(registry).resolve(r('minimal'))
-    expect(resolved).toEqual({ lat: 0, lon: 0 })
-    // No altitude/heading/speed/timestamp/source/meta keys when not provided.
-    expect(Object.keys(resolved!).sort()).toEqual(['lat', 'lon'])
-  })
-
-  it('plugs into attachLocations end-to-end', () => {
-    const registry: AssetTrackerLikeRegistry = {
-      getById: (id) => id === 'truck-101' ? samplePosition : null,
-    }
-    const result = attachLocations(
-      [r('truck-101'), r('truck-202')],
-      [fromAssetTrackerRegistry(registry)],
-    )
-    expect((result[0]!.meta as any).location.lat).toBe(40.7608)
-    expect((result[1]!.meta as any).location).toBeUndefined()
+  it('supports positions() fallback', () => {
+    const registry: AssetTrackerLikeRegistry = { positions: () => [samplePosition] }
+    const integration = createAssetTrackerIntegration(registry)
+    const loc = integration.locationAdapter.resolve({ id: 'truck-101', name: 'Truck 101' })
+    expect(loc?.lat).toBe(40.7608)
   })
 })

--- a/src/integrations/asset-tracker.ts
+++ b/src/integrations/asset-tracker.ts
@@ -1,115 +1,92 @@
-/**
- * `asset-tracker` bridge — issue #386 v2 distance.
- *
- * Wraps a [`asset-tracker`](https://github.com/natehorst240-sketch/Map_Idea)
- * `PositionPluginRegistry` (or any object that exposes a
- * `Position[]`-shaped iterable keyed by `id`) as a
- * `ResourceLocationAdapter`, so a host that already feeds ADS-B /
- * NMEA / Traccar / APRS / Samsara / MQTT through the tracker can
- * point WorksCalendar's pool resolver at it without writing any
- * glue code.
- *
- * Why this lives in `src/integrations/`: the tracker is an optional
- * peer dependency. WorksCalendar's main bundle stays free of any
- * tracker-specific code; consumers reach for this path only when
- * they install both packages. We don't import the tracker package
- * here either — the bridge accepts a structural type so it works
- * whether the host is using the published `asset-tracker` package,
- * a fork, or a hand-rolled registry that happens to match the
- * normalized-position shape.
- */
+import type { EngineResource } from '../core/engine/schema/resourceSchema'
 import type { ResourceLocationAdapter, ResourceLocation } from '../core/pools/locationAdapters'
+import type {
+  GeoPoint,
+  ResourceTrackingMeta,
+  AssetTrackerPosition,
+} from '../core/geo/geoTypes'
+import type { WorksCalendarMapAdapter } from '../core/geo/mapAdapterTypes'
+import { isValidPosition } from '../core/geo/positionGuards'
+import { positionToResourceTrackingMeta } from '../core/geo/positionToResourceMeta'
 
-/**
- * The minimum surface from `asset-tracker` we depend on. The real
- * package's `PositionPluginRegistry` exposes much more — we only
- * need a way to look up the latest normalized position for a given
- * resource id. Two lookup styles are supported so this bridge fits
- * whichever shape the upstream package settles on:
- *
- *   - `getById(id)` returning the position (preferred — O(1))
- *   - `positions()` returning the whole list (fallback — O(n))
- */
+export type { GeoPoint, ResourceTrackingMeta, AssetTrackerPosition, WorksCalendarMapAdapter }
+export { isValidPosition, positionToResourceTrackingMeta }
+
 export interface AssetTrackerLikeRegistry {
   readonly getById?: (id: string) => AssetTrackerPosition | null | undefined
   readonly positions?: () => Iterable<AssetTrackerPosition>
 }
 
-export interface AssetTrackerPosition {
-  readonly id: string
-  readonly lat: number
-  readonly lon: number
-  readonly altitude?: number | null
-  readonly heading?: number | null
-  readonly speed?: number | null
-  readonly timestamp?: number
-  readonly source?: string
-  readonly label?: string
-  readonly meta?: Readonly<Record<string, unknown>>
-}
-
-export interface FromAssetTrackerOptions {
-  /** Override the adapter id; useful when you have multiple feeds. */
+export interface AssetMapIntegrationOptions {
   readonly id?: string
+  readonly staleThresholdSeconds?: number
+  readonly nowSeconds?: () => number
+  readonly resourceIdFromPosition?: (position: AssetTrackerPosition) => string
 }
 
-/**
- * Build a `ResourceLocationAdapter` backed by an asset-tracker-style
- * registry.
- *
- *   import { buildRegistry, adsbAdapter } from 'asset-tracker';
- *   import { fromAssetTrackerRegistry, attachLocations } from 'works-calendar';
- *
- *   const registry  = buildRegistry([adsbAdapter()]);
- *   await registry.refresh();   // host owns the polling cadence
- *   const located   = attachLocations(resources, [
- *     fromAssetTrackerRegistry(registry),
- *   ]);
- *
- * The adapter reads from the registry on each `resolve` call —
- * cheap when `getById` is available; the host should call this
- * helper once per registry refresh tick, not per resolve.
- */
-export function fromAssetTrackerRegistry(
+export interface AssetTrackerIntegration {
+  readonly locationAdapter: ResourceLocationAdapter
+  readonly mapPositionToResourceMeta: (position: AssetTrackerPosition) => ResourceTrackingMeta | null
+}
+
+export function mapPositionToResourceMeta(
+  position: AssetTrackerPosition,
+  nowSeconds: number,
+  staleThresholdSeconds: number,
+): ResourceTrackingMeta | null {
+  return positionToResourceTrackingMeta(position, nowSeconds, staleThresholdSeconds)
+}
+
+export function createAssetTrackerIntegration(
   registry: AssetTrackerLikeRegistry,
-  options: FromAssetTrackerOptions = {},
-): ResourceLocationAdapter {
-  return {
-    id: options.id ?? 'asset-tracker',
-    resolve(resource) {
-      const pos = lookup(registry, resource.id)
-      return pos ? toLocation(pos) : null
-    },
-  }
-}
+  options: AssetMapIntegrationOptions = {},
+): AssetTrackerIntegration {
+  const staleThresholdSeconds = options.staleThresholdSeconds ?? 120
+  const nowSeconds = options.nowSeconds ?? (() => Math.floor(Date.now() / 1000))
+  const resourceIdFromPosition = options.resourceIdFromPosition ?? ((p: AssetTrackerPosition) => p.id)
 
-// ─── Internals ────────────────────────────────────────────────────────────
-
-function lookup(reg: AssetTrackerLikeRegistry, id: string): AssetTrackerPosition | null {
-  if (typeof reg.getById === 'function') {
-    return reg.getById(id) ?? null
-  }
-  if (typeof reg.positions === 'function') {
-    for (const p of reg.positions()) {
-      if (p.id === id) return p
+  const byResourceId = (): ReadonlyMap<string, AssetTrackerPosition> => {
+    const map = new Map<string, AssetTrackerPosition>()
+    if (typeof registry.positions === 'function') {
+      for (const pos of registry.positions()) {
+        map.set(resourceIdFromPosition(pos), pos)
+      }
     }
+    return map
   }
-  return null
+
+  return {
+    locationAdapter: {
+      id: options.id ?? 'asset-tracker',
+      resolve(resource: EngineResource): ResourceLocation | null {
+        const pos = lookupPosition(registry, resource.id, byResourceId())
+        if (!pos || !isValidPosition(pos)) return null
+        return {
+          lat: pos.lat,
+          lon: pos.lon,
+          ...(pos.altitude != null ? { altitude: pos.altitude } : {}),
+          ...(pos.heading != null ? { heading: pos.heading } : {}),
+          ...(pos.speed != null ? { speed: pos.speed } : {}),
+          timestamp: pos.timestamp,
+          source: pos.source,
+          meta: {
+            tracking: mapPositionToResourceMeta(pos, nowSeconds(), staleThresholdSeconds),
+            label: pos.label,
+            ...(pos.meta ? { upstream: pos.meta } : {}),
+          },
+        }
+      },
+    },
+    mapPositionToResourceMeta: (position) =>
+      mapPositionToResourceMeta(position, nowSeconds(), staleThresholdSeconds),
+  }
 }
 
-function toLocation(p: AssetTrackerPosition): ResourceLocation {
-  // Map_Idea's normalized schema is already a strict superset of our
-  // `ResourceLocation` — pass it through unchanged so altitude /
-  // heading / speed / timestamp / source / meta survive into
-  // `resource.meta.location` for downstream consumers.
-  return {
-    lat: p.lat,
-    lon: p.lon,
-    ...(p.altitude  != null ? { altitude:  p.altitude  } : {}),
-    ...(p.heading   != null ? { heading:   p.heading   } : {}),
-    ...(p.speed     != null ? { speed:     p.speed     } : {}),
-    ...(p.timestamp != null ? { timestamp: p.timestamp } : {}),
-    ...(p.source    != null ? { source:    p.source    } : {}),
-    ...(p.meta      != null ? { meta:      p.meta      } : {}),
-  }
+function lookupPosition(
+  registry: AssetTrackerLikeRegistry,
+  resourceId: string,
+  indexed: ReadonlyMap<string, AssetTrackerPosition>,
+): AssetTrackerPosition | null {
+  if (typeof registry.getById === 'function') return registry.getById(resourceId) ?? null
+  return indexed.get(resourceId) ?? null
 }


### PR DESCRIPTION
### Motivation
- Add a small, reusable geo layer (types, validation, and utilities) to normalize upstream tracker positions and support mapping/location adapters. 
- Replace the older `fromAssetTrackerRegistry` surface with a clearer integration API that composes a `ResourceLocationAdapter` and a position->meta mapper to better support both `getById` and `positions()` registry shapes. 

### Description
- Add core geo types and utilities: `GeoPoint`, `ResourceTrackingMeta`, `AssetTrackerPosition` in `core/geo/geoTypes.ts`, `haversineDistanceKm` in `core/geo/haversine.ts`, `isValidPosition` in `core/geo/positionGuards.ts`, and `positionToResourceTrackingMeta` in `core/geo/positionToResourceMeta.ts`. 
- Add `WorksCalendarMapAdapter` map adapter interface in `core/geo/mapAdapterTypes.ts` and an empty `geoConflictRules` array in `core/conflicts/geoConflictRules.ts`. 
- Refactor the asset-tracker bridge in `integrations/asset-tracker.ts` to export types and helpers, introduce `createAssetTrackerIntegration` which returns `{ locationAdapter, mapPositionToResourceMeta }`, and keep support for both `getById` and `positions()` via an indexed fallback; remove the old `fromAssetTrackerRegistry` function. 
- Update tests in `integrations/__tests__/asset-tracker.test.ts` to exercise the new API and utility functions (`isValidPosition`, `positionToResourceTrackingMeta` / `mapPositionToResourceMeta`) and to validate both `getById` and `positions()` flows. 

### Testing
- Ran the integration unit tests with `vitest` focusing on `src/integrations/__tests__/asset-tracker.test.ts` and the updated tests passed. 
- Ran TypeScript type-check with `tsc --noEmit` and it succeeded for the modified files.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2d783a9d4832c9e49f2c7c8e26c0a)