### PR TITLE
feat(demo): walkthrough auto-navigates, mobile-hides, persists dismiss

### DIFF
--- a/demo/App.tsx
+++ b/demo/App.tsx
@@ -1,5 +1,5 @@
 // @ts-nocheck — demo fixture, re-typed after Phase 2 d.ts regeneration
-import { StrictMode, useState, useCallback, useMemo, useEffect } from 'react';
+import { StrictMode, useState, useCallback, useMemo, useEffect, useRef } from 'react';
 import { createRoot } from 'react-dom/client';
 import { registerSW } from 'virtual:pwa-register';
 import {
@@ -950,8 +950,25 @@ function App() {
     delegate: { onEventSave: handleEventSave },
   });
 
+  // Snap the calendar to the walkthrough seed date on first guided mount so
+  // Mission Alpha is at the natural focus point (especially for Week/Day
+  // views, where today's date would otherwise hide the seeds entirely).
+  // Skipped in EMBED_MODE so e2e tests keep their real "today" landing.
+  const calendarRef = useRef(null);
+  const didSnapRef  = useRef(false);
+  useEffect(() => {
+    if (EMBED_MODE) return;
+    if (didSnapRef.current) return;
+    if (walkthrough.state.mode === 'free-play') return;
+    if (walkthrough.state.history.length > 0) return; // user has already engaged
+    if (!calendarRef.current?.navigateTo) return;
+    calendarRef.current.navigateTo(new Date(ALPHA_INITIAL_START_ISO));
+    didSnapRef.current = true;
+  }, [walkthrough.state.mode, walkthrough.state.history.length]);
+
   const calendar = (
     <WorksCalendar
+      ref={calendarRef}
       events={events}
       employees={employees}
       assets={AIRCRAFT_RESOURCES}

--- a/demo/walkthrough/Walkthrough.module.css
+++ b/demo/walkthrough/Walkthrough.module.css
@@ -125,3 +125,14 @@
 .resumePill:hover {
   background: #1e293b;
 }
+
+/* Below 1100px the demo swaps the live calendar for a static MobileShowcase
+ * (see Landing.tsx). The walkthrough has nothing to operate on there, so
+ * suppress the banner and resume pill outright. Same breakpoint as Landing's
+ * MOBILE_BREAKPOINT_PX. */
+@media (max-width: 1099px) {
+  .banner,
+  .resumePill {
+    display: none;
+  }
+}

--- a/demo/walkthrough/useWalkthrough.ts
+++ b/demo/walkthrough/useWalkthrough.ts
@@ -14,15 +14,41 @@
  * button that we'll wire when we mount the UI.
  */
 
-import { useCallback, useMemo, useReducer, useRef } from 'react';
+import { useCallback, useEffect, useMemo, useReducer, useRef } from 'react';
 import { INITIAL_STATE, reducer } from './reducer';
 import { STEPS } from './steps';
 import type {
   Step,
   StepContext,
   WalkthroughEvent,
+  WalkthroughMode,
   WalkthroughState,
 } from './types';
+
+/** localStorage key for the dismissed-tour flag. Only the mode is persisted —
+ *  the active step always resets so a returning visitor who restarts the tour
+ *  starts from step 1 with a clean event log. */
+const STORAGE_KEY = 'wc-walkthrough-mode';
+
+function readPersistedMode(): WalkthroughMode {
+  if (typeof window === 'undefined') return 'guided';
+  try {
+    return window.localStorage.getItem(STORAGE_KEY) === 'free-play'
+      ? 'free-play'
+      : 'guided';
+  } catch {
+    return 'guided';
+  }
+}
+
+function persistMode(mode: WalkthroughMode): void {
+  if (typeof window === 'undefined') return;
+  try {
+    window.localStorage.setItem(STORAGE_KEY, mode);
+  } catch {
+    // quota / private mode — silent failure, just won't persist
+  }
+}
 
 interface UseWalkthroughArgs {
   ctx: StepContext;
@@ -62,8 +88,16 @@ export function useWalkthrough({ ctx, delegate }: UseWalkthroughArgs): Walkthrou
   const [state, dispatch] = useReducer(
     (s: WalkthroughState, a: Parameters<typeof reducer>[1]) =>
       reducer(s, a, { steps: STEPS, ctx }),
-    INITIAL_STATE,
+    undefined,
+    () => ({ ...INITIAL_STATE, mode: readPersistedMode() }),
   );
+
+  // Persist mode changes so a dismissed tour stays dismissed across reloads.
+  // Only the mode is saved — currentStep / history reset on each load so
+  // restarting starts cleanly at step 1.
+  useEffect(() => {
+    persistMode(state.mode);
+  }, [state.mode]);
 
   // Snapshot of the previous state of Alpha so we can tell a "move" (time
   // change, same resource) from a "reassign" (resource change). Refs because


### PR DESCRIPTION
Three follow-up gaps from the components milestone:

1. Auto-navigate. The calendar opens at new Date() (today), but the walkthrough seeds are anchored to ALPHA_INITIAL_START_ISO (2026-04-23). In Month view they were technically visible but inconspicuous; in Week/Day they were entirely off-screen. App.tsx now holds a ref to WorksCalendar's CalendarApi and calls navigateTo(seed-date) once on first guided mount. Skipped in EMBED_MODE so e2e tests keep their real "today" landing, and skipped if the user has already engaged (history non-empty).

2. Mobile suppression. Landing.tsx swaps the live calendar for a static MobileShowcase below 1100px; the walkthrough has nothing to operate on there. Walkthrough.module.css now hides .banner and .resumePill at the same breakpoint via @media (max-width: 1099px). No JS state needed.

3. Dismiss persistence. Users who clicked "Skip tour" still saw the banner reappear on every reload. useWalkthrough now persists state.mode to localStorage (key: wc-walkthrough-mode) and re-initializes the reducer from it on mount. Only the mode is stored — currentStep / history always reset, so a returning user who clicks "Restart tour" gets a clean run from step 1.

Verified: 2654 vitest tests pass; tsc --noEmit clean; demo build succeeds.

Drop-onto-conflict semantics confirmed by code-read of src/core/engine/validation/validateOverlap.ts and
src/WorksCalendar.tsx:1378-1407: the default conflictPolicy='warn' yields a 'pending-confirmation' alert which, on user confirm, fires onEventSave with the new resource. Step 2 of the walkthrough advances correctly through that path. No code change needed.

https://claude.ai/code/session_01GzH5mhsAHCjQkFDUBWXqYy

## Summary
Describe exactly what this PR changes.

## Scope
- Stage: 
- Planned PR number in sprint: 
- Target files/directories: 
- Why this slice is isolated: 

## Lessons Learned Check (REQUIRED)
Confirm these were actively used while building this PR:

- [ ] PR is intentionally small and isolated
- [ ] Boundary typing was prioritized over internal perfection
- [ ] No silent spread of `any`
- [ ] Advisory root `tsc` was used to catch integration issues
- [ ] I did not assume “looks typed” means “safe”
- [ ] I stopped and isolated typing cascades instead of expanding scope

## Definition of Done (ALL REQUIRED)
This PR is not done unless every box is checked.

- [ ] `npm run type-check:strict` passes
- [ ] Root advisory `tsc --noEmit` passes
- [ ] Tests pass for touched scope at minimum
- [ ] No uncontrolled increase in `any`
- [ ] All new types are intentional and named
- [ ] Public interfaces and exported functions are explicitly typed
- [ ] PR scope matches the sprint plan with no scope creep
- [ ] Any new `any` has an adjacent justification comment
- [ ] No file-wide `: any`
- [ ] No implicit `any` in exported functions

## What Was Typed
List exactly what was typed in this PR.

- 
- 
- 

## What Was Intentionally Left Loose
List anything intentionally not tightened yet.

- 
- 
- 

## `any` Ledger (REQUIRED)
- New `any` added: 
- Existing `any` removed: 
- Net change: 

For every new `any`, explain why it is required and why a safer type was not used yet.

1. 
2. 
3. 

## Boundary Notes
Document any public seams, caller-protection choices, or compatibility decisions.

- 
- 
- 

## Risk Level
- [ ] Low
- [ ] Medium
- [ ] High

Why:

## Validation Evidence
Paste the exact commands run and a short result summary.

```bash
npm run type-check:strict
npx tsc --noEmit -p tsconfig.json
```

Test commands run:

```bash
# paste commands here
```

## Stop Conditions Check
If any item below happened, explain how scope was reduced before merge.

- [ ] `any` started spreading across files
- [ ] Root `tsc` broke repeatedly
- [ ] Types required cross-module rewrites
- [ ] Scope was reduced to keep the PR reviewable

Notes:

## Reviewer Focus
What should reviewers look at first?

- 
- 
- 
