### PR TITLE
fix(walkthrough): close out remaining Phase A polish items (W2/W3/W6/…

### DIFF
--- a/demo/App.tsx
+++ b/demo/App.tsx
@@ -954,6 +954,7 @@ function App() {
       pilotIds:               walkthroughPilotIds,
     },
     delegate: { onEventSave: handleEventSave },
+    calendarId: DEMO_CALENDAR_ID,
   });
 
   // Snap the calendar to the walkthrough seed slot on first guided mount.

--- a/demo/emsData.ts
+++ b/demo/emsData.ts
@@ -6,12 +6,38 @@
  * rotation, maintenance, training, aircraft requests, and one international
  * critical-care transfer mission (São Paulo → Munich, 4 legs).
  *
- * All datetimes are local-time ISO-8601 strings anchored to the week of
- * 2026-04-20 (Mon). All records are plain objects — no Date, Map, Set, or
+ * All datetimes are local-time ISO-8601 strings, anchored to the Monday
+ * of the current week (whatever "today" is at module load). Originally the
+ * dataset was hardcoded to the week of 2026-04-20; without anchoring, the
+ * events drifted out of the calendar's visible window once the system
+ * clock moved past late April 2026, leaving public visitors with a blank
+ * demo. The week-relative offsets below preserve the original schedule
+ * shape (Mon → Sun = offsets 0–6, next-week Mon → Tue = 7–8, week-3 Mon
+ * = 14) so the same narrative reads the same regardless of when the
+ * demo loads. Records are still plain objects — no Date, Map, Set, or
  * class instances.
  */
 
+import { addDays, format, startOfWeek } from 'date-fns';
+
 import type { DemoRegion, DemoBase, DemoAircraft } from './types';
+
+// ── Date anchor ──────────────────────────────────────────────────────────────
+// `_DATASET_ANCHOR` = Monday of the current week. Every event below derives
+// its date from `ymd(offset)` so the dataset slides forward with real time.
+// Computed once at module load so a multi-day session doesn't shift events
+// mid-render. Refreshing the page picks up the new anchor.
+const _DATASET_ANCHOR = startOfWeek(new Date(), { weekStartsOn: 1 });
+
+/** YYYY-MM-DD for an offset (in days) from the dataset's Monday anchor. */
+function ymd(offset: number): string {
+  return format(addDays(_DATASET_ANCHOR, offset), 'yyyy-MM-dd');
+}
+
+/** Local-time ISO `YYYY-MM-DDTHH:MM` for an offset + time-of-day. */
+function dt(offset: number, time: string): string {
+  return `${ymd(offset)}T${time}`;
+}
 
 // ── Geography ─────────────────────────────────────────────────────────────────
 
@@ -146,10 +172,10 @@ function nightShifts(
   }));
 }
 
-// Weekdays of the anchor week (Mon Apr 20 – Fri Apr 24, 2026)
-const WD: readonly string[] = ['2026-04-20','2026-04-21','2026-04-22','2026-04-23','2026-04-24'];
-// Full week (Mon Apr 20 – Sun Apr 26)
-const W1: readonly string[] = [...WD, '2026-04-25', '2026-04-26'];
+// Weekdays of the anchor week (Mon–Fri, offsets 0–4).
+const WD: readonly string[] = [ymd(0), ymd(1), ymd(2), ymd(3), ymd(4)];
+// Full week (Mon–Sun, offsets 0–6).
+const W1: readonly string[] = [...WD, ymd(5), ymd(6)];
 
 // ── Dispatch shifts ───────────────────────────────────────────────────────────
 
@@ -167,9 +193,9 @@ export const dispatchShifts: DemoEvent[] = [
 ];
 
 // ── Pilot shifts ──────────────────────────────────────────────────────────────
-// James and Elena are on the mission Apr 24, so their shifts end Thu Apr 23.
+// James and Elena are on the mission Fri (offset 4), so their shifts end Thu (offset 3).
 
