### PR TITLE
fix(map): drop duplicate Region map panel; MapPeekWidget owns the sur…

### DIFF
--- a/src/WorksCalendar.tsx
+++ b/src/WorksCalendar.tsx
@@ -54,7 +54,7 @@ import { AppHeader }          from './ui/AppHeader';
 import { LeftRail }           from './ui/LeftRail';
 import { SubToolbar }         from './ui/SubToolbar';
 import { DayWindowPills }     from './ui/DayWindowPills';
-import { RightPanel, RightPanelSection, RegionMapWidget, CrewOnShiftList } from './ui/RightPanel';
+import { RightPanel, RightPanelSection, CrewOnShiftList } from './ui/RightPanel';
 import { shiftEmployeeIdsAt } from './hooks/useShiftOverlap';
 import FilterBar              from './ui/FilterBar';
 import ProfileBar             from './ui/ProfileBar';
@@ -2539,9 +2539,12 @@ export const WorksCalendar = forwardRef<CalendarApi, WorksCalendarProps>(functio
           }
           rightPanel={
             <RightPanel>
-              <RightPanelSection title="Region map">
-                <RegionMapWidget events={visibleEvents} />
-              </RightPanelSection>
+              {/* The old `<RegionMapWidget>` SVG-dot plot used to live
+                  here. It's been replaced by the chrome-level
+                  `<MapPeekWidget>` (peek -> panel -> fullscreen) that
+                  renders the real MapLibre basemap; keeping a second,
+                  layer-less map in the side rail just confused the
+                  picture. */}
               <RightPanelSection title="Crew on shift">
                 <CrewOnShiftList employees={configuredEmployees} onShiftIds={onShiftIds} />
               </RightPanelSection>


### PR DESCRIPTION
…face

The right rail still mounted the legacy <RegionMapWidget> — a tiny SVG-dot plot with no tile layer — even though the new chrome-level <MapPeekWidget> already renders a real MapLibre basemap from the same event set. Two map UIs side by side made the layer-less one look broken; removing the side-rail mount so the peek pill is the single map entry point. Crew-on-shift section stays.

The RegionMapWidget component itself is left exported for now since its unit tests still exercise it as a primitive — only the duplicate mount is gone.

## Summary
Describe exactly what this PR changes.

## Scope
- Stage: 
- Planned PR number in sprint: 
- Target files/directories: 
- Why this slice is isolated: 

## Lessons Learned Check (REQUIRED)
Confirm these were actively used while building this PR:

- [ ] PR is intentionally small and isolated
- [ ] Boundary typing was prioritized over internal perfection
- [ ] No silent spread of `any`
- [ ] Advisory root `tsc` was used to catch integration issues
- [ ] I did not assume “looks typed” means “safe”
- [ ] I stopped and isolated typing cascades instead of expanding scope

## Definition of Done (ALL REQUIRED)
This PR is not done unless every box is checked.

- [ ] `npm run type-check:strict` passes
- [ ] Root advisory `tsc --noEmit` passes
- [ ] Tests pass for touched scope at minimum
- [ ] No uncontrolled increase in `any`
- [ ] All new types are intentional and named
- [ ] Public interfaces and exported functions are explicitly typed
- [ ] PR scope matches the sprint plan with no scope creep
- [ ] Any new `any` has an adjacent justification comment
- [ ] No file-wide `: any`
- [ ] No implicit `any` in exported functions

## What Was Typed
List exactly what was typed in this PR.

- 
- 
- 

## What Was Intentionally Left Loose
List anything intentionally not tightened yet.

- 
- 
- 

## `any` Ledger (REQUIRED)
- New `any` added: 
- Existing `any` removed: 
- Net change: 

For every new `any`, explain why it is required and why a safer type was not used yet.

1. 
2. 
3. 

## Boundary Notes
Document any public seams, caller-protection choices, or compatibility decisions.

- 
- 
- 

## Risk Level
- [ ] Low
- [ ] Medium
- [ ] High

Why:

## Validation Evidence
Paste the exact commands run and a short result summary.

```bash
npm run type-check:strict
npx tsc --noEmit -p tsconfig.json
```

Test commands run:

```bash
# paste commands here
```

## Stop Conditions Check
If any item below happened, explain how scope was reduced before merge.

- [ ] `any` started spreading across files
- [ ] Root `tsc` broke repeatedly
- [ ] Types required cross-module rewrites
- [ ] Scope was reduced to keep the PR reviewable

Notes:

## Reviewer Focus
What should reviewers look at first?

- 
- 
- 
