### PR TITLE
fix(chrome): rails fill calendar height + add embedder slot props

### DIFF
--- a/src/WorksCalendar.tsx
+++ b/src/WorksCalendar.tsx
@@ -52,6 +52,7 @@ import { buildActiveFilterPills, buildFilterSummary, hasActiveFilters } from './
 import { AppShell }           from './ui/AppShell';
 import { AppHeader }          from './ui/AppHeader';
 import { LeftRail }           from './ui/LeftRail';
+import type { LeftRailAction } from './ui/LeftRail';
 import { SubToolbar }         from './ui/SubToolbar';
 import { DayWindowPills }     from './ui/DayWindowPills';
 import { RightPanel, RightPanelSection, CrewOnShiftList } from './ui/RightPanel';
@@ -243,6 +244,19 @@ export type WorksCalendarProps = {
   renderEvent?: (event: WorksCalendarEvent, context?: UnknownRecord) => ReactNode;
   renderHoverCard?: (event: WorksCalendarEvent, onClose: () => void) => ReactNode;
   renderToolbar?: (api: CalendarApi) => ReactNode;
+  /** Extra icon-button actions appended to the LeftRail after the built-in
+   *  Saved-views / Focus-filters / Settings buttons. Each entry has the
+   *  same shape as the rail's internal actions (see `LeftRailAction` in
+   *  the package's public exports): `{ id, label, icon, hint?, active?,
+   *  onClick }`. Use this to surface embedder-specific shortcuts (export,
+   *  notifications, custom drawers, etc.) without forking the chrome. */
+  leftRailExtras?: LeftRailAction[];
+  /** ReactNode appended to the RightPanel after the built-in Region map
+   *  + Crew on shift sections. For visual consistency wrap your content
+   *  in `<RightPanelSection title="…">…</RightPanelSection>` (also
+   *  exported). Pass any number of sections; they stack vertically and
+   *  inherit theme tokens. */
+  rightPanelExtras?: ReactNode;
   renderFilterBar?: (args: UnknownRecord) => ReactNode;
   renderSavedViewsBar?: (args: UnknownRecord) => ReactNode;
   /**
@@ -588,6 +602,8 @@ export const WorksCalendar = forwardRef<CalendarApi, WorksCalendarProps>(functio
     renderEvent,
     renderHoverCard,
     renderToolbar,
+    leftRailExtras,
+    rightPanelExtras,
     renderFilterBar,
     renderSavedViewsBar,
     focusChips,
@@ -2556,6 +2572,12 @@ export const WorksCalendar = forwardRef<CalendarApi, WorksCalendarProps>(functio
                   icon: <Settings size={18} aria-hidden="true" />,
                   onClick: () => ownerCfg.setConfigOpen(true),
                 }] : []),
+                // Embedder-supplied actions (optional). Appended last so
+                // the built-in actions keep stable positions across
+                // consumer apps. Filter out any id collisions defensively.
+                ...(leftRailExtras ?? []).filter(extra =>
+                  !['saved-views', 'focus', 'settings'].includes(extra.id),
+                ),
               ]}
             />
           }
@@ -2575,6 +2597,9 @@ export const WorksCalendar = forwardRef<CalendarApi, WorksCalendarProps>(functio
               <RightPanelSection title="Crew on shift">
                 <CrewOnShiftList employees={configuredEmployees} onShiftIds={onShiftIds} />
               </RightPanelSection>
+              {/* Embedder-supplied sections (optional). Appended after the
+                  built-ins so the stock content keeps stable position. */}
+              {rightPanelExtras}
             </RightPanel>
           }
           header={<>

--- a/src/index.ts
+++ b/src/index.ts
@@ -61,6 +61,15 @@ export { WorksCalendar }                  from './WorksCalendar.tsx';
 export { default as ScheduleView }        from './views/ScheduleView';
 export { default as MapView }             from './views/MapView';
 export type { MapViewProps }              from './views/MapView';
+
+// Embedder slot helpers — paired with the WorksCalendar `leftRailExtras` /
+// `rightPanelExtras` props. Consumer apps wrap their custom widgets in
+// these so the appended content blends with the stock chrome (theme
+// tokens, section headers, icon-button styling) instead of looking
+// pasted-on.
+export { RightPanel, RightPanelSection } from './ui/RightPanel';
+export type { RightPanelSectionProps }   from './ui/RightPanel';
+export type { LeftRailAction }           from './ui/LeftRail';
 export { normalizeEvent, normalizeEvents } from './core/eventModel';
 export { loadConfig, saveConfig, DEFAULT_CONFIG, FIELD_TYPES } from './core/configSchema';
 export { applyFilters, getCategories, getResources } from './filters/filterEngine';

--- a/src/ui/LeftRail.module.css
+++ b/src/ui/LeftRail.module.css
@@ -7,6 +7,13 @@
 
 .root {
   width: 56px;
+  /* Fill the aside's full height so the rail's surface + border-right
+   * extend to match the calendar grid below. The parent aside is a flex
+   * item in AppShell.body and stretches via the default align-items, but
+   * `.root` is a normal block child of that aside — without explicit
+   * height it collapses to content-height and leaves a transparent gap
+   * below the buttons. */
+  height: 100%;
   flex-shrink: 0;
   background: var(--wc-surface);
   border-right: var(--wc-border-width, 1px) solid var(--wc-border);

--- a/src/ui/RightPanel.module.css
+++ b/src/ui/RightPanel.module.css
@@ -7,6 +7,12 @@
 
 .root {
   width: 240px;
+  /* Fill the aside's full height so the panel's surface + border-left
+   * extend down to match the calendar grid below. Same reason as
+   * LeftRail's .root: the parent aside stretches via flex but our
+   * inner block collapses to content-height without an explicit
+   * height. */
+  height: 100%;
   flex-shrink: 0;
   background: var(--wc-surface);
   border-left: var(--wc-border-width, 1px) solid var(--wc-border);


### PR DESCRIPTION
Two reported issues from the live demo screenshot:

1. The left rail (saved-views / focus / settings icon column) and the right panel (Region map / Crew on shift) were rendering shorter than the calendar grid — leaving a transparent gap below each rail that bled the parent surface through, making the rails read as "cut off". Fix: add `height: 100%` to the inner `.root` of both LeftRail and RightPanel modules. The parent <aside> in AppShell already stretches via flex; the inner root just wasn't claiming that available height, so its surface + border ended at content edge instead of the body's bottom.

2. Embedder request: an "optional empty box" so consumer apps could plug their own buttons / widgets / icons into the chrome. Added two new optional props on <WorksCalendar>:

     leftRailExtras?: LeftRailAction[]
       Appended after the built-in saved-views / focus / settings
       buttons. Same shape as the rail's internal actions (id /
       label / icon / hint / active / onClick). De-duplicates against
       the built-in ids defensively so an embedder accidentally
       passing { id: 'settings', ... } can't overwrite the chrome.

     rightPanelExtras?: ReactNode
       Appended after the built-in Region map + Crew on shift
       sections. Embedders wrap each section in
       <RightPanelSection title="…">…</RightPanelSection> so theme
       tokens + section dividers stay consistent with the stock
       chrome.

   Both are additive — existing consumers see no change. Built-in sections keep stable positions so an embedder appending content never displaces the demo / regression fixtures.

   New public exports in src/index.ts:
     - RightPanel, RightPanelSection (component + helper)
     - RightPanelSectionProps (type) - LeftRailAction (type)

   Without these the new prop types resolve to an internal symbol
   and consumers can't actually construct values that satisfy them.

Verified:
  - tsc --noEmit clean
  - vitest: 187 files / 2657 tests pass | 0 skipped
  - playwright e2e: 98 / 98 pass

https://claude.ai/code/session_01GzH5mhsAHCjQkFDUBWXqYy

## Summary
Describe exactly what this PR changes.

## Scope
- Stage: 
- Planned PR number in sprint: 
- Target files/directories: 
- Why this slice is isolated: 

## Lessons Learned Check (REQUIRED)
Confirm these were actively used while building this PR:

- [ ] PR is intentionally small and isolated
- [ ] Boundary typing was prioritized over internal perfection
- [ ] No silent spread of `any`
- [ ] Advisory root `tsc` was used to catch integration issues
- [ ] I did not assume “looks typed” means “safe”
- [ ] I stopped and isolated typing cascades instead of expanding scope

## Definition of Done (ALL REQUIRED)
This PR is not done unless every box is checked.

- [ ] `npm run type-check:strict` passes
- [ ] Root advisory `tsc --noEmit` passes
- [ ] Tests pass for touched scope at minimum
- [ ] No uncontrolled increase in `any`
- [ ] All new types are intentional and named
- [ ] Public interfaces and exported functions are explicitly typed
- [ ] PR scope matches the sprint plan with no scope creep
- [ ] Any new `any` has an adjacent justification comment
- [ ] No file-wide `: any`
- [ ] No implicit `any` in exported functions

## What Was Typed
List exactly what was typed in this PR.

- 
- 
- 

## What Was Intentionally Left Loose
List anything intentionally not tightened yet.

- 
- 
- 

## `any` Ledger (REQUIRED)
- New `any` added: 
- Existing `any` removed: 
- Net change: 

For every new `any`, explain why it is required and why a safer type was not used yet.

1. 
2. 
3. 

## Boundary Notes
Document any public seams, caller-protection choices, or compatibility decisions.

- 
- 
- 

## Risk Level
- [ ] Low
- [ ] Medium
- [ ] High

Why:

## Validation Evidence
Paste the exact commands run and a short result summary.

```bash
npm run type-check:strict
npx tsc --noEmit -p tsconfig.json
```

Test commands run:

```bash
# paste commands here
```

## Stop Conditions Check
If any item below happened, explain how scope was reduced before merge.

- [ ] `any` started spreading across files
- [ ] Root `tsc` broke repeatedly
- [ ] Types required cross-module rewrites
- [ ] Scope was reduced to keep the PR reviewable

Notes:

## Reviewer Focus
What should reviewers look at first?

- 
- 
- 
