### PR TITLE
feat(walkthrough): wire MapPeekWidget open detection into step 5

### DIFF
--- a/demo/App.tsx
+++ b/demo/App.tsx
@@ -951,20 +951,36 @@ function App() {
   });
 
   // Snap the calendar to the walkthrough seed date on first guided mount so
-  // Mission Alpha is at the natural focus point (especially for Week/Day
-  // views, where today's date would otherwise hide the seeds entirely).
-  // Skipped in EMBED_MODE so e2e tests keep their real "today" landing.
-  const calendarRef = useRef(null);
-  const didSnapRef  = useRef(false);
-  useEffect(() => {
-    if (EMBED_MODE) return;
+  // Mission Alpha is at the natural focus point — important across views:
+  //   • Schedule view's 6-week window starts at startOfWeek(currentDate);
+  //     today (Apr 30) puts the window at Apr 26 → Jun 6, hiding the
+  //     Apr 23 seeds entirely.
+  //   • Week / Day views show only the current period.
+  //   • Month view is forgiving (April 23 is in April), but the pulse is
+  //     more obvious when alpha is the focused cell.
+  // Implemented as a callback ref rather than useEffect because the parent
+  // mount effect can occasionally fire before forwardRef + useImperativeHandle
+  // has populated the imperative handle. Callback refs run synchronously the
+  // moment the ref is attached, so we never race the calendar's mount.
+  // Skipped in EMBED_MODE so e2e tests keep their real "today" landing, and
+  // skipped if the user has already engaged with the walkthrough.
+  const calendarApiRef = useRef(null);
+  const didSnapRef     = useRef(false);
+  const walkthroughModeRef    = useRef(walkthrough.state.mode);
+  const walkthroughHistoryRef = useRef(walkthrough.state.history.length);
+  walkthroughModeRef.current    = walkthrough.state.mode;
+  walkthroughHistoryRef.current = walkthrough.state.history.length;
+
+  const calendarRef = useCallback((api) => {
+    calendarApiRef.current = api;
+    if (!api?.navigateTo) return;
     if (didSnapRef.current) return;
-    if (walkthrough.state.mode === 'free-play') return;
-    if (walkthrough.state.history.length > 0) return; // user has already engaged
-    if (!calendarRef.current?.navigateTo) return;
-    calendarRef.current.navigateTo(new Date(ALPHA_INITIAL_START_ISO));
+    if (EMBED_MODE) return;
+    if (walkthroughModeRef.current === 'free-play') return;
+    if (walkthroughHistoryRef.current > 0) return;
+    api.navigateTo(new Date(ALPHA_INITIAL_START_ISO));
     didSnapRef.current = true;
-  }, [walkthrough.state.mode, walkthrough.state.history.length]);
+  }, []);
 
   const calendar = (
     <WorksCalendar

--- a/demo/App.tsx
+++ b/demo/App.tsx
@@ -987,6 +987,7 @@ function App() {
       onNoteDelete={handleNoteDelete}
       onEventSave={EMBED_MODE ? handleEventSave : walkthrough.wrapped.onEventSave}
       onViewChange={EMBED_MODE ? undefined : walkthrough.wrapped.onViewChange}
+      onMapWidgetOpenChange={EMBED_MODE ? undefined : walkthrough.wrapped.onMapWidgetOpenChange}
       onEventDelete={handleEventDelete}
       onScheduleSave={handleEventSave}
       onAvailabilitySave={handleEventSave}

--- a/demo/walkthrough/steps.ts
+++ b/demo/walkthrough/steps.ts
@@ -84,14 +84,15 @@ export const STEPS: readonly Step[] = [
     id: 'open-map',
     banner: {
       title: 'Bonus — See where your fleet is',
-      body:  'Open the map widget to see resource locations at a glance.',
+      body:  'Click the corner map peek to expand it. Resource locations show at a glance.',
     },
-    // Two emit paths: dedicated map widget (preferred, coming on another
-    // branch) or the existing built-in `map` view as a fallback.
+    spotlight: { selector: '[data-wc-map-widget="peek"]' },
+    // Two emit paths: the dedicated MapPeekWidget (primary), or a host that
+    // routes the legacy 'map' view as a fallback.
     matches: (event) =>
       event.kind === 'map-widget-opened'
       || (event.kind === 'view-changed' && event.view === 'map'),
-    hint: 'Click the map icon — it shows where each aircraft is right now.',
+    hint: 'Look for the small "Region map" tile in the corner of the calendar — click it to expand.',
   },
 
   {

--- a/demo/walkthrough/steps.ts
+++ b/demo/walkthrough/steps.ts
@@ -84,7 +84,7 @@ export const STEPS: readonly Step[] = [
     id: 'open-map',
     banner: {
       title: 'Bonus — See where your fleet is',
-      body:  'Click the corner map peek to expand it. Resource locations show at a glance.',
+      body:  'Click the Region map mini-plot to expand it. Resource locations show at a glance.',
     },
     spotlight: { selector: '[data-wc-map-widget="peek"]' },
     // Two emit paths: the dedicated MapPeekWidget (primary), or a host that
@@ -92,7 +92,7 @@ export const STEPS: readonly Step[] = [
     matches: (event) =>
       event.kind === 'map-widget-opened'
       || (event.kind === 'view-changed' && event.view === 'map'),
-    hint: 'Look for the small "Region map" tile in the corner of the calendar — click it to expand.',
+    hint: 'Look for the "Region map" preview in the right rail — click it to expand.',
   },
 
   {

--- a/demo/walkthrough/useWalkthrough.ts
+++ b/demo/walkthrough/useWalkthrough.ts
@@ -62,6 +62,7 @@ export interface HostDelegate {
   onEventSave?: (event: HostEvent) => void;
   onConflictCheck?: (event: HostEvent, candidate: HostEvent) => Promise<unknown> | unknown;
   onViewChange?: (view: string) => void;
+  onMapWidgetOpenChange?: (open: boolean) => void;
 }
 
 /** Minimal event shape the adapter cares about — kept loose so the demo's
@@ -179,6 +180,13 @@ export function useWalkthrough({ ctx, delegate }: UseWalkthroughArgs): Walkthrou
     onViewChange: (view) => {
       delegate.onViewChange?.(view);
       observe({ kind: 'view-changed', view });
+    },
+
+    onMapWidgetOpenChange: (open) => {
+      delegate.onMapWidgetOpenChange?.(open);
+      // Only the open transition advances the walkthrough; closing the modal
+      // shouldn't fire a redundant observation.
+      if (open) observe({ kind: 'map-widget-opened' });
     },
   }), [delegate, ctx.alphaEventId, ctx.bravoEventId, observe]);
 

--- a/src/WorksCalendar.tsx
+++ b/src/WorksCalendar.tsx
@@ -218,6 +218,7 @@ export type WorksCalendarProps = {
   onEventGroupChange?: (event: WorksCalendarEvent, patch: EventGroupPatch) => void;
   onDateSelect?: (start: Date, end: Date, resourceId?: string) => void;
   onViewChange?: (view: CalendarView) => void;
+  onMapWidgetOpenChange?: (open: boolean) => void;
   supabaseUrl?: string;
   supabaseKey?: string;
   supabaseTable?: string;
@@ -552,6 +553,7 @@ export const WorksCalendar = forwardRef<CalendarApi, WorksCalendarProps>(functio
     onEventGroupChange,
     onDateSelect,
     onViewChange,
+    onMapWidgetOpenChange,
 
     // ── Supabase realtime ──
     supabaseUrl,
@@ -2961,6 +2963,7 @@ export const WorksCalendar = forwardRef<CalendarApi, WorksCalendarProps>(functio
                 events={expandedEvents as never}
                 onEventClick={handleEventClick as never}
                 {...(mapStyle ? { mapStyle } : {})}
+                {...(onMapWidgetOpenChange ? { onOpenChange: onMapWidgetOpenChange } : {})}
               />
             </>
           )}

--- a/src/ui/MapPeekWidget.tsx
+++ b/src/ui/MapPeekWidget.tsx
@@ -8,7 +8,7 @@
  * basemap. Closing the modal returns to the corner preview; the corner
  * never disappears, so the operator's "where am I" reference stays put.
  */
-import { useEffect, useMemo, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import { X } from 'lucide-react'
 import MapView from '../views/MapView'
 import styles from './MapPeekWidget.module.css'
@@ -27,6 +27,10 @@ export interface MapPeekWidgetProps {
   readonly onEventClick?: (event: EventLike) => void
   /** MapLibre style URL, forwarded to MapView. */
   readonly mapStyle?: string
+  /** Fires whenever the corner widget toggles its modal open or closed.
+   *  Used by the demo walkthrough to advance the "open the map" step; also
+   *  available to any host that wants to react to map peeks. */
+  readonly onOpenChange?: (open: boolean) => void
 }
 
 interface Plotted { id: string; lat: number; lon: number }
@@ -49,8 +53,22 @@ const MINI_W = 200
 const MINI_H = 96
 const MINI_PAD = 10
 
-export function MapPeekWidget({ events, onEventClick, mapStyle }: MapPeekWidgetProps) {
+export function MapPeekWidget({ events, onEventClick, mapStyle, onOpenChange }: MapPeekWidgetProps) {
   const [open, setOpen] = useState(false)
+
+  // Notify host on toggle. Skips the initial mount so consumers don't get a
+  // synthetic 'closed' event for the default state. Mirrors WorksCalendar's
+  // onViewChange pattern.
+  const lastOpenRef = useRef<boolean | null>(null)
+  useEffect(() => {
+    if (lastOpenRef.current === null) {
+      lastOpenRef.current = open
+      return
+    }
+    if (lastOpenRef.current === open) return
+    lastOpenRef.current = open
+    onOpenChange?.(open)
+  }, [open, onOpenChange])
 
   const plotted = useMemo<Plotted[]>(() => {
     const out: Plotted[] = []
@@ -73,7 +91,7 @@ export function MapPeekWidget({ events, onEventClick, mapStyle }: MapPeekWidgetP
 
   return (
     <>
-      <div className={styles['host']}>
+      <div className={styles['host']} data-wc-map-widget="peek">
         <button
           type="button"
           className={styles['mini']}


### PR DESCRIPTION
Now that MapPeekWidget has landed on main (33eec5f / 321f861), the "open the map" walkthrough step can key off the actual widget instead of the legacy 'map' view fallback.

Library plumbing
- src/ui/MapPeekWidget.tsx: new onOpenChange?: (open: boolean) => void prop. Fires via useEffect on the open state change, skipping the initial mount (mirrors WorksCalendar's onViewChange pattern, so the callback only emits real toggle transitions).
- src/ui/MapPeekWidget.tsx: data-wc-map-widget="peek" on the host div so the walkthrough Step 5 spotlight has a stable selector for the pulse animation. Module-scoped CSS class names won't survive a build, so an explicit data-* hook is required.
- src/WorksCalendar.tsx: new onMapWidgetOpenChange?: (open: boolean) => void prop forwarded to the embedded <MapPeekWidget>. Conditional spread keeps the prop off the widget when the host doesn't wire it, preserving the legacy default behavior.

Walkthrough wiring
- demo/walkthrough/useWalkthrough.ts: HostDelegate gains onMapWidgetOpenChange; the wrapped version emits observe({ kind: 'map-widget-opened' }) only on the open transition (closing the modal shouldn't generate redundant observations).
- demo/walkthrough/steps.ts: Step 5 banner copy now references the corner peek tile, and its spotlight selector points at [data-wc-map-widget="peek"] so the mini-plot pulses while the user is on this step. Kept the view-changed:'map' fallback in the match predicate as defensive dual-pathing.
- demo/App.tsx: passes walkthrough.wrapped.onMapWidgetOpenChange to <WorksCalendar>, gated on !EMBED_MODE alongside the other walkthrough hooks.

Verified: tsc --noEmit clean; 2661 vitest tests pass (up from 2654 via the merge from main); demo build succeeds.

https://claude.ai/code/session_01GzH5mhsAHCjQkFDUBWXqYy

## Summary
Describe exactly what this PR changes.

## Scope
- Stage: 
- Planned PR number in sprint: 
- Target files/directories: 
- Why this slice is isolated: 

## Lessons Learned Check (REQUIRED)
Confirm these were actively used while building this PR:

- [ ] PR is intentionally small and isolated
- [ ] Boundary typing was prioritized over internal perfection
- [ ] No silent spread of `any`
- [ ] Advisory root `tsc` was used to catch integration issues
- [ ] I did not assume “looks typed” means “safe”
- [ ] I stopped and isolated typing cascades instead of expanding scope

## Definition of Done (ALL REQUIRED)
This PR is not done unless every box is checked.

- [ ] `npm run type-check:strict` passes
- [ ] Root advisory `tsc --noEmit` passes
- [ ] Tests pass for touched scope at minimum
- [ ] No uncontrolled increase in `any`
- [ ] All new types are intentional and named
- [ ] Public interfaces and exported functions are explicitly typed
- [ ] PR scope matches the sprint plan with no scope creep
- [ ] Any new `any` has an adjacent justification comment
- [ ] No file-wide `: any`
- [ ] No implicit `any` in exported functions

## What Was Typed
List exactly what was typed in this PR.

- 
- 
- 

## What Was Intentionally Left Loose
List anything intentionally not tightened yet.

- 
- 
- 

## `any` Ledger (REQUIRED)
- New `any` added: 
- Existing `any` removed: 
- Net change: 

For every new `any`, explain why it is required and why a safer type was not used yet.

1. 
2. 
3. 

## Boundary Notes
Document any public seams, caller-protection choices, or compatibility decisions.

- 
- 
- 

## Risk Level
- [ ] Low
- [ ] Medium
- [ ] High

Why:

## Validation Evidence
Paste the exact commands run and a short result summary.

```bash
npm run type-check:strict
npx tsc --noEmit -p tsconfig.json
```

Test commands run:

```bash
# paste commands here
```

## Stop Conditions Check
If any item below happened, explain how scope was reduced before merge.

- [ ] `any` started spreading across files
- [ ] Root `tsc` broke repeatedly
- [ ] Types required cross-module rewrites
- [ ] Scope was reduced to keep the PR reviewable

Notes:

## Reviewer Focus
What should reviewers look at first?

- 
- 
- 
