### PR TITLE
ci: make nightly QA resilient to failed steps

### DIFF
--- a/.github/workflows/nightly-ai-qa.yml
+++ b/.github/workflows/nightly-ai-qa.yml
@@ -12,6 +12,7 @@ permissions:
 jobs:
   qa:
     runs-on: ubuntu-latest
+    timeout-minutes: 45
 
     steps:
       - uses: actions/checkout@v4
@@ -22,26 +23,46 @@ jobs:
           cache: npm
 
       - run: npm ci
+        timeout-minutes: 10
 
       - run: npm run type-check
+        timeout-minutes: 8
 
       - run: npm run test
+        timeout-minutes: 12
 
       - run: npm run build:demo
+        timeout-minutes: 8
 
       - run: npx playwright install --with-deps
+        timeout-minutes: 10
 
-      - run: npm run test:browser
+      # Keep this to a focused smoke pass. The visual QA and confused-user
+      # runs below collect the artifacts that feed the nightly issue.
+      - name: Browser smoke tests
+        run: npm run test:browser
+        timeout-minutes: 12
 
-      - run: npx playwright test tests-e2e/confused-user.spec.ts
+      - name: Confused user exploratory QA
+        if: always()
+        run: npx playwright test tests-e2e/confused-user.spec.ts
+        timeout-minutes: 8
+        continue-on-error: true
 
-      - run: npm run qa:visual
+      - name: Visual screenshot capture and AI review
+        if: always()
+        run: npm run qa:visual
+        timeout-minutes: 12
+        continue-on-error: true
         env:
           OPENAI_BASE_URL: https://api.openai.com/v1
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           LM_STUDIO_MODEL: gpt-4o-mini
 
-      - run: node scripts/post-nightly-qa-issue.mjs
+      - name: Post or update nightly QA issue
+        if: always()
+        run: node scripts/post-nightly-qa-issue.mjs
+        timeout-minutes: 3
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -50,4 +71,8 @@ jobs:
         if: always()
         with:
           name: nightly-qa
-          path: qa-output/
+          path: |
+            qa-output/
+            test-results/
+            playwright-report/
+          if-no-files-found: warn

--- a/.github/workflows/nightly-ai-qa.yml
+++ b/.github/workflows/nightly-ai-qa.yml
@@ -12,7 +12,9 @@ permissions:
 jobs:
   qa:
     runs-on: ubuntu-latest
-    timeout-minutes: 45
+    # Must exceed the cumulative bounded step runtime so if an early step
+    # times out, the always-run reporting and artifact upload steps still fire.
+    timeout-minutes: 90
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
Describe exactly what this PR changes.

## Scope
- Stage: 
- Planned PR number in sprint: 
- Target files/directories: 
- Why this slice is isolated: 

## Lessons Learned Check (REQUIRED)
Confirm these were actively used while building this PR:

- [ ] PR is intentionally small and isolated
- [ ] Boundary typing was prioritized over internal perfection
- [ ] No silent spread of `any`
- [ ] Advisory root `tsc` was used to catch integration issues
- [ ] I did not assume “looks typed” means “safe”
- [ ] I stopped and isolated typing cascades instead of expanding scope

## Definition of Done (ALL REQUIRED)
This PR is not done unless every box is checked.

- [ ] `npm run type-check:strict` passes
- [ ] Root advisory `tsc --noEmit` passes
- [ ] Tests pass for touched scope at minimum
- [ ] No uncontrolled increase in `any`
- [ ] All new types are intentional and named
- [ ] Public interfaces and exported functions are explicitly typed
- [ ] PR scope matches the sprint plan with no scope creep
- [ ] Any new `any` has an adjacent justification comment
- [ ] No file-wide `: any`
- [ ] No implicit `any` in exported functions

## What Was Typed
List exactly what was typed in this PR.

- 
- 
- 

## What Was Intentionally Left Loose
List anything intentionally not tightened yet.

- 
- 
- 

## `any` Ledger (REQUIRED)
- New `any` added: 
- Existing `any` removed: 
- Net change: 

For every new `any`, explain why it is required and why a safer type was not used yet.

1. 
2. 
3. 

## Boundary Notes
Document any public seams, caller-protection choices, or compatibility decisions.

- 
- 
- 

## Risk Level
- [ ] Low
- [ ] Medium
- [ ] High

Why:

## Validation Evidence
Paste the exact commands run and a short result summary.

```bash
npm run type-check:strict
npx tsc --noEmit -p tsconfig.json
```

Test commands run:

```bash
# paste commands here
```

## Stop Conditions Check
If any item below happened, explain how scope was reduced before merge.

- [ ] `any` started spreading across files
- [ ] Root `tsc` broke repeatedly
- [ ] Types required cross-module rewrites
- [ ] Scope was reduced to keep the PR reviewable

Notes:

## Reviewer Focus
What should reviewers look at first?

- 
- 
- 
