### PR TITLE
fix(map): mount Region map in right rail above Crew on shift

### DIFF
--- a/src/WorksCalendar.module.css
+++ b/src/WorksCalendar.module.css
@@ -517,11 +517,6 @@
   overflow: hidden;
   display: flex;
   flex-direction: column;
-  /* Anchors absolutely-positioned chrome overlays (e.g. MapPeekWidget)
-     to the workspace below the SubToolbar — without this the host's
-     `position: absolute` would resolve up to the viewport and float
-     over the toolbar buttons / Owner gear. */
-  position: relative;
 }
 
 /* Main pane: padded shell holding the bordered calendar card. */

--- a/src/WorksCalendar.tsx
+++ b/src/WorksCalendar.tsx
@@ -2539,12 +2539,17 @@ export const WorksCalendar = forwardRef<CalendarApi, WorksCalendarProps>(functio
           }
           rightPanel={
             <RightPanel>
-              {/* The old `<RegionMapWidget>` SVG-dot plot used to live
-                  here. It's been replaced by the chrome-level
-                  `<MapPeekWidget>` (peek -> panel -> fullscreen) that
-                  renders the real MapLibre basemap; keeping a second,
-                  layer-less map in the side rail just confused the
-                  picture. */}
+              {/* Region map is the inline preview; clicking it pops a
+                  70vw modal that mounts the real MapLibre basemap.
+                  Sitting above Crew so the spatial reference is always
+                  the first thing the operator sees in the rail. */}
+              <RightPanelSection title="Region map">
+                <MapPeekWidget
+                  events={expandedEvents as never}
+                  onEventClick={handleEventClick as never}
+                  {...(mapStyle ? { mapStyle } : {})}
+                />
+              </RightPanelSection>
               <RightPanelSection title="Crew on shift">
                 <CrewOnShiftList employees={configuredEmployees} onShiftIds={onShiftIds} />
               </RightPanelSection>
@@ -2926,21 +2931,9 @@ export const WorksCalendar = forwardRef<CalendarApi, WorksCalendarProps>(functio
                   onEventClick={handleEventClick}
                 />
               )}
-              {/* Floating chrome-level map. Lives at the workspace
-                  level (not inside any view) so toggling it never
-                  unmounts the active view. Rendered last so its
-                  absolutely-positioned host stacks above the grid.
-                  Fed `expandedEvents` (the unscoped, recurring-expanded
-                  set), NOT `visibleEvents`, so opening the map from
-                  Month/Week doesn't drop coord-bearing schedule events
-                  the active tab's view-scope filtered out — that
-                  regressed the prior `'map'` view's all-events scope
-                  and could mislead operators about what's nearby. */}
-              <MapPeekWidget
-                events={expandedEvents as never}
-                onEventClick={handleEventClick as never}
-                {...(mapStyle ? { mapStyle } : {})}
-              />
+              {/* Map lives in the right rail (see `rightPanel` above)
+                  rather than as a workspace overlay — it shouldn't sit
+                  on top of the active view's content. */}
             </>
           )}
         </div>

