### PR TITLE
fix(demo/Landing): coerce ev.start before localeCompare in approval q…

### DIFF
--- a/demo/Landing.test.ts
+++ b/demo/Landing.test.ts
@@ -1,25 +1,27 @@
 /**
- * Regression test for the chrome-level approval queue.
+ * Regression tests for the chrome-level approval queue.
  *
- * The bug: dragging an approval-tagged event (e.g. an aircraft request that
- * shares a row with the São Paulo → Munich mission) wrote a Date back into
- * the demo's `events` state via the calendar's onEventSave round-trip.
- * Landing's `splitApprovalQueues` then sorted those items with
- * `b.start.localeCompare(a.start)` — Date doesn't have `.localeCompare`, so
- * the chrome crashed with `i.start.localeCompare is not a function` the
- * moment React re-rendered after the drop.
+ * Two bugs covered here:
  *
- * Fix: coerce `ev.start` to ISO string at the boundary so the comparator
- * stays type-safe regardless of whether the host hands us strings or
- * Dates. This test pins the crash by feeding mixed string/Date starts.
+ * 1. Crash on Date starts. Dragging an approval-tagged event in the calendar
+ *    rewrote `events[i].start` as a real Date via the calendar's onEventSave
+ *    round-trip. Landing's splitApprovalQueues then sorted with
+ *    `b.start.localeCompare(a.start)` — Date doesn't have `.localeCompare`,
+ *    so the chrome's useMemo crashed on the next render with
+ *    `i.start.localeCompare is not a function`.
+ *
+ * 2. Mixed-format ordering. Coercing only Date → ISO (`...Z`) while leaving
+ *    naive local strings (`YYYY-MM-DDTHH:mm`) untouched mixes UTC and local
+ *    in the same lexical sort key, which inverts chronology in non-UTC
+ *    timezones. Comparing epoch ms removes the format axis entirely.
  */
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, afterEach, beforeEach } from 'vitest';
 import { splitApprovalQueues } from './Landing';
 import { findProfile } from './profiles';
 
