### PR TITLE
fix(walkthrough): spotlight breaks pill clicks; week pill clutter

### DIFF
--- a/demo/App.tsx
+++ b/demo/App.tsx
@@ -960,29 +960,37 @@ function App() {
   // teaches lives there ("a request lands on the week, scheduler moves it,
   // then fills it"), and (b) navigates currentDate to the seed date so the
   // unassigned mission is on screen regardless of "today".
-  // Implemented as a callback ref rather than useEffect because the parent
-  // mount effect can occasionally fire before forwardRef + useImperativeHandle
-  // has populated the imperative handle. Callback refs run synchronously the
-  // moment the ref is attached, so we never race the calendar's mount.
+  //
+  // Wiring: callback ref populates calendarApiRef when WorksCalendar attaches
+  // its imperative handle. The actual setView/navigateTo calls live in a
+  // parent useEffect so they run AFTER the calendar's own mount effects —
+  // specifically the defaultView-applied effect at WorksCalendar.tsx:745
+  // which would otherwise reset state.view to the stored 'schedule' (or
+  // whatever returning visitors had) right after our snap.
+  //
   // Skipped in EMBED_MODE so e2e tests keep their real "today" landing, and
   // skipped if the user has already engaged with the walkthrough.
   const calendarApiRef = useRef(null);
   const didSnapRef     = useRef(false);
-  const walkthroughModeRef    = useRef(walkthrough.state.mode);
-  const walkthroughHistoryRef = useRef(walkthrough.state.history.length);
-  walkthroughModeRef.current    = walkthrough.state.mode;
-  walkthroughHistoryRef.current = walkthrough.state.history.length;
 
   const calendarRef = useCallback((api) => {
     calendarApiRef.current = api;
-    if (!api?.navigateTo) return;
+  }, []);
+
+  useEffect(() => {
     if (didSnapRef.current) return;
     if (EMBED_MODE) return;
-    if (walkthroughModeRef.current === 'free-play') return;
-    if (walkthroughHistoryRef.current > 0) return;
-    api.setView?.('week');
+    if (walkthrough.state.mode === 'free-play') return;
+    if (walkthrough.state.history.length > 0) return;
+    const api = calendarApiRef.current;
+    if (!api?.navigateTo || !api?.setView) return;
+    api.setView('week');
     api.navigateTo(new Date(ALPHA_INITIAL_START_ISO));
     didSnapRef.current = true;
+    // Intentionally empty deps: this is a once-on-mount snap. Re-running on
+    // mode/history changes would risk yanking the user back to the seed
+    // date if they've navigated away.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   const calendar = (

--- a/demo/walkthrough/WalkthroughHost.tsx
+++ b/demo/walkthrough/WalkthroughHost.tsx
@@ -70,12 +70,14 @@ function buildSpotlightCss(spotlight: StepSpotlight | undefined): string | null 
     : spotlight.selector ?? null;
   if (!selector) return null;
 
-  // outline + box-shadow pulse. Position relative + z-index keeps the glow
-  // above neighboring pills without changing layout.
+  // outline + box-shadow pulse. We deliberately do NOT touch `position` or
+  // `z-index` here — Week / Day pills rely on `position: absolute` for their
+  // inline top/left/width/height percentages, and overriding that to relative
+  // breaks the layout (the pill renders at static flow position, leaving the
+  // click area empty so click-to-edit becomes click-to-create-new-event).
+  // outline is "outside" the box layout so it doesn't need positioning help.
   return `
     ${selector} {
-      position: relative;
-      z-index: 5;
       outline: 3px solid #f59e0b;
       outline-offset: 2px;
       border-radius: 6px;

--- a/src/views/WeekView.tsx
+++ b/src/views/WeekView.tsx
@@ -333,7 +333,6 @@ export default function WeekView({
     const display = ((ev.meta ?? {}) as { _display?: { large?: boolean; bold?: boolean } })._display ?? {};
     const isUltraCompact = height < 42;
     const isCompact = height < 72;
-    const timeRangeLabel = `${format(ev.start, 'h:mm a')} - ${format(ev.end, 'h:mm a')}`;
 
     const inner = ctx?.renderEvent
       ? ctx.renderEvent(ev, { view: 'week', isCompact: false, onClick, color })
@@ -372,15 +371,14 @@ export default function WeekView({
               <EventStatusBadge lifecycle={(ev as { lifecycle?: unknown }).lifecycle as never} variant="compact" />
               {ev.title}
             </span>
-            {isUltraCompact ? null : (
-              <span className={styles['evTimeRange']}>{timeRangeLabel}</span>
-            )}
+            {/* Pill height + grid position already encode start/end visually,
+             *  so the duplicated time labels (timeRange, Start, End) only
+             *  starved the title of legible space. Keep the resource line
+             *  (non-time, useful when row identity is grid-conveyed but
+             *  pills overlap or wrap). aria-label still includes everything
+             *  for screen readers. */}
             {isCompact ? null : (
-              <>
-                <span className={styles['evTime']}>Start: {format(ev.start, 'h:mm a')}</span>
-                <span className={styles['evTime']}>End: {format(ev.end, 'h:mm a')}</span>
-                <span className={styles['evMeta']}>Resource: {pillResource(ev)}</span>
-              </>
+              <span className={styles['evMeta']}>Resource: {pillResource(ev)}</span>
             )}
           </>
         )}

--- a/src/views/__tests__/WeekDayView.offHoursClipping.test.tsx
+++ b/src/views/__tests__/WeekDayView.offHoursClipping.test.tsx
@@ -79,7 +79,11 @@ describe('WeekView off-hours event clipping', () => {
     expect(btn).toBeInTheDocument();
     expect(screen.queryByText('Title: Type rating')).not.toBeInTheDocument();
     expect(screen.getByText('Type rating')).toBeInTheDocument();
-    expect(screen.getByText(/10:00 AM - 11:00 AM/)).toBeInTheDocument();
+    // Pill height + grid position encode start/end visually, so we no longer
+    // duplicate the time range as text — it just stole space from the title.
+    // The aria-label retains the hours for screen readers (asserted via the
+    // role="button" name match above).
+    expect(screen.queryByText(/10:00 AM - 11:00 AM/)).not.toBeInTheDocument();
   });
 
   it('clips event that starts before dayStart but ends inside the window', () => {


### PR DESCRIPTION
Three bugs surfaced in live demo testing:

1. Click-to-edit Mission Alpha opened a "new event" modal instead of the edit form. The walkthrough spotlight CSS was setting `position: relative` + `z-index: 5` on the targeted pill. Week / Day pills depend on `position: absolute` so their inline `top` / `left` / `width` / `height` percentages place them on the grid; the spotlight override pulled them out of absolute positioning, leaving the original click area empty. Clicking where the pill *appeared* to be hit the empty grid cell behind it, which fires the create-new-event handler. Fix: drop position + z-index from the spotlight rule. Outline + box-shadow pulse don't need positioning help (outline lives outside the box layout).

2. Demo opened to Schedule view despite the auto-nav `setView('week')`. The setView call lived in a callback ref that runs synchronously during commit, but WorksCalendar's `defaultViewApplied` effect (WorksCalendar.tsx:745-753) runs after commit and resets state.view to whatever `display.defaultView` says — overwriting our snap on returning visitors who had 'schedule' stored from a previous session. Fix: split the wiring. Callback ref still attaches the imperative handle, but the actual setView/navigateTo calls move to a parent `useEffect([])` so they run AFTER the calendar's child effects — guaranteeing they win the last-write race.

3. Week pills were rendering 5 lines per pill (title + "8:00 AM - 4:00 PM" timeRange + "Start: ..." + "End: ..." + "Resource: ..."). The duplicated time labels starved the title of legible space, and pill height + grid position already encode start/end visually. Fix (src/views/WeekView.tsx): drop the timeRange / Start / End spans. Keep title (with ApprovalDot + EventStatusBadge prefixes) and Resource. aria-label retains all hour info for screen readers. Test updated: WeekDayView.offHoursClipping now asserts the time range is NOT present in the pill text.

Verified: tsc --noEmit clean; 2650 vitest tests pass; demo build succeeds.

https://claude.ai/code/session_01GzH5mhsAHCjQkFDUBWXqYy

## Summary
Describe exactly what this PR changes.

## Scope
- Stage: 
- Planned PR number in sprint: 
- Target files/directories: 
- Why this slice is isolated: 

## Lessons Learned Check (REQUIRED)
Confirm these were actively used while building this PR:

- [ ] PR is intentionally small and isolated
- [ ] Boundary typing was prioritized over internal perfection
- [ ] No silent spread of `any`
- [ ] Advisory root `tsc` was used to catch integration issues
- [ ] I did not assume “looks typed” means “safe”
- [ ] I stopped and isolated typing cascades instead of expanding scope

## Definition of Done (ALL REQUIRED)
This PR is not done unless every box is checked.

- [ ] `npm run type-check:strict` passes
- [ ] Root advisory `tsc --noEmit` passes
- [ ] Tests pass for touched scope at minimum
- [ ] No uncontrolled increase in `any`
- [ ] All new types are intentional and named
- [ ] Public interfaces and exported functions are explicitly typed
- [ ] PR scope matches the sprint plan with no scope creep
- [ ] Any new `any` has an adjacent justification comment
- [ ] No file-wide `: any`
- [ ] No implicit `any` in exported functions

## What Was Typed
List exactly what was typed in this PR.

- 
- 
- 

## What Was Intentionally Left Loose
List anything intentionally not tightened yet.

- 
- 
- 

## `any` Ledger (REQUIRED)
- New `any` added: 
- Existing `any` removed: 
- Net change: 

For every new `any`, explain why it is required and why a safer type was not used yet.

1. 
2. 
3. 

## Boundary Notes
Document any public seams, caller-protection choices, or compatibility decisions.

- 
- 
- 

## Risk Level
- [ ] Low
- [ ] Medium
- [ ] High

Why:

## Validation Evidence
Paste the exact commands run and a short result summary.

```bash
npm run type-check:strict
npx tsc --noEmit -p tsconfig.json
```

Test commands run:

```bash
# paste commands here
```

## Stop Conditions Check
If any item below happened, explain how scope was reduced before merge.

- [ ] `any` started spreading across files
- [ ] Root `tsc` broke repeatedly
- [ ] Types required cross-module rewrites
- [ ] Scope was reduced to keep the PR reviewable

Notes:

## Reviewer Focus
What should reviewers look at first?

- 
- 
- 
