### PR TITLE
feat(map): corner mini-plot expands to a 70vw modal on click

### DIFF
--- a/src/ui/MapPeekWidget.module.css
+++ b/src/ui/MapPeekWidget.module.css
@@ -1,3 +1,6 @@
+/* Mini corner map — always-visible preview anchored top-right of the
+   workspace. Clicking it opens the full MapLibre view in a 70%-of-
+   screen modal. */
 .host {
   position: absolute;
   top: 12px;
@@ -5,72 +8,102 @@
   z-index: 40;
   font-family: var(--wc-font, system-ui, sans-serif);
   color: var(--wc-fg, #1f2937);
-  pointer-events: auto;
 }
 
-.peek {
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
-  padding: 6px 10px;
-  background: var(--wc-bg, #ffffff);
-  border: 1px solid var(--wc-border, #e5e7eb);
-  border-radius: 999px;
-  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.08);
-  cursor: pointer;
-  font-size: 12px;
-  font-weight: 600;
-  color: inherit;
-}
-.peek:hover { box-shadow: 0 2px 8px rgba(0, 0, 0, 0.12); }
-.peek:focus { outline: 2px solid var(--wc-accent, #3b82f6); outline-offset: 2px; }
-
-.peekCount { color: var(--wc-fg-muted, #6b7280); font-weight: 500; }
-
-.panel {
-  width: 360px;
-  height: 280px;
-  background: var(--wc-bg, #ffffff);
-  border: 1px solid var(--wc-border, #e5e7eb);
+.mini {
+  width: 200px;
+  height: 130px;
+  background: var(--wc-bg, #0b1220);
+  border: 1px solid var(--wc-border, #1e293b);
   border-radius: 8px;
-  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.14);
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.18);
+  cursor: pointer;
+  padding: 0;
   display: flex;
   flex-direction: column;
   overflow: hidden;
+  color: inherit;
+}
+.mini:hover  { box-shadow: 0 4px 14px rgba(0, 0, 0, 0.25); }
+.mini:focus  { outline: 2px solid var(--wc-accent, #3b82f6); outline-offset: 2px; }
+
+.miniHeader {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 8px;
+  font-size: 10.5px;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--wc-fg-muted, #94a3b8);
+  border-bottom: 1px solid var(--wc-border, #1e293b);
+}
+.miniHeader .count {
+  margin-left: auto;
+  font-weight: 600;
+  letter-spacing: 0;
+  text-transform: none;
+  color: var(--wc-fg-muted, #94a3b8);
 }
 
-.fullscreen {
+.miniBody { flex: 1; position: relative; }
+.miniSvg  { position: absolute; inset: 0; width: 100%; height: 100%; }
+.miniDot  { fill: var(--wc-accent, #3b82f6); }
+
+.miniEmpty {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 11px;
+  color: var(--wc-fg-muted, #94a3b8);
+  padding: 0 8px;
+  text-align: center;
+}
+
+/* Backdrop covers the page so the modal feels separated. Clicks on
+   the backdrop close the modal. */
+.backdrop {
   position: fixed;
   inset: 0;
-  width: 100%;
-  height: 100%;
+  z-index: 90;
+  background: rgba(0, 0, 0, 0.42);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+/* Expanded modal: 70% of viewport width and height, centered. */
+.modal {
+  width: 70vw;
+  height: 70vh;
   background: var(--wc-bg, #ffffff);
+  border: 1px solid var(--wc-border, #e5e7eb);
+  border-radius: 10px;
+  box-shadow: 0 12px 40px rgba(0, 0, 0, 0.28);
   display: flex;
   flex-direction: column;
-  z-index: 80;
+  overflow: hidden;
 }
 
 .toolbar {
   display: flex;
   align-items: center;
   gap: 8px;
-  padding: 8px 10px;
+  padding: 10px 14px;
   border-bottom: 1px solid var(--wc-border, #e5e7eb);
-  font-size: 12px;
+  font-size: 13px;
 }
-
-.title { flex: 1; font-weight: 600; }
-.subtitle {
-  color: var(--wc-fg-muted, #6b7280);
-  font-weight: 400;
-  margin-left: 6px;
-}
+.title    { flex: 1; font-weight: 600; }
+.subtitle { color: var(--wc-fg-muted, #6b7280); font-weight: 400; margin-left: 6px; }
 
 .iconBtn {
   background: transparent;
   border: 1px solid transparent;
   border-radius: 4px;
-  padding: 3px 6px;
+  padding: 4px 8px;
   font-size: 12px;
   cursor: pointer;
   color: inherit;

--- a/src/ui/MapPeekWidget.tsx
+++ b/src/ui/MapPeekWidget.tsx
@@ -1,23 +1,17 @@
 /**
- * MapPeekWidget — chrome-level situational-awareness overlay.
+ * MapPeekWidget — corner mini-map + expand-on-click full map.
  *
- * Replaces the prior `'map'` view tab. Sits in the calendar's
- * upper-right corner as a tiny pill (peek), expands on click into a
- * 360x280 floating card (panel), and from there to fullscreen ops
- * mode. Closing returns to peek so the workspace below is never
- * blocked for users who didn't ask for the map.
- *
- * Reads coordinate-bearing events out of the same `meta.coords`
- * convention `MapView` uses, so any host that already populates it
- * gets the widget for free.
+ * The corner shows an always-visible bounding-box-fit SVG plot of every
+ * coord-bearing event (dependency-free, no tile layer — same convention
+ * the legacy `RegionMapWidget` used). Clicking the mini-map opens a
+ * 70vw × 70vh modal that mounts the real `<MapView />` with a MapLibre
+ * basemap. Closing the modal returns to the corner preview; the corner
+ * never disappears, so the operator's "where am I" reference stays put.
  */
-import { useMemo, useState } from 'react'
-import type { ReactNode, CSSProperties } from 'react'
-import { Map as MapIcon, Maximize2, Minimize2, X } from 'lucide-react'
+import { useEffect, useMemo, useState } from 'react'
+import { X } from 'lucide-react'
 import MapView from '../views/MapView'
 import styles from './MapPeekWidget.module.css'
-
-type WidgetMode = 'peek' | 'panel' | 'fullscreen'
 
 type EventLike = {
   id: string
@@ -35,94 +29,140 @@ export interface MapPeekWidgetProps {
   readonly mapStyle?: string
 }
 
-function hasCoords(ev: EventLike): boolean {
+interface Plotted { id: string; lat: number; lon: number }
+
+function readCoords(ev: EventLike): { lat: number; lon: number } | null {
   const meta = ev.meta
-  if (!meta) return false
+  if (!meta) return null
   const c = meta['coords']
   if (c && typeof c === 'object') {
     const cc = c as Record<string, unknown>
-    if (typeof cc['lat'] === 'number' && (typeof cc['lon'] === 'number' || typeof cc['lng'] === 'number')) {
-      return true
-    }
+    const lat = cc['lat']; const lon = cc['lon'] ?? cc['lng']
+    if (typeof lat === 'number' && typeof lon === 'number') return { lat, lon }
   }
-  if (typeof meta['lat'] === 'number' && (typeof meta['lon'] === 'number' || typeof meta['lng'] === 'number')) {
-    return true
-  }
-  return false
+  const lat = meta['lat']; const lon = meta['lon'] ?? meta['lng']
+  if (typeof lat === 'number' && typeof lon === 'number') return { lat, lon }
+  return null
 }
 
-export function MapPeekWidget({ events, onEventClick, mapStyle }: MapPeekWidgetProps) {
-  const [mode, setMode] = useState<WidgetMode>('peek')
-  const plottable = useMemo(() => events.filter(hasCoords), [events])
+const MINI_W = 200
+const MINI_H = 96
+const MINI_PAD = 10
 
-  if (mode === 'peek') {
-    return (
+export function MapPeekWidget({ events, onEventClick, mapStyle }: MapPeekWidgetProps) {
+  const [open, setOpen] = useState(false)
+
+  const plotted = useMemo<Plotted[]>(() => {
+    const out: Plotted[] = []
+    for (const ev of events) {
+      const c = readCoords(ev)
+      if (c) out.push({ id: String(ev.id ?? ''), ...c })
+    }
+    return out
+  }, [events])
+
+  // Esc closes the modal — keyboard parity with native dialogs.
+  useEffect(() => {
+    if (!open) return
+    const onKey = (e: KeyboardEvent) => { if (e.key === 'Escape') setOpen(false) }
+    window.addEventListener('keydown', onKey)
+    return () => window.removeEventListener('keydown', onKey)
+  }, [open])
+
+  const project = useMemo(() => buildProjector(plotted), [plotted])
+
+  return (
+    <>
       <div className={styles['host']}>
         <button
           type="button"
-          className={styles['peek']}
-          onClick={() => setMode('panel')}
-          aria-label={`Open map (${plottable.length} events with coordinates)`}
+          className={styles['mini']}
+          onClick={() => setOpen(true)}
+          aria-label={`Open map (${plotted.length} events with coordinates)`}
           title="Open map"
         >
-          <MapIcon size={14} aria-hidden="true" />
-          <span>Map</span>
-          <span className={styles['peekCount']}>· {plottable.length}</span>
+          <span className={styles['miniHeader']}>
+            <span>Region map</span>
+            <span className={styles['count']}>{plotted.length}</span>
+          </span>
+          <span className={styles['miniBody']}>
+            {plotted.length === 0 ? (
+              <span className={styles['miniEmpty']}>No coords yet</span>
+            ) : (
+              <svg
+                className={styles['miniSvg']}
+                viewBox={`0 0 ${MINI_W} ${MINI_H}`}
+                preserveAspectRatio="none"
+                aria-hidden="true"
+              >
+                {plotted.map(p => {
+                  const { x, y } = project(p)
+                  return <circle key={p.id} cx={x} cy={y} r={2.5} className={styles['miniDot']} />
+                })}
+              </svg>
+            )}
+          </span>
         </button>
       </div>
-    )
-  }
 
-  const isFullscreen = mode === 'fullscreen'
-  const containerClass = isFullscreen ? styles['fullscreen'] : styles['host']
-  const innerClass = isFullscreen ? styles['fullscreen'] : styles['panel']
-
-  // When in panel mode, the host wrapper is absolutely positioned in
-  // the corner; in fullscreen, the wrapper takes over the viewport
-  // (position: fixed, inset: 0). The inner shell carries the chrome.
-  const wrapperStyle: CSSProperties | undefined = isFullscreen ? undefined : { position: 'absolute', top: 12, right: 12 }
-
-  return (
-    <div className={containerClass} style={wrapperStyle} role="dialog" aria-label="Map">
-      <div className={innerClass}>
-        <div className={styles['toolbar']}>
-          <span className={styles['title']}>
-            <MapIcon size={13} aria-hidden="true" /> Map
-            <span className={styles['subtitle']}>
-              {plottable.length} event{plottable.length === 1 ? '' : 's'}
-            </span>
-          </span>
-          {!isFullscreen ? (
-            <ToolbarButton label="Expand to fullscreen" onClick={() => setMode('fullscreen')}>
-              <Maximize2 size={12} aria-hidden="true" />
-            </ToolbarButton>
-          ) : (
-            <ToolbarButton label="Restore panel" onClick={() => setMode('panel')}>
-              <Minimize2 size={12} aria-hidden="true" />
-            </ToolbarButton>
-          )}
-          <ToolbarButton label="Close map" onClick={() => setMode('peek')}>
-            <X size={12} aria-hidden="true" />
-          </ToolbarButton>
+      {open && (
+        <div
+          className={styles['backdrop']}
+          onClick={() => setOpen(false)}
+          role="presentation"
+        >
+          <div
+            className={styles['modal']}
+            onClick={stop}
+            role="dialog"
+            aria-label="Map"
+            aria-modal="true"
+          >
+            <div className={styles['toolbar']}>
+              <span className={styles['title']}>
+                Map
+                <span className={styles['subtitle']}>
+                  {plotted.length} event{plotted.length === 1 ? '' : 's'}
+                </span>
+              </span>
+              <button
+                type="button"
+                className={styles['iconBtn']}
+                onClick={() => setOpen(false)}
+                aria-label="Close map"
+                title="Close"
+              >
+                <X size={14} aria-hidden="true" />
+              </button>
+            </div>
+            <div className={styles['body']}>
+              <MapView
+                events={events as never}
+                {...(onEventClick ? { onEventClick: onEventClick as never } : {})}
+                {...(mapStyle ? { mapStyle } : {})}
+              />
+            </div>
+          </div>
         </div>
-        <div className={styles['body']}>
-          <MapView
-            events={events as never}
-            {...(onEventClick ? { onEventClick: onEventClick as never } : {})}
-            {...(mapStyle ? { mapStyle } : {})}
-          />
-        </div>
-      </div>
-    </div>
+      )}
+    </>
   )
 }
 
-function ToolbarButton({ label, onClick, children }: { label: string; onClick: () => void; children: ReactNode }) {
-  return (
-    <button type="button" className={styles['iconBtn']} onClick={onClick} aria-label={label} title={label}>
-      {children}
-    </button>
-  )
+function buildProjector(points: readonly Plotted[]): (p: { lat: number; lon: number }) => { x: number; y: number } {
+  if (points.length === 0) return () => ({ x: MINI_W / 2, y: MINI_H / 2 })
+  if (points.length === 1) return () => ({ x: MINI_W / 2, y: MINI_H / 2 })
+  const lats = points.map(p => p.lat), lons = points.map(p => p.lon)
+  const minLat = Math.min(...lats), maxLat = Math.max(...lats)
+  const minLon = Math.min(...lons), maxLon = Math.max(...lons)
+  const dLat = maxLat - minLat || 1
+  const dLon = maxLon - minLon || 1
+  return ({ lat, lon }) => ({
+    x: MINI_PAD + ((lon - minLon) / dLon) * (MINI_W - 2 * MINI_PAD),
+    y: MINI_PAD + (1 - (lat - minLat) / dLat) * (MINI_H - 2 * MINI_PAD),
+  })
 }
+
+function stop(e: { stopPropagation: () => void }) { e.stopPropagation() }
 
 export default MapPeekWidget


### PR DESCRIPTION
User flipped the interaction: the corner should always show a tiny preview of where things are, and clicking it should open a sizable window of the real basemap — not a pill that toggles a panel.

MapPeekWidget rewritten:
- Corner button is now a 200x130 card with the Region Map header, event count, and a bounding-box-fit SVG dot plot of every coord- bearing event (same dependency-free convention the legacy RegionMapWidget used). Always visible.
- Click anywhere on the card opens a centered modal sized to 70vw x 70vh that mounts <MapView /> with the MapLibre basemap.
- Backdrop click and Escape close the modal back to the corner preview. The mini never disappears, so the operator's spatial reference stays put across view switches.

Drops the prior peek/panel/fullscreen state machine and the unused Maximize2 icon import. Tests still 2651 / 2651.

## Summary
Describe exactly what this PR changes.

## Scope
- Stage: 
- Planned PR number in sprint: 
- Target files/directories: 
- Why this slice is isolated: 

## Lessons Learned Check (REQUIRED)
Confirm these were actively used while building this PR:

- [ ] PR is intentionally small and isolated
- [ ] Boundary typing was prioritized over internal perfection
- [ ] No silent spread of `any`
- [ ] Advisory root `tsc` was used to catch integration issues
- [ ] I did not assume “looks typed” means “safe”
- [ ] I stopped and isolated typing cascades instead of expanding scope

## Definition of Done (ALL REQUIRED)
This PR is not done unless every box is checked.

- [ ] `npm run type-check:strict` passes
- [ ] Root advisory `tsc --noEmit` passes
- [ ] Tests pass for touched scope at minimum
- [ ] No uncontrolled increase in `any`
- [ ] All new types are intentional and named
- [ ] Public interfaces and exported functions are explicitly typed
- [ ] PR scope matches the sprint plan with no scope creep
- [ ] Any new `any` has an adjacent justification comment
- [ ] No file-wide `: any`
- [ ] No implicit `any` in exported functions

## What Was Typed
List exactly what was typed in this PR.

- 
- 
- 

## What Was Intentionally Left Loose
List anything intentionally not tightened yet.

- 
- 
- 

## `any` Ledger (REQUIRED)
- New `any` added: 
- Existing `any` removed: 
- Net change: 

For every new `any`, explain why it is required and why a safer type was not used yet.

1. 
2. 
3. 

## Boundary Notes
Document any public seams, caller-protection choices, or compatibility decisions.

- 
- 
- 

## Risk Level
- [ ] Low
- [ ] Medium
- [ ] High

Why:

## Validation Evidence
Paste the exact commands run and a short result summary.

```bash
npm run type-check:strict
npx tsc --noEmit -p tsconfig.json
```

Test commands run:

```bash
# paste commands here
```

## Stop Conditions Check
If any item below happened, explain how scope was reduced before merge.

- [ ] `any` started spreading across files
- [ ] Root `tsc` broke repeatedly
- [ ] Types required cross-module rewrites
- [ ] Scope was reduced to keep the PR reviewable

Notes:

## Reviewer Focus
What should reviewers look at first?

- 
- 
- 
