### PR TITLE
Add deploy smoke gate for GitHub Pages publish

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -50,10 +50,12 @@ jobs:
           E2E_WEB_SERVER_CMD: npx vite preview --config vite.demo.config.ts --host localhost --port 4173 --strictPort
 
       - name: Upload Pages artifact
+        if: success()
         uses: actions/upload-pages-artifact@v3
         with:
           path: dist-demo
 
       - name: Deploy to GitHub Pages
+        if: success()
         id: deployment
         uses: actions/deploy-pages@v4


### PR DESCRIPTION
### Motivation
- Ensure the Pages artifact upload and deploy steps only run when the pre-deploy smoke checks pass, keeping the deploy path small and reliable without adding additional E2E coverage.

### Description
- Add `if: success()` guards to the `Upload Pages artifact` and `Deploy to GitHub Pages` steps in `.github/workflows/deploy-pages.yml` so both steps are skipped if the smoke tests fail.

### Testing
- Ran `git diff -- .github/workflows/deploy-pages.yml` to verify the change and committed the update with `git commit -m "Add deploy smoke gate for Pages publish"`, both commands succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7f98019c4832cb3cbc90fbeb03937)