### PR TITLE
fix: 5 issues — grid lines, pill click, mission visibility, map filte…

### DIFF
--- a/demo/App.tsx
+++ b/demo/App.tsx
@@ -809,30 +809,6 @@ function App() {
     });
   }, [events]);
 
-  // When the dispatcher clicks "Assign" on an available aircraft row, create
-  // a mission-assignment event that books the aircraft for the mission window.
-  const handleDispatchAssign = useCallback((assetId, missionId, _asOf) => {
-    const m = missionId === mission.id ? mission : null;
-    if (!m) {
-      log(`Dispatch: unknown mission ${missionId}`);
-      return;
-    }
-    const asset = EMS_ASSETS.find(a => a.id === assetId);
-    const assetName = asset?.name ?? assetId;
-    const newEvent = {
-      id: `dispatch-${assetId}-${Date.now()}`,
-      title: `${m.title} — ${assetName}`,
-      start: m.start,
-      end:   m.end,
-      category: 'mission-assignment',
-      resource: assetId,
-      color: MISSION_COLOR,
-      visualPriority: 'high',
-    };
-    handleEventSave(newEvent);
-    log(`Dispatched ${assetName} to ${m.title}`);
-  }, [handleEventSave]);
-
   const [updateSW] = useState(() =>
     registerSW({
       onNeedRefresh()  { setNeedsRefresh(true); },
@@ -867,6 +843,30 @@ function App() {
     });
     log(`Saved: ${ev.title}`);
   }, []);
+
+  // When the dispatcher clicks "Assign" on an available aircraft row, create
+  // a mission-assignment event that books the aircraft for the mission window.
+  const handleDispatchAssign = useCallback((assetId, missionId, _asOf) => {
+    const m = missionId === mission.id ? mission : null;
+    if (!m) {
+      log(`Dispatch: unknown mission ${missionId}`);
+      return;
+    }
+    const asset = EMS_ASSETS.find(a => a.id === assetId);
+    const assetName = asset?.name ?? assetId;
+    const newEvent = {
+      id: `dispatch-${assetId}-${Date.now()}`,
+      title: `${m.title} — ${assetName}`,
+      start: m.start,
+      end:   m.end,
+      category: 'mission-assignment',
+      resource: assetId,
+      color: MISSION_COLOR,
+      visualPriority: 'high',
+    };
+    handleEventSave(newEvent);
+    log(`Dispatched ${assetName} to ${m.title}`);
+  }, [handleEventSave]);
 
   const handleEventDelete = useCallback((id) => {
     setEvents(prev => prev.filter(e => e.id !== id));

--- a/demo/App.tsx
+++ b/demo/App.tsx
@@ -809,6 +809,30 @@ function App() {
     });
   }, [events]);
 
