### PR TITLE
fix(walkthrough): restart resets seeds + view + snapshot; drop dead adapter

### DIFF
--- a/demo/App.tsx
+++ b/demo/App.tsx
@@ -37,6 +37,7 @@ import { useWalkthrough } from './walkthrough/useWalkthrough';
 import {
   ALPHA_INITIAL_START_ISO,
   CONFLICT_PILOT_ID,
+  WALKTHROUGH_DECOY_SHIFT_ID,
   WALKTHROUGH_MISSION_ID,
   buildWalkthroughEvents,
 } from './walkthrough/fixtures';
@@ -993,6 +994,26 @@ function App() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
+  // Restart wraps walkthrough.restart with the cleanup the state-machine
+  // alone can't do: re-seed the demo events (so Mission Alpha is unassigned
+  // and Bravo's conflicting shift is back in place) and snap the calendar
+  // view + date back to the seed slot. Without this, hitting "Restart tour"
+  // after completing the run sends the user to Step 1 ("drag the unassigned
+  // mission") with the mission still pinned to whatever pilot they assigned
+  // last time — narrative breaks immediately.
+  const handleRestart = useCallback(() => {
+    setEvents(prev => {
+      const nonWalkthrough = prev.filter(e =>
+        e.id !== WALKTHROUGH_MISSION_ID && e.id !== WALKTHROUGH_DECOY_SHIFT_ID,
+      );
+      return [...nonWalkthrough, ...buildWalkthroughEvents()];
+    });
+    const api = calendarApiRef.current;
+    api?.setView?.('week');
+    api?.navigateTo?.(new Date(ALPHA_INITIAL_START_ISO));
+    walkthrough.restart();
+  }, [walkthrough.restart]);
+
   const calendar = (
     <WorksCalendar
       ref={calendarRef}
@@ -1074,7 +1095,7 @@ function App() {
           state={walkthrough.state}
           steps={walkthrough.steps}
           onAdvance={walkthrough.advance}
-          onRestart={walkthrough.restart}
+          onRestart={handleRestart}
           onExit={walkthrough.exit}
         />
       )}

--- a/demo/walkthrough/useWalkthrough.ts
+++ b/demo/walkthrough/useWalkthrough.ts
@@ -60,7 +60,6 @@ interface UseWalkthroughArgs {
 export interface HostDelegate {
   onEventMove?: (event: HostEvent, newStart: Date, newEnd: Date) => void;
   onEventSave?: (event: HostEvent) => void;
-  onConflictCheck?: (event: HostEvent, candidate: HostEvent) => Promise<unknown> | unknown;
   onViewChange?: (view: string) => void;
   onMapWidgetOpenChange?: (open: boolean) => void;
 }
@@ -114,7 +113,19 @@ export function useWalkthrough({ ctx, delegate }: UseWalkthroughArgs): Walkthrou
   }, []);
 
   const advance = useCallback(() => dispatch({ type: 'advance' }), []);
-  const restart = useCallback(() => dispatch({ type: 'restart' }), []);
+  const restart = useCallback(() => {
+    // Reset the mission snapshot in lockstep with the state-machine reset so
+    // the first user gesture after restart isn't compared against a stale
+    // post-tour assignment. Without this, a user who finishes the tour with
+    // Mission Alpha assigned to emp-priya and then clicks "Restart" would
+    // see their next drag misclassified as an `event-reassigned` (priya →
+    // null) instead of `mission-moved`, leaving Step 1 stuck.
+    lastMissionSnapshot.current = {
+      resource: null,
+      startIso: ctx.missionInitialStartIso,
+    };
+    dispatch({ type: 'restart' });
+  }, [ctx.missionInitialStartIso]);
   const exit    = useCallback(() => dispatch({ type: 'exit' }), []);
 
   const wrapped = useMemo<HostDelegate>(() => ({
@@ -160,13 +171,6 @@ export function useWalkthrough({ ctx, delegate }: UseWalkthroughArgs): Walkthrou
       }
 
       lastMissionSnapshot.current = { resource: nextResource, startIso: nextStartIso };
-    },
-
-    onConflictCheck: async (ev, candidate) => {
-      // The walkthrough doesn't use this for advancement (the assign step
-      // is satisfied by mission-assigned events). Kept for future use and
-      // so wrapping it stays a no-op pass-through if a host wires it.
-      return delegate.onConflictCheck?.(ev, candidate);
     },
 
     onViewChange: (view) => {


### PR DESCRIPTION
Three Phase A punch-list items closed in one pass — all touch the
restart flow + walkthrough adapter cleanup:

W4 — Restart resets seeded mission state
  Before: clicking "Restart tour" reset the state machine but left
  the events array as-is. After completing the tour with Mission
  Alpha assigned to emp-priya, restart sent the user to Step 1
  ("drag the unassigned mission") with the mission still pinned to
  priya — narrative breaks immediately.
  Fix (demo/App.tsx): wrap walkthrough.restart with a handleRestart
  that re-seeds the demo events. Filters out the existing walkthrough
  events (wt-mission, wt-decoy-shift) and concatenates fresh
  buildWalkthroughEvents() so Mission Alpha is unassigned again and
  the conflict shift on Capt. Wright is back in place.

W5 — Auto-nav re-fires on restart
  Before: useEffect([]) auto-nav only ran on first guided mount. A
  restart left the calendar at whatever date / view the user had
  navigated to during the tour. Step 1's spotlight could end up
  pointing at an off-screen pill.
  Fix (demo/App.tsx): handleRestart also calls api.setView('week')
  + api.navigateTo(seed) so restart re-establishes the same starting
  state as a first-time mount.

W7 — Drop dead onConflictCheck adapter
  Before: useWalkthrough wrapped onConflictCheck in a pure
  pass-through with a "kept for future use" comment. After the
  workflow rewrite the walkthrough no longer reads conflict events
  (the assign-busy step is satisfied by mission-assigned), making
  the wrapper dead code that just leaked an internal HostDelegate
  field downstream.
  Fix (demo/walkthrough/useWalkthrough.ts): remove onConflictCheck
  from the HostDelegate interface and from the wrapped object.

Internal fix tagged onto W4: restart now also resets
lastMissionSnapshot to { resource: null, startIso: missionInitialStartIso }
in lockstep with the state-machine reset. Without this, the first
user gesture after restart would be compared against the stale
post-tour assignment and misclassified as event-reassigned (priya →
null) instead of mission-moved, leaving Step 1 stuck even with the
events re-seeded.

Verified:
  - tsc --noEmit clean
  - vitest: 187 files / 2655 tests pass | 0 skipped
  - playwright e2e: 94 / 94 pass
  - Walkthrough reducer tests: 11 / 11 pass

Punch-list items remaining (UX polish, lower priority):
  W1 already handled, W2/W3/W6/W8/W9 deferred to a later polish PR
  if the team thinks they're worth it.

https://claude.ai/code/session_01GzH5mhsAHCjQkFDUBWXqYy