### PR TITLE
Runtime hardening for demo: Error boundary, safe storage, and PWA/recovery controls

### DIFF
--- a/demo/App.tsx
+++ b/demo/App.tsx
@@ -1,12 +1,15 @@
-// @ts-nocheck — demo fixture, re-typed after Phase 2 d.ts regeneration
+// @ts-nocheck — demo fixture with progressive typing work in progress
 import { StrictMode, useState, useCallback, useMemo, useEffect, useRef } from 'react';
 import { createRoot } from 'react-dom/client';
 import { registerSW } from 'virtual:pwa-register';
 import {
   WorksCalendar,
+  type WorksCalendarEvent,
   DEFAULT_CATEGORIES,
   createManualLocationProvider,
 } from '../src/index.ts';
+import { safeGetLocalStorage, safeSetLocalStorage } from '../src/core/safeLocalStorage';
+import DemoErrorBoundary from './DemoErrorBoundary';
 import { saveProfiles } from '../src/core/profileStore';
 import { loadConfig, saveConfig, DEFAULT_CONFIG } from '../src/core/configSchema';
 import { loadPools, savePools } from '../src/core/pools/poolStore';
@@ -46,6 +49,24 @@ import {
 // Air EMS demo: new calendar id so the IHC Fleet localStorage doesn't bleed
 // through. Returning users see a clean slate with Air EMS defaults.
 const DEMO_CALENDAR_ID = 'air-ems-demo';
+const DEMO_FEATURES = {
+  walkthrough: true,
+  missionHoverCard: true,
+  pwaRegistration: import.meta.env.VITE_ENABLE_DEMO_PWA !== '0',
+  mapWidget: true,
+  workflowBuilder: true,
+} as const;
+
+if (typeof window !== 'undefined' && new URLSearchParams(window.location.search).get('resetDemo') === '1') {
+  try {
+    Object.keys(localStorage)
+      .filter((k) => k.startsWith('wc-'))
+      .forEach((k) => localStorage.removeItem(k));
+  } catch {}
+  if ('serviceWorker' in navigator) {
+    void navigator.serviceWorker.getRegistrations().then((regs) => Promise.all(regs.map((r) => r.unregister())));
+  }
+}
 
 /* ─── Profiles (saved filter sets in the profile bar) ──────────── */
 // Sprint 3 (issue #268 Task 5): seed the 6 required operational saved
@@ -64,12 +85,12 @@ const DEMO_PROFILES = [
 // Reseed profiles on first load AND when DEMO_SEED_VERSION bumps so
 // returning visitors pick up new profile-list changes (like the Sprint 3
 // rename from "Full Ops / Pilots / …" to the 6 issue-required views).
-const storedProfiles = localStorage.getItem(`wc-profiles-${DEMO_CALENDAR_ID}`);
-const storedProfileSeedVer = Number(localStorage.getItem(`wc-demo-profiles-v-${DEMO_CALENDAR_ID}`) ?? 0);
+const storedProfiles = safeGetLocalStorage(`wc-profiles-${DEMO_CALENDAR_ID}`);
+const storedProfileSeedVer = Number(safeGetLocalStorage(`wc-demo-profiles-v-${DEMO_CALENDAR_ID}`) ?? 0);
 const PROFILES_SEED_VERSION = 3;
 if (!storedProfiles || storedProfiles === '[]' || storedProfileSeedVer < PROFILES_SEED_VERSION) {
   saveProfiles(DEMO_CALENDAR_ID, DEMO_PROFILES);
-  localStorage.setItem(`wc-demo-profiles-v-${DEMO_CALENDAR_ID}`, String(PROFILES_SEED_VERSION));
+  safeSetLocalStorage(`wc-demo-profiles-v-${DEMO_CALENDAR_ID}`, String(PROFILES_SEED_VERSION));
 }
 
 /* ─── Bases ─────────────────────────────────────────────────────── */
@@ -107,8 +128,8 @@ const BASE_COORDS: Record<string, { lat: number; lon: number }> = {
 //     because it wasn't in enabledViews.
 const DEMO_SEED_VERSION = 9;
 const SEED_VER_KEY      = `wc-demo-seed-v-${DEMO_CALENDAR_ID}`;
-const storedCfg         = localStorage.getItem(`wc-config-${DEMO_CALENDAR_ID}`);
-const storedSeedVer     = Number(localStorage.getItem(SEED_VER_KEY) ?? 0);
+const storedCfg         = safeGetLocalStorage(`wc-config-${DEMO_CALENDAR_ID}`);
+const storedSeedVer     = Number(safeGetLocalStorage(SEED_VER_KEY) ?? 0);
 
 // Seed the demo regions list (shared between the fresh-install and migration paths).
 const DEMO_REGIONS = regions.map(r => ({ id: r.id, name: r.name }));
@@ -126,7 +147,7 @@ if (!storedCfg) {
     team: { ...DEFAULT_CONFIG.team, bases: DEMO_BASES, regions: DEMO_REGIONS },
     approvals: { ...DEFAULT_CONFIG.approvals, enabled: true },
   });
-  localStorage.setItem(SEED_VER_KEY, String(DEMO_SEED_VERSION));
+  safeSetLocalStorage(SEED_VER_KEY, String(DEMO_SEED_VERSION));
 } else if (storedSeedVer < DEMO_SEED_VERSION) {
   const existing = loadConfig(DEMO_CALENDAR_ID);
   const carriedDefaultView = existing.display?.defaultView;
@@ -147,7 +168,7 @@ if (!storedCfg) {
     team:      { ...existing.team, bases: DEMO_BASES, regions: DEMO_REGIONS },
     approvals: { ...existing.approvals, enabled: true },
   });
-  localStorage.setItem(SEED_VER_KEY, String(DEMO_SEED_VERSION));
+  safeSetLocalStorage(SEED_VER_KEY, String(DEMO_SEED_VERSION));
 }
 
 // Theme is managed entirely inside the library's ownerConfig (setup.preferredTheme)
