### PR TITLE
fix: week view scroll alignment and day view event click

### DIFF
--- a/src/views/DayView.tsx
+++ b/src/views/DayView.tsx
@@ -36,7 +36,7 @@ export default function DayView({
   const bizHours  = ctx?.['businessHours'] ?? null;
 
   const gridRef            = useRef<HTMLDivElement | null>(null);
-  const clickCandidateRef  = useRef<CalendarViewEvent | null>(null);
+  const clickCandidateRef  = useRef<{ ev: CalendarViewEvent; startX: number; startY: number; moved: boolean } | null>(null);
   const days               = useMemo(() => [currentDate], [currentDate]);
 
   const hours: number[] = [];
@@ -136,6 +136,12 @@ export default function DayView({
 
   const handleGridPointerMove = useCallback((e: ReactPointerEvent<HTMLDivElement>) => {
     drag.onPointerMove(e);
+    const cc = clickCandidateRef.current;
+    if (cc && !cc.moved) {
+      const dx = Math.abs(e.clientX - cc.startX);
+      const dy = Math.abs(e.clientY - cc.startY);
+      if (dx > 4 || dy > 4) cc.moved = true;
+    }
   }, [drag.onPointerMove]);
 
   const handleGridPointerUp = useCallback(() => {
@@ -143,8 +149,10 @@ export default function DayView({
     clickCandidateRef.current = null;
     const result = drag.onPointerUp();
     if (!result) {
-      // No real drag — pointer capture ate the click event, so fire it manually.
-      if (candidate) onEventClick?.(candidate);
+      // Only treat as click when the pointer never moved past the drag threshold.
+      // onPointerUp also returns null for drags that snap back to the original
+      // timeslot; candidate.moved distinguishes those from a true click.
+      if (candidate && !candidate.moved) onEventClick?.(candidate.ev);
       return;
     }
     if (result.type === 'create') {
@@ -187,7 +195,7 @@ export default function DayView({
             aria-label={ariaLabel}
             onClick={onClick}
             onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); onClick(); } }}
-            onPointerDown={(e: ReactPointerEvent<HTMLDivElement>) => { if (e.button !== 0 || !ctx?.['permissions']?.canDrag || !gridRef.current) return; e.stopPropagation(); clickCandidateRef.current = ev; drag.startMove(ev as NormalizedEvent, e, gridRef.current, days, GUTTER_W); }}
+            onPointerDown={(e: ReactPointerEvent<HTMLDivElement>) => { if (e.button !== 0 || !ctx?.['permissions']?.canDrag || !gridRef.current) return; e.stopPropagation(); clickCandidateRef.current = { ev, startX: e.clientX, startY: e.clientY, moved: false }; drag.startMove(ev as NormalizedEvent, e, gridRef.current, days, GUTTER_W); }}
           >
             <div className={styles['resizeHandleTop']}
               onPointerDown={(e: ReactPointerEvent<HTMLDivElement>) => { if (e.button !== 0 || !ctx?.['permissions']?.canDrag || !gridRef.current) return; e.stopPropagation(); drag.startResizeTop(ev as NormalizedEvent, e, gridRef.current, days, GUTTER_W); }}
@@ -212,7 +220,7 @@ export default function DayView({
         aria-label={ariaLabel}
         onClick={onClick}
         onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); onClick(); } }}
-        onPointerDown={(e: ReactPointerEvent<HTMLDivElement>) => { if (e.button !== 0 || !ctx?.['permissions']?.canDrag || !gridRef.current) return; e.stopPropagation(); clickCandidateRef.current = ev; drag.startMove(ev as NormalizedEvent, e, gridRef.current, days, GUTTER_W); }}
+        onPointerDown={(e: ReactPointerEvent<HTMLDivElement>) => { if (e.button !== 0 || !ctx?.['permissions']?.canDrag || !gridRef.current) return; e.stopPropagation(); clickCandidateRef.current = { ev, startX: e.clientX, startY: e.clientY, moved: false }; drag.startMove(ev as NormalizedEvent, e, gridRef.current, days, GUTTER_W); }}
       >
         <div className={styles['resizeHandleTop']}
           onPointerDown={(e: ReactPointerEvent<HTMLDivElement>) => { if (e.button !== 0 || !ctx?.['permissions']?.canDrag || !gridRef.current) return; e.stopPropagation(); drag.startResizeTop(ev as NormalizedEvent, e, gridRef.current, days, GUTTER_W); }}

--- a/src/views/DayView.tsx
+++ b/src/views/DayView.tsx
@@ -35,8 +35,9 @@ export default function DayView({
   const pxPerHour = 64;
   const bizHours  = ctx?.['businessHours'] ?? null;
 
-  const gridRef = useRef<HTMLDivElement | null>(null);
-  const days    = useMemo(() => [currentDate], [currentDate]);
+  const gridRef            = useRef<HTMLDivElement | null>(null);
+  const clickCandidateRef  = useRef<CalendarViewEvent | null>(null);
+  const days               = useMemo(() => [currentDate], [currentDate]);
 
   const hours: number[] = [];
   for (let h = dayStart; h <= dayEnd; h++) hours.push(h);
@@ -138,8 +139,14 @@ export default function DayView({
   }, [drag.onPointerMove]);
 
   const handleGridPointerUp = useCallback(() => {
+    const candidate = clickCandidateRef.current;
+    clickCandidateRef.current = null;
     const result = drag.onPointerUp();
-    if (!result) return;
+    if (!result) {
+      // No real drag — pointer capture ate the click event, so fire it manually.
+      if (candidate) onEventClick?.(candidate);
+      return;
+    }
     if (result.type === 'create') {
       onDateSelect?.(result.newStart, result.newEnd);
     } else if (result.type === 'resize' || result.type === 'resize-top') {
@@ -147,7 +154,7 @@ export default function DayView({
     } else if (result.type === 'move') {
       onEventMove?.(result.ev, result.newStart, result.newEnd);
     }
-  }, [drag.onPointerUp, onEventMove, onEventResize, onDateSelect]);
+  }, [drag.onPointerUp, onEventMove, onEventResize, onDateSelect, onEventClick]);
 
   // ── Renderers ─────────────────────────────────────────────────────────
   function renderEvent(ev: CalendarViewEvent) {
@@ -180,7 +187,7 @@ export default function DayView({
             aria-label={ariaLabel}
             onClick={onClick}
             onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); onClick(); } }}
-            onPointerDown={(e: ReactPointerEvent<HTMLDivElement>) => { if (e.button !== 0 || !ctx?.['permissions']?.canDrag || !gridRef.current) return; e.stopPropagation(); drag.startMove(ev as NormalizedEvent, e, gridRef.current, days, GUTTER_W); }}
+            onPointerDown={(e: ReactPointerEvent<HTMLDivElement>) => { if (e.button !== 0 || !ctx?.['permissions']?.canDrag || !gridRef.current) return; e.stopPropagation(); clickCandidateRef.current = ev; drag.startMove(ev as NormalizedEvent, e, gridRef.current, days, GUTTER_W); }}
           >
             <div className={styles['resizeHandleTop']}
               onPointerDown={(e: ReactPointerEvent<HTMLDivElement>) => { if (e.button !== 0 || !ctx?.['permissions']?.canDrag || !gridRef.current) return; e.stopPropagation(); drag.startResizeTop(ev as NormalizedEvent, e, gridRef.current, days, GUTTER_W); }}
@@ -205,7 +212,7 @@ export default function DayView({
         aria-label={ariaLabel}
         onClick={onClick}
         onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); onClick(); } }}
-        onPointerDown={(e: ReactPointerEvent<HTMLDivElement>) => { if (e.button !== 0 || !ctx?.['permissions']?.canDrag || !gridRef.current) return; e.stopPropagation(); drag.startMove(ev as NormalizedEvent, e, gridRef.current, days, GUTTER_W); }}
+        onPointerDown={(e: ReactPointerEvent<HTMLDivElement>) => { if (e.button !== 0 || !ctx?.['permissions']?.canDrag || !gridRef.current) return; e.stopPropagation(); clickCandidateRef.current = ev; drag.startMove(ev as NormalizedEvent, e, gridRef.current, days, GUTTER_W); }}
       >
         <div className={styles['resizeHandleTop']}
           onPointerDown={(e: ReactPointerEvent<HTMLDivElement>) => { if (e.button !== 0 || !ctx?.['permissions']?.canDrag || !gridRef.current) return; e.stopPropagation(); drag.startResizeTop(ev as NormalizedEvent, e, gridRef.current, days, GUTTER_W); }}
@@ -303,7 +310,7 @@ export default function DayView({
           onPointerDown={handleGridPointerDown}
           onPointerMove={handleGridPointerMove}
           onPointerUp={handleGridPointerUp}
-          onPointerCancel={drag.cancel}
+          onPointerCancel={() => { clickCandidateRef.current = null; drag.cancel(); }}
         >
           {/* Background hour lines */}
           {hours.map(h => (

--- a/src/views/WeekView.module.css
+++ b/src/views/WeekView.module.css
@@ -3,7 +3,7 @@
   display: flex;
   flex-direction: column;
   height: 100%;
-  overflow: hidden;
+  overflow-y: auto; /* single scroll container so header + body share scrollbar gutter */
 }
 
 /* ── Header row ── */
@@ -12,7 +12,9 @@
   grid-template-columns: repeat(7, 1fr);
   background: var(--wc-surface);
   border-bottom: 1px solid var(--wc-border);
-  flex-shrink: 0;
+  position: sticky;
+  top: 0;
+  z-index: 10;
 }
 
 .dayHead {
@@ -54,7 +56,6 @@
 /* ── Body ── */
 .body {
   flex: 1;
-  overflow-y: auto;
   min-height: 0;
 }
 


### PR DESCRIPTION
WeekView: make .week the single scroll container with a sticky header so the scrollbar gutter never misaligns column borders from day headers.

DayView: setPointerCapture routes the synthesised click event to the grid element, so the event div's onClick was silently dropped.  Track the click candidate in a ref and fire onEventClick from handleGridPointerUp when onPointerUp returns null (no real drag occurred).

https://claude.ai/code/session_019YHGYGD1F3oLoZnkKbzwy6

## Summary
Describe exactly what this PR changes.

## Scope
- Stage: 
- Planned PR number in sprint: 
- Target files/directories: 
- Why this slice is isolated: 

## Lessons Learned Check (REQUIRED)
Confirm these were actively used while building this PR:

- [ ] PR is intentionally small and isolated
- [ ] Boundary typing was prioritized over internal perfection
- [ ] No silent spread of `any`
- [ ] Advisory root `tsc` was used to catch integration issues
- [ ] I did not assume “looks typed” means “safe”
- [ ] I stopped and isolated typing cascades instead of expanding scope

## Definition of Done (ALL REQUIRED)
This PR is not done unless every box is checked.

- [ ] `npm run type-check:strict` passes
- [ ] Root advisory `tsc --noEmit` passes
- [ ] Tests pass for touched scope at minimum
- [ ] No uncontrolled increase in `any`
- [ ] All new types are intentional and named
- [ ] Public interfaces and exported functions are explicitly typed
- [ ] PR scope matches the sprint plan with no scope creep
- [ ] Any new `any` has an adjacent justification comment
- [ ] No file-wide `: any`
- [ ] No implicit `any` in exported functions

## What Was Typed
List exactly what was typed in this PR.

- 
- 
- 

## What Was Intentionally Left Loose
List anything intentionally not tightened yet.

- 
- 
- 

## `any` Ledger (REQUIRED)
- New `any` added: 
- Existing `any` removed: 
- Net change: 

For every new `any`, explain why it is required and why a safer type was not used yet.

1. 
2. 
3. 

## Boundary Notes
Document any public seams, caller-protection choices, or compatibility decisions.

- 
- 
- 

## Risk Level
- [ ] Low
- [ ] Medium
- [ ] High

Why:

## Validation Evidence
Paste the exact commands run and a short result summary.

```bash
npm run type-check:strict
npx tsc --noEmit -p tsconfig.json
```

Test commands run:

```bash
# paste commands here
```

## Stop Conditions Check
If any item below happened, explain how scope was reduced before merge.

- [ ] `any` started spreading across files
- [ ] Root `tsc` broke repeatedly
- [ ] Types required cross-module rewrites
- [ ] Scope was reduced to keep the PR reviewable

Notes:

## Reviewer Focus
What should reviewers look at first?

- 
- 
- 