--- a/src/ui/MapPeekWidget.module.css
+++ b/src/ui/MapPeekWidget.module.css
@@ -1,17 +1,12 @@
-/* Mini corner map — always-visible preview anchored top-right of the
-   workspace. Clicking it opens the full MapLibre view in a 70%-of-
-   screen modal. */
+/* Mini map — sits inline inside the right rail's "Region map" section.
+   Clicking it opens the full MapLibre view in a 70%-of-screen modal. */
 .host {
-  position: absolute;
-  top: 12px;
-  right: 12px;
-  z-index: 40;
   font-family: var(--wc-font, system-ui, sans-serif);
   color: var(--wc-fg, #1f2937);
 }
 
 .mini {
-  width: 200px;
+  width: 100%;
   height: 130px;
   background: var(--wc-bg, #0b1220);
   border: 1px solid var(--wc-border, #1e293b);

--- a/src/ui/MapPeekWidget.tsx
+++ b/src/ui/MapPeekWidget.tsx
@@ -1,12 +1,13 @@
 /**
- * MapPeekWidget — corner mini-map + expand-on-click full map.
+ * MapPeekWidget — inline mini-map + expand-on-click full map.
  *
- * The corner shows an always-visible bounding-box-fit SVG plot of every
- * coord-bearing event (dependency-free, no tile layer — same convention
- * the legacy `RegionMapWidget` used). Clicking the mini-map opens a
- * 70vw × 70vh modal that mounts the real `<MapView />` with a MapLibre
- * basemap. Closing the modal returns to the corner preview; the corner
- * never disappears, so the operator's "where am I" reference stays put.
+ * Drops into the right rail's "Region map" section. Renders an
+ * always-visible bounding-box-fit SVG plot of every coord-bearing
+ * event (dependency-free, no tile layer — same convention the legacy
+ * `RegionMapWidget` used). Clicking the mini-map opens a 70vw × 70vh
+ * modal that mounts the real `<MapView />` with a MapLibre basemap.
+ * Closing the modal returns to the rail preview; the mini never
+ * unmounts, so the operator's "where am I" reference stays put.
  */
 import { useEffect, useMemo, useState } from 'react'
 import { X } from 'lucide-react'
@@ -81,10 +82,6 @@ export function MapPeekWidget({ events, onEventClick, mapStyle }: MapPeekWidgetP
           aria-label={`Open map (${plotted.length} events with coordinates)`}
           title="Open map"
         >
-          <span className={styles['miniHeader']}>
-            <span>Region map</span>
-            <span className={styles['count']}>{plotted.length}</span>
-          </span>
           <span className={styles['miniBody']}>
             {plotted.length === 0 ? (
               <span className={styles['miniEmpty']}>No coords yet</span>


### PR DESCRIPTION
User direction: the inline mini-plot belongs in the right rail where the team list was, not as a floating overlay above the grid.

Changes:
- MapPeekWidget mounts inside RightPanelSection title='Region map' in WorksCalendar's rightPanel slot, ordered above 'Crew on shift'.
- Drop the inline 'Region map' header from the widget itself; the RightPanelSection's title is the single label now (no duplication).
- Mini width becomes 100% so it fills the rail's column instead of the prior fixed 200px. Height stays at 130px.
- Remove the host's position: absolute / top / right / z-index; the widget is inline-flow now. Modal stays position: fixed.
- Drop the workspace overlay mount from the view-area block.
- Revert position: relative on .viewArea — no longer needed since there's no absolutely-positioned chrome child to anchor.

Click behavior unchanged: tap the mini, modal opens at 70vw x 70vh with the real MapLibre basemap.

## Summary
Describe exactly what this PR changes.

## Scope
- Stage: 
- Planned PR number in sprint: 
- Target files/directories: 
- Why this slice is isolated: 

## Lessons Learned Check (REQUIRED)
Confirm these were actively used while building this PR:

- [ ] PR is intentionally small and isolated
- [ ] Boundary typing was prioritized over internal perfection
- [ ] No silent spread of `any`
- [ ] Advisory root `tsc` was used to catch integration issues
- [ ] I did not assume “looks typed” means “safe”
- [ ] I stopped and isolated typing cascades instead of expanding scope

## Definition of Done (ALL REQUIRED)
This PR is not done unless every box is checked.

- [ ] `npm run type-check:strict` passes
- [ ] Root advisory `tsc --noEmit` passes
- [ ] Tests pass for touched scope at minimum
- [ ] No uncontrolled increase in `any`
- [ ] All new types are intentional and named
- [ ] Public interfaces and exported functions are explicitly typed
- [ ] PR scope matches the sprint plan with no scope creep
- [ ] Any new `any` has an adjacent justification comment
- [ ] No file-wide `: any`
- [ ] No implicit `any` in exported functions

## What Was Typed
List exactly what was typed in this PR.

- 
- 
- 

## What Was Intentionally Left Loose
List anything intentionally not tightened yet.

- 
- 
- 

## `any` Ledger (REQUIRED)
- New `any` added: 
- Existing `any` removed: 
- Net change: 

For every new `any`, explain why it is required and why a safer type was not used yet.

1. 
2. 
3. 

## Boundary Notes
Document any public seams, caller-protection choices, or compatibility decisions.

- 
- 
- 

## Risk Level
- [ ] Low
- [ ] Medium
- [ ] High

Why:

## Validation Evidence
Paste the exact commands run and a short result summary.

```bash
npm run type-check:strict
npx tsc --noEmit -p tsconfig.json
```

Test commands run:

```bash
# paste commands here
```

## Stop Conditions Check
If any item below happened, explain how scope was reduced before merge.

- [ ] `any` started spreading across files
- [ ] Root `tsc` broke repeatedly
- [ ] Types required cross-module rewrites
- [ ] Scope was reduced to keep the PR reviewable

Notes:

## Reviewer Focus
What should reviewers look at first?

- 
- 
- 
