### PR TITLE
feat(demo): add guided walkthrough state machine + onViewChange hook

### DIFF
--- a/demo/App.tsx
+++ b/demo/App.tsx
@@ -32,6 +32,16 @@ import {
   findProfile,
   APPROVAL_ACTION_CAP,
 } from './profiles';
+import WalkthroughHost from './walkthrough/WalkthroughHost';
+import { useWalkthrough } from './walkthrough/useWalkthrough';
+import {
+  ALPHA_INITIAL_RESOURCE,
+  ALPHA_INITIAL_START_ISO,
+  BRAVO_RESOURCE,
+  WALKTHROUGH_ALPHA_ID,
+  WALKTHROUGH_BRAVO_ID,
+  buildWalkthroughEvents,
+} from './walkthrough/fixtures';
 
 /* ─── Demo identity ─────────────────────────────────────────────── */
 // Air EMS demo: new calendar id so the IHC Fleet localStorage doesn't bleed
@@ -335,6 +345,13 @@ const INITIAL_EVENTS = allEvents.map(e => {
     ...(meta ? { meta } : {}),
   };
 });
+
+// Walkthrough fixtures: two seeded mission-assignment events at the same
+// time on different aircraft. Step 2 of the guided tour exploits the
+// overlap to demonstrate conflict detection. Aircraft were chosen because
+// emsData has no other events on those slots, so the conflict is solely
+// caused by Alpha+Bravo.
+INITIAL_EVENTS.push(...buildWalkthroughEvents());
 
 /* ─── Resource pools (#212) ─────────────────────────────────────── */
 // Group aircraft by region so bookings can target a pool instead of a tail
@@ -917,6 +934,22 @@ function App() {
     />
   ), [activeProfile.approval, handleApprovalAction, handleEventDelete]);
 
