### PR TITLE
docs(map): document AssetMapWidget integration + example 12

### DIFF
--- a/docs/AssetMapWidget.md
+++ b/docs/AssetMapWidget.md
@@ -1,0 +1,188 @@
+# AssetMapWidget (optional integration)
+
+`AssetMapWidget` is a strict, **map-agnostic** situational-awareness overlay
+that lives **alongside** `<WorksCalendar />` rather than inside it. Use it
+when you want a "where are my assets right now?" peek without forcing users
+to switch to the full Map view.
+
+> Why not a calendar tab? The calendar's job is scheduling; live positions
+> are situational awareness. Keeping them as a separate overlay means
+> the calendar stays renderer-free and the widget can scale from a 200 px
+> peek pill to a fullscreen ops console without affecting the schedule grid.
+
+## Three modes, one component
+
+```
+┌──────────────────────────────┐
+│ WorksCalendar                │
+│                              │
+│                      ┌─────┐ │
+│                      │ MAP │ │  ← peek (default)
+│                      └─────┘ │
+└──────────────────────────────┘
+```
+
+| Mode         | Trigger                        | What it shows |
+| ------------ | ------------------------------ | ------------- |
+| `peek`       | initial; click → `panel`       | corner pill: title, asset count, stale-dot if any positions are aged out |
+| `panel`      | click peek; expand → fullscreen | 360 × 280 floating card with the renderer (or SVG fallback) |
+| `fullscreen` | expand button                  | full-viewport ops map; restore returns to `panel` |
+
+## Installation
+
+The widget ships on its own subpath so the main calendar bundle stays
+unaffected for hosts that don't need it:
+
+```bash
+# already in your dependencies
+npm install works-calendar
+```
+
+No extra runtime peers are required for the **fallback SVG plot** — useful
+for QA, demos, or when you just want a low-fidelity overview. To render a
+real basemap, supply a `WorksCalendarMapAdapter` (see "Bring your own
+renderer" below). The widget itself never imports MapLibre, Leaflet, or
+Cesium.
+
+## Quick start (fallback plot)
+
+```tsx
+import { WorksCalendar } from 'works-calendar';
+import { AssetMapWidget } from 'works-calendar/integrations/asset-map-widget';
+import 'works-calendar/styles';
+
+const positions = [
+  {
+    id: 'ac-n801aw',
+    label: 'AW139 N801AW',
+    lat: 47.45, lon: -122.31,
+    altitude: null, heading: null, speed: null,
+    timestamp: Math.floor(Date.now() / 1000),
+    source: 'demo',
+  },
+  // …more AssetTrackerPosition records
+];
+
+<>
+  <WorksCalendar /* …calendar props… */ />
+  <AssetMapWidget positions={positions} position="top-right" />
+</>
+```
+
+The widget reads `AssetTrackerPosition[]` — the same shape produced by
+[`works-calendar/integrations/asset-tracker`](./LocationProvider.md) and the
+[`Map_Idea` asset-tracker](https://github.com/natehorst240-sketch/Map_Idea)
+project. Invalid positions (NaN coords, out-of-range lat/lon, missing
+timestamps) are silently skipped via `isValidPosition`.
+
+## Bring your own renderer
+
+Production deployments should pass a `WorksCalendarMapAdapter`. The contract
+is intentionally minimal:
+
+```ts
+interface WorksCalendarMapAdapter {
+  mount(container: HTMLElement): void;
+  updatePositions(positions: readonly AssetTrackerPosition[]): void;
+  focusPosition(id: string): void;
+  destroy(): void;
+}
+```
+
+The widget will:
+
+1. Call `mount(container)` once when the panel/fullscreen view opens, with a
+   `<div>` already sized to the body container.
+2. Push every render to `updatePositions(positions)` — the adapter decides
+   its own diffing strategy.
+3. Call `destroy()` on unmount or when the adapter prop identity changes.
+
+Example wiring against MapLibre:
+
+```tsx
+import maplibregl from 'maplibre-gl';
+import 'maplibre-gl/dist/maplibre-gl.css';
+import type {
+  WorksCalendarMapAdapter,
+  AssetTrackerPosition,
+} from 'works-calendar/integrations/asset-map-widget';
+
+function createMaplibreAdapter(styleUrl: string): WorksCalendarMapAdapter {
+  let map: maplibregl.Map | null = null;
+  const markers = new Map<string, maplibregl.Marker>();
+
+  return {
+    mount(container) {
+      map = new maplibregl.Map({ container, style: styleUrl, center: [0, 20], zoom: 2 });
+    },
+    updatePositions(positions) {
+      if (!map) return;
+      const seen = new Set<string>();
+      for (const p of positions) {
+        seen.add(p.id);
+        const existing = markers.get(p.id);
+        if (existing) {
+          existing.setLngLat([p.lon, p.lat]);
+        } else {
+          markers.set(p.id, new maplibregl.Marker().setLngLat([p.lon, p.lat]).addTo(map));
+        }
+      }
+      for (const [id, marker] of markers) {
+        if (!seen.has(id)) { marker.remove(); markers.delete(id); }
+      }
+    },
+    focusPosition(id) {
+      const m = markers.get(id);
+      if (m && map) map.flyTo({ center: m.getLngLat(), zoom: 8 });
+    },
+    destroy() {
+      for (const m of markers.values()) m.remove();
+      markers.clear();
+      map?.remove();
+      map = null;
+    },
+  };
+}
+```
+
+You can ship the adapter as its own package (`asset-tracker-maplibre`,
+`asset-tracker-leaflet`, `asset-tracker-cesium`, …); the calendar package
+never depends on it.
+
+## Props
+
+| Prop                    | Type                                              | Default        | Notes |
+| ----------------------- | ------------------------------------------------- | -------------- | ----- |
+| `positions`             | `readonly AssetTrackerPosition[]`                 | required       | Filtered through `isValidPosition` before render. |
+| `adapter`               | `WorksCalendarMapAdapter`                         | —              | Omit for the dependency-free SVG fallback. |
+| `initialMode`           | `'peek' \| 'panel' \| 'fullscreen'`               | `'peek'`       | Persist via `onModeChange` if you want to restore. |
+| `position`              | `'top-right' \| 'top-left' \| 'bottom-right' \| 'bottom-left'` | `'top-right'` | Anchor for `peek` and `panel`. |
+| `staleThresholdSeconds` | `number`                                          | `120`          | Above this, a position renders with the stale color and counts toward the peek's stale dot. |
+| `nowSeconds`            | `() => number`                                    | `Date.now`     | Override for tests / SSR snapshots. |
+| `title`                 | `string`                                          | `'Asset map'`  | Shown in the peek pill and toolbar. |
+| `onModeChange`          | `(mode) => void`                                  | —              | Fired on every transition so hosts can persist `panel` / `fullscreen`. |
+
+## When to pick the widget vs `MapView`
+
+| Need                                    | Use                                |
+| --------------------------------------- | ---------------------------------- |
+| "Where are my assets right now?"         | `AssetMapWidget` (this page)        |
+| "Plot scheduled events on a basemap"     | [`MapView`](./MapView.md)            |
+| Both                                    | Render both — they share zero state |
+
+`MapView` reads from the calendar's event list (anything with
+`meta.coords`); `AssetMapWidget` reads live positions independent of the
+schedule. Real ops centers usually want both.
+
+## Architecture (why it's split out)
+
+- The integration subpath ships only what it needs: ~8 KB gzipped.
+- `WorksCalendar` itself never imports a map renderer. The single
+  contract between them is `resource.meta.tracking` (set by the
+  `asset-tracker` integration).
+- Adapters are external. `asset-tracker-maplibre`, `-leaflet`, `-cesium`,
+  or any custom renderer can satisfy `WorksCalendarMapAdapter` — the
+  widget doesn't care.
+
+See also: [`LocationProvider`](./LocationProvider.md),
+[`MapView`](./MapView.md).

--- a/docs/README.md
+++ b/docs/README.md
@@ -19,6 +19,7 @@ This index is the canonical docs entrypoint for the package.
 - [Resource pools](./ResourcePools.md)
 - [Location provider](./LocationProvider.md)
 - [Map view (optional plugin)](./MapView.md)
+- [AssetMapWidget (optional integration)](./AssetMapWidget.md)
 - [Maintenance & invoicing integration](./MaintenanceAndInvoicing.md)
 
 ## Provider setup guides

--- a/examples/12-AssetMapWidget.tsx
+++ b/examples/12-AssetMapWidget.tsx
@@ -1,0 +1,97 @@
+/**
+ * Example 12 — AssetMapWidget (optional integration)
+ *
+ * Shows the strict, map-agnostic situational-awareness overlay sitting
+ * alongside `<WorksCalendar />`. The widget reads `AssetTrackerPosition`s
+ * and renders one of three modes:
+ *
+ *   peek       a corner pill (asset count + stale dot)
+ *   panel      a 360x280 floating card
+ *   fullscreen a full-viewport ops map
+ *
+ * No MapLibre / Leaflet / Cesium required: this example uses the
+ * dependency-free SVG fallback. To wire a real basemap, build an adapter
+ * that satisfies `WorksCalendarMapAdapter` and pass it via the `adapter`
+ * prop — see docs/AssetMapWidget.md for a MapLibre example.
+ */
+import { useMemo, useState } from 'react';
+import { WorksCalendar } from '../src/index.ts';
+import { AssetMapWidget } from '../src/integrations/asset-map-widget.tsx';
+import type { AssetTrackerPosition } from '../src/integrations/asset-map-widget.tsx';
+
+// ── Live position fixtures ────────────────────────────────────────────────────
+// In a real deployment these come from your asset-tracking backend (push
+// updates over a WebSocket, polling REST, MQTT, etc.). Here we stage a
+// static snapshot — one stale entry to show the warning dot.
+const NOW = Math.floor(Date.now() / 1000);
+
+const POSITIONS: AssetTrackerPosition[] = [
+  {
+    id: 'ac-n801aw',
+    label: 'AW139 N801AW',
+    lat: 47.4502, lon: -122.3088,
+    altitude: 1200, heading: 90, speed: 140,
+    timestamp: NOW - 30,
+    source: 'demo',
+  },
+  {
+    id: 'ac-n804aw',
+    label: 'AW139 N804AW',
+    lat: 39.8561, lon: -104.6737,
+    altitude: 6500, heading: 270, speed: 150,
+    timestamp: NOW - 45,
+    source: 'demo',
+  },
+  {
+    id: 'ac-n805pc',
+    label: 'PC-12 N805PC',
+    lat: 40.7899, lon: -111.9791,
+    altitude: 18000, heading: 45, speed: 240,
+    timestamp: NOW - 600,            // ← stale (> 120s default)
+    source: 'demo',
+  },
+];
+
+// ── Calendar fixtures ─────────────────────────────────────────────────────────
+const today = new Date();
+const at = (h: number) => {
+  const d = new Date(today); d.setHours(h, 0, 0, 0); return d;
+};
+
+const EVENTS = [
+  { id: 'sea-1', title: 'SEA — Day shift',     start: at(7),  end: at(19), color: '#3b82f6' },
+  { id: 'den-1', title: 'DEN — Inter-facility', start: at(10), end: at(14), color: '#10b981' },
+];
+
+const EMPLOYEES = [
+  { id: 'emp-james', name: 'Capt. James Wright', role: 'Pilot' },
+  { id: 'emp-keely', name: 'Keely Frost',        role: 'RN — Critical Care' },
+];
+
+export function AssetMapWidgetExample() {
+  const [mode, setMode] = useState<'peek' | 'panel' | 'fullscreen'>('peek');
+
+  const positions = useMemo(() => POSITIONS, []);
+
+  return (
+    <div style={{ position: 'relative', height: '100vh' }}>
+      <WorksCalendar
+        events={EVENTS}
+        employees={EMPLOYEES}
+        calendarId="example-12-asset-map-widget"
+      />
+
+      {/* The widget overlays in the chosen corner; it doesn't reflow the
+          calendar so it works for any host layout. */}
+      <AssetMapWidget
+        positions={positions}
+        position="top-right"
+        initialMode={mode}
+        onModeChange={setMode}
+        title="Live fleet"
+        // staleThresholdSeconds={300}  // override default of 120s
+        // adapter={createMaplibreAdapter('https://tiles.openfreemap.org/styles/liberty')}
+      />
+    </div>
+  );
+}

--- a/examples/App.tsx
+++ b/examples/App.tsx
@@ -22,6 +22,7 @@ import { GroupingExample }         from './09-Grouping';
 import { DragAndDropExample }      from './10-DragAndDrop';
 import { MapExample }              from './11-Map';
 import { MaintenanceAndInvoicingExample } from './11-MaintenanceAndInvoicing';
+import { AssetMapWidgetExample }     from './12-AssetMapWidget';
 import { BasicUsageExample }       from './basic-usage';
 import { SetupWizardExample }      from './setup-wizard';
 import { AdvancedFiltersExample }  from './advanced-filters';
@@ -157,6 +158,13 @@ const EXAMPLES = [
     desc:  'Asset-row badges show due/overdue maintenance; completing service in the form auto-stamps next-due. One-click CSV export for invoices and maintenance log.',
     component: MaintenanceAndInvoicingExample,
   },
+  {
+    id:    'asset-map-widget',
+    label: 'Asset Map Widget',
+    tag:   'Optional integration · peek/panel/fullscreen',
+    desc:  'Map-agnostic situational-awareness overlay. Pass live AssetTrackerPositions; supply a WorksCalendarMapAdapter for a real basemap or use the built-in SVG fallback.',
+    component: AssetMapWidgetExample,
+  },
 ];
 
 // ── Sidebar ───────────────────────────────────────────────────────────────────