@@ -758,7 +779,7 @@ function App() {
     ...mission.assignments,
     aircraft: null, // starts unassigned so the pulsing badge is visible on load
   });
-  const [activeMissionEvent, setActiveMissionEvent] = useState<any | null>(null);
+  const [activeMissionEvent, setActiveMissionEvent] = useState<WorksCalendarEvent | null>(null);
   const [activeProfileId,   setActiveProfileId]   = useState(DEFAULT_PROFILE_ID);
   const activeProfile = useMemo(() => findProfile(activeProfileId), [activeProfileId]);
   const [pools, setPools] = useState(() => {
@@ -810,7 +831,7 @@ function App() {
   }, [events]);
 
   const [updateSW] = useState(() =>
-    registerSW({
+    DEMO_FEATURES.pwaRegistration ? registerSW({
       onNeedRefresh()  { setNeedsRefresh(true); },
       onOfflineReady() { console.info('[PWA] App ready to work offline.'); },
       onRegisteredSW(_swUrl, r) {
@@ -820,7 +841,7 @@ function App() {
         window.addEventListener('focus', check);
         document.addEventListener('visibilitychange', check);
       },
-    })
+    }) : (() => undefined)
   );
 
   useEffect(() => {
@@ -1051,11 +1072,7 @@ function App() {
     api.setView('week');
     api.navigateTo(new Date(ALPHA_INITIAL_START_ISO));
     didSnapRef.current = true;
-    // Intentionally empty deps: this is a once-on-mount snap. Re-running on
-    // mode/history changes would risk yanking the user back to the seed
-    // date if they've navigated away.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [walkthrough.state.mode, walkthrough.state.history.length]);
 
   // Restart wraps walkthrough.restart with the cleanup the state-machine
   // alone can't do: re-seed the demo events (so Mission Alpha is unassigned
@@ -1154,7 +1171,7 @@ function App() {
         />
       )}
 
-      {!EMBED_MODE && (
+      {!EMBED_MODE && DEMO_FEATURES.walkthrough && (
         <WalkthroughHost
           step={walkthrough.step}
           state={walkthrough.state}
@@ -1168,6 +1185,6 @@ function App() {
   );
 }
 
-createRoot(document.getElementById('root')).render(
-  <StrictMode><App /></StrictMode>
+createRoot(document.getElementById('root')!).render(
+  <StrictMode><DemoErrorBoundary><App /></DemoErrorBoundary></StrictMode>
 );

--- a/demo/DemoErrorBoundary.tsx
+++ b/demo/DemoErrorBoundary.tsx
@@ -1,0 +1,28 @@
+import { Component, type ReactNode } from 'react';
+
+interface Props { children: ReactNode }
+interface State { hasError: boolean; message: string | null }
+
+export default class DemoErrorBoundary extends Component<Props, State> {
+  state: State = { hasError: false, message: null };
+
+  static getDerivedStateFromError(error: unknown): State {
+    return { hasError: true, message: error instanceof Error ? error.message : 'Unknown error' };
+  }
+
+  handleReset = (): void => {
+    this.setState({ hasError: false, message: null });
+    window.location.reload();
+  };
+
+  render(): ReactNode {
+    if (!this.state.hasError) return this.props.children;
+    return (
+      <div style={{ padding: 24, fontFamily: 'system-ui', maxWidth: 640, margin: '10vh auto' }}>
+        <h1>Demo failed to render</h1>
+        <p>{this.state.message ?? 'A render error occurred.'}</p>
+        <button type="button" onClick={this.handleReset}>Reload demo</button>
+      </div>
+    );
+  }
+}

--- a/demo/DemoHoverCard.tsx
+++ b/demo/DemoHoverCard.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck — demo hover card, follows App.tsx convention
 //
 // Custom hover card for the Air EMS demo. Replaces the library's default
 // HoverCard via WorksCalendar's `renderHoverCard` prop. The default card
@@ -15,17 +14,19 @@
 //     title, time, category, resource, notes) so the rest of the
 //     calendar's events keep their familiar look.
 
+// @ts-nocheck — demo hover card with progressive typing work in progress
 import { useEffect, useRef, useState } from 'react';
 import { format, isSameDay } from 'date-fns';
 import { Anchor, Check, Clock, Pencil, Tag, X } from 'lucide-react';
 import type { DemoApprovalCaps } from './profiles';
+import type { WorksCalendarEvent } from '../src';
 
 interface DemoHoverCardProps {
-  event: any;
+  event: WorksCalendarEvent;
   onClose: () => void;
-  onEdit?: ((ev: any) => void) | null;
+  onEdit?: ((ev: WorksCalendarEvent) => void) | null;
   onDelete?: ((eventId: string) => void) | null;
-  onApprovalAction?: (event: any, actionId: string, payload?: any) => void;
+  onApprovalAction?: (event: WorksCalendarEvent, actionId: string, payload?: unknown) => void;
   approvalCaps?: DemoApprovalCaps;
   resolveResourceLabel?: (id: string) => string;
 }

--- a/demo/walkthrough/useWalkthrough.ts
+++ b/demo/walkthrough/useWalkthrough.ts
@@ -15,6 +15,7 @@
  */
 
 import { useCallback, useEffect, useMemo, useReducer, useRef } from 'react';
+import { safeGetLocalStorage, safeSetLocalStorage } from '../../src/core/safeLocalStorage';
 import { INITIAL_STATE, reducer } from './reducer';
 import { STEPS } from './steps';
 import type {
@@ -41,7 +42,7 @@ function storageKey(calendarId: string | undefined): string {
 function readPersistedMode(calendarId: string | undefined): WalkthroughMode {
   if (typeof window === 'undefined') return 'guided';
   try {
-    return window.localStorage.getItem(storageKey(calendarId)) === 'free-play'
+    return safeGetLocalStorage(storageKey(calendarId)) === 'free-play'
       ? 'free-play'
       : 'guided';
   } catch {
@@ -52,7 +53,7 @@ function readPersistedMode(calendarId: string | undefined): WalkthroughMode {
 function persistMode(mode: WalkthroughMode, calendarId: string | undefined): void {
   if (typeof window === 'undefined') return;
   try {
-    window.localStorage.setItem(storageKey(calendarId), mode);
+    safeSetLocalStorage(storageKey(calendarId), mode);
   } catch {
     // quota / private mode — silent failure, just won't persist
   }

--- a/src/core/configSchema.ts
+++ b/src/core/configSchema.ts
@@ -2,6 +2,8 @@
  * configSchema.js — Owner config schema, defaults, and localStorage persistence.
  */
 
+import { safeGetLocalStorage, safeSetLocalStorage } from './safeLocalStorage';
+
 /**
  * On-disk schema version for `wc-config-<calendarId>`.
  *
@@ -208,7 +210,7 @@ function mergeDeep(target: ConfigObject, source: ConfigObject): ConfigObject {
 export function loadConfig(calendarId: string): ConfigObject {
   const key = `wc-config-${calendarId}`;
   try {
-    const raw = localStorage.getItem(key);
+    const raw = safeGetLocalStorage(key);
     if (!raw) return DEFAULT_CONFIG as ConfigObject;
 
     const parsed = JSON.parse(raw);
@@ -251,7 +253,7 @@ export function loadConfig(calendarId: string): ConfigObject {
 export function saveConfig(calendarId: string, config: unknown): void {
   const key = `wc-config-${calendarId}`;
   try {
-    localStorage.setItem(key, JSON.stringify(config));
+    safeSetLocalStorage(key, JSON.stringify(config));
   } catch {
     // quota exceeded or SSR — silent fail
   }

--- a/src/core/pools/poolStore.ts
+++ b/src/core/pools/poolStore.ts
@@ -16,6 +16,7 @@
 
 import type { ResourcePool, PoolStrategy, PoolType } from './resourcePoolSchema';
 import type { ResourceQuery } from './poolQuerySchema';
+import { safeGetLocalStorage, safeRemoveLocalStorage, safeSetLocalStorage } from '../safeLocalStorage';
 
 // ─── Storage key ─────────────────────────────────────────────────────────────
 
@@ -35,7 +36,7 @@ export function savePools(
 ): void {
   try {
     const arr = Array.isArray(pools) ? pools : Array.from((pools as ReadonlyMap<string, ResourcePool>).values());
-    localStorage.setItem(poolStorageKey(calendarId), JSON.stringify(arr));
+    safeSetLocalStorage(poolStorageKey(calendarId), JSON.stringify(arr));
   } catch { /* non-fatal: private mode, quota, serialization */ }
 }
 
@@ -77,7 +78,7 @@ export interface LoadPoolsResult {
 export function loadPoolsDetailed(calendarId: string): LoadPoolsResult {
   let raw: string | null = null;
   try {
-    raw = localStorage.getItem(poolStorageKey(calendarId));
+    raw = safeGetLocalStorage(poolStorageKey(calendarId));
   } catch {
     return { pools: [], dropped: 0, storageError: true };
   }
@@ -103,7 +104,7 @@ export function loadPoolsDetailed(calendarId: string): LoadPoolsResult {
 
 /** Remove the stored pools entry (e.g. on "reset demo" actions). */
 export function clearPools(calendarId: string): void {
-  try { localStorage.removeItem(poolStorageKey(calendarId)); } catch { /* ignore */ }
+  safeRemoveLocalStorage(poolStorageKey(calendarId));
 }
 
 // ─── Internals ───────────────────────────────────────────────────────────────

--- a/src/core/profileStore.ts
+++ b/src/core/profileStore.ts
@@ -3,15 +3,15 @@
  * that `useSavedViews` migrates from on first load.
  */
 
+import { safeGetLocalStorage, safeSetLocalStorage } from './safeLocalStorage';
+
 export function saveProfiles(calendarId: string, profiles: unknown): void {
-  try {
-    localStorage.setItem(`wc-profiles-${calendarId}`, JSON.stringify(profiles));
-  } catch {}
+  safeSetLocalStorage(`wc-profiles-${calendarId}`, JSON.stringify(profiles));
 }
 
 export function loadProfiles(calendarId: string): unknown {
   try {
-    const raw = localStorage.getItem(`wc-profiles-${calendarId}`);
+    const raw = safeGetLocalStorage(`wc-profiles-${calendarId}`);
     return raw ? JSON.parse(raw) : [];
   } catch { return []; }
 }

--- a/src/core/safeLocalStorage.ts
+++ b/src/core/safeLocalStorage.ts
@@ -1,0 +1,25 @@
+export function safeGetLocalStorage(key: string): string | null {
+  try {
+    return localStorage.getItem(key);
+  } catch {
+    return null;
+  }
+}
+
+export function safeSetLocalStorage(key: string, value: string): boolean {
+  try {
+    localStorage.setItem(key, value);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function safeRemoveLocalStorage(key: string): boolean {
+  try {
+    localStorage.removeItem(key);
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/vite.demo.config.ts
+++ b/vite.demo.config.ts
@@ -5,13 +5,14 @@ import { VitePWA } from 'vite-plugin-pwa';
 // Set VITE_BASE=/CalendarThatWorks/ when building for GitHub Pages.
 // Defaults to '/' for local dev and preview.
 const base = process.env['VITE_BASE'] ?? '/';
+const demoPwaEnabled = process.env['VITE_ENABLE_DEMO_PWA'] !== '0';
 
 export default defineConfig({
   base,
   plugins: [
     react(),
-    VitePWA({
-      registerType: 'autoUpdate',
+    demoPwaEnabled && VitePWA({
+      registerType: 'prompt',
       includeAssets: ['favicon.svg', 'apple-touch-icon.svg', 'icon-192.svg', 'icon-512.svg'],
       manifest: {
         name: 'WorksCalendar — Air EMS Operations Demo',


### PR DESCRIPTION
### Motivation
- Prevent the demo from white-screening on a render exception by adding a top-level error boundary with a visible reload action so users can recover from runtime crashes.  
- Reduce the blast radius from stale/broken PWA builds and provide visible/operable recovery paths for demo visitors.  
- Make localStorage usage defensive so private-mode/quota errors do not crash the demo and persistent demo state can be reliably cleared by users or hosts.  

### Description
- Add `DemoErrorBoundary` and wrap the demo root so render errors show a fallback UI with a `Reload demo` button that reloads the page.  
- Add safe localStorage wrappers in `src/core/safeLocalStorage.ts` (`safeGetLocalStorage`, `safeSetLocalStorage`, `safeRemoveLocalStorage`) and replace direct storage calls in `src/core/configSchema.ts`, `src/core/profileStore.ts`, `src/core/pools/poolStore.ts`, `demo/walkthrough/useWalkthrough.ts`, and demo bootstrap logic to degrade gracefully on storage errors.  
- Introduce a demo feature flag object `DEMO_FEATURES` and a `?resetDemo=1` host escape hatch that clears `wc-*` localStorage keys and unregisters service workers for self-recovery from stale/corrupt state.  
- Change demo PWA behaviour: `vite.demo.config.ts` now supports disabling demo PWA builds via `VITE_ENABLE_DEMO_PWA=0` and uses `registerType: 'prompt'` to surface updates instead of `autoUpdate`.  
- Guard demo PWA registration and walkthrough mounting behind the feature flags, and replace the walkthrough snap suppression with a stable `didSnapRef` + dependency-driven `useEffect`.  
- Small typing improvements in demo surfaces (narrowed `activeMissionEvent` type and `DemoHoverCard` props) while preserving demo-level `@ts-nocheck` for incremental typing work.  

### Testing
- Ran TypeScript checks with `npm run -s type-check` and the type-check completed successfully.  
- Verified that the demo root is wrapped by the error boundary and that the reload action is present in the fallback (manual verification during development).  
- Confirmed the PWA plugin can be disabled via `VITE_ENABLE_DEMO_PWA=0` and that `vite.demo.config.ts` uses `registerType: 'prompt'` for update prompts.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7bd92b224832cbd76343d8abbb86a)