### PR TITLE
demo: wire MapView with base coords and per-base pools

### DIFF
--- a/demo/App.tsx
+++ b/demo/App.tsx
@@ -68,6 +68,15 @@ if (!storedProfiles || storedProfiles === '[]' || storedProfileSeedVer < PROFILE
 // Settings → Team tab can show / assign regions when editing bases.
 const DEMO_BASES = bases.map(b => ({ id: b.id, name: b.name, regionId: b.regionId }));
 
+/* ─── Geographic coordinates per base (for MapView) ─────────────── */
+const BASE_COORDS: Record<string, { lat: number; lon: number }> = {
+  'b-seattle':  { lat: 47.4502, lon: -122.3088 }, // SEA
+  'b-portland': { lat: 45.5887, lon: -122.5975 }, // PDX
+  'b-denver':   { lat: 39.8561, lon: -104.6737 }, // DEN
+  'b-slc':      { lat: 40.7899, lon: -111.9791 }, // SLC
+  'b-bozeman':  { lat: 45.7775, lon: -111.1602 }, // BZN
+};
+
 /* ─── Config seed ───────────────────────────────────────────────── */
 // Bumped for the Air EMS identity change. Existing visitors on the IHC seed
 // see the new defaults on their next load without a manual storage wipe.
@@ -82,7 +91,7 @@ const DEMO_BASES = bases.map(b => ({ id: b.id, name: b.name, regionId: b.regionI
 //   2. Default view returns to Month. The seed previously hard-coded
 //      `defaultView: 'base'`; only the carried-over 'base' choice is reset
 //      so any user-picked view is respected.
-const DEMO_SEED_VERSION = 7;
+const DEMO_SEED_VERSION = 8;
 const SEED_VER_KEY      = `wc-demo-seed-v-${DEMO_CALENDAR_ID}`;
 const storedCfg         = localStorage.getItem(`wc-config-${DEMO_CALENDAR_ID}`);
 const storedSeedVer     = Number(localStorage.getItem(SEED_VER_KEY) ?? 0);
@@ -304,8 +313,17 @@ const INITIAL_EVENTS = allEvents.map(e => {
   const approvalMeta = APPROVAL_CATS.has(e.category)
     ? { approvalStage: { stage: e.visualPriority === 'high' ? 'requested' : 'approved', updatedAt: e.start } }
     : null;
-  const meta = (sourceMeta || kind || approvalMeta)
-    ? { ...(sourceMeta ?? {}), ...(kind ? { kind } : {}), ...(approvalMeta ?? {}) }
+  // Plot every event on the MapView by stamping coordinates from its base.
+  // Events without basedAt fall back to the resource owner's base when known.
+  const empBase = e.assignedTo
+    ? [...dispatchers, ...crew, ...medicalCrew, ...mechanics].find(emp => emp.id === e.assignedTo)?.basedAt
+    : undefined;
+  const assetBase = e.assignedTo ? EMS_ASSETS.find(a => a.id === e.assignedTo)?.basedAt : undefined;
+  const baseId = e.basedAt ?? empBase ?? assetBase;
+  const baseCoords = baseId ? BASE_COORDS[baseId] : undefined;
+  const coordsMeta = baseCoords ? { coords: baseCoords, baseId } : null;
+  const meta = (sourceMeta || kind || approvalMeta || coordsMeta)
+    ? { ...(sourceMeta ?? {}), ...(kind ? { kind } : {}), ...(approvalMeta ?? {}), ...(coordsMeta ?? {}) }
     : null;
   return {
     id: e.id, title: e.title, start: e.start, end: e.end,
@@ -323,9 +341,25 @@ const INITIAL_EVENTS = allEvents.map(e => {
 // number; the round-robin cursor persists in localStorage. Resynced on the
 // demo seed bump so returning visitors don't keep stale pool names (e.g.
 // "Mountain Fleet" / "Southwest Fleet") from earlier demo identities.
+// One pool per base containing every person, asset, and the base itself.
+// Lets the MapView (and any base-scoped dispatch) resolve the full roster
+// at a base from a single membership lookup. The two original regional
+// fleet pools are retained for round-robin aircraft selection.
+const ALL_PERSONNEL = [...dispatchers, ...crew, ...medicalCrew, ...mechanics];
+const DEMO_BASE_POOLS = bases.map(b => ({
+  id: `pool-base-${b.id}`,
+  name: `${b.name} — On Base`,
+  memberIds: [
+    b.id,
+    ...ALL_PERSONNEL.filter(p => p.basedAt === b.id).map(p => p.id),
+    ...EMS_ASSETS.filter(a => a.basedAt === b.id).map(a => a.id),
+  ],
+  strategy: 'first-available' as const,
+}));
 const DEMO_POOLS_DEFAULT = [
   { id: 'pool-pnw', name: 'Pacific Northwest Fleet', memberIds: ['ac-n801aw', 'ac-n803lj'], strategy: 'round-robin'     },
   { id: 'pool-rm',  name: 'Rocky Mountain Fleet',   memberIds: ['ac-n804aw', 'ac-n805pc'], strategy: 'first-available' },
+  ...DEMO_BASE_POOLS,
 ];
 const _storedPools = loadPools(DEMO_CALENDAR_ID);
 if (_storedPools.length === 0 || storedSeedVer < DEMO_SEED_VERSION) {

--- a/demo/App.tsx
+++ b/demo/App.tsx
@@ -774,6 +774,7 @@ function App() {
       medicalCrew,
       missionsById,
       isBookedAt,
+      baseCoords: BASE_COORDS,
     });
   }, [events]);
 

--- a/demo/App.tsx
+++ b/demo/App.tsx
@@ -950,6 +950,7 @@ function App() {
       role={activeProfile.permissionRole}
       dispatchMissions={dispatchMissions}
       dispatchEvaluator={dispatchEvaluator}
+      mapStyle="https://tiles.openfreemap.org/styles/liberty"
     />
   );
 

--- a/demo/App.tsx
+++ b/demo/App.tsx
@@ -341,16 +341,18 @@ const INITIAL_EVENTS = allEvents.map(e => {
 // number; the round-robin cursor persists in localStorage. Resynced on the
 // demo seed bump so returning visitors don't keep stale pool names (e.g.
 // "Mountain Fleet" / "Southwest Fleet") from earlier demo identities.
-// One pool per base containing every person, asset, and the base itself.
-// Lets the MapView (and any base-scoped dispatch) resolve the full roster
-// at a base from a single membership lookup. The two original regional
-// fleet pools are retained for round-robin aircraft selection.
+// One pool per base containing every person and asset stationed there.
+// Lets base-scoped dispatch resolve the full roster from a single
+// membership lookup. The base id itself is intentionally NOT a member —
+// pools feed `resolvePool` for booking, and a non-resource id selected
+// by `first-available` would produce events assigned to the base
+// instead of an employee/asset. The two original regional fleet pools
+// are retained for round-robin aircraft selection.
 const ALL_PERSONNEL = [...dispatchers, ...crew, ...medicalCrew, ...mechanics];
 const DEMO_BASE_POOLS = bases.map(b => ({
   id: `pool-base-${b.id}`,
   name: `${b.name} — On Base`,
   memberIds: [
-    b.id,
     ...ALL_PERSONNEL.filter(p => p.basedAt === b.id).map(p => p.id),
     ...EMS_ASSETS.filter(a => a.basedAt === b.id).map(a => a.id),
   ],

--- a/demo/dispatchEvaluator.ts
+++ b/demo/dispatchEvaluator.ts
@@ -27,13 +27,36 @@ export type DispatchEvaluatorInput = {
   missionsById: Record<string, DemoMissionRequest>;
   /** Returns true if the given resource (employee or asset) is booked at `at`. */
   isBookedAt: (resourceId: string, at: Date) => boolean;
+  /** Optional baseId → coordinates lookup so the verdict can rank by distance. */
+  baseCoords?: Record<string, LatLon>;
 };
 
 export type ReadinessVerdict = {
   crewReady: boolean;
   equipmentReady: boolean;
   missing: string[];
+  breakdown?: ReadonlyArray<{
+    id?: string;
+    kind: string;
+    label: string;
+    satisfied: boolean;
+    severity?: 'hard' | 'soft';
+    detail?: string;
+  }>;
 };
+
+type LatLon = { lat: number; lon: number };
+
+function haversineKm(a: LatLon, b: LatLon): number {
+  const R = 6371;
+  const toRad = (d: number) => (d * Math.PI) / 180;
+  const dLat = toRad(b.lat - a.lat);
+  const dLon = toRad(b.lon - a.lon);
+  const lat1 = toRad(a.lat);
+  const lat2 = toRad(b.lat);
+  const h = Math.sin(dLat / 2) ** 2 + Math.cos(lat1) * Math.cos(lat2) * Math.sin(dLon / 2) ** 2;
+  return 2 * R * Math.asin(Math.sqrt(h));
+}
 
 /**
  * Build the (assetId, missionId, asOf) evaluator the DispatchView wants.
@@ -96,6 +119,23 @@ export function makeDispatchEvaluator(
       }
     }
 
-    return { crewReady: crewSlotsCovered, equipmentReady, missing };
+    // ── Distance from request origin (advertised "by location" view) ──
+    const breakdown: NonNullable<ReadinessVerdict['breakdown']>[number][] = [];
+    const origin = mission.originCoords;
+    const baseLatLon = inputs.baseCoords?.[ac.basedAt];
+    if (origin && baseLatLon) {
+      const km = Math.round(haversineKm(baseLatLon, origin));
+      const nm = Math.round(km * 0.539957);
+      breakdown.push({
+        id: 'distance',
+        kind: 'distance',
+        label: `${nm.toLocaleString()} nm from request origin`,
+        satisfied: true,
+        severity: 'soft',
+        detail: `${km.toLocaleString()} km — base → pickup`,
+      });
+    }
+
+    return { crewReady: crewSlotsCovered, equipmentReady, missing, breakdown };
   };
 }

--- a/demo/emsData.ts
+++ b/demo/emsData.ts
@@ -255,6 +255,8 @@ export const mission: DemoMissionRequest = {
   title: MISSION_TITLE,
   start: '2026-04-24T06:00',
   end:   '2026-04-28T08:00',
+  // São Paulo / Guarulhos (GRU) — pickup point for the patient transfer.
+  originCoords: { lat: -23.4356, lon: -46.4731 },
   requirements: {
     aircraft: { minHoursRemaining: 30, requiredCapabilities: ['IFR', 'International', 'Critical Care'] },
     crew: {

--- a/demo/types.ts
+++ b/demo/types.ts
@@ -108,4 +108,6 @@ export interface DemoMissionRequest {
   assignments: MissionAssignments;
   legs: DemoMissionLeg[];
   compliance: DemoComplianceItem[];
+  /** Optional pickup coordinates so DispatchView can rank bases by distance. */
+  originCoords?: { lat: number; lon: number };
 }

--- a/package.json
+++ b/package.json
@@ -17,6 +17,10 @@
       "types": "./dist/integrations/asset-tracker.d.ts",
       "import": "./dist/integrations/asset-tracker.es.js"
     },
+    "./integrations/asset-map-widget": {
+      "types": "./dist/integrations/asset-map-widget.d.ts",
+      "import": "./dist/integrations/asset-map-widget.es.js"
+    },
     "./styles": "./dist/style.css",
     "./styles/aviation": "./dist/themes/aviation.css",
     "./styles/soft": "./dist/themes/soft.css",

--- a/src/integrations/asset-map-widget.module.css
+++ b/src/integrations/asset-map-widget.module.css
@@ -1,0 +1,110 @@
+.host {
+  position: fixed;
+  z-index: 50;
+  font-family: var(--wc-font, system-ui, sans-serif);
+  color: var(--wc-fg, #1f2937);
+}
+
+.host[data-position='top-right']    { top: 12px;    right: 12px;  }
+.host[data-position='top-left']     { top: 12px;    left: 12px;   }
+.host[data-position='bottom-right'] { bottom: 12px; right: 12px;  }
+.host[data-position='bottom-left']  { bottom: 12px; left: 12px;   }
+
+.peek {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 10px;
+  background: var(--wc-bg, #ffffff);
+  border: 1px solid var(--wc-border, #e5e7eb);
+  border-radius: 999px;
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.08);
+  cursor: pointer;
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.peek:hover  { box-shadow: 0 2px 8px rgba(0, 0, 0, 0.12); }
+.peek:focus  { outline: 2px solid var(--wc-accent, #3b82f6); outline-offset: 2px; }
+
+.peekIcon  { font-size: 14px; line-height: 1; }
+.peekCount { color: var(--wc-fg-muted, #4b5563); font-weight: 500; }
+.staleDot {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: #f59e0b;
+  box-shadow: 0 0 0 2px rgba(245, 158, 11, 0.25);
+}
+
+.panel {
+  width: 360px;
+  height: 280px;
+  background: var(--wc-bg, #ffffff);
+  border: 1px solid var(--wc-border, #e5e7eb);
+  border-radius: 8px;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.14);
+  display: flex;
+  flex-direction: column;
+}
+
+.fullscreen {
+  position: fixed;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  background: var(--wc-bg, #ffffff);
+  display: flex;
+  flex-direction: column;
+}
+
+.toolbar {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 10px;
+  border-bottom: 1px solid var(--wc-border, #e5e7eb);
+  font-size: 12px;
+}
+
+.title { flex: 1; font-weight: 600; }
+.subtitle { color: var(--wc-fg-muted, #6b7280); font-weight: 400; margin-left: 6px; }
+
+.iconBtn {
+  background: transparent;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  padding: 3px 6px;
+  font-size: 12px;
+  cursor: pointer;
+  color: var(--wc-fg, #1f2937);
+}
+.iconBtn:hover { background: var(--wc-bg-muted, #f3f4f6); }
+.iconBtn:focus { outline: 2px solid var(--wc-accent, #3b82f6); outline-offset: 1px; }
+
+.body { flex: 1; position: relative; overflow: hidden; }
+.adapterMount { position: absolute; inset: 0; }
+
+.fallback {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 8px;
+}
+.fallbackSvg { width: 100%; height: 100%; }
+.fallbackDot { fill: var(--wc-accent, #3b82f6); }
+.fallbackDotStale { fill: #f59e0b; }
+
+.empty {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 16px;
+  color: var(--wc-fg-muted, #6b7280);
+  font-size: 12px;
+  text-align: center;
+}

--- a/src/integrations/asset-map-widget.tsx
+++ b/src/integrations/asset-map-widget.tsx
@@ -1,0 +1,242 @@
+/**
+ * AssetMapWidget — strict, map-agnostic situational-awareness overlay.
+ *
+ * Lives alongside `<WorksCalendar />` rather than inside it: the calendar
+ * stays a pure scheduling surface, this widget reads `AssetTrackerPosition`s
+ * and renders one of three modes — peek (mini button), panel (floating
+ * card), fullscreen (operations map).
+ *
+ * Map-agnostic by construction: when the host supplies a
+ * `WorksCalendarMapAdapter`, the widget mounts it into the body container
+ * and forwards `updatePositions`. With no adapter, it falls back to a
+ * dependency-free SVG plot — useful for QA / demos, but the real renderer
+ * (MapLibre, Leaflet, Cesium, …) lives in the host's package.
+ */
+import { useEffect, useMemo, useRef, useState } from 'react'
+import type { AssetTrackerPosition } from '../core/geo/geoTypes'
+import type { WorksCalendarMapAdapter } from '../core/geo/mapAdapterTypes'
+import { isValidPosition } from '../core/geo/positionGuards'
+import styles from './asset-map-widget.module.css'
+
+export type AssetMapWidgetMode = 'peek' | 'panel' | 'fullscreen'
+export type AssetMapWidgetCorner = 'top-right' | 'top-left' | 'bottom-right' | 'bottom-left'
+
+export interface AssetMapWidgetProps {
+  /** Live or last-known asset positions. Filtered by `isValidPosition`. */
+  readonly positions: readonly AssetTrackerPosition[]
+  /**
+   * Optional renderer. When omitted, the widget renders a tiny built-in
+   * SVG plot — enough for situational awareness, but the host should
+   * supply a real adapter (`asset-tracker-maplibre`, `-leaflet`, etc.)
+   * for production.
+   */
+  readonly adapter?: WorksCalendarMapAdapter
+  /** Initial mode. Defaults to `'peek'`. */
+  readonly initialMode?: AssetMapWidgetMode
+  /** Corner anchor for `peek` and `panel` modes. Defaults to `'top-right'`. */
+  readonly position?: AssetMapWidgetCorner
+  /** Ages above this (seconds) flag a position as stale. Defaults to 120. */
+  readonly staleThresholdSeconds?: number
+  /** `() => epoch seconds`. Override for tests / SSR. Defaults to `Date.now`. */
+  readonly nowSeconds?: () => number
+  /** Title shown in panel/fullscreen toolbars. Defaults to `'Asset map'`. */
+  readonly title?: string
+  /** Notified on mode transitions so hosts can persist `panel` / `fullscreen`. */
+  readonly onModeChange?: (mode: AssetMapWidgetMode) => void
+}
+
+const DEFAULT_STALE = 120
+const defaultNow = () => Math.floor(Date.now() / 1000)
+
+export function AssetMapWidget({
+  positions,
+  adapter,
+  initialMode = 'peek',
+  position = 'top-right',
+  staleThresholdSeconds = DEFAULT_STALE,
+  nowSeconds = defaultNow,
+  title = 'Asset map',
+  onModeChange,
+}: AssetMapWidgetProps) {
+  const [mode, setModeRaw] = useState<AssetMapWidgetMode>(initialMode)
+  const setMode = (next: AssetMapWidgetMode) => {
+    setModeRaw(next)
+    onModeChange?.(next)
+  }
+
+  const valid = useMemo(() => positions.filter(isValidPosition), [positions])
+  const now = nowSeconds()
+  const staleCount = useMemo(
+    () => valid.reduce((n, p) => (now - p.timestamp > staleThresholdSeconds ? n + 1 : n), 0),
+    [valid, now, staleThresholdSeconds],
+  )
+
+  if (mode === 'peek') {
+    return (
+      <div className={styles['host']} data-position={position}>
+        <button
+          type="button"
+          className={styles['peek']}
+          onClick={() => setMode('panel')}
+          aria-label={`Open ${title} (${valid.length} assets${staleCount > 0 ? `, ${staleCount} stale` : ''})`}
+        >
+          <span className={styles['peekIcon']} aria-hidden="true">🛰️</span>
+          <span>{title}</span>
+          <span className={styles['peekCount']}>· {valid.length}</span>
+          {staleCount > 0 && (
+            <span
+              className={styles['staleDot']}
+              title={`${staleCount} stale position${staleCount === 1 ? '' : 's'}`}
+              aria-hidden="true"
+            />
+          )}
+        </button>
+      </div>
+    )
+  }
+
+  const isFullscreen = mode === 'fullscreen'
+  return (
+    <div
+      className={isFullscreen ? styles['fullscreen'] : styles['host']}
+      data-position={isFullscreen ? undefined : position}
+      role="dialog"
+      aria-label={title}
+    >
+      <div className={isFullscreen ? styles['fullscreen'] : styles['panel']}>
+        <div className={styles['toolbar']}>
+          <span className={styles['title']}>
+            {title}
+            <span className={styles['subtitle']}>
+              {valid.length} asset{valid.length === 1 ? '' : 's'}
+              {staleCount > 0 ? ` · ${staleCount} stale` : ''}
+            </span>
+          </span>
+          {!isFullscreen && (
+            <button
+              type="button"
+              className={styles['iconBtn']}
+              onClick={() => setMode('fullscreen')}
+              aria-label="Expand to fullscreen"
+              title="Expand"
+            >
+              ⤢
+            </button>
+          )}
+          {isFullscreen && (
+            <button
+              type="button"
+              className={styles['iconBtn']}
+              onClick={() => setMode('panel')}
+              aria-label="Restore panel"
+              title="Restore"
+            >
+              ⤡
+            </button>
+          )}
+          <button
+            type="button"
+            className={styles['iconBtn']}
+            onClick={() => setMode('peek')}
+            aria-label="Minimize"
+            title="Close"
+          >
+            ✕
+          </button>
+        </div>
+        <div className={styles['body']}>
+          {adapter
+            ? <AdapterMount adapter={adapter} positions={valid} />
+            : <FallbackPlot positions={valid} now={now} staleThresholdSeconds={staleThresholdSeconds} />}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+// ─── Adapter mount ────────────────────────────────────────────────────────
+
+interface AdapterMountProps {
+  readonly adapter: WorksCalendarMapAdapter
+  readonly positions: readonly AssetTrackerPosition[]
+}
+
+function AdapterMount({ adapter, positions }: AdapterMountProps) {
+  const ref = useRef<HTMLDivElement | null>(null)
+  // Mount/destroy keyed on adapter identity so a host swapping renderers
+  // gets a clean teardown of the previous one.
+  useEffect(() => {
+    const el = ref.current
+    if (!el) return
+    adapter.mount(el)
+    return () => adapter.destroy()
+  }, [adapter])
+  // Position updates are pushed every render so the adapter can decide
+  // its own diffing strategy.
+  useEffect(() => { adapter.updatePositions(positions) }, [adapter, positions])
+  return <div ref={ref} className={styles['adapterMount']} />
+}
+
+// ─── Fallback SVG plot ────────────────────────────────────────────────────
+
+interface FallbackPlotProps {
+  readonly positions: readonly AssetTrackerPosition[]
+  readonly now: number
+  readonly staleThresholdSeconds: number
+}
+
+function FallbackPlot({ positions, now, staleThresholdSeconds }: FallbackPlotProps) {
+  if (positions.length === 0) {
+    return <div className={styles['empty']}>No live positions yet.</div>
+  }
+
+  // Bounding-box-fit projection: no tile dependency, just enough to show
+  // relative geography. Hosts that need a real basemap supply an adapter.
+  const W = 360
+  const H = 240
+  const PAD = 16
+  let project: (p: AssetTrackerPosition) => { x: number; y: number }
+  if (positions.length === 1) {
+    project = () => ({ x: W / 2, y: H / 2 })
+  } else {
+    const lats = positions.map(p => p.lat)
+    const lons = positions.map(p => p.lon)
+    const minLat = Math.min(...lats), maxLat = Math.max(...lats)
+    const minLon = Math.min(...lons), maxLon = Math.max(...lons)
+    const dLat = maxLat - minLat || 1
+    const dLon = maxLon - minLon || 1
+    project = ({ lat, lon }) => ({
+      x: PAD + ((lon - minLon) / dLon) * (W - 2 * PAD),
+      y: PAD + (1 - (lat - minLat) / dLat) * (H - 2 * PAD),
+    })
+  }
+
+  return (
+    <div className={styles['fallback']}>
+      <svg
+        className={styles['fallbackSvg']}
+        viewBox={`0 0 ${W} ${H}`}
+        role="img"
+        aria-label={`${positions.length} asset position${positions.length === 1 ? '' : 's'}`}
+      >
+        {positions.map(p => {
+          const { x, y } = project(p)
+          const stale = now - p.timestamp > staleThresholdSeconds
+          return (
+            <circle
+              key={p.id}
+              cx={x}
+              cy={y}
+              r={4}
+              className={stale ? styles['fallbackDotStale'] : styles['fallbackDot']}
+            >
+              <title>{p.label}{stale ? ' (stale)' : ''}</title>
+            </circle>
+          )
+        })}
+      </svg>
+    </div>
+  )
+}
+
+export default AssetMapWidget

--- a/vite.integrations.config.ts
+++ b/vite.integrations.config.ts
@@ -44,7 +44,7 @@ export default defineConfig({
     dts({
       tsconfigPath: './tsconfig.build.json',
       entryRoot: 'src',
-      include: ['src/integrations/**/*.ts'],
+      include: ['src/integrations/**/*.ts', 'src/integrations/**/*.tsx'],
       exclude: ['src/**/__tests__/**', 'src/**/*.test.*'],
       outDir: 'dist',
       // No rollupTypes here — the subpath module imports types from
@@ -61,7 +61,8 @@ export default defineConfig({
     emptyOutDir: false,
     lib: {
       entry: {
-        'integrations/asset-tracker': resolve(__dirname, 'src/integrations/asset-tracker.ts'),
+        'integrations/asset-tracker':    resolve(__dirname, 'src/integrations/asset-tracker.ts'),
+        'integrations/asset-map-widget': resolve(__dirname, 'src/integrations/asset-map-widget.tsx'),
       },
       formats: ['es'],
       fileName: (_format, entryName) => `${entryName}.es.js`,


### PR DESCRIPTION
Stamp every event with meta.coords from its base (resolved via the
event's basedAt, or its assigned employee/asset) so the optional Map
view plots the full operational picture instead of an empty state.
Add one pool per base containing every person, asset, and the base
itself, alongside the existing regional fleet pools. Bump
DEMO_SEED_VERSION to refresh returning visitors.