@@ -247,6 +255,7 @@ function SourceHint({ id }) {
     'drag-and-drop':        '10-DragAndDrop.jsx',
     'map':                  '11-Map.jsx',
     'maintenance-invoicing': '11-MaintenanceAndInvoicing.jsx',
+    'asset-map-widget':     '12-AssetMapWidget.jsx',
     'basic-usage-modern':   'basic-usage.jsx',
     'setup-wizard':         'setup-wizard.jsx',
     'advanced-filters-new': 'advanced-filters.jsx',

--- a/examples/README.md
+++ b/examples/README.md
@@ -22,6 +22,7 @@ npm run examples
 - `10-DragAndDrop.jsx` — drag events across groups / rows
 - `11-Map.jsx` — geographic plot via the optional MapView plugin (see [docs/MapView.md](../docs/MapView.md))
 - `11-MaintenanceAndInvoicing.jsx` — asset-health badges, in-form maintenance completion, CSV export for invoicing + maintenance log
+- `12-AssetMapWidget.jsx` — peek/panel/fullscreen live-asset overlay via the optional `integrations/asset-map-widget` subpath (see [docs/AssetMapWidget.md](../docs/AssetMapWidget.md))
 
 ## Focused examples
 


### PR DESCRIPTION
- docs/AssetMapWidget.md: full guide for the new optional subpath — three modes (peek/panel/fullscreen), prop reference, MapLibre adapter recipe, when-to-pick-vs-MapView matrix.
- examples/12-AssetMapWidget.tsx: drop-in demo using the dependency-free SVG fallback so it runs without extra peers; one stale position to showcase the warning dot.
- examples/App.tsx: register the example so it shows up in the runner.
- docs/README.md, examples/README.md: link the new pages.

## Summary
Describe exactly what this PR changes.

## Scope
- Stage: 
- Planned PR number in sprint: 
- Target files/directories: 
- Why this slice is isolated: 

## Lessons Learned Check (REQUIRED)
Confirm these were actively used while building this PR:

- [ ] PR is intentionally small and isolated
- [ ] Boundary typing was prioritized over internal perfection
- [ ] No silent spread of `any`
- [ ] Advisory root `tsc` was used to catch integration issues
- [ ] I did not assume “looks typed” means “safe”
- [ ] I stopped and isolated typing cascades instead of expanding scope

## Definition of Done (ALL REQUIRED)
This PR is not done unless every box is checked.

- [ ] `npm run type-check:strict` passes
- [ ] Root advisory `tsc --noEmit` passes
- [ ] Tests pass for touched scope at minimum
- [ ] No uncontrolled increase in `any`
- [ ] All new types are intentional and named
- [ ] Public interfaces and exported functions are explicitly typed
- [ ] PR scope matches the sprint plan with no scope creep
- [ ] Any new `any` has an adjacent justification comment
- [ ] No file-wide `: any`
- [ ] No implicit `any` in exported functions

## What Was Typed
List exactly what was typed in this PR.

- 
- 
- 

## What Was Intentionally Left Loose
List anything intentionally not tightened yet.

- 
- 
- 

## `any` Ledger (REQUIRED)
- New `any` added: 
- Existing `any` removed: 
- Net change: 

For every new `any`, explain why it is required and why a safer type was not used yet.

1. 
2. 
3. 

## Boundary Notes
Document any public seams, caller-protection choices, or compatibility decisions.

- 
- 
- 

## Risk Level
- [ ] Low
- [ ] Medium
- [ ] High

Why:

## Validation Evidence
Paste the exact commands run and a short result summary.

```bash
npm run type-check:strict
npx tsc --noEmit -p tsconfig.json
```

Test commands run:

```bash
# paste commands here
```

## Stop Conditions Check
If any item below happened, explain how scope was reduced before merge.

- [ ] `any` started spreading across files
- [ ] Root `tsc` broke repeatedly
- [ ] Types required cross-module rewrites
- [ ] Scope was reduced to keep the PR reviewable

Notes:

## Reviewer Focus
What should reviewers look at first?

- 
- 
- 