+  // When the dispatcher clicks "Assign" on an available aircraft row, create
+  // a mission-assignment event that books the aircraft for the mission window.
+  const handleDispatchAssign = useCallback((assetId, missionId, _asOf) => {
+    const m = missionId === mission.id ? mission : null;
+    if (!m) {
+      log(`Dispatch: unknown mission ${missionId}`);
+      return;
+    }
+    const asset = EMS_ASSETS.find(a => a.id === assetId);
+    const assetName = asset?.name ?? assetId;
+    const newEvent = {
+      id: `dispatch-${assetId}-${Date.now()}`,
+      title: `${m.title} — ${assetName}`,
+      start: m.start,
+      end:   m.end,
+      category: 'mission-assignment',
+      resource: assetId,
+      color: MISSION_COLOR,
+      visualPriority: 'high',
+    };
+    handleEventSave(newEvent);
+    log(`Dispatched ${assetName} to ${m.title}`);
+  }, [handleEventSave]);
+
   const [updateSW] = useState(() =>
     registerSW({
       onNeedRefresh()  { setNeedsRefresh(true); },
@@ -1078,6 +1102,7 @@ function App() {
       role={activeProfile.permissionRole}
       dispatchMissions={dispatchMissions}
       dispatchEvaluator={dispatchEvaluator}
+      onDispatchAssign={handleDispatchAssign}
       mapStyle="https://tiles.openfreemap.org/styles/liberty"
     />
   );

--- a/demo/walkthrough/fixtures.ts
+++ b/demo/walkthrough/fixtures.ts
@@ -28,20 +28,21 @@ export const WALKTHROUGH_DECOY_SHIFT_ID = 'wt-decoy-shift';
 /** The pilot whose shift overlaps the mission slot — Step 2 conflict target. */
 export const CONFLICT_PILOT_ID = 'emp-james';
 
-// Anchor the seed events to "this week's Thursday" — same anchor logic as
-// emsData (Monday of current week + day offset), so events render today's
-// week regardless of when the demo loads. Computed at module load; doesn't
-// shift mid-session.
-const _MONDAY = startOfWeek(new Date(), { weekStartsOn: 1 });
+// Anchor the seed events to "this week's Thursday" using Sunday as the week
+// start — matching WeekView's default weekStartDay. This ensures Mission Alpha
+// lands in the week currently visible in Week view AND in the same calendar
+// month shown by Month view, regardless of today's day-of-week.
+const _WEEK_SUN = startOfWeek(new Date(), { weekStartsOn: 0 });
 function _seedDt(dayOffset: number, time: string): string {
-  return `${format(addDays(_MONDAY, dayOffset), 'yyyy-MM-dd')}T${time}`;
+  return `${format(addDays(_WEEK_SUN, dayOffset), 'yyyy-MM-dd')}T${time}`;
 }
 
-export const ALPHA_INITIAL_START_ISO = _seedDt(3, '14:00:00');
+// Thursday = Sunday + 4 (Sun=0, Mon=1, Tue=2, Wed=3, Thu=4)
+export const ALPHA_INITIAL_START_ISO = _seedDt(4, '14:00:00');
 
-const MISSION_END_ISO = _seedDt(3, '15:00:00');
-const SHIFT_START_ISO = _seedDt(3, '13:00:00');
-const SHIFT_END_ISO   = _seedDt(3, '17:00:00');
+const MISSION_END_ISO = _seedDt(4, '15:00:00');
+const SHIFT_START_ISO = _seedDt(4, '13:00:00');
+const SHIFT_END_ISO   = _seedDt(4, '17:00:00');
 
 const MISSION_COLOR = '#a855f7';
 const PILOT_COLOR   = '#3b82f6';

--- a/src/WorksCalendar.tsx
+++ b/src/WorksCalendar.tsx
@@ -2598,7 +2598,7 @@ export const WorksCalendar = forwardRef<CalendarApi, WorksCalendarProps>(functio
                 <MapPeekWidget
                   events={(expandedEvents as any[]).filter(ev => !isScheduleWorkflowEvent(ev)) as never}
                   onEventClick={handleEventClick as never}
-                  onOpenChange={onMapWidgetOpenChange}
+                  {...(onMapWidgetOpenChange ? { onOpenChange: onMapWidgetOpenChange } : {})}
                   {...(mapStyle ? { mapStyle } : {})}
                 />
               </RightPanelSection>

--- a/src/WorksCalendar.tsx
+++ b/src/WorksCalendar.tsx
@@ -44,7 +44,7 @@ import SetupLanding, { type SetupLandingResult, type SetupRecipeId } from './ui/
 import { applyFilters, getCategories, getResources } from './filters/filterEngine';
 import { resolveCssTheme, normalizeTheme, THEME_META } from './styles/themes';
 import { DEFAULT_FILTER_SCHEMA, buildDefaultFilterSchema, makeResourceResolver, viewScopedSchema, type FilterField } from './filters/filterSchema';
-import { SCHEDULE_WORKFLOW_CATEGORIES } from './core/scheduleModel';
+import { SCHEDULE_WORKFLOW_CATEGORIES, isScheduleWorkflowEvent } from './core/scheduleModel';
 import { useTabScopedEvents } from './hooks/useTabScopedEvents';
 import { captureSavedViewFields, type ViewId } from './core/viewScope';
 import { resolveLabels } from './core/config/resolveLabels';
@@ -282,6 +282,12 @@ export type WorksCalendarProps = {
    * hours remaining, etc.) into the readiness shape the table expects.
    */
   dispatchEvaluator?: DispatchEvaluator;
+  /**
+   * Called when the dispatcher clicks "Assign" on an available asset row.
+   * Receives the asset id, the selected mission id (or null), and the
+   * active as-of time. Hosts should create a booking event and call onEventSave.
+   */
+  onDispatchAssign?: (assetId: string, missionId: string | null, asOf: Date) => void;
   emptyState?: ReactNode;
   filterSchema?: FilterField[];
   /**
@@ -609,6 +615,7 @@ export const WorksCalendar = forwardRef<CalendarApi, WorksCalendarProps>(functio
     focusChips,
     dispatchMissions,
     dispatchEvaluator,
+    onDispatchAssign,
     emptyState,
 
     // ── Filter schema (pass a custom FilterField[] to extend or replace defaults) ──
@@ -2589,8 +2596,9 @@ export const WorksCalendar = forwardRef<CalendarApi, WorksCalendarProps>(functio
                   the first thing the operator sees in the rail. */}
               <RightPanelSection title="Region map">
                 <MapPeekWidget
-                  events={expandedEvents as never}
+                  events={(expandedEvents as any[]).filter(ev => !isScheduleWorkflowEvent(ev)) as never}
                   onEventClick={handleEventClick as never}
+                  onOpenChange={onMapWidgetOpenChange}
                   {...(mapStyle ? { mapStyle } : {})}
                 />
               </RightPanelSection>
@@ -2959,6 +2967,7 @@ export const WorksCalendar = forwardRef<CalendarApi, WorksCalendarProps>(functio
                   onEventClick={handleEventClick}
                   missions={dispatchMissions}
                   evaluateForMission={dispatchEvaluator}
+                  onAssign={onDispatchAssign}
                   // Sync the calendar's currentDate with the dispatcher's chosen
                   // as-of moment so recurring-event expansion + fetch ranges
                   // re-anchor around it. Without this, a far-future as-of would

--- a/src/views/DispatchView.tsx
+++ b/src/views/DispatchView.tsx
@@ -169,6 +169,13 @@ export type DispatchViewProps = {
    * Not invoked on initial mount — only on user-driven changes.
    */
   onAsOfChange?: ((asOf: Date) => void) | undefined;
+  /**
+   * Called when the user clicks "Assign" on an available asset row. Receives
+   * the asset id, the currently-selected mission id (or null when no mission
+   * is chosen in the picker), and the active as-of time. Hosts should create
+   * the corresponding booking event and call onEventSave.
+   */
+  onAssign?: ((assetId: string, missionId: string | null, asOf: Date) => void) | undefined;
 };
 
 type Status = 'available' | 'busy' | 'maintenance';
@@ -484,6 +491,7 @@ export default function DispatchView({
   missions,
   evaluateForMission,
   onAsOfChange,
+  onAssign,
 }: DispatchViewProps) {
   const labelLower = label.toLowerCase();
   const labelPluralLower = `${labelLower}s`;
@@ -724,6 +732,9 @@ export default function DispatchView({
                           row={row}
                           onView={onEventClick}
                           missionLabel={activeMission?.label}
+                          onAssign={onAssign
+                            ? () => onAssign(String(row.asset.id), forMissionId, asOf)
+                            : undefined}
                         />
                       </td>
                     </tr>
@@ -817,10 +828,12 @@ function ActionButton({
   row,
   onView,
   missionLabel,
+  onAssign,
 }: {
   row: Row;
   onView?: ((event: LooseEvent) => void) | undefined;
   missionLabel?: string | undefined;
+  onAssign?: (() => void) | undefined;
 }) {
   const blockingEvent = row.blockingEvent;
   if (row.status === 'maintenance') {
@@ -840,5 +853,14 @@ function ActionButton({
     return <span className={styles['actionMuted']}>Not eligible</span>;
   }
   const assignLabel = missionLabel ? `Assign to ${missionLabel}` : 'Assign';
-  return <button type="button" className={[styles['actionBtn'], styles['actionPrimary']].join(' ')}>{assignLabel}</button>;
+  return (
+    <button
+      type="button"
+      className={[styles['actionBtn'], styles['actionPrimary']].join(' ')}
+      onClick={onAssign}
+      disabled={!onAssign}
+    >
+      {assignLabel}
+    </button>
+  );
 }

--- a/src/views/WeekView.module.css
+++ b/src/views/WeekView.module.css
@@ -59,17 +59,25 @@
   flex: 1;
   min-height: 0;
   overflow-y: auto;
+  /* flex column so .daysArea can take flex:1, giving it a definite height
+     that percentage children (weekCells height:100%) can resolve against */
+  display: flex;
+  flex-direction: column;
 }
 
 .daysArea {
   position: relative;
-  min-height: 100%;
+  flex: 1;
+  min-height: 240px;
 }
 
 .weekCells {
   display: grid;
   grid-template-columns: repeat(7, 1fr);
-  min-height: 100%;
+  /* height:100% resolves now because .daysArea has a definite flex height;
+     min-height keeps cells from collapsing when content is sparse */
+  height: 100%;
+  min-height: 240px;
 }
 
 .cell {
@@ -98,69 +106,11 @@
   padding: 4px 6px 8px;
 }
 
-/* Horizontal rule drawn at the bottom of the spans zone so the grid reads
-   as a continuous surface rather than two disconnected sections. */
-.spansEdge {
-  position: absolute;
-  left: 0;
-  right: 0;
-  height: 1px;
-  background: var(--wc-border);
-  pointer-events: none;
-  z-index: 2;
-}
-
-/* ── Spanning bars layer ── */
-.spansLayer {
-  position: absolute;
-  left: 0;
-  right: 0;
-  pointer-events: none;
-}
-
-.spanBar {
-  position: absolute;
-  display: flex;
-  align-items: center;
-  padding: 0 8px;
-  border-radius: var(--wc-radius-sm);
-  background: var(--ev-color, var(--wc-accent));
-  color: #fff;
-  font-size: calc(12px * var(--wc-font-scale, 1));
-  font-weight: 500;
-  border: none;
-  cursor: pointer;
-  overflow: hidden;
-  white-space: nowrap;
-  text-overflow: ellipsis;
-  box-sizing: border-box;
-  transition: filter 0.1s;
-  box-shadow: var(--wc-event-glow, none);
-  pointer-events: auto;
-  touch-action: none;
-}
-.spanBar:hover { filter: brightness(1.1); }
-.spanBar:focus { outline: 2px solid rgba(255,255,255,.7); outline-offset: -2px; }
-
-.continuesBefore { border-top-left-radius: 0; border-bottom-left-radius: 0; left: 0 !important; }
-.continuesAfter  { border-top-right-radius: 0; border-bottom-right-radius: 0; }
-
 /* Highlighted column shown while dragging a pill to a new day */
 .pillDragTarget {
   background: color-mix(in srgb, var(--wc-accent) 8%, transparent) !important;
 }
 
-.spanBar.tentative { opacity: 0.65; background-image: repeating-linear-gradient(45deg, transparent, transparent 3px, rgba(255,255,255,.25) 3px, rgba(255,255,255,.25) 6px); }
-.spanBar.cancelled { opacity: 0.45; text-decoration: line-through; }
-.spanBar.dragging  { opacity: 0.35; pointer-events: none; }
-
-.spanGhost {
-  opacity: 0.45;
-  pointer-events: none;
-  border: 2px dashed rgba(255,255,255,0.6);
-}
-
-.spanBar[data-wc-conflicting="true"],
 .pill[data-wc-conflicting="true"] {
   outline: 2px solid var(--wc-danger, #e53935);
   outline-offset: -1px;

--- a/src/views/WeekView.module.css
+++ b/src/views/WeekView.module.css
@@ -180,11 +180,12 @@
 /* ── Event pills (single-day timed events) ── */
 .pill {
   display: flex;
-  align-items: center;
-  gap: 5px;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 2px;
   width: 100%;
-  min-height: 30px;
-  padding: 5px 8px;
+  min-height: 52px;
+  padding: 6px 8px;
   border-radius: var(--wc-radius-sm);
   background: var(--ev-color, var(--wc-accent));
   color: #fff;
@@ -193,14 +194,11 @@
   text-align: left;
   border: 1px solid color-mix(in srgb, var(--ev-color, var(--wc-accent)) 65%, #000);
   cursor: pointer;
-  white-space: nowrap;
   overflow: hidden;
-  text-overflow: ellipsis;
   transition: opacity 0.1s;
   box-shadow: var(--wc-event-glow, none);
   box-sizing: border-box;
   flex-shrink: 0;
-  /* Prevent pill from blowing out its column */
   min-width: 0;
 }
 .pill:hover { opacity: 0.87; }
@@ -213,14 +211,18 @@
   opacity: 0.82;
   flex-shrink: 0;
   font-weight: 400;
+  white-space: nowrap;
 }
 
 .pillTitle {
-  flex: 1;
+  width: 100%;
   overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
+  /* Allow title to wrap up to 2 lines so more text is visible */
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
   font-weight: 600;
+  word-break: break-word;
 }
 
 .pillResource {
@@ -230,7 +232,7 @@
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  max-width: 30%;
+  max-width: 100%;
 }
 
 /* ── "+N more" button ── */

--- a/src/views/WeekView.module.css
+++ b/src/views/WeekView.module.css
@@ -12,7 +12,9 @@
   grid-template-columns: repeat(7, 1fr);
   background: var(--wc-surface);
   border-bottom: 1px solid var(--wc-border);
-  flex-shrink: 0;
+  position: sticky;
+  top: 0;
+  z-index: 10;
 }
 
 .dayHead {

--- a/src/views/WeekView.module.css
+++ b/src/views/WeekView.module.css
@@ -25,6 +25,8 @@
   border-right: 1px solid var(--wc-border);
   box-sizing: border-box;
   gap: 4px;
+  /* Prevent header cells from being squeezed by content in body cells */
+  min-width: 0;
 }
 .dayHead:last-child { border-right: none; }
 
@@ -59,8 +61,8 @@
   flex: 1;
   min-height: 0;
   overflow-y: auto;
-  /* flex column so .daysArea can take flex:1, giving it a definite height
-     that percentage children (weekCells height:100%) can resolve against */
+  /* flex column lets .daysArea use flex:1 to get a definite height,
+     which allows .weekCells { height:100% } to resolve properly */
   display: flex;
   flex-direction: column;
 }
@@ -74,15 +76,17 @@
 .weekCells {
   display: grid;
   grid-template-columns: repeat(7, 1fr);
-  /* height:100% resolves now because .daysArea has a definite flex height;
-     min-height keeps cells from collapsing when content is sparse */
+  /* height:100% fills .daysArea (definite flex height); min-height lets
+     cells grow when they contain many events */
   height: 100%;
   min-height: 240px;
 }
 
 .cell {
   border-right: 1px solid var(--wc-border);
-  min-height: 240px;
+  /* min-width:0 prevents grid blowout — without it, a cell's content
+     (long pill title) can widen its column beyond 1fr */
+  min-width: 0;
   cursor: pointer;
   position: relative;
   box-sizing: border-box;
@@ -106,11 +110,68 @@
   padding: 4px 6px 8px;
 }
 
+/* Horizontal rule at the bottom of the spans zone */
+.spansEdge {
+  position: absolute;
+  left: 0;
+  right: 0;
+  height: 1px;
+  background: var(--wc-border);
+  pointer-events: none;
+  z-index: 2;
+}
+
+/* ── Spanning bars layer ── */
+.spansLayer {
+  position: absolute;
+  left: 0;
+  right: 0;
+  pointer-events: none;
+}
+
+.spanBar {
+  position: absolute;
+  display: flex;
+  align-items: center;
+  padding: 0 8px;
+  border-radius: var(--wc-radius-sm);
+  background: var(--ev-color, var(--wc-accent));
+  color: #fff;
+  font-size: calc(12px * var(--wc-font-scale, 1));
+  font-weight: 500;
+  border: none;
+  cursor: pointer;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  box-sizing: border-box;
+  transition: filter 0.1s;
+  box-shadow: var(--wc-event-glow, none);
+  pointer-events: auto;
+  touch-action: none;
+}
+.spanBar:hover { filter: brightness(1.1); }
+.spanBar:focus { outline: 2px solid rgba(255,255,255,.7); outline-offset: -2px; }
+
+.continuesBefore { border-top-left-radius: 0; border-bottom-left-radius: 0; left: 0 !important; }
+.continuesAfter  { border-top-right-radius: 0; border-bottom-right-radius: 0; }
+
 /* Highlighted column shown while dragging a pill to a new day */
 .pillDragTarget {
   background: color-mix(in srgb, var(--wc-accent) 8%, transparent) !important;
 }
 
+.spanBar.tentative { opacity: 0.65; background-image: repeating-linear-gradient(45deg, transparent, transparent 3px, rgba(255,255,255,.25) 3px, rgba(255,255,255,.25) 6px); }
+.spanBar.cancelled { opacity: 0.45; text-decoration: line-through; }
+.spanBar.dragging  { opacity: 0.35; pointer-events: none; }
+
+.spanGhost {
+  opacity: 0.45;
+  pointer-events: none;
+  border: 2px dashed rgba(255,255,255,0.6);
+}
+
+.spanBar[data-wc-conflicting="true"],
 .pill[data-wc-conflicting="true"] {
   outline: 2px solid var(--wc-danger, #e53935);
   outline-offset: -1px;
@@ -139,6 +200,8 @@
   box-shadow: var(--wc-event-glow, none);
   box-sizing: border-box;
   flex-shrink: 0;
+  /* Prevent pill from blowing out its column */
+  min-width: 0;
 }
 .pill:hover { opacity: 0.87; }
 .pill:focus { outline: 2px solid rgba(255,255,255,.7); outline-offset: -2px; }
@@ -237,5 +300,4 @@
   .pillTime    { display: none; }
   .pillResource { display: none; }
   .pill        { font-size: calc(11px * var(--wc-font-scale, 1)); min-height: 26px; }
-  .cell        { min-height: 120px; }
 }

--- a/src/views/WeekView.tsx
+++ b/src/views/WeekView.tsx
@@ -6,16 +6,12 @@ import {
 } from 'date-fns';
 import type { Day } from 'date-fns';
 import { useCalendarContext, resolveColor } from '../core/CalendarContext';
-import { layoutSpans } from '../core/layout';
 import ApprovalDot from '../ui/ApprovalDot';
 import EventStatusBadge from '../ui/EventStatusBadge';
 import styles from './WeekView.module.css';
 import type { CalendarViewEvent } from '../types/ui';
 
-const SPAN_H            = 28;
-const SPAN_GAP          = 3;
-const MAX_SPANS_VISIBLE = 4;
-const MAX_PILLS         = 8;
+const MAX_PILLS = 8;
 
 type WeekViewEvent = CalendarViewEvent & { color?: string };
 
@@ -28,11 +24,6 @@ interface WeekViewProps {
   onDateSelect?: (start: Date, end: Date) => void;
   config?: { display?: { dayStart?: number; dayEnd?: number } };
   weekStartDay?: Day;
-}
-
-function isMultiDay(ev: WeekViewEvent) {
-  if (ev.allDay) return true;
-  return startOfDay(ev.start).getTime() !== startOfDay(ev.end).getTime();
 }
 
 export default function WeekView({
@@ -56,34 +47,28 @@ export default function WeekView({
   const weekStart = days[0]!;
   const weekEnd   = days[6]!;
 
-  const { multiDay, singleDay } = useMemo(() => {
-    const multi: WeekViewEvent[] = [];
-    const single: WeekViewEvent[] = [];
-    events.forEach(ev => (isMultiDay(ev) ? multi : single).push(ev));
-    return { multiDay: multi, singleDay: single };
-  }, [events]);
-
-  const singleByDay = useMemo(() => {
+  // All events — both single-day and multi-day — are shown as pills within
+  // each day cell they fall on. Multi-day events appear in every day of the
+  // visible week they overlap, so there is no separate all-day row.
+  const eventsByDay = useMemo(() => {
     const map = new Map<string, WeekViewEvent[]>();
-    singleDay.forEach(ev => {
-      const key = format(ev.start, 'yyyy-MM-dd');
-      let bucket = map.get(key);
-      if (!bucket) { bucket = []; map.set(key, bucket); }
-      bucket.push(ev);
+    days.forEach(day => map.set(format(day, 'yyyy-MM-dd'), []));
+    events.forEach(ev => {
+      days.forEach(day => {
+        const dayStart = startOfDay(day);
+        const dayEnd   = new Date(dayStart.getTime() + 86_400_000 - 1);
+        // Event overlaps this day if it starts before day-end and ends after day-start.
+        if (ev.start <= dayEnd && ev.end > dayStart) {
+          map.get(format(day, 'yyyy-MM-dd'))!.push(ev);
+        }
+      });
     });
     map.forEach((dayEvs, key) => {
       dayEvs.sort((a, b) => a.start.getTime() - b.start.getTime());
       map.set(key, dayEvs);
     });
     return map;
-  }, [singleDay]);
-
-  const spans = useMemo(
-    () => layoutSpans(multiDay, weekStart, weekEnd),
-    [multiDay, weekStart, weekEnd],
-  );
-  const laneCount   = spans.length ? Math.max(...spans.map(s => s.lane)) + 1 : 0;
-  const spansHeight = Math.min(laneCount, MAX_SPANS_VISIBLE) * (SPAN_H + SPAN_GAP);
+  }, [events, days]);
 
   // ── Keyboard navigation ───────────────────────────────────────────────────
   const lastKeyNav = useRef(false);
@@ -115,13 +100,7 @@ export default function WeekView({
     }
   }, [onDateSelect]);
 
-  // ── Span bar drag (day-to-day only) ──────────────────────────────────────
-  type SpanDrag = { ev: WeekViewEvent; startCol: number; endCol: number; width: number; clickOffset: number; colW: number };
-  const spanDragRef  = useRef<SpanDrag | null>(null);
-  const [spanGhost, setSpanGhost] = useState<{ ev: WeekViewEvent; startCol: number; endCol: number } | null>(null);
-  const spansRef     = useRef<HTMLDivElement | null>(null);
-
-  // ── Pill drag (single-day events, day-to-day only) ────────────────────────
+  // ── Pill drag (day-to-day only) ──────────────────────────────────────────
   type PillDrag = { ev: WeekViewEvent; startCol: number; colW: number; moved: boolean };
   const pillDragRef    = useRef<PillDrag | null>(null);
   const [pillTargetCol, setPillTargetCol] = useState<number | null>(null);
@@ -164,39 +143,6 @@ export default function WeekView({
     }
     if (targetCol === null) return;
     const diff = targetCol - d.startCol;
-    if (diff === 0) return;
-    onEventMove?.(d.ev, addDays(d.ev.start, diff), addDays(d.ev.end, diff));
-  }
-
-  function startSpanDrag(ev: WeekViewEvent, e: ReactPointerEvent<HTMLButtonElement>, startCol: number, endCol: number) {
-    e.preventDefault();
-    e.stopPropagation();
-    const grid = spansRef.current;
-    if (!grid) return;
-    const rect   = grid.getBoundingClientRect();
-    const colW   = rect.width / 7;
-    const clickCol = Math.max(0, Math.min(6, Math.floor((e.clientX - rect.left) / colW)));
-    spanDragRef.current = { ev, startCol, endCol, width: endCol - startCol, clickOffset: clickCol - startCol, colW };
-    grid.setPointerCapture(e.pointerId);
-    setSpanGhost({ ev, startCol, endCol });
-  }
-
-  function handleSpanPointerMove(e: ReactPointerEvent<HTMLDivElement>) {
-    const d = spanDragRef.current;
-    if (!d || !spansRef.current) return;
-    const rect   = spansRef.current.getBoundingClientRect();
-    const col    = Math.max(0, Math.min(6, Math.floor((e.clientX - rect.left) / d.colW)));
-    const start  = Math.max(0, Math.min(7 - d.width - 1, col - d.clickOffset));
-    setSpanGhost({ ev: d.ev, startCol: start, endCol: start + d.width });
-  }
-
-  function handleSpanPointerUp() {
-    const d = spanDragRef.current;
-    const g = spanGhost;
-    spanDragRef.current = null;
-    setSpanGhost(null);
-    if (!d || !g) return;
-    const diff = g.startCol - d.startCol;
     if (diff === 0) return;
     onEventMove?.(d.ev, addDays(d.ev.start, diff), addDays(d.ev.end, diff));
   }
@@ -273,20 +219,16 @@ export default function WeekView({
           onPointerUp={handleDaysAreaPointerUp}
           onPointerCancel={() => { pillDragRef.current = null; setPillTargetCol(null); }}
         >
-          {/* Day cells */}
+          {/* Day cells — all events (single-day and multi-day) are pills here */}
           <div className={styles['weekCells']} role="row" aria-rowindex={2}>
             {days.map((day, di) => {
-              const dayKey     = format(day, 'yyyy-MM-dd');
-              const daySingles = singleByDay.get(dayKey) || [];
-              const isFocused  = isSameDay(day, focusedDay);
-
-              const spansOnDay    = spans.filter(s => s.startCol <= di && s.endCol >= di);
-              const hiddenSpans   = spansOnDay.filter(s => s.lane >= MAX_SPANS_VISIBLE).length;
-              const overflow      = hiddenSpans + Math.max(0, daySingles.length - MAX_PILLS);
+              const dayKey  = format(day, 'yyyy-MM-dd');
+              const dayEvs  = eventsByDay.get(dayKey) || [];
+              const isFocused = isSameDay(day, focusedDay);
+              const overflow = Math.max(0, dayEvs.length - MAX_PILLS);
               const isOverflowOpen = overflowDay && isSameDay(overflowDay, day);
-              const totalEvents   = daySingles.length + spansOnDay.length;
-              const cellLabel     = `${format(day, 'EEEE, MMMM d')}${isToday(day) ? ', today' : ''}${totalEvents > 0 ? `, ${totalEvents} event${totalEvents === 1 ? '' : 's'}` : ''}`;
-              const isPillTarget  = pillTargetCol === di && pillDragRef.current !== null;
+              const cellLabel = `${format(day, 'EEEE, MMMM d')}${isToday(day) ? ', today' : ''}${dayEvs.length > 0 ? `, ${dayEvs.length} event${dayEvs.length === 1 ? '' : 's'}` : ''}`;
+              const isPillTarget = pillTargetCol === di && pillDragRef.current !== null;
 
               return (
                 <div
@@ -306,8 +248,8 @@ export default function WeekView({
                   }}
                   onKeyDown={e => handleCellKeyDown(e, day)}
                 >
-                  <div className={styles['events']} style={{ paddingTop: spansHeight }}>
-                    {daySingles.slice(0, MAX_PILLS).map(ev => renderPill(ev, di))}
+                  <div className={styles['events']}>
+                    {dayEvs.slice(0, MAX_PILLS).map(ev => renderPill(ev, di))}
                     {overflow > 0 && (
                       <button
                         className={styles['moreLink']}
@@ -327,85 +269,13 @@ export default function WeekView({
                         <span>{format(day, 'MMMM d')}</span>
                         <button onClick={() => setOverflowDay(null)} aria-label="Close">×</button>
                       </div>
-                      {daySingles.slice(MAX_PILLS).map(ev => renderPill(ev, undefined, () => setOverflowDay(null)))}
+                      {dayEvs.slice(MAX_PILLS).map(ev => renderPill(ev, undefined, () => setOverflowDay(null)))}
                     </div>
                   )}
                 </div>
               );
             })}
           </div>
-
-          {/* Horizontal rule at the bottom of the spans zone */}
-          {laneCount > 0 && (
-            <div className={styles['spansEdge']} style={{ top: spansHeight }} aria-hidden="true" />
-          )}
-
-          {/* Spanning event bars */}
-          {laneCount > 0 && (
-            <div
-              className={styles['spansLayer']}
-              style={{ top: 0, height: spansHeight }}
-              ref={spansRef}
-              onPointerMove={handleSpanPointerMove}
-              onPointerUp={handleSpanPointerUp}
-              onPointerCancel={() => { spanDragRef.current = null; setSpanGhost(null); }}
-            >
-              {spans
-                .filter(s => s.lane < MAX_SPANS_VISIBLE)
-                .map(({ ev, startCol, endCol, lane, continuesBefore, continuesAfter }) => {
-                  const color = resolveColor(ev as never, ctx?.['colorRules']);
-                  const isConflicting = !!(ctx?.['conflictingEventIds'] as ReadonlySet<string> | undefined)?.has(ev.id);
-                  const statusClass = ev.status === 'cancelled' ? styles['cancelled']
-                    : ev.status === 'tentative' ? styles['tentative'] : '';
-                  const isDimmed = spanGhost?.ev?.id === ev.id;
-                  return (
-                    <button
-                      key={ev.id}
-                      className={[
-                        styles['spanBar'],
-                        continuesBefore && styles['continuesBefore'],
-                        continuesAfter  && styles['continuesAfter'],
-                        statusClass,
-                        isDimmed && styles['dragging'],
-                      ].filter(Boolean).join(' ')}
-                      data-wc-conflicting={isConflicting ? 'true' : undefined}
-                      style={{
-                        '--ev-color': color,
-                        left:   `${(startCol / 7) * 100}%`,
-                        width:  `${((endCol - startCol + 1) / 7) * 100}%`,
-                        top:    lane * (SPAN_H + SPAN_GAP),
-                        height: SPAN_H,
-                      }}
-                      onClick={e => { e.stopPropagation(); if (!isDimmed) onEventClick?.(ev); }}
-                      onPointerDown={e => startSpanDrag(ev, e, startCol, endCol)}
-                      aria-label={`${ev.title}${ev.category ? `, ${ev.category}` : ''}${continuesBefore ? ', continues from previous week' : ''}${continuesAfter ? ', continues next week' : ''}`}
-                    >
-                      {!continuesBefore && (
-                        <>
-                          <EventStatusBadge lifecycle={(ev as { lifecycle?: unknown }).lifecycle as never} variant="compact" />
-                          {ev.title}
-                        </>
-                      )}
-                    </button>
-                  );
-                })}
-
-              {/* Drag ghost */}
-              {spanGhost && (
-                <div
-                  className={[styles['spanBar'], styles['spanGhost']].join(' ')}
-                  aria-hidden="true"
-                  style={{
-                    '--ev-color': resolveColor(spanGhost.ev as never, ctx?.['colorRules']),
-                    left:   `${(spanGhost.startCol / 7) * 100}%`,
-                    width:  `${((spanGhost.endCol - spanGhost.startCol + 1) / 7) * 100}%`,
-                    top:    0,
-                    height: SPAN_H,
-                  }}
-                />
-              )}
-            </div>
-          )}
         </div>
       </div>
     </div>

--- a/src/views/WeekView.tsx
+++ b/src/views/WeekView.tsx
@@ -129,7 +129,9 @@ export default function WeekView({
 
   function startPillDrag(ev: WeekViewEvent, e: ReactPointerEvent<HTMLButtonElement>, dayCol: number) {
     if (!ctx?.['permissions']?.canDrag) return;
-    e.preventDefault();
+    // No e.preventDefault() — that would suppress the synthesized click event.
+    // setPointerCapture on daysArea redirects pointerup there, so click won't
+    // fire on the pill button; handleDaysAreaPointerUp handles the tap case.
     e.stopPropagation();
     const grid = daysAreaRef.current;
     if (!grid) return;
@@ -153,7 +155,14 @@ export default function WeekView({
     const targetCol = pillTargetCol;
     pillDragRef.current = null;
     setPillTargetCol(null);
-    if (!d || !d.moved || targetCol === null) return;
+    if (!d) return;
+    if (!d.moved) {
+      // Tap/click with no movement. setPointerCapture redirected pointerup to
+      // daysArea so the pill's onClick never fires — trigger it manually here.
+      onEventClick?.(d.ev);
+      return;
+    }
+    if (targetCol === null) return;
     const diff = targetCol - d.startCol;
     if (diff === 0) return;
     onEventMove?.(d.ev, addDays(d.ev.start, diff), addDays(d.ev.end, diff));
@@ -239,24 +248,24 @@ export default function WeekView({
       aria-label={`Week of ${format(weekStart, 'MMMM d')} – ${format(weekEnd, 'MMMM d, yyyy')}`}
       ref={gridRef}
     >
-      {/* ── Header ── */}
-      <div className={styles['headerRow']} role="row" aria-rowindex={1}>
-        {days.map(day => (
-          <div key={format(day, 'yyyy-MM-dd')}
-            role="columnheader"
-            aria-label={`${format(day, 'EEEE, MMMM d')}${isToday(day) ? ', today' : ''}`}
-            className={[styles['dayHead'], isToday(day) && styles['todayHead']].filter(Boolean).join(' ')}
-          >
-            <span className={styles['dayAbbr']} aria-hidden="true">{format(day, 'EEE')}</span>
-            <span className={[styles['dayNum'], isToday(day) && styles['todayNum']].filter(Boolean).join(' ')} aria-hidden="true">
-              {format(day, 'd')}
-            </span>
-          </div>
-        ))}
-      </div>
-
-      {/* ── Body ── */}
+      {/* ── Body (single scroll container — header sticky at top, cells below) ── */}
       <div className={styles['body']}>
+        {/* Header: sticky inside the scroll container so both header and cell
+            columns are always the same width, regardless of scrollbar presence. */}
+        <div className={styles['headerRow']} role="row" aria-rowindex={1}>
+          {days.map(day => (
+            <div key={format(day, 'yyyy-MM-dd')}
+              role="columnheader"
+              aria-label={`${format(day, 'EEEE, MMMM d')}${isToday(day) ? ', today' : ''}`}
+              className={[styles['dayHead'], isToday(day) && styles['todayHead']].filter(Boolean).join(' ')}
+            >
+              <span className={styles['dayAbbr']} aria-hidden="true">{format(day, 'EEE')}</span>
+              <span className={[styles['dayNum'], isToday(day) && styles['todayNum']].filter(Boolean).join(' ')} aria-hidden="true">
+                {format(day, 'd')}
+              </span>
+            </div>
+          ))}
+        </div>
         <div
           className={styles['daysArea']}
           ref={daysAreaRef}

--- a/src/views/WeekView.tsx
+++ b/src/views/WeekView.tsx
@@ -6,12 +6,16 @@ import {
 } from 'date-fns';
 import type { Day } from 'date-fns';
 import { useCalendarContext, resolveColor } from '../core/CalendarContext';
+import { layoutSpans } from '../core/layout';
 import ApprovalDot from '../ui/ApprovalDot';
 import EventStatusBadge from '../ui/EventStatusBadge';
 import styles from './WeekView.module.css';
 import type { CalendarViewEvent } from '../types/ui';
 
-const MAX_PILLS = 8;
+const SPAN_H            = 28;
+const SPAN_GAP          = 3;
+const MAX_SPANS_VISIBLE = 4;
+const MAX_PILLS         = 8;
 
 type WeekViewEvent = CalendarViewEvent & { color?: string };
 
@@ -24,6 +28,11 @@ interface WeekViewProps {
   onDateSelect?: (start: Date, end: Date) => void;
   config?: { display?: { dayStart?: number; dayEnd?: number } };
   weekStartDay?: Day;
+}
+
+function isMultiDay(ev: WeekViewEvent) {
+  if (ev.allDay) return true;
+  return startOfDay(ev.start).getTime() !== startOfDay(ev.end).getTime();
 }
 
 export default function WeekView({
@@ -47,28 +56,34 @@ export default function WeekView({
   const weekStart = days[0]!;
   const weekEnd   = days[6]!;
 
-  // All events — both single-day and multi-day — are shown as pills within
-  // each day cell they fall on. Multi-day events appear in every day of the
-  // visible week they overlap, so there is no separate all-day row.
-  const eventsByDay = useMemo(() => {
+  const { multiDay, singleDay } = useMemo(() => {
+    const multi: WeekViewEvent[] = [];
+    const single: WeekViewEvent[] = [];
+    events.forEach(ev => (isMultiDay(ev) ? multi : single).push(ev));
+    return { multiDay: multi, singleDay: single };
+  }, [events]);
+
+  const singleByDay = useMemo(() => {
     const map = new Map<string, WeekViewEvent[]>();
-    days.forEach(day => map.set(format(day, 'yyyy-MM-dd'), []));
-    events.forEach(ev => {
-      days.forEach(day => {
-        const dayStart = startOfDay(day);
-        const dayEnd   = new Date(dayStart.getTime() + 86_400_000 - 1);
-        // Event overlaps this day if it starts before day-end and ends after day-start.
-        if (ev.start <= dayEnd && ev.end > dayStart) {
-          map.get(format(day, 'yyyy-MM-dd'))!.push(ev);
-        }
-      });
+    singleDay.forEach(ev => {
+      const key = format(ev.start, 'yyyy-MM-dd');
+      let bucket = map.get(key);
+      if (!bucket) { bucket = []; map.set(key, bucket); }
+      bucket.push(ev);
     });
     map.forEach((dayEvs, key) => {
       dayEvs.sort((a, b) => a.start.getTime() - b.start.getTime());
       map.set(key, dayEvs);
     });
     return map;
-  }, [events, days]);
+  }, [singleDay]);
+
+  const spans = useMemo(
+    () => layoutSpans(multiDay, weekStart, weekEnd),
+    [multiDay, weekStart, weekEnd],
+  );
+  const laneCount   = spans.length ? Math.max(...spans.map(s => s.lane)) + 1 : 0;
+  const spansHeight = Math.min(laneCount, MAX_SPANS_VISIBLE) * (SPAN_H + SPAN_GAP);
 
   // ── Keyboard navigation ───────────────────────────────────────────────────
   const lastKeyNav = useRef(false);
@@ -100,7 +115,13 @@ export default function WeekView({
     }
   }, [onDateSelect]);
 
-  // ── Pill drag (day-to-day only) ──────────────────────────────────────────
+  // ── Span bar drag (multi-day events, day-to-day) ──────────────────────────
+  type SpanDrag = { ev: WeekViewEvent; startCol: number; endCol: number; width: number; clickOffset: number; colW: number };
+  const spanDragRef  = useRef<SpanDrag | null>(null);
+  const [spanGhost, setSpanGhost] = useState<{ ev: WeekViewEvent; startCol: number; endCol: number } | null>(null);
+  const spansRef     = useRef<HTMLDivElement | null>(null);
+
+  // ── Pill drag (single-day events, day-to-day) ─────────────────────────────
   type PillDrag = { ev: WeekViewEvent; startCol: number; colW: number; moved: boolean };
   const pillDragRef    = useRef<PillDrag | null>(null);
   const [pillTargetCol, setPillTargetCol] = useState<number | null>(null);
@@ -143,6 +164,39 @@ export default function WeekView({
     }
     if (targetCol === null) return;
     const diff = targetCol - d.startCol;
+    if (diff === 0) return;
+    onEventMove?.(d.ev, addDays(d.ev.start, diff), addDays(d.ev.end, diff));
+  }
+
+  function startSpanDrag(ev: WeekViewEvent, e: ReactPointerEvent<HTMLButtonElement>, startCol: number, endCol: number) {
+    e.preventDefault();
+    e.stopPropagation();
+    const grid = spansRef.current;
+    if (!grid) return;
+    const rect   = grid.getBoundingClientRect();
+    const colW   = rect.width / 7;
+    const clickCol = Math.max(0, Math.min(6, Math.floor((e.clientX - rect.left) / colW)));
+    spanDragRef.current = { ev, startCol, endCol, width: endCol - startCol, clickOffset: clickCol - startCol, colW };
+    grid.setPointerCapture(e.pointerId);
+    setSpanGhost({ ev, startCol, endCol });
+  }
+
+  function handleSpanPointerMove(e: ReactPointerEvent<HTMLDivElement>) {
+    const d = spanDragRef.current;
+    if (!d || !spansRef.current) return;
+    const rect   = spansRef.current.getBoundingClientRect();
+    const col    = Math.max(0, Math.min(6, Math.floor((e.clientX - rect.left) / d.colW)));
+    const start  = Math.max(0, Math.min(7 - d.width - 1, col - d.clickOffset));
+    setSpanGhost({ ev: d.ev, startCol: start, endCol: start + d.width });
+  }
+
+  function handleSpanPointerUp() {
+    const d = spanDragRef.current;
+    const g = spanGhost;
+    spanDragRef.current = null;
+    setSpanGhost(null);
+    if (!d || !g) return;
+    const diff = g.startCol - d.startCol;
     if (diff === 0) return;
     onEventMove?.(d.ev, addDays(d.ev.start, diff), addDays(d.ev.end, diff));
   }
@@ -197,7 +251,7 @@ export default function WeekView({
       {/* ── Body (single scroll container — header sticky at top, cells below) ── */}
       <div className={styles['body']}>
         {/* Header: sticky inside the scroll container so both header and cell
-            columns are always the same width, regardless of scrollbar presence. */}
+            columns share the same container width, including any scrollbar. */}
         <div className={styles['headerRow']} role="row" aria-rowindex={1}>
           {days.map(day => (
             <div key={format(day, 'yyyy-MM-dd')}
@@ -219,15 +273,19 @@ export default function WeekView({
           onPointerUp={handleDaysAreaPointerUp}
           onPointerCancel={() => { pillDragRef.current = null; setPillTargetCol(null); }}
         >
-          {/* Day cells — all events (single-day and multi-day) are pills here */}
+          {/* Day cells — single-day events as pills */}
           <div className={styles['weekCells']} role="row" aria-rowindex={2}>
             {days.map((day, di) => {
-              const dayKey  = format(day, 'yyyy-MM-dd');
-              const dayEvs  = eventsByDay.get(dayKey) || [];
-              const isFocused = isSameDay(day, focusedDay);
-              const overflow = Math.max(0, dayEvs.length - MAX_PILLS);
+              const dayKey     = format(day, 'yyyy-MM-dd');
+              const daySingles = singleByDay.get(dayKey) || [];
+              const isFocused  = isSameDay(day, focusedDay);
+
+              const spansOnDay  = spans.filter(s => s.startCol <= di && s.endCol >= di);
+              const hiddenSpans = spansOnDay.filter(s => s.lane >= MAX_SPANS_VISIBLE).length;
+              const overflow    = hiddenSpans + Math.max(0, daySingles.length - MAX_PILLS);
               const isOverflowOpen = overflowDay && isSameDay(overflowDay, day);
-              const cellLabel = `${format(day, 'EEEE, MMMM d')}${isToday(day) ? ', today' : ''}${dayEvs.length > 0 ? `, ${dayEvs.length} event${dayEvs.length === 1 ? '' : 's'}` : ''}`;
+              const totalEvents = daySingles.length + spansOnDay.length;
+              const cellLabel   = `${format(day, 'EEEE, MMMM d')}${isToday(day) ? ', today' : ''}${totalEvents > 0 ? `, ${totalEvents} event${totalEvents === 1 ? '' : 's'}` : ''}`;
               const isPillTarget = pillTargetCol === di && pillDragRef.current !== null;
 
               return (
@@ -248,8 +306,8 @@ export default function WeekView({
                   }}
                   onKeyDown={e => handleCellKeyDown(e, day)}
                 >
-                  <div className={styles['events']}>
-                    {dayEvs.slice(0, MAX_PILLS).map(ev => renderPill(ev, di))}
+                  <div className={styles['events']} style={{ paddingTop: spansHeight }}>
+                    {daySingles.slice(0, MAX_PILLS).map(ev => renderPill(ev, di))}
                     {overflow > 0 && (
                       <button
                         className={styles['moreLink']}
@@ -269,13 +327,85 @@ export default function WeekView({
                         <span>{format(day, 'MMMM d')}</span>
                         <button onClick={() => setOverflowDay(null)} aria-label="Close">×</button>
                       </div>
-                      {dayEvs.slice(MAX_PILLS).map(ev => renderPill(ev, undefined, () => setOverflowDay(null)))}
+                      {daySingles.slice(MAX_PILLS).map(ev => renderPill(ev, undefined, () => setOverflowDay(null)))}
                     </div>
                   )}
                 </div>
               );
             })}
           </div>
+
+          {/* Horizontal rule at the bottom of the spans zone */}
+          {laneCount > 0 && (
+            <div className={styles['spansEdge']} style={{ top: spansHeight }} aria-hidden="true" />
+          )}
+
+          {/* Multi-day spanning bars — absolutely overlaid at the top of the cells */}
+          {laneCount > 0 && (
+            <div
+              className={styles['spansLayer']}
+              style={{ top: 0, height: spansHeight }}
+              ref={spansRef}
+              onPointerMove={handleSpanPointerMove}
+              onPointerUp={handleSpanPointerUp}
+              onPointerCancel={() => { spanDragRef.current = null; setSpanGhost(null); }}
+            >
+              {spans
+                .filter(s => s.lane < MAX_SPANS_VISIBLE)
+                .map(({ ev, startCol, endCol, lane, continuesBefore, continuesAfter }) => {
+                  const color = resolveColor(ev as never, ctx?.['colorRules']);
+                  const isConflicting = !!(ctx?.['conflictingEventIds'] as ReadonlySet<string> | undefined)?.has(ev.id);
+                  const statusClass = ev.status === 'cancelled' ? styles['cancelled']
+                    : ev.status === 'tentative' ? styles['tentative'] : '';
+                  const isDimmed = spanGhost?.ev?.id === ev.id;
+                  return (
+                    <button
+                      key={ev.id}
+                      className={[
+                        styles['spanBar'],
+                        continuesBefore && styles['continuesBefore'],
+                        continuesAfter  && styles['continuesAfter'],
+                        statusClass,
+                        isDimmed && styles['dragging'],
+                      ].filter(Boolean).join(' ')}
+                      data-wc-conflicting={isConflicting ? 'true' : undefined}
+                      style={{
+                        '--ev-color': color,
+                        left:   `${(startCol / 7) * 100}%`,
+                        width:  `${((endCol - startCol + 1) / 7) * 100}%`,
+                        top:    lane * (SPAN_H + SPAN_GAP),
+                        height: SPAN_H,
+                      }}
+                      onClick={e => { e.stopPropagation(); if (!isDimmed) onEventClick?.(ev); }}
+                      onPointerDown={e => startSpanDrag(ev, e, startCol, endCol)}
+                      aria-label={`${ev.title}${ev.category ? `, ${ev.category}` : ''}${continuesBefore ? ', continues from previous week' : ''}${continuesAfter ? ', continues next week' : ''}`}
+                    >
+                      {!continuesBefore && (
+                        <>
+                          <EventStatusBadge lifecycle={(ev as { lifecycle?: unknown }).lifecycle as never} variant="compact" />
+                          {ev.title}
+                        </>
+                      )}
+                    </button>
+                  );
+                })}
+
+              {/* Drag ghost */}
+              {spanGhost && (
+                <div
+                  className={[styles['spanBar'], styles['spanGhost']].join(' ')}
+                  aria-hidden="true"
+                  style={{
+                    '--ev-color': resolveColor(spanGhost.ev as never, ctx?.['colorRules']),
+                    left:   `${(spanGhost.startCol / 7) * 100}%`,
+                    width:  `${((spanGhost.endCol - spanGhost.startCol + 1) / 7) * 100}%`,
+                    top:    0,
+                    height: SPAN_H,
+                  }}
+                />
+              )}
+            </div>
+          )}
         </div>
       </div>
     </div>


### PR DESCRIPTION
…r, dispatch assign

1. Grid lines (WeekView): move headerRow inside .body so both header and cells live in the same scroll container. Scrollbar now narrows both together — column borders can no longer diverge.

2. Pill click broken (WeekView): removed e.preventDefault() from startPillDrag (it suppressed synthesized click events). Added manual onEventClick dispatch in handleDaysAreaPointerUp when pointer was released without movement (setPointerCapture redirects click to daysArea, so we have to fire it explicitly for taps).

3. Mission Alpha only in week view (fixtures): changed week anchor from weekStartsOn:1 (Monday) to weekStartsOn:0 (Sunday) to match WeekView's default. Thursday is now offset 4 not 3, putting the event on the current week's Thursday in both Week and Month views.

4. Region map shows schedule events (WorksCalendar): filter expandedEvents through isScheduleWorkflowEvent before passing to MapPeekWidget so shift/on-call/pto clutter is excluded. Also wires the missing onMapWidgetOpenChange → MapPeekWidget.onOpenChange so the walkthrough can observe the map open event.

5. Dispatch assign button (DispatchView + WorksCalendar + App): added onAssign prop to DispatchView, wired to the "Assign" button onClick. Added onDispatchAssign prop to WorksCalendar and forwarded it through. Demo handler creates a mission-assignment event for the chosen aircraft.

https://claude.ai/code/session_01KCrMk4w8WFWJmZpK42cLGu

## Summary
Describe exactly what this PR changes.

## Scope
- Stage: 
- Planned PR number in sprint: 
- Target files/directories: 
- Why this slice is isolated: 

## Lessons Learned Check (REQUIRED)
Confirm these were actively used while building this PR:

- [ ] PR is intentionally small and isolated
- [ ] Boundary typing was prioritized over internal perfection
- [ ] No silent spread of `any`
- [ ] Advisory root `tsc` was used to catch integration issues
- [ ] I did not assume “looks typed” means “safe”
- [ ] I stopped and isolated typing cascades instead of expanding scope

## Definition of Done (ALL REQUIRED)
This PR is not done unless every box is checked.

- [ ] `npm run type-check:strict` passes
- [ ] Root advisory `tsc --noEmit` passes
- [ ] Tests pass for touched scope at minimum
- [ ] No uncontrolled increase in `any`
- [ ] All new types are intentional and named
- [ ] Public interfaces and exported functions are explicitly typed
- [ ] PR scope matches the sprint plan with no scope creep
- [ ] Any new `any` has an adjacent justification comment
- [ ] No file-wide `: any`
- [ ] No implicit `any` in exported functions

## What Was Typed
List exactly what was typed in this PR.

- 
- 
- 

## What Was Intentionally Left Loose
List anything intentionally not tightened yet.

- 
- 
- 

## `any` Ledger (REQUIRED)
- New `any` added: 
- Existing `any` removed: 
- Net change: 

For every new `any`, explain why it is required and why a safer type was not used yet.

1. 
2. 
3. 

## Boundary Notes
Document any public seams, caller-protection choices, or compatibility decisions.

- 
- 
- 

## Risk Level
- [ ] Low
- [ ] Medium
- [ ] High

Why:

## Validation Evidence
Paste the exact commands run and a short result summary.

```bash
npm run type-check:strict
npx tsc --noEmit -p tsconfig.json
```

Test commands run:

```bash
# paste commands here
```

## Stop Conditions Check
If any item below happened, explain how scope was reduced before merge.

- [ ] `any` started spreading across files
- [ ] Root `tsc` broke repeatedly
- [ ] Types required cross-module rewrites
- [ ] Scope was reduced to keep the PR reviewable

Notes:

## Reviewer Focus
What should reviewers look at first?

- 
- 
- 
