### PR TITLE
Wire walkthrough onEventMove, fix drag-vs-click in WeekView, and add walkthrough e2e test

### DIFF
--- a/demo/App.tsx
+++ b/demo/App.tsx
@@ -967,9 +967,6 @@ function App() {
   }, [missionAssignments]);
 
   const renderHoverCard = useCallback((ev, onCloseHover) => {
-    // wt-mission uses the built-in HoverCard → Edit → EventForm path so the
-    // walkthrough can intercept onEventSave for pilot assignment.
-    if (ev.id === WALKTHROUGH_MISSION_ID) return null;
     return (
       <DemoHoverCard
         event={ev}
@@ -1001,7 +998,7 @@ function App() {
       missionInitialStartIso: ALPHA_INITIAL_START_ISO,
       pilotIds:               walkthroughPilotIds,
     },
-    delegate: { onEventSave: handleEventSave },
+    delegate: { onEventMove: handleEventMove, onEventSave: handleEventSave },
     calendarId: DEMO_CALENDAR_ID,
   });
 
@@ -1083,6 +1080,7 @@ function App() {
       onNoteSave={handleNoteSave}
       onNoteDelete={handleNoteDelete}
       onEventSave={EMBED_MODE ? handleEventSave : walkthrough.wrapped.onEventSave}
+      onEventMove={EMBED_MODE ? handleEventMove : walkthrough.wrapped.onEventMove}
       onViewChange={EMBED_MODE ? undefined : walkthrough.wrapped.onViewChange}
       onMapWidgetOpenChange={EMBED_MODE ? undefined : walkthrough.wrapped.onMapWidgetOpenChange}
       onEventDelete={handleEventDelete}

--- a/src/views/WeekView.tsx
+++ b/src/views/WeekView.tsx
@@ -116,7 +116,15 @@ export default function WeekView({
   }, [onDateSelect]);
 
   // ── Span bar drag (multi-day events, day-to-day) ──────────────────────────
-  type SpanDrag = { ev: WeekViewEvent; startCol: number; endCol: number; width: number; clickOffset: number; colW: number };
+  type SpanDrag = {
+    ev: WeekViewEvent;
+    startCol: number;
+    endCol: number;
+    width: number;
+    clickOffset: number;
+    colW: number;
+    moved: boolean;
+  };
   const spanDragRef  = useRef<SpanDrag | null>(null);
   const [spanGhost, setSpanGhost] = useState<{ ev: WeekViewEvent; startCol: number; endCol: number } | null>(null);
   const spansRef     = useRef<HTMLDivElement | null>(null);
@@ -176,7 +184,15 @@ export default function WeekView({
     const rect   = grid.getBoundingClientRect();
     const colW   = rect.width / 7;
     const clickCol = Math.max(0, Math.min(6, Math.floor((e.clientX - rect.left) / colW)));
-    spanDragRef.current = { ev, startCol, endCol, width: endCol - startCol, clickOffset: clickCol - startCol, colW };
+    spanDragRef.current = {
+      ev,
+      startCol,
+      endCol,
+      width: endCol - startCol,
+      clickOffset: clickCol - startCol,
+      colW,
+      moved: false,
+    };
     grid.setPointerCapture(e.pointerId);
     setSpanGhost({ ev, startCol, endCol });
   }
@@ -187,6 +203,7 @@ export default function WeekView({
     const rect   = spansRef.current.getBoundingClientRect();
     const col    = Math.max(0, Math.min(6, Math.floor((e.clientX - rect.left) / d.colW)));
     const start  = Math.max(0, Math.min(7 - d.width - 1, col - d.clickOffset));
+    if (!d.moved && start !== d.startCol) d.moved = true;
     setSpanGhost({ ev: d.ev, startCol: start, endCol: start + d.width });
   }
 
@@ -196,6 +213,10 @@ export default function WeekView({
     spanDragRef.current = null;
     setSpanGhost(null);
     if (!d || !g) return;
+    if (!d.moved) {
+      onEventClick?.(d.ev);
+      return;
+    }
     const diff = g.startCol - d.startCol;
     if (diff === 0) return;
     onEventMove?.(d.ev, addDays(d.ev.start, diff), addDays(d.ev.end, diff));
@@ -376,7 +397,7 @@ export default function WeekView({
                         top:    lane * (SPAN_H + SPAN_GAP),
                         height: SPAN_H,
                       }}
-                      onClick={e => { e.stopPropagation(); if (!isDimmed) onEventClick?.(ev); }}
+                      onClick={e => { e.stopPropagation(); }}
                       onPointerDown={e => startSpanDrag(ev, e, startCol, endCol)}
                       aria-label={`${ev.title}${ev.category ? `, ${ev.category}` : ''}${continuesBefore ? ', continues from previous week' : ''}${continuesAfter ? ', continues next week' : ''}`}
                     >

--- a/tests-e2e/walkthrough.happy.spec.ts
+++ b/tests-e2e/walkthrough.happy.spec.ts
@@ -1,0 +1,52 @@
+import { expect, test } from '@playwright/test';
+
+test('guided walkthrough happy path reaches schedule step with mission move/save', async ({ page }) => {
+  await page.addInitScript(() => localStorage.clear());
+  await page.setViewportSize({ width: 1440, height: 900 });
+  await page.goto('/');
+
+  const banner = page.getByRole('dialog', { name: /guided walkthrough/i });
+  await expect(banner).toBeVisible();
+  await expect(banner.getByText(/move the mission request/i)).toBeVisible();
+
+  const mission = page.locator('[data-wc-event-id="wt-mission"]').first();
+  await expect(mission).toBeVisible();
+
+  // Step 1: drag mission to trigger onEventMove and advance.
+  const box = await mission.boundingBox();
+  if (!box) throw new Error('Mission not measurable for drag');
+  await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2);
+  await page.mouse.down();
+  await page.mouse.move(box.x + box.width / 2 + 180, box.y + box.height / 2 + 90, { steps: 12 });
+  await page.mouse.up();
+
+  await expect(banner.getByText(/assign a pilot/i)).toBeVisible();
+
+  // Step 2: open built-in event form path from Mission Alpha and assign James.
+  await mission.click();
+  await page.getByRole('button', { name: /^edit$/i }).click();
+  await page.getByLabel(/^resource$/i).selectOption('emp-james');
+  await page.getByRole('button', { name: /^save$/i }).click();
+
+  await expect(page.getByText(/conflict/i)).toBeVisible();
+  await page.getByRole('button', { name: /apply anyway/i }).click();
+
+  await expect(banner.getByText(/resolve the conflict/i)).toBeVisible();
+
+  // Step 3: reassign to another pilot and save.
+  await mission.click();
+  await page.getByRole('button', { name: /^edit$/i }).click();
+  await page.getByLabel(/^resource$/i).selectOption('emp-priya');
+  await page.getByRole('button', { name: /^save$/i }).click();
+
+  await expect(banner.getByText(/see it as a schedule/i)).toBeVisible();
+
+  // Step 4: switch to schedule and verify mission appears on assigned row.
+  await page.getByRole('button', { name: /^schedule$/i }).first().click();
+  await expect(banner.getByText(/bonus — see where your fleet is/i)).toBeVisible();
+  await expect(page.getByText(/mission alpha/i).first()).toBeVisible();
+
+  // Evidence that move and save callbacks fired for walkthrough mission.
+  const log = page.locator('text=/Moved: Mission Alpha|Saved: Mission Alpha/i');
+  await expect(log.first()).toBeVisible();
+});


### PR DESCRIPTION
### Motivation

- Ensure the guided walkthrough can detect and handle drag/move gestures for the seeded mission so the tutorial can advance when the mission is moved. 
- Fix lost click/tap behavior when a pointer capture drag starts so single-tap opens events while drags still trigger move callbacks. 
- Add an end-to-end test that exercises the full happy path of the guided walkthrough including move and save flows.

### Description

- Removed the special-case suppression in `renderHoverCard` so the walkthrough mission shows the built-in hover/edit path. 
- Passed `onEventMove` into the walkthrough `delegate` and wired `onEventMove` into `WorksCalendar` so walkthrough can intercept move events via `walkthrough.wrapped.onEventMove`. 
- Updated `WeekView` drag types to include a `moved` flag and set/observe it during `start*`, `pointermove`, and `pointerup` handlers so taps without movement trigger `onEventClick` while actual drags call `onEventMove`. 
- Adjusted span button `onClick` to stop propagation and rely on the pointer-up logic to invoke click behavior to avoid duplicate/incorrect handling during pointer capture. 
- Added a new Playwright e2e test `tests-e2e/walkthrough.happy.spec.ts` that drives the guided walkthrough happy path (move mission, edit/save with conflict/apply, reassign, switch to schedule) as evidence of the integrated flow.

### Testing

- Added and ran the Playwright e2e test `tests-e2e/walkthrough.happy.spec.ts`, which completed the guided walkthrough happy path and passed. 
- No changes were required to existing unit tests and the existing test suite remained green after the changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f782627a84832ca493497e839f9735)