### PR TITLE
Restore guided walkthrough Playwright happy-path (PR 2)

### DIFF
--- a/tests-e2e/walkthrough.happy.spec.ts
+++ b/tests-e2e/walkthrough.happy.spec.ts
@@ -1,9 +1,14 @@
 import { expect, test } from '@playwright/test';
 
-test('guided walkthrough happy path reaches schedule step with mission move/save', async ({ page }) => {
+test('guided walkthrough happy path: move, edit, save, apply-anyway, and schedule update', async ({ page }) => {
   await page.addInitScript(() => localStorage.clear());
   await page.setViewportSize({ width: 1440, height: 900 });
   await page.goto('/');
+
+  const restartTour = page.getByRole('button', { name: /restart tour/i });
+  if (await restartTour.isVisible()) {
+    await restartTour.click();
+  }
 
   const banner = page.getByRole('dialog', { name: /guided walkthrough/i });
   await expect(banner).toBeVisible();
@@ -28,7 +33,7 @@ test('guided walkthrough happy path reaches schedule step with mission move/save
   await page.getByLabel(/^resource$/i).selectOption('emp-james');
   await page.getByRole('button', { name: /^save$/i }).click();
 
-  await expect(page.getByText(/conflict/i)).toBeVisible();
+  await expect(page.getByRole('dialog', { name: /conflicts found/i })).toBeVisible();
   await page.getByRole('button', { name: /apply anyway/i }).click();
 
   await expect(banner.getByText(/resolve the conflict/i)).toBeVisible();
@@ -47,6 +52,6 @@ test('guided walkthrough happy path reaches schedule step with mission move/save
   await expect(page.getByText(/mission alpha/i).first()).toBeVisible();
 
   // Evidence that move and save callbacks fired for walkthrough mission.
-  const log = page.locator('text=/Moved: Mission Alpha|Saved: Mission Alpha/i');
-  await expect(log.first()).toBeVisible();
+  await expect(page.getByText(/Moved: Mission Alpha/i).first()).toBeVisible();
+  await expect(page.getByText(/Saved: Mission Alpha/i).first()).toBeVisible();
 });


### PR DESCRIPTION
### Motivation
- The guided tour was regressed and the end-to-end flow (move → edit → save → conflict → apply-anyway → schedule update) must be restored per issue #523 PR 2 so the demo walkthrough uses real UI callbacks.
- The change focuses only on PR 2 scope: repair the walkthrough happy-path coverage and do not implement PR 3, PR 4, or PR 5 yet.

### Description
- Updated `tests-e2e/walkthrough.happy.spec.ts` to exercise the real guided tour flow (drag Mission Alpha, open edit, assign `emp-james`, save, assert conflict dialog, click **Apply anyway**, reassign, switch to Schedule, and verify mission placement).
- Added an initial `Restart tour` check so the test reliably begins in guided mode when the UI exposes the restart control.
- Strengthened conflict-path assertions by explicitly awaiting the conflict dialog (`dialog[name=/conflicts found/i]`) and clicking the `Apply anyway` button before proceeding.
- Split and tightened callback-evidence checks to assert both `Moved: Mission Alpha` and `Saved: Mission Alpha` separately to prove the real move/save callbacks ran.

### Testing
- Ran the walkthrough reducer unit tests with `npm run test -- demo/walkthrough/reducer.test.ts`, and all tests passed (`13 tests, 0 failures`).
- Attempted to run Playwright with `npm run test:browser -- tests-e2e/walkthrough.happy.spec.ts`, but the environment lacked Playwright browser binaries causing the run to fail with the message recommending `npx playwright install` (no test logic failures reported in the spec itself).
- Validation commands to run locally/CI: `npx playwright install` then `npm run test:browser -- tests-e2e/walkthrough.happy.spec.ts` and `npm run test` for full suite; the PR is scoped to E2E test coverage updates only.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7a2ca013c832c8b2872c90d7dc9d5)