### PR TITLE
fix: week view grid lines, pill drag, and walkthrough assignment flow

### DIFF
--- a/demo/App.tsx
+++ b/demo/App.tsx
@@ -896,6 +896,11 @@ function App() {
 
   const handleEventClick = useCallback((ev) => {
     log(`Clicked: ${ev.title}`);
+    // wt-mission is the walkthrough's Mission Alpha — it uses the standard
+    // HoverCard → Edit → EventForm flow so onEventSave fires and the
+    // walkthrough can detect the pilot assignment. Exclude it from opening
+    // the São Paulo MissionHoverCard.
+    if (ev.id === WALKTHROUGH_MISSION_ID) return;
     if (ev.category === 'mission-assignment' || ev.category === 'aircraft-request') {
       setMissionOpen(true);
     }
@@ -937,15 +942,20 @@ function App() {
     );
   }, [missionAssignments]);
 
-  const renderHoverCard = useCallback((ev, onCloseHover) => (
-    <DemoHoverCard
-      event={ev}
-      onClose={onCloseHover}
-      onApprovalAction={handleApprovalAction}
-      approvalCaps={activeProfile.approval}
-      onDelete={(id) => { handleEventDelete(id); onCloseHover(); }}
-    />
-  ), [activeProfile.approval, handleApprovalAction, handleEventDelete]);
+  const renderHoverCard = useCallback((ev, onCloseHover) => {
+    // wt-mission uses the built-in HoverCard → Edit → EventForm path so the
+    // walkthrough can intercept onEventSave for pilot assignment.
+    if (ev.id === WALKTHROUGH_MISSION_ID) return null;
+    return (
+      <DemoHoverCard
+        event={ev}
+        onClose={onCloseHover}
+        onApprovalAction={handleApprovalAction}
+        approvalCaps={activeProfile.approval}
+        onDelete={(id) => { handleEventDelete(id); onCloseHover(); }}
+      />
+    );
+  }, [activeProfile.approval, handleApprovalAction, handleEventDelete]);
 
   // ── Guided walkthrough wiring ───────────────────────────────────
   // The walkthrough wraps the existing host callbacks so it can detect

--- a/src/WorksCalendar.tsx
+++ b/src/WorksCalendar.tsx
@@ -3025,21 +3025,19 @@ export const WorksCalendar = forwardRef<CalendarApi, WorksCalendarProps>(functio
 
         {/* ── Hover card ── */}
         {selectedEvent && (
-          renderHoverCard
-            ? renderHoverCard(selectedEvent, () => setSelectedEvent(null))
-            : (
-              <HoverCard
-                event={selectedEvent}
-                config={ownerCfg.config}
-                note={notes[selectedEvent.id]}
-                onClose={() => setSelectedEvent(null)}
-                onNoteSave={onNoteSave}
-                onNoteDelete={onNoteDelete}
-                onEdit={(ownerCfg.isOwner || perms.canEditEvent) ? handleEditFromHoverCard : null}
-                anchor={null}
-                resolveResourceLabel={resolveResourceLabel}
-              />
-            )
+          (renderHoverCard && renderHoverCard(selectedEvent, () => setSelectedEvent(null))) ?? (
+            <HoverCard
+              event={selectedEvent}
+              config={ownerCfg.config}
+              note={notes[selectedEvent.id]}
+              onClose={() => setSelectedEvent(null)}
+              onNoteSave={onNoteSave}
+              onNoteDelete={onNoteDelete}
+              onEdit={(ownerCfg.isOwner || perms.canEditEvent) ? handleEditFromHoverCard : null}
+              anchor={null}
+              resolveResourceLabel={resolveResourceLabel}
+            />
+          )
         )}
 
         {/* ── Event form ── */}

--- a/src/views/WeekView.module.css
+++ b/src/views/WeekView.module.css
@@ -23,6 +23,7 @@
   align-items: center;
   padding: calc(8px * var(--wc-density, 1)) calc(4px * var(--wc-density, 1));
   border-right: 1px solid var(--wc-border);
+  box-sizing: border-box;
   gap: 4px;
 }
 .dayHead:last-child { border-right: none; }
@@ -96,6 +97,18 @@
   padding: 4px 6px 8px;
 }
 
