### PR TITLE
fix(month): guard MonthView drag commit against non-Date start/end

### DIFF
--- a/src/views/MonthView.tsx
+++ b/src/views/MonthView.tsx
@@ -170,7 +170,18 @@ export default function MonthView({
     if (!d || !d.moved || !d.targetDay) return;
     if (isSameDay(d.targetDay, d.ev.start)) return;
 
-    const durationMs = d.ev.end.getTime() - d.ev.start.getTime();
+    // Bail before invoking onEventMove if the source event is missing a
+    // valid start/end. NormalizedEvent guarantees Dates at the type level,
+    // but some hosts feed partially-constructed payloads through and a NaN
+    // .getTime() here would propagate as Invalid Date into engine
+    // validation, which formats violations via date-fns — and `format()`
+    // throws RangeError on Invalid Date, surfacing as a calendar-wide
+    // crash on the next render rather than a silent no-op move.
+    const startMs = d.ev.start instanceof Date ? d.ev.start.getTime() : NaN;
+    const endMs   = d.ev.end   instanceof Date ? d.ev.end.getTime()   : NaN;
+    if (!Number.isFinite(startMs) || !Number.isFinite(endMs)) return;
+
+    const durationMs = endMs - startMs;
     const newStart   = new Date(startOfDay(d.targetDay));
     if (!d.ev.allDay) {
       newStart.setHours(d.ev.start.getHours(), d.ev.start.getMinutes(), 0, 0);

--- a/src/views/__tests__/MonthView.test.tsx
+++ b/src/views/__tests__/MonthView.test.tsx
@@ -112,6 +112,44 @@ describe('MonthView — multi-day / allDay event span bars', () => {
     expect(onEventClick).toHaveBeenCalledOnce();
     expect(onEventClick).toHaveBeenCalledWith(events[0]);
   });
+
+  // Regression: a multi-day timed event (e.g. the demo's São Paulo → Munich
+  // 4-day mission) dragged onto an empty date in another week must not
+  // throw and must hand newStart/newEnd to onEventMove as valid Dates.
+  it('moves a multi-day timed event to an empty cell without throwing', () => {
+    const onEventMove = vi.fn();
+    const events = [
+      { id: 'mission', title: 'São Paulo → Munich Critical Care Transfer',
+        // 4-day window with non-midnight times — matches the demo mission.
+        start: new Date(2026, 3, 24, 6, 0),
+        end:   new Date(2026, 3, 28, 8, 0),
+        allDay: false,
+        category: 'mission-assignment' },
+    ];
+    render(
+      <CalendarContext.Provider value={{ permissions: { canDrag: true } } as any}>
+        <MonthView currentDate={currentDate} events={events as any} onEventMove={onEventMove} />
+      </CalendarContext.Provider>,
+    );
+
+    const span = screen.getAllByRole('button', { name: /São Paulo → Munich/i })[0]!;
+    const target = screen.getByRole('gridcell', { name: /April 1\b/ });
+    expect(() => {
+      fireEvent.pointerDown(span, { button: 0, pointerId: 1 });
+      fireEvent.pointerEnter(target);
+      fireEvent.pointerUp(target);
+    }).not.toThrow();
+
+    expect(onEventMove).toHaveBeenCalledOnce();
+    const [, newStart, newEnd] = onEventMove.mock.calls[0] as [unknown, Date, Date];
+    expect(newStart).toBeInstanceOf(Date);
+    expect(newEnd).toBeInstanceOf(Date);
+    expect(Number.isFinite(newStart.getTime())).toBe(true);
+    expect(Number.isFinite(newEnd.getTime())).toBe(true);
+    // 4-day duration preserved on the new dates.
+    expect(newEnd.getTime() - newStart.getTime())
+      .toBe(events[0]!.end.getTime() - events[0]!.start.getTime());
+  });
 });
 
 // ─── Date selection ───────────────────────────────────────────────────────────


### PR DESCRIPTION
Multi-day events like the demo's São Paulo → Munich critical care transfer expose a span bar in every week row they touch. When the user grabs one of those bars and drops it on an empty date, commitDrag unconditionally calls .getTime() on `ev.start` / `ev.end`. NormalizedEvent guarantees these are Dates at the type level, but hosts that feed partially-constructed payloads through normalization escape hatches (e.g. a moved event whose date round-tripped through host state as a string) reach this code with non-Date values. The resulting NaN duration produces an Invalid Date for newStart/newEnd, which the engine forwards to date-fns `format()` during validation — and `format()` throws RangeError on Invalid Date, surfacing as a calendar-wide crash on the next render.

Bail before invoking onEventMove when start/end aren't Date instances or their .getTime() isn't finite. dragRef is already cleared at the top of commitDrag, so the early return leaves the calendar in a clean state.

Adds a regression test covering the demo scenario: a 4-day mission with non-midnight times dragged onto an empty cell completes with a valid Date pair and preserves the original duration.

https://claude.ai/code/session_015242vwwg5fqNWusuyyPejx

## Summary
Describe exactly what this PR changes.

## Scope
- Stage: 
- Planned PR number in sprint: 
- Target files/directories: 
- Why this slice is isolated: 

## Lessons Learned Check (REQUIRED)
Confirm these were actively used while building this PR:

- [ ] PR is intentionally small and isolated
- [ ] Boundary typing was prioritized over internal perfection
- [ ] No silent spread of `any`
- [ ] Advisory root `tsc` was used to catch integration issues
- [ ] I did not assume “looks typed” means “safe”
- [ ] I stopped and isolated typing cascades instead of expanding scope

## Definition of Done (ALL REQUIRED)
This PR is not done unless every box is checked.

- [ ] `npm run type-check:strict` passes
- [ ] Root advisory `tsc --noEmit` passes
- [ ] Tests pass for touched scope at minimum
- [ ] No uncontrolled increase in `any`
- [ ] All new types are intentional and named
- [ ] Public interfaces and exported functions are explicitly typed
- [ ] PR scope matches the sprint plan with no scope creep
- [ ] Any new `any` has an adjacent justification comment
- [ ] No file-wide `: any`
- [ ] No implicit `any` in exported functions

## What Was Typed
List exactly what was typed in this PR.

- 
- 
- 

## What Was Intentionally Left Loose
List anything intentionally not tightened yet.

- 
- 
- 

## `any` Ledger (REQUIRED)
- New `any` added: 
- Existing `any` removed: 
- Net change: 

For every new `any`, explain why it is required and why a safer type was not used yet.

1. 
2. 
3. 

## Boundary Notes
Document any public seams, caller-protection choices, or compatibility decisions.

- 
- 
- 

## Risk Level
- [ ] Low
- [ ] Medium
- [ ] High

Why:

## Validation Evidence
Paste the exact commands run and a short result summary.

```bash
npm run type-check:strict
npx tsc --noEmit -p tsconfig.json
```

Test commands run:

```bash
# paste commands here
```

## Stop Conditions Check
If any item below happened, explain how scope was reduced before merge.

- [ ] `any` started spreading across files
- [ ] Root `tsc` broke repeatedly
- [ ] Types required cross-module rewrites
- [ ] Scope was reduced to keep the PR reviewable

Notes:

## Reviewer Focus
What should reviewers look at first?

- 
- 
- 
