### PR TITLE
docs(changelog): document walkthrough-era library changes in Unreleased

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,67 @@ All notable changes to this project are documented in this file.
 The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [Unreleased]
+
+Library and demo changes since 0.5.0 that originated in the
+guided-walkthrough work — limited to the public-API surface a downstream
+consumer would feel. Many other PRs have landed against `main` since
+0.5.0 (strict-null migration, asset setup flow, dispatch board, base
+view redesign, map layer, invoicing integration, etc.); those should be
+folded into this section by their respective authors before the next
+release is cut.
+
+### Added
+
+- **`onViewChange?: (view: CalendarView) => void`** prop on
+  `<WorksCalendar>`. Fires whenever the active view changes (toolbar
+  click, keyboard shortcut, programmatic `cal.setView`, saved-view
+  apply). Skips the initial mount so consumers don't get a synthetic
+  event for the default view.
+- **`onMapWidgetOpenChange?: (open: boolean) => void`** prop on
+  `<WorksCalendar>`, forwarded to the embedded `<MapPeekWidget>`. Fires
+  on the open / close transition of the rail map peek's expanded modal.
+- **`onOpenChange?: (open: boolean) => void`** prop on `MapPeekWidget`.
+  Same semantics as the WorksCalendar passthrough above; useful when
+  embedding the widget directly outside the calendar.
+- **DOM hooks for host tooling**:
+  - `data-wc-event-id="<id>"` on event pills in Day, Week, Month, and
+    Schedule views. Lets host code (e.g. tour overlays, automated
+    tests) target a specific event pill across views by id rather than
+    the volatile module-scoped CSS class.
+  - `data-wc-view-button="<viewId>"` on the toolbar view buttons so
+    automation can pick a specific view button without relying on
+    accessible-name regexes.
+  - `data-wc-map-widget="peek"` on the `MapPeekWidget` host wrapper.
+
+### Changed
+
+- **WeekView pills no longer render duplicate time text.** The pill's
+  vertical position and height already encode the start / end visually,
+  and the timeRange ("8:00 AM – 4:00 PM") + Start / End rows just
+  starved the title of legible space when columns were narrow. Pills
+  now render the title (with ApprovalDot + EventStatusBadge prefixes)
+  and Resource only. **The pill `aria-label` retains the full hour
+  range for screen readers.** Visual change for any consumer asserting
+  on those exact strings.
+
+### Breaking
+
+- **`TimelineView` component renamed to `ScheduleView`.** The toolbar
+  user-facing label has always been "Schedule" and the view id has
+  always been `'schedule'`; the internal component name was an
+  outlier. The public re-export is now `import { ScheduleView } from
+  'works-calendar'` (was `TimelineView`). The view id stays
+  `'schedule'`, so consumer config (`display.defaultView`,
+  `cal.setView('schedule')`, saved views, etc.) does **not** need to
+  change.
+- **Dead `ScheduleView` 6-week grid component removed.** This was an
+  earlier prototype that hadn't been re-rendered since the production
+  ScheduleView (formerly TimelineView) shipped. It had no public
+  re-export and no consumer references, but is being noted here for
+  completeness in case a consumer was reaching into `src/views/`
+  directly.
+
 ## [0.5.0] — 2026-04-19
 
 The "Full TypeScript" release. The library is now written end-to-end in


### PR DESCRIPTION
Adds an [Unreleased] section to CHANGELOG.md covering the public-API surface changes that originated in the guided-walkthrough work. Limits the entry to changes I have confident first-hand context on:

  Added
    - onViewChange prop (WorksCalendar)
    - onMapWidgetOpenChange prop (WorksCalendar) + onOpenChange passthrough on MapPeekWidget
    - data-wc-event-id / data-wc-view-button / data-wc-map-widget DOM hooks for host tooling

  Changed
    - WeekView pills drop duplicate time labels (timeRange / Start / End) so the title is legible. aria-label retains hours for screen readers.

  Breaking
    - TimelineView component renamed → ScheduleView (the view id stays 'schedule', so consumer config doesn't change)
    - Dead 6-week grid ScheduleView removed (was never re-exported)

Notes that many other PRs have landed against main since 0.5.0 (strict-null sprints, asset setup flow, dispatch board, base view redesign, map layer, invoicing, etc.) and that those should be folded into this section by their respective authors before the next release is cut. Deliberately did NOT bump package.json version to 0.6.0 — that should happen as part of the actual release ceremony when the rest of main's work is also documented and a release manager owns the call.

Verified: tsc --noEmit clean; vitest 187 files / 2655 tests pass.

https://claude.ai/code/session_01GzH5mhsAHCjQkFDUBWXqYy

## Summary
Describe exactly what this PR changes.

## Scope
- Stage: 
- Planned PR number in sprint: 
- Target files/directories: 
- Why this slice is isolated: 

## Lessons Learned Check (REQUIRED)
Confirm these were actively used while building this PR:

- [ ] PR is intentionally small and isolated
- [ ] Boundary typing was prioritized over internal perfection
- [ ] No silent spread of `any`
- [ ] Advisory root `tsc` was used to catch integration issues
- [ ] I did not assume “looks typed” means “safe”
- [ ] I stopped and isolated typing cascades instead of expanding scope

## Definition of Done (ALL REQUIRED)
This PR is not done unless every box is checked.

- [ ] `npm run type-check:strict` passes
- [ ] Root advisory `tsc --noEmit` passes
- [ ] Tests pass for touched scope at minimum
- [ ] No uncontrolled increase in `any`
- [ ] All new types are intentional and named
- [ ] Public interfaces and exported functions are explicitly typed
- [ ] PR scope matches the sprint plan with no scope creep
- [ ] Any new `any` has an adjacent justification comment
- [ ] No file-wide `: any`
- [ ] No implicit `any` in exported functions

## What Was Typed
List exactly what was typed in this PR.

- 
- 
- 

## What Was Intentionally Left Loose
List anything intentionally not tightened yet.

- 
- 
- 

## `any` Ledger (REQUIRED)
- New `any` added: 
- Existing `any` removed: 
- Net change: 

For every new `any`, explain why it is required and why a safer type was not used yet.

1. 
2. 
3. 

## Boundary Notes
Document any public seams, caller-protection choices, or compatibility decisions.

- 
- 
- 

## Risk Level
- [ ] Low
- [ ] Medium
- [ ] High

Why:

## Validation Evidence
Paste the exact commands run and a short result summary.

```bash
npm run type-check:strict
npx tsc --noEmit -p tsconfig.json
```

Test commands run:

```bash
# paste commands here
```

## Stop Conditions Check
If any item below happened, explain how scope was reduced before merge.

- [ ] `any` started spreading across files
- [ ] Root `tsc` broke repeatedly
- [ ] Types required cross-module rewrites
- [ ] Scope was reduced to keep the PR reviewable

Notes:

## Reviewer Focus
What should reviewers look at first?

- 
- 
- 