+/* Horizontal rule drawn at the bottom of the spans zone so the grid reads
+   as a continuous surface rather than two disconnected sections. */
+.spansEdge {
+  position: absolute;
+  left: 0;
+  right: 0;
+  height: 1px;
+  background: var(--wc-border);
+  pointer-events: none;
+  z-index: 2;
+}
+
 /* ── Spanning bars layer ── */
 .spansLayer {
   position: absolute;
@@ -130,6 +143,11 @@
 
 .continuesBefore { border-top-left-radius: 0; border-bottom-left-radius: 0; left: 0 !important; }
 .continuesAfter  { border-top-right-radius: 0; border-bottom-right-radius: 0; }
+
+/* Highlighted column shown while dragging a pill to a new day */
+.pillDragTarget {
+  background: color-mix(in srgb, var(--wc-accent) 8%, transparent) !important;
+}
 
 .spanBar.tentative { opacity: 0.65; background-image: repeating-linear-gradient(45deg, transparent, transparent 3px, rgba(255,255,255,.25) 3px, rgba(255,255,255,.25) 6px); }
 .spanBar.cancelled { opacity: 0.45; text-decoration: line-through; }

--- a/src/views/WeekView.tsx
+++ b/src/views/WeekView.tsx
@@ -121,6 +121,44 @@ export default function WeekView({
   const [spanGhost, setSpanGhost] = useState<{ ev: WeekViewEvent; startCol: number; endCol: number } | null>(null);
   const spansRef     = useRef<HTMLDivElement | null>(null);
 
+  // ── Pill drag (single-day events, day-to-day only) ────────────────────────
+  type PillDrag = { ev: WeekViewEvent; startCol: number; colW: number; moved: boolean };
+  const pillDragRef    = useRef<PillDrag | null>(null);
+  const [pillTargetCol, setPillTargetCol] = useState<number | null>(null);
+  const daysAreaRef    = useRef<HTMLDivElement | null>(null);
+
+  function startPillDrag(ev: WeekViewEvent, e: ReactPointerEvent<HTMLButtonElement>, dayCol: number) {
+    if (!ctx?.['permissions']?.canDrag) return;
+    e.preventDefault();
+    e.stopPropagation();
+    const grid = daysAreaRef.current;
+    if (!grid) return;
+    const colW = grid.getBoundingClientRect().width / 7;
+    pillDragRef.current = { ev, startCol: dayCol, colW, moved: false };
+    grid.setPointerCapture(e.pointerId);
+    setPillTargetCol(dayCol);
+  }
+
+  function handleDaysAreaPointerMove(e: ReactPointerEvent<HTMLDivElement>) {
+    const d = pillDragRef.current;
+    if (!d || !daysAreaRef.current) return;
+    const rect = daysAreaRef.current.getBoundingClientRect();
+    const col  = Math.max(0, Math.min(6, Math.floor((e.clientX - rect.left) / d.colW)));
+    if (!d.moved && col !== d.startCol) d.moved = true;
+    setPillTargetCol(col);
+  }
+
+  function handleDaysAreaPointerUp() {
+    const d = pillDragRef.current;
+    const targetCol = pillTargetCol;
+    pillDragRef.current = null;
+    setPillTargetCol(null);
+    if (!d || !d.moved || targetCol === null) return;
+    const diff = targetCol - d.startCol;
+    if (diff === 0) return;
+    onEventMove?.(d.ev, addDays(d.ev.start, diff), addDays(d.ev.end, diff));
+  }
+
   function startSpanDrag(ev: WeekViewEvent, e: ReactPointerEvent<HTMLButtonElement>, startCol: number, endCol: number) {
     e.preventDefault();
     e.stopPropagation();
@@ -155,9 +193,10 @@ export default function WeekView({
   }
 
   // ── Renderers ─────────────────────────────────────────────────────────────
-  function renderPill(ev: WeekViewEvent, onAfterClick?: () => void) {
+  function renderPill(ev: WeekViewEvent, dayCol?: number, onAfterClick?: () => void) {
     const color    = resolveColor(ev as never, ctx?.['colorRules']);
-    const onClick  = () => { onEventClick?.(ev); onAfterClick?.(); };
+    const isDragging = pillDragRef.current?.ev.id === ev.id;
+    const onClick  = () => { if (isDragging) return; onEventClick?.(ev); onAfterClick?.(); };
     const isConflicting = !!(ctx?.['conflictingEventIds'] as ReadonlySet<string> | undefined)?.has(ev.id);
     const statusClass   = ev.status === 'cancelled' ? styles['cancelled']
       : ev.status === 'tentative' ? styles['tentative'] : '';
@@ -170,13 +209,14 @@ export default function WeekView({
 
     return (
       <button key={ev.id}
-        className={[styles['pill'], statusClass].filter(Boolean).join(' ')}
+        className={[styles['pill'], statusClass, isDragging && styles['dragging']].filter(Boolean).join(' ')}
         data-wc-event-id={ev.id}
         data-wc-conflicting={isConflicting ? 'true' : undefined}
         data-wc-priority={ev.visualPriority ?? undefined}
         style={{ '--ev-color': color }}
         onClick={e => { e.stopPropagation(); onClick(); }}
         onKeyDown={e => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); e.stopPropagation(); onClick(); } }}
+        onPointerDown={dayCol !== undefined ? (e: ReactPointerEvent<HTMLButtonElement>) => startPillDrag(ev, e, dayCol) : undefined}
         aria-label={ev.lifecycle ? `${ariaLabel}, lifecycle ${ev.lifecycle}` : ariaLabel}
       >
         {inner ?? (
@@ -217,7 +257,13 @@ export default function WeekView({
 
       {/* ── Body ── */}
       <div className={styles['body']}>
-        <div className={styles['daysArea']}>
+        <div
+          className={styles['daysArea']}
+          ref={daysAreaRef}
+          onPointerMove={handleDaysAreaPointerMove}
+          onPointerUp={handleDaysAreaPointerUp}
+          onPointerCancel={() => { pillDragRef.current = null; setPillTargetCol(null); }}
+        >
           {/* Day cells */}
           <div className={styles['weekCells']} role="row" aria-rowindex={2}>
             {days.map((day, di) => {
@@ -231,6 +277,7 @@ export default function WeekView({
               const isOverflowOpen = overflowDay && isSameDay(overflowDay, day);
               const totalEvents   = daySingles.length + spansOnDay.length;
               const cellLabel     = `${format(day, 'EEEE, MMMM d')}${isToday(day) ? ', today' : ''}${totalEvents > 0 ? `, ${totalEvents} event${totalEvents === 1 ? '' : 's'}` : ''}`;
+              const isPillTarget  = pillTargetCol === di && pillDragRef.current !== null;
 
               return (
                 <div
@@ -240,7 +287,7 @@ export default function WeekView({
                   data-date={dayKey}
                   aria-label={cellLabel}
                   aria-selected={isFocused}
-                  className={[styles['cell'], isToday(day) && styles['todayCell']].filter(Boolean).join(' ')}
+                  className={[styles['cell'], isToday(day) && styles['todayCell'], isPillTarget && styles['pillDragTarget']].filter(Boolean).join(' ')}
                   onClick={() => {
                     setFocusedDay(startOfDay(day));
                     if (!onDateSelect) return;
@@ -251,7 +298,7 @@ export default function WeekView({
                   onKeyDown={e => handleCellKeyDown(e, day)}
                 >
                   <div className={styles['events']} style={{ paddingTop: spansHeight }}>
-                    {daySingles.slice(0, MAX_PILLS).map(ev => renderPill(ev))}
+                    {daySingles.slice(0, MAX_PILLS).map(ev => renderPill(ev, di))}
                     {overflow > 0 && (
                       <button
                         className={styles['moreLink']}
@@ -271,13 +318,18 @@ export default function WeekView({
                         <span>{format(day, 'MMMM d')}</span>
                         <button onClick={() => setOverflowDay(null)} aria-label="Close">×</button>
                       </div>
-                      {daySingles.slice(MAX_PILLS).map(ev => renderPill(ev, () => setOverflowDay(null)))}
+                      {daySingles.slice(MAX_PILLS).map(ev => renderPill(ev, undefined, () => setOverflowDay(null)))}
                     </div>
                   )}
                 </div>
               );
             })}
           </div>
+
+          {/* Horizontal rule at the bottom of the spans zone */}
+          {laneCount > 0 && (
+            <div className={styles['spansEdge']} style={{ top: spansHeight }} aria-hidden="true" />
+          )}
 
           {/* Spanning event bars */}
           {laneCount > 0 && (


### PR DESCRIPTION
Grid lines: normalize box-sizing on .dayHead to match .cell (eliminates
1px column-border offset between header and body rows); add a .spansEdge
horizontal rule at the bottom of the spans zone so the spans area reads
as connected to the events area below.

Pill drag: re-add day-to-day drag for single-day events in the week view.
The redesign (381ca47) removed time-grid drag but left pills with no
onPointerDown handler. Uses daysAreaRef as the pointer-capture target,
a pillDragRef to track movement, and highlights the target column while
dragging. Fires onEventMove on drop.

Walkthrough assignment (issue 3): clicking wt-mission (Mission Alpha)
was opening the São Paulo MissionHoverCard, which has all 4 pilot slots
pre-filled — no empty slots for the user to assign James Wright as step 2
requires. Fix: exclude wt-mission from setMissionOpen; return null from
renderHoverCard for wt-mission; update WorksCalendar's hover-card
ternary to fall through to the built-in HoverCard when renderHoverCard
returns null, giving wt-mission the standard HoverCard → Edit → EventForm
path that fires onEventSave and lets the walkthrough advance.

https://claude.ai/code/session_01KCrMk4w8WFWJmZpK42cLGu