### PR TITLE
Fix walkthrough smoke test TypeScript type errors

### DIFF
--- a/demo/walkthrough/WalkthroughHost.smoke.test.tsx
+++ b/demo/walkthrough/WalkthroughHost.smoke.test.tsx
@@ -10,6 +10,7 @@ const step: Step = {
     body: 'Drag Mission Alpha to a new slot.',
   },
   spotlight: { eventId: 'wt-mission' },
+  matches: () => false,
 };
 
 describe('WalkthroughHost smoke', () => {
@@ -17,7 +18,7 @@ describe('WalkthroughHost smoke', () => {
     const { container } = render(
       <WalkthroughHost
         step={step}
-        state={{ mode: 'guided', currentStepId: step.id }}
+        state={{ mode: 'guided', currentStep: step.id, history: [], bootstrapping: false }}
         steps={[step]}
         onAdvance={vi.fn()}
         onRestart={vi.fn()}


### PR DESCRIPTION
### Motivation
- The smoke test was failing type-checking because the `Step` and `WalkthroughState` shapes changed and the test fixture no longer satisfied the updated TypeScript types.

### Description
- Update `demo/walkthrough/WalkthroughHost.smoke.test.tsx` to add a `matches` predicate to the `step` fixture and replace the deprecated `currentStepId` state field with the current `WalkthroughState` shape (`currentStep`, `history`, `bootstrapping`).

### Testing
- Ran `npm run type-check` and the TypeScript check completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7bbd49340832cb38c6ba73463b7fd)