-const WD_PRE_MISSION: readonly string[] = ['2026-04-20','2026-04-21','2026-04-22','2026-04-23'];
+const WD_PRE_MISSION: readonly string[] = [ymd(0), ymd(1), ymd(2), ymd(3)];
 
 export const pilotShifts: DemoEvent[] = [
   ...dayShifts  ('ps-james',  'Pilot Day',   'emp-james',  'b-seattle',  WD_PRE_MISSION, 'pilot-shift'),
@@ -189,7 +215,7 @@ export const medicalShifts: DemoEvent[] = [
   ...dayShifts  ('ms-nina',   'Medical Day',   'emp-nina',   'b-denver',   WD,             'medical-shift'),
   ...nightShifts('ms-david',  'Medical Night', 'emp-david',  'b-denver',   WD,             'medical-shift'),
   // Grace Taylor — PTO Mon/Tue, day shifts Wed–Fri
-  ...dayShifts  ('ms-grace',  'Medical Day',   'emp-grace',  'b-slc',      ['2026-04-22','2026-04-23','2026-04-24'], 'medical-shift'),
+  ...dayShifts  ('ms-grace',  'Medical Day',   'emp-grace',  'b-slc',      [ymd(2), ymd(3), ymd(4)], 'medical-shift'),
 ];
 
 // ── Mechanic shifts ───────────────────────────────────────────────────────────
@@ -201,11 +227,11 @@ export const mechanicShifts: DemoEvent[] = [
 // ── On-call rotation (week-long blocks) ───────────────────────────────────────
 
 export const mechanicOnCall: DemoEvent[] = [
-  { id: 'oc-mike-w1',  title: 'On Call – Week A', category: 'on-call', visualPriority: 'muted', start: '2026-04-20T00:00', end: '2026-04-27T00:00', assignedTo: 'emp-mike',  basedAt: 'b-seattle' },
-  { id: 'oc-sarah-w2', title: 'On Call – Week B', category: 'on-call', visualPriority: 'muted', start: '2026-04-27T00:00', end: '2026-05-04T00:00', assignedTo: 'emp-sarah', basedAt: 'b-denver'  },
-  { id: 'oc-sam-w1',   title: 'On Call – Week A', category: 'on-call', visualPriority: 'muted', start: '2026-04-20T00:00', end: '2026-04-27T00:00', assignedTo: 'emp-sam',   basedAt: 'b-seattle' },
-  { id: 'oc-grace-w2', title: 'On Call – Week B', category: 'on-call', visualPriority: 'muted', start: '2026-04-27T00:00', end: '2026-05-04T00:00', assignedTo: 'emp-grace', basedAt: 'b-slc'     },
-  { id: 'oc-cody-w1',  title: 'On Call – Week A', category: 'on-call', visualPriority: 'muted', start: '2026-04-20T00:00', end: '2026-04-27T00:00', assignedTo: 'emp-cody',  basedAt: 'b-bozeman' },
+  { id: 'oc-mike-w1',  title: 'On Call – Week A', category: 'on-call', visualPriority: 'muted', start: dt(0,  '00:00'), end: dt(7,  '00:00'), assignedTo: 'emp-mike',  basedAt: 'b-seattle' },
+  { id: 'oc-sarah-w2', title: 'On Call – Week B', category: 'on-call', visualPriority: 'muted', start: dt(7,  '00:00'), end: dt(14, '00:00'), assignedTo: 'emp-sarah', basedAt: 'b-denver'  },
+  { id: 'oc-sam-w1',   title: 'On Call – Week A', category: 'on-call', visualPriority: 'muted', start: dt(0,  '00:00'), end: dt(7,  '00:00'), assignedTo: 'emp-sam',   basedAt: 'b-seattle' },
+  { id: 'oc-grace-w2', title: 'On Call – Week B', category: 'on-call', visualPriority: 'muted', start: dt(7,  '00:00'), end: dt(14, '00:00'), assignedTo: 'emp-grace', basedAt: 'b-slc'     },
+  { id: 'oc-cody-w1',  title: 'On Call – Week A', category: 'on-call', visualPriority: 'muted', start: dt(0,  '00:00'), end: dt(7,  '00:00'), assignedTo: 'emp-cody',  basedAt: 'b-bozeman' },
 ];
 
 import type { DemoMissionRequest } from './types';
@@ -213,37 +239,37 @@ import type { DemoMissionRequest } from './types';
 // ── PTO ───────────────────────────────────────────────────────────────────────
 
 export const ptoEvents: DemoEvent[] = [
-  { id: 'pto-derek', title: 'PTO – Derek Mills',  category: 'pto', visualPriority: 'muted', start: '2026-04-24T00:00', end: '2026-04-26T00:00', assignedTo: 'emp-derek', basedAt: 'b-portland' },
-  { id: 'pto-grace', title: 'PTO – Grace Taylor', category: 'pto', visualPriority: 'muted', start: '2026-04-20T00:00', end: '2026-04-22T00:00', assignedTo: 'emp-grace', basedAt: 'b-slc'      },
+  { id: 'pto-derek', title: 'PTO – Derek Mills',  category: 'pto', visualPriority: 'muted', start: dt(4, '00:00'), end: dt(6, '00:00'), assignedTo: 'emp-derek', basedAt: 'b-portland' },
+  { id: 'pto-grace', title: 'PTO – Grace Taylor', category: 'pto', visualPriority: 'muted', start: dt(0, '00:00'), end: dt(2, '00:00'), assignedTo: 'emp-grace', basedAt: 'b-slc'      },
 ];
 
 // ── Maintenance ───────────────────────────────────────────────────────────────
 
 export const maintenanceEvents: DemoEvent[] = [
-  { id: 'maint-n806ec', title: 'Scheduled Inspection – EC135 N806EC', category: 'maintenance', visualPriority: 'high',  start: '2026-04-21T08:00', end: '2026-04-24T17:00', assignedTo: 'ac-n806ec', basedAt: 'b-bozeman' },
-  { id: 'maint-n803lj', title: 'Pre-Mission Check – Learjet N803LJ',  category: 'maintenance', visualPriority: 'high',  start: '2026-04-22T07:00', end: '2026-04-23T12:00', assignedTo: 'ac-n803lj', basedAt: 'b-seattle'  },
+  { id: 'maint-n806ec', title: 'Scheduled Inspection – EC135 N806EC', category: 'maintenance', visualPriority: 'high',  start: dt(1, '08:00'), end: dt(4, '17:00'), assignedTo: 'ac-n806ec', basedAt: 'b-bozeman' },
+  { id: 'maint-n803lj', title: 'Pre-Mission Check – Learjet N803LJ',  category: 'maintenance', visualPriority: 'high',  start: dt(2, '07:00'), end: dt(3, '12:00'), assignedTo: 'ac-n803lj', basedAt: 'b-seattle'  },
 ];
 
 // ── Training ──────────────────────────────────────────────────────────────────
 
 export const trainingEvents: DemoEvent[] = [
-  { id: 'trn-cody', title: 'IFR Recurrent – Cody Barnes',    category: 'training', visualPriority: 'muted', start: '2026-04-23T09:00', end: '2026-04-23T15:00', assignedTo: 'emp-cody',  basedAt: 'b-bozeman' },
-  { id: 'trn-sam',  title: 'ECMO Recertification – Sam Nguyen', category: 'training', visualPriority: 'muted', start: '2026-04-22T08:00', end: '2026-04-22T16:00', assignedTo: 'emp-sam',   basedAt: 'b-seattle'  },
+  { id: 'trn-cody', title: 'IFR Recurrent – Cody Barnes',    category: 'training', visualPriority: 'muted', start: dt(3, '09:00'), end: dt(3, '15:00'), assignedTo: 'emp-cody',  basedAt: 'b-bozeman' },
+  { id: 'trn-sam',  title: 'ECMO Recertification – Sam Nguyen', category: 'training', visualPriority: 'muted', start: dt(2, '08:00'), end: dt(2, '16:00'), assignedTo: 'emp-sam',   basedAt: 'b-seattle'  },
 ];
 
 // ── Aircraft + asset requests ─────────────────────────────────────────────────
 
 export const requests: DemoEvent[] = [
-  { id: 'req-n803lj', title: 'Lift Request – N803LJ (International Mission)', category: 'aircraft-request', visualPriority: 'high',  start: '2026-04-23T08:00', end: '2026-04-23T17:00', assignedTo: 'ac-n803lj', basedAt: 'b-seattle'  },
-  { id: 'req-nicu',   title: 'NICU Equipment Check – AW139 N801AW',            category: 'asset-request',    visualPriority: 'muted', start: '2026-04-24T09:00', end: '2026-04-24T11:00', assignedTo: 'ac-n801aw', basedAt: 'b-seattle'  },
+  { id: 'req-n803lj', title: 'Lift Request – N803LJ (International Mission)', category: 'aircraft-request', visualPriority: 'high',  start: dt(3, '08:00'), end: dt(3, '17:00'), assignedTo: 'ac-n803lj', basedAt: 'b-seattle'  },
+  { id: 'req-nicu',   title: 'NICU Equipment Check – AW139 N801AW',            category: 'asset-request',    visualPriority: 'muted', start: dt(4, '09:00'), end: dt(4, '11:00'), assignedTo: 'ac-n801aw', basedAt: 'b-seattle'  },
 ];
 
 // ── Base events ───────────────────────────────────────────────────────────────
 
 export const baseEvents: DemoEvent[] = [
-  { id: 'base-sea-allhands', title: 'Seattle All-Hands',        category: 'base-event', visualPriority: 'muted', start: '2026-04-21T08:00', end: '2026-04-21T09:00', basedAt: 'b-seattle' },
-  { id: 'base-sea-brief',    title: 'Pre-Mission Briefing',     category: 'base-event', visualPriority: 'high',  start: '2026-04-23T14:00', end: '2026-04-23T15:30', basedAt: 'b-seattle' },
-  { id: 'base-den-standup',  title: 'Denver Crew Standup',      category: 'base-event', visualPriority: 'muted', start: '2026-04-21T07:30', end: '2026-04-21T08:00', basedAt: 'b-denver'  },
+  { id: 'base-sea-allhands', title: 'Seattle All-Hands',        category: 'base-event', visualPriority: 'muted', start: dt(1, '08:00'), end: dt(1, '09:00'), basedAt: 'b-seattle' },
+  { id: 'base-sea-brief',    title: 'Pre-Mission Briefing',     category: 'base-event', visualPriority: 'high',  start: dt(3, '14:00'), end: dt(3, '15:30'), basedAt: 'b-seattle' },
+  { id: 'base-den-standup',  title: 'Denver Crew Standup',      category: 'base-event', visualPriority: 'muted', start: dt(1, '07:30'), end: dt(1, '08:00'), basedAt: 'b-denver'  },
 ];
 
 // ── International mission ─────────────────────────────────────────────────────
@@ -253,8 +279,8 @@ const MISSION_TITLE = 'São Paulo → Munich Critical Care Transfer';
 export const mission: DemoMissionRequest = {
   id: 'mission-sao-muc',
   title: MISSION_TITLE,
-  start: '2026-04-24T06:00',
-  end:   '2026-04-28T08:00',
+  start: dt(4, '06:00'),
+  end:   dt(8, '08:00'),
   // São Paulo / Guarulhos (GRU) — pickup point for the patient transfer.
   originCoords: { lat: -23.4356, lon: -46.4731 },
   requirements: {
@@ -282,10 +308,10 @@ export const mission: DemoMissionRequest = {
     aircraft: { resourceId: 'ac-n803lj', resourceType: 'aircraft' },
   },
   legs: [
-    { id: 'leg-1', from: 'São Paulo (GRU)', to: 'New York (JFK)', start: '2026-04-24T06:00', end: '2026-04-24T14:00' },
-    { id: 'leg-2', from: 'New York (JFK)',  to: 'London (LHR)',   start: '2026-04-24T16:00', end: '2026-04-25T06:00' },
-    { id: 'leg-3', from: 'London (LHR)',    to: 'Munich (MUC)',   start: '2026-04-25T08:00', end: '2026-04-25T11:00' },
-    { id: 'leg-4', from: 'Munich (MUC)',    to: 'Seattle (SEA)',  start: '2026-04-27T10:00', end: '2026-04-28T08:00' },
+    { id: 'leg-1', from: 'São Paulo (GRU)', to: 'New York (JFK)', start: dt(4, '06:00'), end: dt(4, '14:00') },
+    { id: 'leg-2', from: 'New York (JFK)',  to: 'London (LHR)',   start: dt(4, '16:00'), end: dt(5, '06:00') },
+    { id: 'leg-3', from: 'London (LHR)',    to: 'Munich (MUC)',   start: dt(5, '08:00'), end: dt(5, '11:00') },
+    { id: 'leg-4', from: 'Munich (MUC)',    to: 'Seattle (SEA)',  start: dt(7, '10:00'), end: dt(8, '08:00') },
   ],
   compliance: [
     { id: 'comp-1', label: 'Brazil Exit Clearance',       status: 'approved' },

--- a/demo/walkthrough/Walkthrough.module.css
+++ b/demo/walkthrough/Walkthrough.module.css
@@ -144,8 +144,13 @@
 
 /* Below 1100px the demo swaps the live calendar for a static MobileShowcase
  * (see Landing.tsx). The walkthrough has nothing to operate on there, so
- * suppress the banner and resume pill outright. Same breakpoint as Landing's
- * MOBILE_BREAKPOINT_PX. */
+ * suppress the banner and resume pill outright.
+ *
+ * IMPORTANT: this 1099px threshold (= MOBILE_BREAKPOINT_PX − 1) MUST stay in
+ * sync with `MOBILE_BREAKPOINT_PX` in demo/Landing.tsx. CSS modules can't
+ * import JS constants, so this is a manual cross-reference — if you change
+ * the breakpoint there, change it here too. Grep for MOBILE_BREAKPOINT_PX
+ * before editing the constant. */
 @media (max-width: 1099px) {
   .banner,
   .resumePill {

--- a/demo/walkthrough/WalkthroughBanner.tsx
+++ b/demo/walkthrough/WalkthroughBanner.tsx
@@ -67,11 +67,13 @@ export default function WalkthroughBanner({
           </>
         ) : (
           <>
+            {/* Distinct labels so users don't conflate exiting the entire tour
+             *  with advancing past one step. */}
             <button type="button" className={styles['button']} onClick={onExit}>
-              Skip tour
+              Exit tour
             </button>
             <button type="button" className={styles['button']} onClick={onAdvance}>
-              Skip step
+              Skip this step
             </button>
           </>
         )}

--- a/demo/walkthrough/fixtures.ts
+++ b/demo/walkthrough/fixtures.ts
@@ -13,10 +13,14 @@
  *     shift and triggers the engine's soft conflict — that's the Step 2
  *     teaching moment ("you tried to schedule a busy pilot").
  *
- * The pilot id was chosen because emsData.ts has no other 14:00 events on
- * Capt. James Wright on Apr 23, so the conflict is solely caused by the
- * walkthrough seed.
+ * Anchored to "this week's Thursday" so the walkthrough tracks real time
+ * the same way emsData does. Without this, returning visitors past Apr
+ * 2026 would see the walkthrough seeds drift out of the visible window
+ * (auto-nav can compensate but the rest of the dataset around the seeds
+ * would be on completely different dates).
  */
+
+import { addDays, format, startOfWeek } from 'date-fns';
 
 export const WALKTHROUGH_MISSION_ID = 'wt-mission';
 export const WALKTHROUGH_DECOY_SHIFT_ID = 'wt-decoy-shift';
@@ -24,11 +28,20 @@ export const WALKTHROUGH_DECOY_SHIFT_ID = 'wt-decoy-shift';
 /** The pilot whose shift overlaps the mission slot — Step 2 conflict target. */
 export const CONFLICT_PILOT_ID = 'emp-james';
 
-export const ALPHA_INITIAL_START_ISO = '2026-04-23T14:00:00';
+// Anchor the seed events to "this week's Thursday" — same anchor logic as
+// emsData (Monday of current week + day offset), so events render today's
+// week regardless of when the demo loads. Computed at module load; doesn't
+// shift mid-session.
+const _MONDAY = startOfWeek(new Date(), { weekStartsOn: 1 });
+function _seedDt(dayOffset: number, time: string): string {
+  return `${format(addDays(_MONDAY, dayOffset), 'yyyy-MM-dd')}T${time}`;
+}
 
-const MISSION_END_ISO = '2026-04-23T15:00:00';
-const SHIFT_START_ISO = '2026-04-23T13:00:00';
-const SHIFT_END_ISO   = '2026-04-23T17:00:00';
+export const ALPHA_INITIAL_START_ISO = _seedDt(3, '14:00:00');
+
+const MISSION_END_ISO = _seedDt(3, '15:00:00');
+const SHIFT_START_ISO = _seedDt(3, '13:00:00');
+const SHIFT_END_ISO   = _seedDt(3, '17:00:00');
 
 const MISSION_COLOR = '#a855f7';
 const PILOT_COLOR   = '#3b82f6';

--- a/demo/walkthrough/reducer.test.ts
+++ b/demo/walkthrough/reducer.test.ts
@@ -81,6 +81,33 @@ describe('walkthrough reducer', () => {
     expect(stateB.currentStep).toBe('move-mission');
   });
 
+  it('move-mission also advances on a mission-assigned event (not just move)', () => {
+    // W2: a user who clicks Mission Alpha and assigns a pilot directly,
+    // skipping the drag, should not be left stuck on Step 1.
+    const state = reducer(
+      INITIAL_STATE,
+      { type: 'observe', event: assigned('emp-priya', null) },
+      DEPS,
+    );
+    expect(state.currentStep).toBe('assign-busy');
+  });
+
+  it('cascades through multiple steps a single event satisfies', () => {
+    // Pathological-but-realistic case: user assigns to the conflict pilot
+    // directly on first action. The mission-assigned event matches both
+    // move-mission (any first action on the mission) AND assign-busy
+    // (toResource is the conflict pilot). Without cascading the user
+    // would land on assign-busy with the action they just performed
+    // already complete — banner would read "now do the thing you did".
+    const state = reducer(
+      INITIAL_STATE,
+      { type: 'observe', event: assigned(CTX.conflictPilotId, null) },
+      DEPS,
+    );
+    expect(state.currentStep).toBe('reassign-free');
+    expect(state.history).toEqual(['move-mission', 'assign-busy']);
+  });
+
   it('assign-busy only advances when the mission is assigned to the conflict pilot', () => {
     let state = INITIAL_STATE;
     state = reducer(state, { type: 'observe', event: moved(CTX.missionEventId) }, DEPS);

--- a/demo/walkthrough/reducer.ts
+++ b/demo/walkthrough/reducer.ts
@@ -46,16 +46,30 @@ export function reducer(
 
   switch (action.type) {
     case 'observe': {
-      if (state.currentStep === 'done') return state;
-      const step = findStep(deps.steps, state.currentStep);
-      if (!step) return state;
-      if (!step.matches(action.event, deps.ctx)) return state;
-      return {
-        ...state,
-        bootstrapping: false,
-        currentStep: nextStepId(deps.steps, state.currentStep),
-        history: [...state.history, state.currentStep],
-      };
+      // Cascade through consecutive matching steps. A single user gesture
+      // can satisfy more than one step's matcher: e.g. clicking Mission
+      // Alpha and assigning Capt. Wright directly emits ONE
+      // `mission-assigned` event that matches both `move-mission` (any
+      // first action on the mission) and `assign-busy` (toResource is the
+      // conflict pilot). Without cascade, the user would land on
+      // `assign-busy` with their action already done and the banner
+      // telling them to do it again.
+      let next = state;
+      // Bound the loop by step count so a self-matching step (which
+      // shouldn't exist) can't infinite-loop.
+      for (let i = 0; i < deps.steps.length; i++) {
+        if (next.currentStep === 'done') break;
+        const step = findStep(deps.steps, next.currentStep);
+        if (!step) break;
+        if (!step.matches(action.event, deps.ctx)) break;
+        next = {
+          ...next,
+          bootstrapping: false,
+          currentStep: nextStepId(deps.steps, next.currentStep),
+          history: [...next.history, next.currentStep],
+        };
+      }
+      return next;
     }
 
     case 'advance': {

--- a/demo/walkthrough/steps.ts
+++ b/demo/walkthrough/steps.ts
@@ -25,26 +25,32 @@ export const STEPS: readonly Step[] = [
     id: 'move-mission',
     banner: {
       title: 'Move the mission request',
-      body:  'A new mission request landed on the calendar. Drag it to a different time slot.',
+      body:  'A new mission request landed on the calendar. Drag it to a different time slot — or click in to fill the crew now.',
     },
     spotlight: { eventId: WALKTHROUGH_MISSION_ID },
+    // Accept any first action on Mission Alpha — drag to a new time *or*
+    // open the form and assign a pilot. Users who skip straight to
+    // assignment aren't left stuck on Step 1; the assign step's matcher
+    // handles its own filter (toResource === conflictPilotId), so an
+    // assign here naturally falls through.
     matches: (event, ctx) =>
-      event.kind === 'mission-moved' && event.eventId === ctx.missionEventId,
-    hint: 'Click and hold the highlighted "Mission Alpha" request, then drag it to another hour or day.',
+      (event.kind === 'mission-moved' || event.kind === 'mission-assigned')
+      && event.eventId === ctx.missionEventId,
+    hint: 'Click and hold the highlighted "Mission Alpha" request, then drag it to another hour or day. Or click into it to assign crew right away.',
   },
 
   {
     id: 'assign-busy',
     banner: {
       title: 'Assign a pilot — and watch what happens',
-      body:  'Click Mission Alpha and assign Capt. James Wright. He\'s already on shift at that time, so the calendar will flag the conflict.',
+      body:  'Click Mission Alpha and assign Capt. James Wright. He\'s already on shift at that time, so the calendar will flag the conflict — click "Apply anyway" on the prompt to keep going.',
     },
     spotlight: { eventId: WALKTHROUGH_MISSION_ID },
     matches: (event, ctx) =>
       event.kind === 'mission-assigned'
       && event.eventId === ctx.missionEventId
       && event.toResource === ctx.conflictPilotId,
-    hint: 'Click the mission, set the resource to Capt. James Wright in the form, save — confirm the conflict prompt to apply anyway.',
+    hint: 'Click the mission, set the resource to Capt. James Wright in the form, save — when the conflict prompt appears, click "Apply anyway" to commit the assignment.',
   },
 
   {

--- a/demo/walkthrough/useWalkthrough.ts
+++ b/demo/walkthrough/useWalkthrough.ts
@@ -27,13 +27,21 @@ import type {
 
 /** localStorage key for the dismissed-tour flag. Only the mode is persisted —
  *  the active step always resets so a returning visitor who restarts the tour
- *  starts from step 1 with a clean event log. */
-const STORAGE_KEY = 'wc-walkthrough-mode';
+ *  starts from step 1 with a clean event log.
+ *
+ *  Scoped per calendarId so two demo instances on the same origin (or a
+ *  staging vs prod with the same domain) don't share dismissal state.
+ *  Falls back to a generic key when no calendarId is provided. */
+const DEFAULT_STORAGE_KEY = 'wc-walkthrough-mode';
 
-function readPersistedMode(): WalkthroughMode {
+function storageKey(calendarId: string | undefined): string {
+  return calendarId ? `${DEFAULT_STORAGE_KEY}-${calendarId}` : DEFAULT_STORAGE_KEY;
+}
+
+function readPersistedMode(calendarId: string | undefined): WalkthroughMode {
   if (typeof window === 'undefined') return 'guided';
   try {
-    return window.localStorage.getItem(STORAGE_KEY) === 'free-play'
+    return window.localStorage.getItem(storageKey(calendarId)) === 'free-play'
       ? 'free-play'
       : 'guided';
   } catch {
@@ -41,10 +49,10 @@ function readPersistedMode(): WalkthroughMode {
   }
 }
 
-function persistMode(mode: WalkthroughMode): void {
+function persistMode(mode: WalkthroughMode, calendarId: string | undefined): void {
   if (typeof window === 'undefined') return;
   try {
-    window.localStorage.setItem(STORAGE_KEY, mode);
+    window.localStorage.setItem(storageKey(calendarId), mode);
   } catch {
     // quota / private mode — silent failure, just won't persist
   }
@@ -55,6 +63,9 @@ interface UseWalkthroughArgs {
   /** Pre-existing host callbacks. Each `wrap*` returns a decorated version
    *  that calls the original and then emits the right WalkthroughEvent. */
   delegate: HostDelegate;
+  /** Optional calendar id used to scope localStorage persistence. Two demo
+   *  instances on the same origin will otherwise share dismissal state. */
+  calendarId?: string;
 }
 
 export interface HostDelegate {
@@ -84,20 +95,21 @@ export interface WalkthroughHandle {
   exit: () => void;
 }
 
-export function useWalkthrough({ ctx, delegate }: UseWalkthroughArgs): WalkthroughHandle {
+export function useWalkthrough({ ctx, delegate, calendarId }: UseWalkthroughArgs): WalkthroughHandle {
   const [state, dispatch] = useReducer(
     (s: WalkthroughState, a: Parameters<typeof reducer>[1]) =>
       reducer(s, a, { steps: STEPS, ctx }),
     undefined,
-    () => ({ ...INITIAL_STATE, mode: readPersistedMode() }),
+    () => ({ ...INITIAL_STATE, mode: readPersistedMode(calendarId) }),
   );
 
   // Persist mode changes so a dismissed tour stays dismissed across reloads.
   // Only the mode is saved — currentStep / history reset on each load so
-  // restarting starts cleanly at step 1.
+  // restarting starts cleanly at step 1. Scoped per calendarId so multiple
+  // demo instances don't share dismissal state.
   useEffect(() => {
-    persistMode(state.mode);
-  }, [state.mode]);
+    persistMode(state.mode, calendarId);
+  }, [state.mode, calendarId]);
 
   // Snapshot of the mission's previous state so we can tell "moved" (time
   // changed, resource unchanged) from "assigned" (resource changed). Refs

--- a/tests-e2e/walkthrough.spec.ts
+++ b/tests-e2e/walkthrough.spec.ts
@@ -1,0 +1,104 @@
+import { expect, test } from '@playwright/test';
+
+/**
+ * Walkthrough happy-path smoke regression.
+ *
+ * Targets the categories of bug we've actually shipped + caught:
+ *   - Spotlight CSS broke pill positioning (banner intercepted clicks → click
+ *     to edit became click to create-new-event)
+ *   - Default-view race: returning visitors landed on Schedule view, where
+ *     the seeded mission has no row to render in
+ *   - data-wc-event-id was the load-bearing handle for the spotlight pulse;
+ *     a future refactor that drops it would silently break the tour
+ *
+ * Deliberately scoped to mount + first-step assertions rather than driving a
+ * full step-by-step automation. Step matchers + reducer behaviour are
+ * already covered by the unit suite (demo/walkthrough/reducer.test.ts);
+ * what's only catchable in a real browser is "the banner mounted, the
+ * spotlight rendered against the right pill, and a click on that pill
+ * actually reaches the pill".
+ */
+
+test.describe('demo walkthrough', () => {
+  test.beforeEach(async ({ page }) => {
+    // Returning visitors who previously dismissed the tour have
+    // wc-walkthrough-mode-<calendarId>=free-play in localStorage. Clearing
+    // before page load gives us a deterministic guided-mode mount.
+    await page.addInitScript(() => {
+      try {
+        window.localStorage.clear();
+      } catch {
+        // private mode / quota — ignore
+      }
+    });
+    await page.setViewportSize({ width: 1440, height: 900 });
+    // Note: NOT using ?embed=1 — embed mode suppresses the walkthrough chrome.
+    await page.goto('/');
+    await expect(page.getByTestId('works-calendar')).toBeVisible();
+  });
+
+  test('banner mounts in guided mode with Step 1 copy', async ({ page }) => {
+    const banner = page.getByRole('dialog', { name: /guided walkthrough/i });
+    await expect(banner).toBeVisible();
+    // Step 1 banner title.
+    await expect(banner.getByText(/move the mission request/i)).toBeVisible();
+    // Both control buttons present and labelled distinctly (W6 regression
+    // guard — these used to read "Skip tour" / "Skip step").
+    await expect(banner.getByRole('button', { name: /^exit tour$/i })).toBeVisible();
+    await expect(banner.getByRole('button', { name: /^skip this step$/i })).toBeVisible();
+  });
+
+  test('opens in Week view (auto-nav defeats stored Schedule default)', async ({ page }) => {
+    // Returning visitors with display.defaultView=schedule used to land on
+    // the wrong view because WorksCalendar's defaultViewApplied effect ran
+    // after our snap. The current parent-useEffect approach should win the
+    // last-write race regardless of stored preference.
+    const weekButton = page.getByRole('button', { name: /^week$/i }).first();
+    await expect(weekButton).toHaveAttribute('aria-pressed', 'true');
+  });
+
+  test('Mission Alpha pill is rendered with the spotlight data attribute', async ({ page }) => {
+    // Single load-bearing DOM hook for the spotlight CSS injection. If a
+    // future refactor drops this attribute the tour's pulse silently fails
+    // even though everything else still works.
+    const missionPill = page.locator('[data-wc-event-id="wt-mission"]').first();
+    await expect(missionPill).toBeVisible();
+    // Title contains the seed copy so we know the right event got the hook.
+    await expect(missionPill).toContainText(/mission alpha/i);
+  });
+
+  test('banner panel does not intercept hit-testing for clicks behind it', async ({ page }) => {
+    // Regression guard for the pointer-events bug. The walkthrough
+    // banner is fixed-position over the center of the demo; with
+    // `pointer-events: none` on the panel, a click on the banner's
+    // body text should pass through to whatever's behind. Without that
+    // (the original screenshot bug), the banner intercepts clicks on
+    // calendar pills underneath and confused-user.spec.ts crashes on
+    // the first safeClick.
+    const banner = page.getByRole('dialog', { name: /guided walkthrough/i });
+    const titleHeading = banner.getByRole('heading', { name: /move the mission request/i });
+    await expect(titleHeading).toBeVisible();
+    const box = await titleHeading.boundingBox();
+    if (!box) throw new Error('Banner heading not measurable');
+
+    // document.elementFromPoint at the heading's center should resolve
+    // to an element OUTSIDE the banner. With pointer-events: none on
+    // the .banner panel, hit-testing skips it. Without the fix, this
+    // would land on a banner descendant (the heading itself or a
+    // banner-internal div).
+    const piercedThrough = await page.evaluate(([x, y]: [number, number]) => {
+      const el = document.elementFromPoint(x, y);
+      if (!el) return false;
+      // Walk up; if we never hit a [role="dialog"][aria-label="Guided
+      // walkthrough"] ancestor, the click pierced through.
+      let cursor: Element | null = el;
+      while (cursor) {
+        if (cursor.getAttribute?.('aria-label') === 'Guided walkthrough') return false;
+        cursor = cursor.parentElement;
+      }
+      return true;
+    }, [box.x + box.width / 2, box.y + box.height / 2]);
+
+    expect(piercedThrough).toBe(true);
+  });
+});


### PR DESCRIPTION
…W8/W9)

W2 — Step 1 advances on mission-assigned, not just mission-moved
  Banner says "drag the mission to a new time", but if a user clicks
  Mission Alpha and assigns a pilot directly (skipping the drag),
  mission-assigned was the only event that fired and the matcher
  rejected it. User left stranded on Step 1 even though they did
  reasonable work.
  Fix (steps.ts): broaden Step 1's matcher to accept either
  mission-moved OR mission-assigned. Banner copy + hint extended to
  mention "or click into it to assign crew right away".

  Subtle implication: if the first action IS an assign to the
  conflict pilot, the SAME observation also satisfies Step 2's
  matcher (assign-busy expects toResource === conflictPilotId). The
  reducer now cascades through consecutive matching steps inside a
  single observe action so the user doesn't land on a step whose
  banner asks them to do the thing they just did.
  Fix (reducer.ts): observe handler loops while the current step's
  matcher accepts the event, advancing the chain. Bounded by step
  count to defend against an accidental self-matching step.

W3 — Step 2 banner now mentions the conflict prompt explicitly
  Users who hit the engine's pending-confirmation alert and clicked
  Cancel were left wondering what happened. The hint already
  mentioned "confirm the prompt", but the primary banner copy did
  not. Banner body + hint now both call out clicking "Apply anyway"
  on the conflict prompt to keep going.

W6 — Banner buttons renamed for clarity
  "Skip tour" and "Skip step" looked too similar at a glance and
  conflated exiting the whole tour with advancing past one step.
  Renamed to "Exit tour" and "Skip this step".

W8 — Cross-reference Landing's MOBILE_BREAKPOINT_PX
  Walkthrough.module.css's `@media (max-width: 1099px)` matches
  Landing.tsx's `MOBILE_BREAKPOINT_PX = 1100` − 1, but CSS modules
  can't import JS constants. Strengthened the comment so anyone
  changing the breakpoint will hit a grep and update both places.

W9 — Storage key scoped per calendarId
  `wc-walkthrough-mode` was a global localStorage key; two demo
  instances on the same origin (or staging vs prod) would share
  dismissal state. useWalkthrough now accepts an optional
  `calendarId` and uses `wc-walkthrough-mode-<calendarId>` when
  present, falling back to the unscoped key when omitted (no
  breaking change for any existing caller). App.tsx passes
  DEMO_CALENDAR_ID through.

Tests:
  - 2 new reducer tests covering the cascade behavior + the mission-assigned-as-first-action path.
  - All other walkthrough tests still pass without modification.

Verified:
  - tsc --noEmit clean
  - vitest: 187 files / 2657 tests pass | 0 skipped
  - playwright e2e: 94 / 94 pass

Phase A punch list now exhausted. Walkthrough is in maintenance mode; further tuning should be driven by user testing rather than speculative polish.

https://claude.ai/code/session_01GzH5mhsAHCjQkFDUBWXqYy

## Summary
Describe exactly what this PR changes.

## Scope
- Stage: 
- Planned PR number in sprint: 
- Target files/directories: 
- Why this slice is isolated: 

## Lessons Learned Check (REQUIRED)
Confirm these were actively used while building this PR:

- [ ] PR is intentionally small and isolated
- [ ] Boundary typing was prioritized over internal perfection
- [ ] No silent spread of `any`
- [ ] Advisory root `tsc` was used to catch integration issues
- [ ] I did not assume “looks typed” means “safe”
- [ ] I stopped and isolated typing cascades instead of expanding scope

## Definition of Done (ALL REQUIRED)
This PR is not done unless every box is checked.

- [ ] `npm run type-check:strict` passes
- [ ] Root advisory `tsc --noEmit` passes
- [ ] Tests pass for touched scope at minimum
- [ ] No uncontrolled increase in `any`
- [ ] All new types are intentional and named
- [ ] Public interfaces and exported functions are explicitly typed
- [ ] PR scope matches the sprint plan with no scope creep
- [ ] Any new `any` has an adjacent justification comment
- [ ] No file-wide `: any`
- [ ] No implicit `any` in exported functions

## What Was Typed
List exactly what was typed in this PR.

- 
- 
- 

## What Was Intentionally Left Loose
List anything intentionally not tightened yet.

- 
- 
- 

## `any` Ledger (REQUIRED)
- New `any` added: 
- Existing `any` removed: 
- Net change: 

For every new `any`, explain why it is required and why a safer type was not used yet.

1. 
2. 
3. 

## Boundary Notes
Document any public seams, caller-protection choices, or compatibility decisions.

- 
- 
- 

## Risk Level
- [ ] Low
- [ ] Medium
- [ ] High

Why:

## Validation Evidence
Paste the exact commands run and a short result summary.

```bash
npm run type-check:strict
npx tsc --noEmit -p tsconfig.json
```

Test commands run:

```bash
# paste commands here
```

## Stop Conditions Check
If any item below happened, explain how scope was reduced before merge.

- [ ] `any` started spreading across files
- [ ] Root `tsc` broke repeatedly
- [ ] Types required cross-module rewrites
- [ ] Scope was reduced to keep the PR reviewable

Notes:

## Reviewer Focus
What should reviewers look at first?

- 
- 
- 