+  // ── Guided walkthrough wiring ───────────────────────────────────
+  // The walkthrough wraps the existing host callbacks so it can detect
+  // user gestures (drag-to-move, drag-to-reassign, view switch) without
+  // changing the demo's behavior. Suppressed in EMBED_MODE so the raw
+  // calendar embed used by e2e tests stays free of demo chrome.
+  const walkthrough = useWalkthrough({
+    ctx: {
+      alphaEventId:         WALKTHROUGH_ALPHA_ID,
+      bravoEventId:         WALKTHROUGH_BRAVO_ID,
+      bravoResource:        BRAVO_RESOURCE,
+      alphaInitialResource: ALPHA_INITIAL_RESOURCE,
+      alphaInitialStartIso: ALPHA_INITIAL_START_ISO,
+    },
+    delegate: { onEventSave: handleEventSave },
+  });
+
   const calendar = (
     <WorksCalendar
       events={events}
@@ -935,7 +968,8 @@ function App() {
       notes={notes}
       onNoteSave={handleNoteSave}
       onNoteDelete={handleNoteDelete}
-      onEventSave={handleEventSave}
+      onEventSave={EMBED_MODE ? handleEventSave : walkthrough.wrapped.onEventSave}
+      onViewChange={EMBED_MODE ? undefined : walkthrough.wrapped.onViewChange}
       onEventDelete={handleEventDelete}
       onScheduleSave={handleEventSave}
       onAvailabilitySave={handleEventSave}
@@ -986,6 +1020,17 @@ function App() {
         <UpdateToast
           onUpdate={() => { updateSW(true); setNeedsRefresh(false); }}
           onDismiss={() => setNeedsRefresh(false)}
+        />
+      )}
+
+      {!EMBED_MODE && (
+        <WalkthroughHost
+          step={walkthrough.step}
+          state={walkthrough.state}
+          steps={walkthrough.steps}
+          onAdvance={walkthrough.advance}
+          onRestart={walkthrough.restart}
+          onExit={walkthrough.exit}
         />
       )}
     </>

--- a/demo/walkthrough/Walkthrough.module.css
+++ b/demo/walkthrough/Walkthrough.module.css
@@ -1,0 +1,127 @@
+/* demo/walkthrough/Walkthrough.module.css
+ *
+ * Floating banner + button styling for the guided walkthrough. The pulse
+ * animation that highlights the spotlight target is injected as a global
+ * <style> element from WalkthroughHost so it can parameterize the selector
+ * by the active step's target id.
+ */
+
+.banner {
+  position: fixed;
+  top: 80px;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 200;
+  width: min(560px, calc(100vw - 32px));
+  background: #0f172a;
+  color: #f1f5f9;
+  border: 1px solid #334155;
+  border-radius: 12px;
+  padding: 16px 20px;
+  box-shadow: 0 18px 48px rgba(15, 23, 42, 0.4);
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+  font-size: 14px;
+  line-height: 1.45;
+  display: grid;
+  gap: 10px;
+}
+
+.bannerHeader {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.progress {
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: #94a3b8;
+}
+
+.title {
+  font-size: 16px;
+  font-weight: 700;
+  margin: 0;
+  color: #f8fafc;
+}
+
+.body {
+  margin: 0;
+  color: #cbd5e1;
+}
+
+.hint {
+  font-size: 12px;
+  color: #94a3b8;
+  margin: 0;
+  font-style: italic;
+}
+
+.controls {
+  display: flex;
+  gap: 8px;
+  justify-content: flex-end;
+  margin-top: 4px;
+}
+
+.button {
+  background: transparent;
+  color: #cbd5e1;
+  border: 1px solid #334155;
+  border-radius: 6px;
+  padding: 6px 12px;
+  font-size: 12px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 120ms, border-color 120ms;
+}
+.button:hover {
+  background: #1e293b;
+  border-color: #475569;
+}
+
+.primary {
+  background: #f59e0b;
+  color: #0f172a;
+  border-color: #f59e0b;
+}
+.primary:hover {
+  background: #fbbf24;
+  border-color: #fbbf24;
+}
+
+.dismiss {
+  background: transparent;
+  color: #64748b;
+  border: none;
+  font-size: 18px;
+  line-height: 1;
+  padding: 0 4px;
+  cursor: pointer;
+}
+.dismiss:hover {
+  color: #cbd5e1;
+}
+
+/* Resume tour pill — small floating button after the user exits to free play. */
+.resumePill {
+  position: fixed;
+  bottom: 24px;
+  right: 24px;
+  z-index: 200;
+  background: #0f172a;
+  color: #f1f5f9;
+  border: 1px solid #334155;
+  border-radius: 999px;
+  padding: 8px 14px;
+  font-size: 12px;
+  font-weight: 600;
+  cursor: pointer;
+  box-shadow: 0 8px 20px rgba(15, 23, 42, 0.3);
+}
+.resumePill:hover {
+  background: #1e293b;
+}

--- a/demo/walkthrough/WalkthroughBanner.tsx
+++ b/demo/walkthrough/WalkthroughBanner.tsx
@@ -1,0 +1,81 @@
+/**
+ * demo/walkthrough/WalkthroughBanner.tsx — the floating step banner.
+ *
+ * Pure presentation. Reads the active Step + state from props and emits
+ * advance/restart/exit clicks back up. Doesn't know about callbacks or
+ * the calendar — just shows what's happening and offers a way out.
+ */
+
+import type { Step, WalkthroughState } from './types';
+import styles from './Walkthrough.module.css';
+
+interface WalkthroughBannerProps {
+  step: Step;
+  state: WalkthroughState;
+  /** Position of the active step in the visible step list (1-based). Pass 0
+   *  to suppress the "Step N of M" eyebrow (e.g. on the terminal step). */
+  stepIndex: number;
+  totalSteps: number;
+  onAdvance: () => void;
+  onRestart: () => void;
+  onExit: () => void;
+}
+
+export default function WalkthroughBanner({
+  step,
+  state,
+  stepIndex,
+  totalSteps,
+  onAdvance,
+  onRestart,
+  onExit,
+}: WalkthroughBannerProps) {
+  if (state.mode === 'free-play') return null;
+
+  const isDone = step.id === 'done';
+
+  return (
+    <div className={styles['banner']} role="dialog" aria-live="polite" aria-label="Guided walkthrough">
+      <div className={styles['bannerHeader']}>
+        {!isDone && stepIndex > 0 && (
+          <span className={styles['progress']}>
+            Step {stepIndex} of {totalSteps}
+          </span>
+        )}
+        <button
+          type="button"
+          className={styles['dismiss']}
+          onClick={onExit}
+          aria-label="Exit guided tour"
+          title="Exit guided tour"
+        >
+          ×
+        </button>
+      </div>
+      <h2 className={styles['title']}>{step.banner.title}</h2>
+      <p className={styles['body']}>{step.banner.body}</p>
+      {!isDone && step.hint && <p className={styles['hint']}>Tip: {step.hint}</p>}
+      <div className={styles['controls']}>
+        {isDone ? (
+          <>
+            <button type="button" className={styles['button']} onClick={onExit}>
+              Free play
+            </button>
+            <button type="button" className={`${styles['button']} ${styles['primary']}`} onClick={onRestart}>
+              Restart tour
+            </button>
+          </>
+        ) : (
+          <>
+            <button type="button" className={styles['button']} onClick={onExit}>
+              Skip tour
+            </button>
+            <button type="button" className={styles['button']} onClick={onAdvance}>
+              Skip step
+            </button>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/demo/walkthrough/WalkthroughHost.tsx
+++ b/demo/walkthrough/WalkthroughHost.tsx
@@ -1,0 +1,95 @@
+/**
+ * demo/walkthrough/WalkthroughHost.tsx — composes banner + spotlight.
+ *
+ * Renders the WalkthroughBanner and injects a global <style> rule that
+ * pulses whichever element matches the current step's spotlight target.
+ * Targeting is done via CSS attribute selectors, so the rule survives
+ * any React-driven DOM re-rendering of the pill or button.
+ *
+ * In free-play mode, renders only a small "Restart tour" pill in the
+ * corner so users who skipped can opt back in.
+ */
+
+import { useMemo } from 'react';
+import WalkthroughBanner from './WalkthroughBanner';
+import type { Step, StepSpotlight, WalkthroughState } from './types';
+import styles from './Walkthrough.module.css';
+
+interface WalkthroughHostProps {
+  step: Step;
+  state: WalkthroughState;
+  steps: readonly Step[];
+  onAdvance: () => void;
+  onRestart: () => void;
+  onExit: () => void;
+}
+
+export default function WalkthroughHost({
+  step,
+  state,
+  steps,
+  onAdvance,
+  onRestart,
+  onExit,
+}: WalkthroughHostProps) {
+  // Visible-step counting: drop the terminal 'done' record so the user sees
+  // "Step 1 of 5" rather than "Step 1 of 6".
+  const visibleSteps = useMemo(() => steps.filter(s => s.id !== 'done'), [steps]);
+  const stepIndex = visibleSteps.findIndex(s => s.id === step.id) + 1;
+
+  const spotlightCss = buildSpotlightCss(step.spotlight);
+
+  if (state.mode === 'free-play') {
+    return (
+      <button type="button" className={styles['resumePill']} onClick={onRestart}>
+        Restart tour
+      </button>
+    );
+  }
+
+  return (
+    <>
+      {spotlightCss && <style>{spotlightCss}</style>}
+      <WalkthroughBanner
+        step={step}
+        state={state}
+        stepIndex={stepIndex}
+        totalSteps={visibleSteps.length}
+        onAdvance={onAdvance}
+        onRestart={onRestart}
+        onExit={onExit}
+      />
+    </>
+  );
+}
+
+function buildSpotlightCss(spotlight: StepSpotlight | undefined): string | null {
+  if (!spotlight) return null;
+  const selector = spotlight.eventId
+    ? `[data-wc-event-id="${escapeAttr(spotlight.eventId)}"]`
+    : spotlight.selector ?? null;
+  if (!selector) return null;
+
+  // outline + box-shadow pulse. Position relative + z-index keeps the glow
+  // above neighboring pills without changing layout.
+  return `
+    ${selector} {
+      position: relative;
+      z-index: 5;
+      outline: 3px solid #f59e0b;
+      outline-offset: 2px;
+      border-radius: 6px;
+      animation: wc-walkthrough-pulse 1.6s ease-in-out infinite;
+    }
+    @keyframes wc-walkthrough-pulse {
+      0%, 100% { box-shadow: 0 0 0 0 rgba(245, 158, 11, 0.55); }
+      50%      { box-shadow: 0 0 0 10px rgba(245, 158, 11, 0); }
+    }
+  `;
+}
+
+/** Strip anything that could escape an attribute-value selector. Our seed ids
+ *  are alphanumeric+dash, so this is defense-in-depth, not a real threat. */
+function escapeAttr(v: string): string {
+  return v.replace(/["\\]/g, '');
+}

--- a/demo/walkthrough/fixtures.ts
+++ b/demo/walkthrough/fixtures.ts
@@ -19,7 +19,8 @@ export const ALPHA_INITIAL_RESOURCE = 'ac-n801aw';
 /** Aircraft id Bravo parks on — Step 2 conflict target. */
 export const BRAVO_RESOURCE = 'ac-n804aw';
 
-const SLOT_START = '2026-04-23T14:00:00';
+export const ALPHA_INITIAL_START_ISO = '2026-04-23T14:00:00';
+const SLOT_START = ALPHA_INITIAL_START_ISO;
 const SLOT_END   = '2026-04-23T15:00:00';
 
 const MISSION_COLOR = '#a855f7';

--- a/demo/walkthrough/fixtures.ts
+++ b/demo/walkthrough/fixtures.ts
@@ -1,0 +1,61 @@
+/**
+ * demo/walkthrough/fixtures.ts — seed events the walkthrough injects on mount.
+ *
+ * Two mission-assignment events at the same time on different aircraft:
+ *   - Alpha: the highlighted job the user manipulates through every step.
+ *   - Bravo: a decoy on a different aircraft, occupying the same time slot
+ *            so Step 2 ("drag onto another resource at the same time") lands
+ *            on a guaranteed conflict.
+ *
+ * Aircraft picked because they have no other events on this date in
+ * emsData.ts, so the conflict in Step 2 is solely caused by Alpha+Bravo.
+ */
+
+export const WALKTHROUGH_ALPHA_ID = 'wt-alpha';
+export const WALKTHROUGH_BRAVO_ID = 'wt-bravo';
+
+/** Aircraft id Alpha starts on. Free at this slot in emsData. */
+export const ALPHA_INITIAL_RESOURCE = 'ac-n801aw';
+/** Aircraft id Bravo parks on — Step 2 conflict target. */
+export const BRAVO_RESOURCE = 'ac-n804aw';
+
+const SLOT_START = '2026-04-23T14:00:00';
+const SLOT_END   = '2026-04-23T15:00:00';
+
+const MISSION_COLOR = '#a855f7';
+
+interface SeedEventInput {
+  id: string;
+  title: string;
+  start: string;
+  end: string;
+  category: string;
+  resource: string;
+  color: string;
+  meta?: Record<string, unknown>;
+}
+
+export function buildWalkthroughEvents(): SeedEventInput[] {
+  return [
+    {
+      id: WALKTHROUGH_ALPHA_ID,
+      title: 'Walkthrough · Mission Alpha',
+      start: SLOT_START,
+      end:   SLOT_END,
+      category: 'mission-assignment',
+      resource: ALPHA_INITIAL_RESOURCE,
+      color: MISSION_COLOR,
+      meta: { walkthroughRole: 'alpha' },
+    },
+    {
+      id: WALKTHROUGH_BRAVO_ID,
+      title: 'Walkthrough · Mission Bravo',
+      start: SLOT_START,
+      end:   SLOT_END,
+      category: 'mission-assignment',
+      resource: BRAVO_RESOURCE,
+      color: MISSION_COLOR,
+      meta: { walkthroughRole: 'bravo' },
+    },
+  ];
+}

--- a/demo/walkthrough/reducer.test.ts
+++ b/demo/walkthrough/reducer.test.ts
@@ -16,6 +16,7 @@ const CTX: StepContext = {
   bravoEventId: 'wt-bravo',
   bravoResource: 'ac-n804aw',
   alphaInitialResource: 'ac-n801aw',
+  alphaInitialStartIso: '2026-04-23T14:00:00',
 };
 
 const DEPS: ReducerDeps = { steps: STEPS, ctx: CTX };

--- a/demo/walkthrough/reducer.test.ts
+++ b/demo/walkthrough/reducer.test.ts
@@ -1,0 +1,142 @@
+/**
+ * demo/walkthrough/reducer.test.ts — pure state machine tests.
+ *
+ * Validates the four action types (observe / advance / restart / exit) drive
+ * the right transitions across every step. The reducer has no React or DOM
+ * dependencies, so we exercise it directly with synthetic events.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { INITIAL_STATE, reducer, type ReducerDeps } from './reducer';
+import { STEPS } from './steps';
+import type { StepContext, WalkthroughEvent } from './types';
+
+const CTX: StepContext = {
+  alphaEventId: 'wt-alpha',
+  bravoEventId: 'wt-bravo',
+  bravoResource: 'ac-n804aw',
+  alphaInitialResource: 'ac-n801aw',
+};
+
+const DEPS: ReducerDeps = { steps: STEPS, ctx: CTX };
+
+const moved = (eventId: string): WalkthroughEvent => ({
+  kind: 'event-moved',
+  eventId,
+  previousResource: CTX.alphaInitialResource,
+  previousStartIso: '2026-04-23T14:00:00',
+});
+
+const reassigned = (toResource: string | null): WalkthroughEvent => ({
+  kind: 'event-reassigned',
+  eventId: CTX.alphaEventId,
+  toResource,
+});
+
+const conflict: WalkthroughEvent = {
+  kind: 'conflict-detected',
+  eventId: CTX.alphaEventId,
+  conflictingEventId: CTX.bravoEventId,
+};
+
+const view = (v: string): WalkthroughEvent => ({ kind: 'view-changed', view: v });
+
+describe('walkthrough reducer', () => {
+  it('starts at move-job in guided mode', () => {
+    expect(INITIAL_STATE.currentStep).toBe('move-job');
+    expect(INITIAL_STATE.mode).toBe('guided');
+    expect(INITIAL_STATE.history).toEqual([]);
+  });
+
+  it('advances through the full happy path on matching observations', () => {
+    let state = INITIAL_STATE;
+    state = reducer(state, { type: 'observe', event: moved(CTX.alphaEventId) }, DEPS);
+    expect(state.currentStep).toBe('cause-conflict');
+
+    state = reducer(state, { type: 'observe', event: conflict }, DEPS);
+    expect(state.currentStep).toBe('fix-conflict');
+
+    state = reducer(state, { type: 'observe', event: reassigned('ac-n802ec') }, DEPS);
+    expect(state.currentStep).toBe('switch-view');
+
+    state = reducer(state, { type: 'observe', event: view('schedule') }, DEPS);
+    expect(state.currentStep).toBe('open-map');
+
+    state = reducer(state, { type: 'observe', event: view('map') }, DEPS);
+    expect(state.currentStep).toBe('done');
+
+    expect(state.history).toEqual([
+      'move-job', 'cause-conflict', 'fix-conflict', 'switch-view', 'open-map',
+    ]);
+    expect(state.bootstrapping).toBe(false);
+  });
+
+  it('ignores observations that do not match the current step', () => {
+    const stateA = reducer(INITIAL_STATE, { type: 'observe', event: view('schedule') }, DEPS);
+    expect(stateA.currentStep).toBe('move-job');
+
+    const stateB = reducer(INITIAL_STATE, { type: 'observe', event: moved('some-other-event') }, DEPS);
+    expect(stateB.currentStep).toBe('move-job');
+  });
+
+  it('treats fix-conflict reassign back to bravo as not yet resolved', () => {
+    let state = INITIAL_STATE;
+    state = reducer(state, { type: 'observe', event: moved(CTX.alphaEventId) }, DEPS);
+    state = reducer(state, { type: 'observe', event: conflict }, DEPS);
+    expect(state.currentStep).toBe('fix-conflict');
+
+    // Reassigning back onto the same conflicting resource should NOT advance.
+    state = reducer(state, { type: 'observe', event: reassigned(CTX.bravoResource) }, DEPS);
+    expect(state.currentStep).toBe('fix-conflict');
+
+    // Any other resource clears it.
+    state = reducer(state, { type: 'observe', event: reassigned('ac-n802ec') }, DEPS);
+    expect(state.currentStep).toBe('switch-view');
+  });
+
+  it('manual advance jumps forward without an observation', () => {
+    const next = reducer(INITIAL_STATE, { type: 'advance' }, DEPS);
+    expect(next.currentStep).toBe('cause-conflict');
+    expect(next.history).toEqual(['move-job']);
+  });
+
+  it('does not advance past done', () => {
+    const done = { ...INITIAL_STATE, currentStep: 'done' as const };
+    expect(reducer(done, { type: 'advance' }, DEPS)).toEqual(done);
+    expect(reducer(done, { type: 'observe', event: moved(CTX.alphaEventId) }, DEPS)).toEqual(done);
+  });
+
+  it('exit switches to free-play and ignores subsequent observations', () => {
+    let state = reducer(INITIAL_STATE, { type: 'exit' }, DEPS);
+    expect(state.mode).toBe('free-play');
+    state = reducer(state, { type: 'observe', event: moved(CTX.alphaEventId) }, DEPS);
+    expect(state.currentStep).toBe('move-job');
+    expect(state.mode).toBe('free-play');
+  });
+
+  it('restart returns to the initial state from any mode', () => {
+    const wandered = reducer(INITIAL_STATE, { type: 'advance' }, DEPS);
+    const reset = reducer(wandered, { type: 'restart' }, DEPS);
+    expect(reset).toEqual(INITIAL_STATE);
+
+    const exited = reducer(INITIAL_STATE, { type: 'exit' }, DEPS);
+    expect(reducer(exited, { type: 'restart' }, DEPS)).toEqual(INITIAL_STATE);
+  });
+
+  it('cause-conflict accepts either a conflict-detected or a reassign-onto-bravo event', () => {
+    const afterMove = reducer(INITIAL_STATE, { type: 'observe', event: moved(CTX.alphaEventId) }, DEPS);
+    expect(afterMove.currentStep).toBe('cause-conflict');
+
+    const viaReassign = reducer(afterMove, { type: 'observe', event: reassigned(CTX.bravoResource) }, DEPS);
+    expect(viaReassign.currentStep).toBe('fix-conflict');
+  });
+
+  it('open-map step accepts either map-widget-opened or view-changed:map', () => {
+    const start = { ...INITIAL_STATE, currentStep: 'open-map' as const };
+    const widget = reducer(start, { type: 'observe', event: { kind: 'map-widget-opened' } }, DEPS);
+    expect(widget.currentStep).toBe('done');
+
+    const viaView = reducer(start, { type: 'observe', event: view('map') }, DEPS);
+    expect(viaView.currentStep).toBe('done');
+  });
+});

--- a/demo/walkthrough/reducer.ts
+++ b/demo/walkthrough/reducer.ts
@@ -1,0 +1,77 @@
+/**
+ * demo/walkthrough/reducer.ts — pure state machine.
+ *
+ * No React, no DOM, no localStorage. Given a state + action, returns the
+ * next state. Tests poke at this directly to verify step ordering,
+ * mismatched events stay on the current step, exit/restart shortcuts, etc.
+ */
+
+import type {
+  Step,
+  StepContext,
+  StepId,
+  WalkthroughAction,
+  WalkthroughState,
+} from './types';
+
+export interface ReducerDeps {
+  steps: readonly Step[];
+  ctx: StepContext;
+}
+
+export const INITIAL_STATE: WalkthroughState = {
+  mode: 'guided',
+  currentStep: 'move-job',
+  history: [],
+  bootstrapping: true,
+};
+
+function findStep(steps: readonly Step[], id: StepId): Step | undefined {
+  return steps.find(s => s.id === id);
+}
+
+function nextStepId(steps: readonly Step[], current: StepId): StepId {
+  const idx = steps.findIndex(s => s.id === current);
+  if (idx < 0 || idx === steps.length - 1) return 'done';
+  return steps[idx + 1]!.id;
+}
+
+export function reducer(
+  state: WalkthroughState,
+  action: WalkthroughAction,
+  deps: ReducerDeps,
+): WalkthroughState {
+  // Free-play swallows every action except restart — the user opted out.
+  if (state.mode === 'free-play' && action.type !== 'restart') return state;
+
+  switch (action.type) {
+    case 'observe': {
+      if (state.currentStep === 'done') return state;
+      const step = findStep(deps.steps, state.currentStep);
+      if (!step) return state;
+      if (!step.matches(action.event, deps.ctx)) return state;
+      return {
+        ...state,
+        bootstrapping: false,
+        currentStep: nextStepId(deps.steps, state.currentStep),
+        history: [...state.history, state.currentStep],
+      };
+    }
+
+    case 'advance': {
+      if (state.currentStep === 'done') return state;
+      return {
+        ...state,
+        bootstrapping: false,
+        currentStep: nextStepId(deps.steps, state.currentStep),
+        history: [...state.history, state.currentStep],
+      };
+    }
+
+    case 'restart':
+      return { ...INITIAL_STATE };
+
+    case 'exit':
+      return { ...state, mode: 'free-play' };
+  }
+}

--- a/demo/walkthrough/steps.ts
+++ b/demo/walkthrough/steps.ts
@@ -1,0 +1,102 @@
+/**
+ * demo/walkthrough/steps.ts — the 6 guided steps + their match predicates.
+ *
+ * Each step is self-contained: banner copy, what to spotlight, and a pure
+ * predicate that the reducer calls against every observed WalkthroughEvent.
+ *
+ * Step order matches the spec in the demo-guided-walkthrough plan:
+ *   1. move-job        — drag highlighted job to a new time
+ *   2. cause-conflict  — drag it onto a busy resource → red highlight
+ *   3. fix-conflict    — reassign to a free resource → conflict clears
+ *   4. switch-view     — toolbar: switch to schedule (timeline)
+ *   5. open-map        — open map widget (deferred; detection wired by the
+ *                        map-widget branch when it lands)
+ *   6. done            — terminal CTA ("Now you get it")
+ */
+
+import type { Step } from './types';
+
+export const STEPS: readonly Step[] = [
+  {
+    id: 'move-job',
+    banner: {
+      title: 'Step 1 of 4 — Move a job',
+      body:  'Drag the highlighted mission to a new time on the calendar.',
+    },
+    spotlight: { /* eventId filled in by the host using ctx.alphaEventId */ },
+    matches: (event, ctx) =>
+      event.kind === 'event-moved' && event.eventId === ctx.alphaEventId,
+    hint: 'Click and hold the purple "Mission Alpha" pill, then drag it to a different hour.',
+  },
+
+  {
+    id: 'cause-conflict',
+    banner: {
+      title: 'Step 2 of 4 — Trigger a conflict',
+      body:  'Now drag Mission Alpha onto Mission Bravo’s aircraft at the same time.',
+    },
+    matches: (event, ctx) => {
+      // A reassign onto Bravo's aircraft should immediately overlap Bravo.
+      // We accept either signal — whichever the host emits first.
+      if (event.kind === 'conflict-detected') {
+        return event.eventId === ctx.alphaEventId
+          && event.conflictingEventId === ctx.bravoEventId;
+      }
+      if (event.kind === 'event-reassigned') {
+        return event.eventId === ctx.alphaEventId
+          && event.toResource === ctx.bravoResource;
+      }
+      return false;
+    },
+    hint: 'Drag Mission Alpha onto Bravo’s row — they’ll overlap and the calendar will flag the conflict.',
+  },
+
+  {
+    id: 'fix-conflict',
+    banner: {
+      title: 'Step 3 of 4 — Resolve the conflict',
+      body:  'Reassign Mission Alpha to any other available aircraft.',
+    },
+    matches: (event, ctx) =>
+      event.kind === 'event-reassigned'
+      && event.eventId === ctx.alphaEventId
+      && event.toResource !== null
+      && event.toResource !== ctx.bravoResource,
+    hint: 'Drag Mission Alpha to a different aircraft row — anything except Bravo’s aircraft works.',
+  },
+
+  {
+    id: 'switch-view',
+    banner: {
+      title: 'Step 4 of 4 — Switch to the schedule view',
+      body:  'See the same data as a resource timeline. Use the view toggle in the toolbar.',
+    },
+    spotlight: { selector: '[data-view-button="schedule"]' },
+    matches: (event) =>
+      event.kind === 'view-changed' && event.view === 'schedule',
+    hint: 'Look for the view toggle in the calendar toolbar and pick "Schedule".',
+  },
+
+  {
+    id: 'open-map',
+    banner: {
+      title: 'Bonus — See where your fleet is',
+      body:  'Open the map widget to see resource locations at a glance.',
+    },
+    // Two emit paths: dedicated map widget (preferred, coming on another
+    // branch) or the existing built-in `map` view as a fallback.
+    matches: (event) =>
+      event.kind === 'map-widget-opened'
+      || (event.kind === 'view-changed' && event.view === 'map'),
+    hint: 'Click the map icon — it shows where each aircraft is right now.',
+  },
+
+  {
+    id: 'done',
+    banner: {
+      title: 'You’ve got it.',
+      body:  'WorksCalendar manages resources, conflicts, and scheduling logic — not just events. Explore on your own, or restart the tour anytime.',
+    },
+    matches: () => false,
+  },
+];

--- a/demo/walkthrough/steps.ts
+++ b/demo/walkthrough/steps.ts
@@ -14,27 +14,29 @@
  *   6. done            — terminal CTA ("Now you get it")
  */
 
+import { WALKTHROUGH_ALPHA_ID } from './fixtures';
 import type { Step } from './types';
 
 export const STEPS: readonly Step[] = [
   {
     id: 'move-job',
     banner: {
-      title: 'Step 1 of 4 — Move a job',
+      title: 'Move a job',
       body:  'Drag the highlighted mission to a new time on the calendar.',
     },
-    spotlight: { /* eventId filled in by the host using ctx.alphaEventId */ },
+    spotlight: { eventId: WALKTHROUGH_ALPHA_ID },
     matches: (event, ctx) =>
       event.kind === 'event-moved' && event.eventId === ctx.alphaEventId,
-    hint: 'Click and hold the purple "Mission Alpha" pill, then drag it to a different hour.',
+    hint: 'Click and hold the highlighted "Mission Alpha" pill, then drag it to a different hour.',
   },
 
   {
     id: 'cause-conflict',
     banner: {
-      title: 'Step 2 of 4 — Trigger a conflict',
+      title: 'Trigger a conflict',
       body:  'Now drag Mission Alpha onto Mission Bravo’s aircraft at the same time.',
     },
+    spotlight: { eventId: WALKTHROUGH_ALPHA_ID },
     matches: (event, ctx) => {
       // A reassign onto Bravo's aircraft should immediately overlap Bravo.
       // We accept either signal — whichever the host emits first.
@@ -54,9 +56,10 @@ export const STEPS: readonly Step[] = [
   {
     id: 'fix-conflict',
     banner: {
-      title: 'Step 3 of 4 — Resolve the conflict',
+      title: 'Resolve the conflict',
       body:  'Reassign Mission Alpha to any other available aircraft.',
     },
+    spotlight: { eventId: WALKTHROUGH_ALPHA_ID },
     matches: (event, ctx) =>
       event.kind === 'event-reassigned'
       && event.eventId === ctx.alphaEventId
@@ -68,10 +71,10 @@ export const STEPS: readonly Step[] = [
   {
     id: 'switch-view',
     banner: {
-      title: 'Step 4 of 4 — Switch to the schedule view',
+      title: 'Switch to the schedule view',
       body:  'See the same data as a resource timeline. Use the view toggle in the toolbar.',
     },
-    spotlight: { selector: '[data-view-button="schedule"]' },
+    spotlight: { selector: '[data-wc-view-button="schedule"]' },
     matches: (event) =>
       event.kind === 'view-changed' && event.view === 'schedule',
     hint: 'Look for the view toggle in the calendar toolbar and pick "Schedule".',

--- a/demo/walkthrough/types.ts
+++ b/demo/walkthrough/types.ts
@@ -61,6 +61,7 @@ export interface StepContext {
   bravoEventId: string;       // the decoy that creates the Step 2 conflict
   bravoResource: string;      // aircraft id Bravo is parked on
   alphaInitialResource: string;
+  alphaInitialStartIso: string; // start time from the seed; used to detect Step 1 moves
 }
 
 export interface WalkthroughState {

--- a/demo/walkthrough/types.ts
+++ b/demo/walkthrough/types.ts
@@ -1,0 +1,79 @@
+/**
+ * demo/walkthrough/types.ts — guided walkthrough state machine types.
+ *
+ * The walkthrough is strictly observational: it wraps the existing demo
+ * callbacks (onEventMove, onConflictCheck, onViewChange, …), inspects each
+ * event, and advances when the user performs the action the current step
+ * is waiting for. It never replaces the demo's own behavior.
+ */
+
+export type StepId =
+  | 'move-job'        // Step 1: drag highlighted event to a new time
+  | 'cause-conflict'  // Step 2: drag it onto a resource that's already busy
+  | 'fix-conflict'    // Step 3: reassign to a free resource
+  | 'switch-view'     // Step 4: switch to schedule (timeline) view
+  | 'open-map'        // Step 5: open the map widget (deferred — other branch)
+  | 'done';           // terminal: "now you get it" CTA
+
+export type WalkthroughMode = 'guided' | 'free-play';
+
+/**
+ * Discriminated union of events the adapter layer pushes into the reducer.
+ * Every step is an `expect` matcher over this union.
+ */
+export type WalkthroughEvent =
+  | { kind: 'event-moved'; eventId: string; previousResource: string | null; previousStartIso: string }
+  | { kind: 'conflict-detected'; eventId: string; conflictingEventId: string }
+  | { kind: 'event-reassigned'; eventId: string; toResource: string | null }
+  | { kind: 'view-changed'; view: string }
+  | { kind: 'map-widget-opened' }
+  | { kind: 'manual-advance' };
+
+export interface StepBanner {
+  title: string;
+  body: string;
+}
+
+export interface StepSpotlight {
+  /** Pulse the event with this id in the calendar grid. */
+  eventId?: string;
+  /** Or pulse the DOM node matching this CSS selector (toolbar buttons, etc.). */
+  selector?: string;
+}
+
+export interface Step {
+  id: StepId;
+  banner: StepBanner;
+  spotlight?: StepSpotlight;
+  /** Predicate evaluated against each observed event; truthy → advance. */
+  matches: (event: WalkthroughEvent, ctx: StepContext) => boolean;
+  /** Hint copy shown after the user has been idle on this step. */
+  hint?: string;
+}
+
+/**
+ * Per-step context the reducer threads through `matches`. Lets steps
+ * reference walkthrough-seeded ids (alpha, bravo, free resource) without
+ * hard-coding strings into the predicates.
+ */
+export interface StepContext {
+  alphaEventId: string;       // the highlighted event the user manipulates
+  bravoEventId: string;       // the decoy that creates the Step 2 conflict
+  bravoResource: string;      // aircraft id Bravo is parked on
+  alphaInitialResource: string;
+}
+
+export interface WalkthroughState {
+  mode: WalkthroughMode;
+  currentStep: StepId;
+  /** Step ids the user has already cleared, oldest → newest. */
+  history: StepId[];
+  /** True between mount + first user gesture; suppresses the banner briefly. */
+  bootstrapping: boolean;
+}
+
+export type WalkthroughAction =
+  | { type: 'observe'; event: WalkthroughEvent }
+  | { type: 'advance' }       // imperative "next" — used by manual-advance buttons
+  | { type: 'restart' }       // jump back to the first step
+  | { type: 'exit' };         // switch to free-play mode

--- a/demo/walkthrough/useWalkthrough.ts
+++ b/demo/walkthrough/useWalkthrough.ts
@@ -1,0 +1,161 @@
+/**
+ * demo/walkthrough/useWalkthrough.ts — React surface for the walkthrough.
+ *
+ * Wraps the pure reducer in a hook and exposes:
+ *   • `state`         — current step, mode, history, etc.
+ *   • `step`          — the active Step record (banner + spotlight + hint)
+ *   • `wrap`          — adapters that decorate the demo's existing host
+ *                       callbacks. They never replace behavior; they just
+ *                       inspect each call and emit observe() events.
+ *   • controls        — `advance`, `restart`, `exit`
+ *
+ * No localStorage persistence yet — the walkthrough is session-scoped.
+ * Returning visitors who saw it once can opt back in via a "Restart tour"
+ * button that we'll wire when we mount the UI.
+ */
+
+import { useCallback, useMemo, useReducer, useRef } from 'react';
+import { INITIAL_STATE, reducer } from './reducer';
+import { STEPS } from './steps';
+import type {
+  Step,
+  StepContext,
+  WalkthroughEvent,
+  WalkthroughState,
+} from './types';
+
+interface UseWalkthroughArgs {
+  ctx: StepContext;
+  /** Pre-existing host callbacks. Each `wrap*` returns a decorated version
+   *  that calls the original and then emits the right WalkthroughEvent. */
+  delegate: HostDelegate;
+}
+
+export interface HostDelegate {
+  onEventMove?: (event: HostEvent, newStart: Date, newEnd: Date) => void;
+  onEventSave?: (event: HostEvent) => void;
+  onConflictCheck?: (event: HostEvent, candidate: HostEvent) => Promise<unknown> | unknown;
+  onViewChange?: (view: string) => void;
+}
+
+/** Minimal event shape the adapter cares about — kept loose so the demo's
+ *  @ts-nocheck event objects flow through without friction. */
+interface HostEvent {
+  id?: string;
+  resource?: string | null;
+  start?: string | Date;
+  end?: string | Date;
+}
+
+export interface WalkthroughHandle {
+  state: WalkthroughState;
+  step: Step;
+  steps: readonly Step[];
+  wrapped: HostDelegate;
+  observe: (event: WalkthroughEvent) => void;
+  advance: () => void;
+  restart: () => void;
+  exit: () => void;
+}
+
+export function useWalkthrough({ ctx, delegate }: UseWalkthroughArgs): WalkthroughHandle {
+  const [state, dispatch] = useReducer(
+    (s: WalkthroughState, a: Parameters<typeof reducer>[1]) =>
+      reducer(s, a, { steps: STEPS, ctx }),
+    INITIAL_STATE,
+  );
+
+  // Snapshot of the previous state of Alpha so we can tell a "move" (time
+  // change, same resource) from a "reassign" (resource change). Refs because
+  // adapters fire outside React's render cycle.
+  const lastAlphaSnapshot = useRef<{ resource: string | null; startIso: string }>({
+    resource: ctx.alphaInitialResource,
+    startIso: '',
+  });
+
+  const observe = useCallback((event: WalkthroughEvent) => {
+    dispatch({ type: 'observe', event });
+  }, []);
+
+  const advance = useCallback(() => dispatch({ type: 'advance' }), []);
+  const restart = useCallback(() => dispatch({ type: 'restart' }), []);
+  const exit    = useCallback(() => dispatch({ type: 'exit' }), []);
+
+  const wrapped = useMemo<HostDelegate>(() => ({
+    onEventMove: (ev, newStart, newEnd) => {
+      delegate.onEventMove?.(ev, newStart, newEnd);
+      if (ev.id !== ctx.alphaEventId) return;
+      const prevStartIso = lastAlphaSnapshot.current.startIso;
+      observe({
+        kind: 'event-moved',
+        eventId: ev.id,
+        previousResource: lastAlphaSnapshot.current.resource,
+        previousStartIso: prevStartIso,
+      });
+      lastAlphaSnapshot.current = {
+        resource: lastAlphaSnapshot.current.resource,
+        startIso: toIso(newStart),
+      };
+    },
+
+    onEventSave: (ev) => {
+      delegate.onEventSave?.(ev);
+      if (ev.id !== ctx.alphaEventId) return;
+      const prevResource = lastAlphaSnapshot.current.resource;
+      const nextResource = ev.resource ?? null;
+      if (prevResource !== nextResource) {
+        observe({
+          kind: 'event-reassigned',
+          eventId: ev.id,
+          toResource: nextResource,
+        });
+        lastAlphaSnapshot.current = {
+          resource: nextResource,
+          startIso: toIso(ev.start ?? lastAlphaSnapshot.current.startIso),
+        };
+      }
+    },
+
+    onConflictCheck: async (ev, candidate) => {
+      const result = await delegate.onConflictCheck?.(ev, candidate);
+      if (ev.id === ctx.alphaEventId && result) {
+        // The host returned a conflict object — the calendar uses it to
+        // flag overlap. We don't care about the shape, only that one was
+        // detected against the Bravo decoy.
+        observe({
+          kind: 'conflict-detected',
+          eventId: ev.id,
+          conflictingEventId: ctx.bravoEventId,
+        });
+      }
+      return result;
+    },
+
+    onViewChange: (view) => {
+      delegate.onViewChange?.(view);
+      observe({ kind: 'view-changed', view });
+    },
+  }), [delegate, ctx.alphaEventId, ctx.bravoEventId, observe]);
+
+  const step = useMemo<Step>(() => {
+    const found = STEPS.find(s => s.id === state.currentStep);
+    // STEPS always contains a 'done' record, so this is unreachable. The
+    // fallback exists only to satisfy the type checker.
+    return found ?? STEPS[STEPS.length - 1]!;
+  }, [state.currentStep]);
+
+  return {
+    state,
+    step,
+    steps: STEPS,
+    wrapped,
+    observe,
+    advance,
+    restart,
+    exit,
+  };
+}
+
+function toIso(d: string | Date): string {
+  return d instanceof Date ? d.toISOString() : d;
+}

--- a/demo/walkthrough/useWalkthrough.ts
+++ b/demo/walkthrough/useWalkthrough.ts
@@ -67,10 +67,11 @@ export function useWalkthrough({ ctx, delegate }: UseWalkthroughArgs): Walkthrou
 
   // Snapshot of the previous state of Alpha so we can tell a "move" (time
   // change, same resource) from a "reassign" (resource change). Refs because
-  // adapters fire outside React's render cycle.
+  // adapters fire outside React's render cycle. Seeded from ctx so the very
+  // first drag is observable — otherwise Step 1 never advances.
   const lastAlphaSnapshot = useRef<{ resource: string | null; startIso: string }>({
     resource: ctx.alphaInitialResource,
-    startIso: '',
+    startIso: ctx.alphaInitialStartIso,
   });
 
   const observe = useCallback((event: WalkthroughEvent) => {
@@ -101,19 +102,29 @@ export function useWalkthrough({ ctx, delegate }: UseWalkthroughArgs): Walkthrou
     onEventSave: (ev) => {
       delegate.onEventSave?.(ev);
       if (ev.id !== ctx.alphaEventId) return;
-      const prevResource = lastAlphaSnapshot.current.resource;
+      const snapshot     = lastAlphaSnapshot.current;
       const nextResource = ev.resource ?? null;
-      if (prevResource !== nextResource) {
+      const nextStartIso = toIso(ev.start ?? snapshot.startIso);
+
+      // The demo wires drag-drop through onEventSave for both time and
+      // resource changes (no separate onEventMove / onEventGroupChange).
+      // Distinguish them here so steps 1 and 2/3 see different events.
+      if (snapshot.resource !== nextResource) {
         observe({
           kind: 'event-reassigned',
-          eventId: ev.id,
+          eventId: ev.id ?? '',
           toResource: nextResource,
         });
-        lastAlphaSnapshot.current = {
-          resource: nextResource,
-          startIso: toIso(ev.start ?? lastAlphaSnapshot.current.startIso),
-        };
+      } else if (snapshot.startIso !== nextStartIso) {
+        observe({
+          kind: 'event-moved',
+          eventId: ev.id ?? '',
+          previousResource: snapshot.resource,
+          previousStartIso: snapshot.startIso,
+        });
       }
+
+      lastAlphaSnapshot.current = { resource: nextResource, startIso: nextStartIso };
     },
 
     onConflictCheck: async (ev, candidate) => {

--- a/src/WorksCalendar.tsx
+++ b/src/WorksCalendar.tsx
@@ -217,6 +217,7 @@ export type WorksCalendarProps = {
   onEventDelete?: (eventId: string) => void;
   onEventGroupChange?: (event: WorksCalendarEvent, patch: EventGroupPatch) => void;
   onDateSelect?: (start: Date, end: Date, resourceId?: string) => void;
+  onViewChange?: (view: CalendarView) => void;
   supabaseUrl?: string;
   supabaseKey?: string;
   supabaseTable?: string;
@@ -546,6 +547,7 @@ export const WorksCalendar = forwardRef<CalendarApi, WorksCalendarProps>(functio
     onEventDelete,
     onEventGroupChange,
     onDateSelect,
+    onViewChange,
 
     // ── Supabase realtime ──
     supabaseUrl,
@@ -688,6 +690,24 @@ export const WorksCalendar = forwardRef<CalendarApi, WorksCalendarProps>(functio
     [filterSchema, configuredEmployees, effectiveAssets],
   );
   const cal = useCalendar([], initialView ?? 'month', schema);
+
+  // Notify host on view changes (toolbar click, keyboard shortcut, programmatic
+  // setView). Skips the initial mount so consumers don't get a synthetic event
+  // for the default view. Used by the demo walkthrough to advance steps when
+  // the user switches to schedule/map.
+  // useCalendar's view type widens to `string`; we narrow at the public API
+  // boundary by casting before invoking the host callback.
+  const lastViewRef = useRef<string | null>(null);
+  useEffect(() => {
+    const next = cal.view;
+    if (lastViewRef.current === null) {
+      lastViewRef.current = next;
+      return;
+    }
+    if (lastViewRef.current === next) return;
+    lastViewRef.current = next;
+    onViewChange?.(next as CalendarView);
+  }, [cal.view, onViewChange]);
 
   // Wrap parent employee handlers so edits from ANY surface (timeline add-form
   // or TeamTab settings) flow both to the consumer's state AND to the owner

--- a/src/WorksCalendar.tsx
+++ b/src/WorksCalendar.tsx
@@ -2628,6 +2628,7 @@ export const WorksCalendar = forwardRef<CalendarApi, WorksCalendarProps>(functio
                     onClick={() => cal.setView(v.id)}
                     aria-pressed={cal.view === v.id}
                     title={v.hint}
+                    data-wc-view-button={v.id}
                   >
                     {v.label}
                   </button>

--- a/src/views/DayView.tsx
+++ b/src/views/DayView.tsx
@@ -173,6 +173,7 @@ export default function DayView({
           <div key={ev.id} data-event="1"
             className={[styles['event'], statusClass, isDimmed && styles['dragging']].filter(Boolean).join(' ')}
             style={{ top, height, '--ev-color': color, left: `${pctLeft}%`, width: `${pctWidth}%` }}
+            data-wc-event-id={ev.id}
             data-wc-priority={ev.visualPriority ?? undefined}
             data-wc-conflicting={isConflicting ? 'true' : undefined}
             role="button" tabIndex={0}
@@ -197,6 +198,7 @@ export default function DayView({
       <div key={ev.id} data-event="1"
         className={[styles['event'], statusClass, isDimmed && styles['dragging']].filter(Boolean).join(' ')}
         style={{ top, height, '--ev-color': color, left: `${pctLeft}%`, width: `${pctWidth}%` }}
+        data-wc-event-id={ev.id}
         data-wc-priority={ev.visualPriority ?? undefined}
         data-wc-conflicting={isConflicting ? 'true' : undefined}
         role="button" tabIndex={0}

--- a/src/views/MonthView.tsx
+++ b/src/views/MonthView.tsx
@@ -330,6 +330,7 @@ export default function MonthView({
             className={[styles['eventPill'], statusClass, isDimmed && styles['dragging']].filter(Boolean).join(' ')}
             role="button"
             tabIndex={0}
+            data-wc-event-id={ev.id}
             data-wc-priority={ev.visualPriority ?? undefined}
             data-wc-conflicting={isConflicting ? 'true' : undefined}
             onClick={e => { e.stopPropagation(); onClick(); }}
@@ -357,6 +358,7 @@ export default function MonthView({
           isDimmed && styles['dragging'],
           ctx?.['editMode'] && styles['editModePill'],
         ].filter(Boolean).join(' ')}
+        data-wc-event-id={ev.id}
         data-wc-priority={ev.visualPriority ?? undefined}
         data-wc-conflicting={isConflicting ? 'true' : undefined}
         style={{

--- a/src/views/ScheduleView.tsx
+++ b/src/views/ScheduleView.tsx
@@ -102,6 +102,7 @@ export default function ScheduleView({ currentDate, events, onEventClick, weekSt
                           return (
                             <div key={ev.id} className={[styles['eventPill'], statusClass].filter(Boolean).join(' ')}
                               style={{ '--ev-color': color }}
+                              data-wc-event-id={ev.id}
                               data-wc-priority={ev['visualPriority'] as string | undefined}
                               onClick={() => onEventClick?.(ev)}>
                               {custom}
@@ -114,6 +115,7 @@ export default function ScheduleView({ currentDate, events, onEventClick, weekSt
                         <button key={ev.id}
                           className={[styles['eventPill'], statusClass].filter(Boolean).join(' ')}
                           style={{ '--ev-color': color }}
+                          data-wc-event-id={ev.id}
                           data-wc-priority={ev['visualPriority'] as string | undefined}
                           onClick={() => onEventClick?.(ev)}
                           title={ev.title}

--- a/src/views/WeekView.tsx
+++ b/src/views/WeekView.tsx
@@ -348,6 +348,7 @@ export default function WeekView({
           isDimmed && styles['dragging'],
           ctx?.['editMode'] && styles['editModeEvent'],
         ].filter(Boolean).join(' ')}
+        data-wc-event-id={ev.id}
         data-wc-priority={ev.visualPriority ?? undefined}
         data-wc-conflicting={isConflicting ? 'true' : undefined}
         style={{

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -8,7 +8,10 @@ export default defineConfig({
     environment: 'happy-dom',
     setupFiles: ['./src/test-setup.ts'],
     css: true,
-    include: ['src/**/*.{test,spec}.{js,jsx,ts,tsx}'],
+    include: [
+      'src/**/*.{test,spec}.{js,jsx,ts,tsx}',
+      'demo/**/*.{test,spec}.{js,jsx,ts,tsx}',
+    ],
     exclude: ['tests-e2e/**', 'node_modules/**', 'dist/**'],
   },
 });


### PR DESCRIPTION
Foundations for the demo guided walkthrough described in the demo-guided-walkthrough-72Kvl branch plan. This change adds:

- WorksCalendar.tsx: new `onViewChange?: (view: CalendarView) => void` prop, fired via useEffect on cal.view changes (skips initial mount). Lets the walkthrough — and any host — observe view switches without monkey-patching internals.

- demo/walkthrough/: pure state machine for the 6-step tour (move-job → cause-conflict → fix-conflict → switch-view → open-map → done). Reducer is React/DOM-free; useWalkthrough exposes wrapped versions of the demo's existing host callbacks (onEventMove, onEventSave, onConflictCheck, onViewChange) that emit observation events without replacing behavior.

- demo/walkthrough/fixtures.ts: two mission-assignment seed events at the same time on different aircraft, picked because no other emsData events occupy those slots — guarantees the Step 2 conflict scenario is solely caused by Alpha+Bravo overlapping.

- demo/walkthrough/reducer.test.ts: 10 unit tests covering happy path, mismatched-event suppression, exit/restart, and the dual-trigger paths (cause-conflict accepts conflict-detected OR reassign-onto- bravo; open-map accepts the dedicated widget event OR view-changed). vitest.config.ts include extended to pick up demo/ tests.

Map-widget detection is wired in steps.ts but currently keys off view-changed:'map' as a fallback; the dedicated widget branch can plug its detector into observe({ kind: 'map-widget-opened' }) when it lands.

UI (banner, spotlight, exit-to-free-play button) is intentionally not mounted yet — that's the next milestone. The state machine + adapter contract is what needed locking in first.

https://claude.ai/code/session_01GzH5mhsAHCjQkFDUBWXqYy

## Summary
Describe exactly what this PR changes.

## Scope
- Stage: 
- Planned PR number in sprint: 
- Target files/directories: 
- Why this slice is isolated: 

## Lessons Learned Check (REQUIRED)
Confirm these were actively used while building this PR:

- [ ] PR is intentionally small and isolated
- [ ] Boundary typing was prioritized over internal perfection
- [ ] No silent spread of `any`
- [ ] Advisory root `tsc` was used to catch integration issues
- [ ] I did not assume “looks typed” means “safe”
- [ ] I stopped and isolated typing cascades instead of expanding scope

## Definition of Done (ALL REQUIRED)
This PR is not done unless every box is checked.

- [ ] `npm run type-check:strict` passes
- [ ] Root advisory `tsc --noEmit` passes
- [ ] Tests pass for touched scope at minimum
- [ ] No uncontrolled increase in `any`
- [ ] All new types are intentional and named
- [ ] Public interfaces and exported functions are explicitly typed
- [ ] PR scope matches the sprint plan with no scope creep
- [ ] Any new `any` has an adjacent justification comment
- [ ] No file-wide `: any`
- [ ] No implicit `any` in exported functions

## What Was Typed
List exactly what was typed in this PR.

- 
- 
- 

## What Was Intentionally Left Loose
List anything intentionally not tightened yet.

- 
- 
- 

## `any` Ledger (REQUIRED)
- New `any` added: 
- Existing `any` removed: 
- Net change: 

For every new `any`, explain why it is required and why a safer type was not used yet.

1. 
2. 
3. 

## Boundary Notes
Document any public seams, caller-protection choices, or compatibility decisions.

- 
- 
- 

## Risk Level
- [ ] Low
- [ ] Medium
- [ ] High

Why:

## Validation Evidence
Paste the exact commands run and a short result summary.

```bash
npm run type-check:strict
npx tsc --noEmit -p tsconfig.json
```

Test commands run:

```bash
# paste commands here
```

## Stop Conditions Check
If any item below happened, explain how scope was reduced before merge.

- [ ] `any` started spreading across files
- [ ] Root `tsc` broke repeatedly
- [ ] Types required cross-module rewrites
- [ ] Scope was reduced to keep the PR reviewable

Notes:

## Reviewer Focus
What should reviewers look at first?

- 
- 
- 