-describe('splitApprovalQueues', () => {
-  const opsManager = findProfile('ops-manager');
+const opsManager = findProfile('ops-manager');
 
+describe('splitApprovalQueues', () => {
   it('does not crash when an approval event has a Date start (post-drag/save shape)', () => {
     const events = [
       // String start — initial event shape from INITIAL_EVENTS.
@@ -35,9 +37,6 @@ describe('splitApprovalQueues', () => {
     expect(() => splitApprovalQueues(events, opsManager)).not.toThrow();
     const { awaiting } = splitApprovalQueues(events, opsManager);
     expect(awaiting.map(i => i.id)).toEqual(['req-b', 'req-a']); // sorted DESC by start
-    // Items are normalized to string starts so downstream renderers stay
-    // string-typed.
-    awaiting.forEach(i => expect(typeof i.start).toBe('string'));
   });
 
   it('keeps working with all-string starts (legacy shape)', () => {
@@ -51,5 +50,43 @@ describe('splitApprovalQueues', () => {
     ];
     const { awaiting } = splitApprovalQueues(events, opsManager);
     expect(awaiting.map(i => i.id)).toEqual(['req-b', 'req-a']);
+  });
+
+  describe('mixed naive-string and UTC-Date ordering (Codex P2 review)', () => {
+    // Simulate a US-Pacific run where one event lives in INITIAL_EVENTS as a
+    // naive local-time string and another came back from the calendar as a
+    // Date (which serialises to UTC ISO with a `Z` suffix). Pure lexical
+    // comparison would invert these because `2026-04-25T07:45:00.000Z` >
+    // `2026-04-25T00:30` as strings even though the Date is *earlier* in
+    // local time. We pin TZ via process.env so the test is deterministic.
+    let originalTZ: string | undefined;
+
+    beforeEach(() => {
+      originalTZ = process.env['TZ'];
+      process.env['TZ'] = 'America/Los_Angeles';
+    });
+    afterEach(() => {
+      process.env['TZ'] = originalTZ;
+    });
+
+    it('orders chronologically when one start is a naive string and the other is a Date', () => {
+      // local 2026-04-24 23:45 PDT (which is 2026-04-25T06:45Z)
+      const earlierAsDate = new Date('2026-04-25T06:45:00.000Z');
+      // naive 2026-04-25 00:30 → in PDT this is 2026-04-25T07:30Z, *later*.
+      const laterAsString = '2026-04-25T00:30';
+
+      const events = [
+        { id: 'earlier', title: 'Earlier (Date)', start: earlierAsDate,
+          category: 'aircraft-request',
+          meta: { approvalStage: { stage: 'requested' } } },
+        { id: 'later', title: 'Later (string)', start: laterAsString,
+          category: 'aircraft-request',
+          meta: { approvalStage: { stage: 'requested' } } },
+      ];
+
+      const { awaiting } = splitApprovalQueues(events, opsManager);
+      // Most-recent-first: laterAsString must come before earlierAsDate.
+      expect(awaiting.map(i => i.id)).toEqual(['later', 'earlier']);
+    });
   });
 });

--- a/demo/Landing.test.ts
+++ b/demo/Landing.test.ts
@@ -1,0 +1,55 @@
+/**
+ * Regression test for the chrome-level approval queue.
+ *
+ * The bug: dragging an approval-tagged event (e.g. an aircraft request that
+ * shares a row with the São Paulo → Munich mission) wrote a Date back into
+ * the demo's `events` state via the calendar's onEventSave round-trip.
+ * Landing's `splitApprovalQueues` then sorted those items with
+ * `b.start.localeCompare(a.start)` — Date doesn't have `.localeCompare`, so
+ * the chrome crashed with `i.start.localeCompare is not a function` the
+ * moment React re-rendered after the drop.
+ *
+ * Fix: coerce `ev.start` to ISO string at the boundary so the comparator
+ * stays type-safe regardless of whether the host hands us strings or
+ * Dates. This test pins the crash by feeding mixed string/Date starts.
+ */
+import { describe, it, expect } from 'vitest';
+import { splitApprovalQueues } from './Landing';
+import { findProfile } from './profiles';
+
+describe('splitApprovalQueues', () => {
+  const opsManager = findProfile('ops-manager');
+
+  it('does not crash when an approval event has a Date start (post-drag/save shape)', () => {
+    const events = [
+      // String start — initial event shape from INITIAL_EVENTS.
+      { id: 'req-a', title: 'Lift Request – A', start: '2026-04-23T08:00',
+        category: 'aircraft-request',
+        meta: { approvalStage: { stage: 'requested' } } },
+      // Date start — what the calendar emits via onEventSave after a move.
+      { id: 'req-b', title: 'Lift Request – B', start: new Date(2026, 3, 24, 9, 0),
+        category: 'aircraft-request',
+        meta: { approvalStage: { stage: 'requested' } } },
+    ];
+
+    expect(() => splitApprovalQueues(events, opsManager)).not.toThrow();
+    const { awaiting } = splitApprovalQueues(events, opsManager);
+    expect(awaiting.map(i => i.id)).toEqual(['req-b', 'req-a']); // sorted DESC by start
+    // Items are normalized to string starts so downstream renderers stay
+    // string-typed.
+    awaiting.forEach(i => expect(typeof i.start).toBe('string'));
+  });
+
+  it('keeps working with all-string starts (legacy shape)', () => {
+    const events = [
+      { id: 'req-a', title: 'A', start: '2026-04-23T08:00',
+        category: 'aircraft-request',
+        meta: { approvalStage: { stage: 'requested' } } },
+      { id: 'req-b', title: 'B', start: '2026-04-25T09:00',
+        category: 'aircraft-request',
+        meta: { approvalStage: { stage: 'requested' } } },
+    ];
+    const { awaiting } = splitApprovalQueues(events, opsManager);
+    expect(awaiting.map(i => i.id)).toEqual(['req-b', 'req-a']);
+  });
+});

--- a/demo/Landing.tsx
+++ b/demo/Landing.tsx
@@ -12,7 +12,13 @@ import {
 interface ApprovalEvent {
   id: string;
   title: string;
-  start: string;
+  // The host (demo/App.tsx) hands us events straight from its events
+  // state, which mixes string starts (from INITIAL_EVENTS) with Date
+  // starts (from `getSavedEventPayload → toLegacyEvent` after any
+  // drag-move or form save). Accept either and coerce when comparing —
+  // calling `.localeCompare` on a Date used to crash the chrome the
+  // moment a host saved a coord-tagged event.
+  start: string | Date;
   category: string;
   meta?: { approvalStage?: { stage?: string; updatedAt?: string } };
 }
@@ -201,11 +207,18 @@ interface ApprovalQueueItem {
   id: string;
   title: string;
   stage: string;
+  // ISO-string form so the queue's sort comparator is type-safe even when
+  // the upstream event arrives with a Date start (post-drag/save shape).
   start: string;
   category: string;
 }
 
-function splitApprovalQueues(
+function startToIso(value: string | Date): string {
+  if (value instanceof Date) return value.toISOString();
+  return value;
+}
+
+export function splitApprovalQueues(
   events: ApprovalEvent[],
   profile: DemoProfile,
 ): { myRequests: ApprovalQueueItem[]; awaiting: ApprovalQueueItem[] } {
@@ -218,7 +231,7 @@ function splitApprovalQueues(
       id: ev.id,
       title: ev.title,
       stage,
-      start: ev.start,
+      start: startToIso(ev.start),
       category: ev.category,
     };
     const isOwnRequest = simulatedRequesterIdFor(ev.category) === profile.id;

--- a/demo/Landing.tsx
+++ b/demo/Landing.tsx
@@ -207,15 +207,27 @@ interface ApprovalQueueItem {
   id: string;
   title: string;
   stage: string;
-  // ISO-string form so the queue's sort comparator is type-safe even when
-  // the upstream event arrives with a Date start (post-drag/save shape).
-  start: string;
+  // Epoch ms so the queue's sort comparator stays correct regardless of
+  // whether the upstream event arrives as a naive local-time string
+  // (`YYYY-MM-DDTHH:mm`, what INITIAL_EVENTS produces) or as a Date
+  // serialised to UTC ISO (`...Z`, what the calendar emits via
+  // toLegacyEvent after a drag-move). Lexically comparing those mixed
+  // shapes inverts chronology in non-UTC time zones — e.g. a moved
+  // event at local 2026-04-24T23:45 becomes 2026-04-25T06:45:00.000Z
+  // and would sort *ahead* of an untouched 2026-04-25T00:30 even though
+  // it's earlier in real time. Comparing milliseconds removes the
+  // format axis entirely.
+  startMs: number;
   category: string;
 }
 
-function startToIso(value: string | Date): string {
-  if (value instanceof Date) return value.toISOString();
-  return value;
+function startToMs(value: string | Date): number {
+  if (value instanceof Date) {
+    const t = value.getTime();
+    return Number.isFinite(t) ? t : 0;
+  }
+  const t = Date.parse(value);
+  return Number.isFinite(t) ? t : 0;
 }
 
 export function splitApprovalQueues(
@@ -231,7 +243,7 @@ export function splitApprovalQueues(
       id: ev.id,
       title: ev.title,
       stage,
-      start: startToIso(ev.start),
+      startMs: startToMs(ev.start),
       category: ev.category,
     };
     const isOwnRequest = simulatedRequesterIdFor(ev.category) === profile.id;
@@ -253,8 +265,8 @@ export function splitApprovalQueues(
     }
   }
   // Most recent first.
-  awaiting.sort((a, b) => b.start.localeCompare(a.start));
-  myRequests.sort((a, b) => b.start.localeCompare(a.start));
+  awaiting.sort((a, b) => b.startMs - a.startMs);
+  myRequests.sort((a, b) => b.startMs - a.startMs);
   return { myRequests, awaiting };
 }
 


### PR DESCRIPTION
…ueue

Console error from the published demo:
  TypeError: i.start.localeCompare is not a function
  at Array.sort  ← splitApprovalQueues comparator

Repro: drag any event in the calendar — including the São Paulo → Munich critical care transfer — to a new date. The library's onEventSave round-trip hands the host (demo/App.tsx) the saved payload via getSavedEventPayload → toLegacyEvent, which exposes start/end as real Date instances. The demo's handleEventSave splices that payload back into its `events` state, so post-drag the array mixes the original string starts (from INITIAL_EVENTS) with Date starts (from the moved event). Landing's splitApprovalQueues then sorts the queue items via `b.start.localeCompare(a.start)` — String#localeCompare doesn't exist on Date, so the chrome's useMemo throws synchronously on the next render and the page goes blank.

Coerce `ev.start` to an ISO string at the boundary inside splitApprovalQueues so the queue items stay string-typed regardless of what shape the host hands us. Widen the ApprovalEvent contract to `string | Date` to document the dual shape.

Adds a regression test that pins the crash by feeding mixed string/Date starts and asserting both ordering and that no exception escapes.

https://claude.ai/code/session_015242vwwg5fqNWusuyyPejx

## Summary
Describe exactly what this PR changes.

## Scope
- Stage: 
- Planned PR number in sprint: 
- Target files/directories: 
- Why this slice is isolated: 

## Lessons Learned Check (REQUIRED)
Confirm these were actively used while building this PR:

- [ ] PR is intentionally small and isolated
- [ ] Boundary typing was prioritized over internal perfection
- [ ] No silent spread of `any`
- [ ] Advisory root `tsc` was used to catch integration issues
- [ ] I did not assume “looks typed” means “safe”
- [ ] I stopped and isolated typing cascades instead of expanding scope

## Definition of Done (ALL REQUIRED)
This PR is not done unless every box is checked.

- [ ] `npm run type-check:strict` passes
- [ ] Root advisory `tsc --noEmit` passes
- [ ] Tests pass for touched scope at minimum
- [ ] No uncontrolled increase in `any`
- [ ] All new types are intentional and named
- [ ] Public interfaces and exported functions are explicitly typed
- [ ] PR scope matches the sprint plan with no scope creep
- [ ] Any new `any` has an adjacent justification comment
- [ ] No file-wide `: any`
- [ ] No implicit `any` in exported functions

## What Was Typed
List exactly what was typed in this PR.

- 
- 
- 

## What Was Intentionally Left Loose
List anything intentionally not tightened yet.

- 
- 
- 

## `any` Ledger (REQUIRED)
- New `any` added: 
- Existing `any` removed: 
- Net change: 

For every new `any`, explain why it is required and why a safer type was not used yet.

1. 
2. 
3. 

## Boundary Notes
Document any public seams, caller-protection choices, or compatibility decisions.

- 
- 
- 

## Risk Level
- [ ] Low
- [ ] Medium
- [ ] High

Why:

## Validation Evidence
Paste the exact commands run and a short result summary.

```bash
npm run type-check:strict
npx tsc --noEmit -p tsconfig.json
```

Test commands run:

```bash
# paste commands here
```

## Stop Conditions Check
If any item below happened, explain how scope was reduced before merge.

- [ ] `any` started spreading across files
- [ ] Root `tsc` broke repeatedly
- [ ] Types required cross-module rewrites
- [ ] Scope was reduced to keep the PR reviewable

Notes:

## Reviewer Focus
What should reviewers look at first?

- 
- 
- 
