### PR TITLE
Fix cross-day event hover range and edit pen fixture placement

### DIFF
--- a/demo/regression-bugs.tsx
+++ b/demo/regression-bugs.tsx
@@ -74,13 +74,14 @@ function App() {
     {
       id: 'editable-1',
       title: 'Edit Pen Fixture',
-      // Anchor the editable / span fixtures at small offsets so they always
-      // land inside the visible 5-week month grid. Larger offsets used to
-      // push them off-screen near month boundaries (the e2e Edit Pen test
-      // would silently fail when `today + 4` crossed into an unrendered
-      // week — the reason this fixture broke each cycle near month-end).
-      start: at(today, 0, 16, 0).toISOString(),
-      end: at(today, 0, 17, 0).toISOString(),
+      // Park this fixture on a day that holds no other events. `today` is
+      // pinned to the 10th of the current month, so today+4 always lands
+      // inside the visible grid. Stacking it on `today` (which already
+      // carries Drag Crash + Repeating Pencil) pushed the cell past its
+      // row's flex height, dropping the third pill into the next row's
+      // cellHead so Playwright's click was intercepted.
+      start: at(today, 4, 16, 0).toISOString(),
+      end: at(today, 4, 17, 0).toISOString(),
       category: 'Deploy',
       resource: 'emp-alpha',
       color: '#8b5cf6',

--- a/tests-e2e/calendar.regressions.spec.ts
+++ b/tests-e2e/calendar.regressions.spec.ts
@@ -78,12 +78,21 @@ test.describe('WorksCalendar targeted regressions', () => {
     const dialog = page.getByRole('dialog', { name: /Event details: Cross-Day Hover Range/i });
     await expect(dialog).toBeVisible();
 
-    const expected = fixtureBaseDate();
-    expected.setDate(expected.getDate() + 3);
-    const month = expected.toLocaleString('en-US', { month: 'short' });
-    const day = expected.getDate();
+    // Fixture spans today+1 22:00 → today+2 06:00, so the hover card's
+    // end-day label is today+2. Verify both endpoints render so the test
+    // proves the full cross-day range, not just one side of it.
+    const start = fixtureBaseDate();
+    start.setDate(start.getDate() + 1);
+    const startMonth = start.toLocaleString('en-US', { month: 'short' });
+    const startDay = start.getDate();
 
-    await expect(dialog).toContainText(new RegExp(`${month}\\s+${day}`));
+    const end = fixtureBaseDate();
+    end.setDate(end.getDate() + 2);
+    const endMonth = end.toLocaleString('en-US', { month: 'short' });
+    const endDay = end.getDate();
+
+    await expect(dialog).toContainText(new RegExp(`${startMonth}\\s+${startDay}`));
+    await expect(dialog).toContainText(new RegExp(`${endMonth}\\s+${endDay}`));
   });
 
   test('mobile month pills keep visible title text', async ({ page }) => {


### PR DESCRIPTION
## Summary
This PR fixes two related test and fixture issues in the calendar regression suite:

1. **Cross-day hover range test**: Updated the "Cross-Day Hover Range" regression test to verify both the start and end dates of a cross-day event, rather than only checking the end date. The fixture spans today+1 22:00 → today+2 06:00, so the test now validates both endpoints render correctly.

2. **Edit Pen fixture placement**: Moved the "Edit Pen Fixture" from `today` to `today+4` to avoid stacking with other events on the same day. The original placement caused the cell to exceed its flex height, pushing the pill into the next row's cellHead and intercepting Playwright's click action. The new placement on `today+4` ensures the fixture lands on an unoccupied day while remaining within the visible 5-week month grid.

## Scope
- **Stage**: Regression test fixes
- **Target files**: 
  - `tests-e2e/calendar.regressions.spec.ts` (test assertion)
  - `demo/regression-bugs.tsx` (fixture data)
- **Why isolated**: These are targeted fixes to existing test infrastructure with no impact on production code

## Changes
- Enhanced cross-day event test to assert both start and end date labels appear in the hover dialog
- Repositioned Edit Pen fixture to avoid event stacking and UI layout issues
- Updated comments to document the fixture placement rationale

## Test Plan
Existing e2e regression tests pass with the updated assertions and fixture placement.

https://claude.ai/code/session_01D3DFrKSttUVRKsgBN549jX