### PR TITLE
Remove @ts-nocheck from selected demo fixtures

### DIFF
--- a/demo/oncall-span-fixture.tsx
+++ b/demo/oncall-span-fixture.tsx
@@ -1,10 +1,9 @@
-// @ts-nocheck — demo fixture, re-typed after Phase 2 d.ts regeneration
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import { addDays, startOfMonth } from 'date-fns';
 import { WorksCalendar } from '../src/index.ts';
 
-function firstMondayInMonth(baseDate) {
+function firstMondayInMonth(baseDate: Date) {
   let day = startOfMonth(baseDate);
   while (day.getDay() !== 1) {
     day = addDays(day, 1);
@@ -57,7 +56,7 @@ function App() {
   );
 }
 
-createRoot(document.getElementById('root')).render(
+createRoot(document.getElementById('root')!).render(
   <StrictMode>
     <App />
   </StrictMode>

--- a/demo/source-single-stack-fixture.tsx
+++ b/demo/source-single-stack-fixture.tsx
@@ -1,10 +1,9 @@
-// @ts-nocheck — demo fixture, re-typed after Phase 2 d.ts regeneration
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import { addDays, startOfMonth } from 'date-fns';
 import { WorksCalendar } from '../src/index.ts';
 
-function firstMondayInMonth(baseDate) {
+function firstMondayInMonth(baseDate: Date) {
   let day = startOfMonth(baseDate);
   while (day.getDay() !== 1) day = addDays(day, 1);
   return day;
@@ -23,4 +22,4 @@ function App() {
   return <WorksCalendar events={events} calendarId="source-single-stack-fixture" theme="light" showAddButton={false} initialView="month" />;
 }
 
-createRoot(document.getElementById('root')).render(<StrictMode><App /></StrictMode>);
+createRoot(document.getElementById('root')!).render(<StrictMode><App /></StrictMode>);

--- a/demo/source-stack-fixture.tsx
+++ b/demo/source-stack-fixture.tsx
@@ -1,10 +1,9 @@
-// @ts-nocheck — demo fixture, re-typed after Phase 2 d.ts regeneration
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import { addDays, startOfMonth } from 'date-fns';
 import { WorksCalendar } from '../src/index.ts';
 
-function firstMondayInMonth(baseDate) {
+function firstMondayInMonth(baseDate: Date) {
   let day = startOfMonth(baseDate);
   while (day.getDay() !== 1) day = addDays(day, 1);
   return day;
@@ -59,7 +58,7 @@ function App() {
   );
 }
 
-createRoot(document.getElementById('root')).render(
+createRoot(document.getElementById('root')!).render(
   <StrictMode>
     <App />
   </StrictMode>


### PR DESCRIPTION
### Motivation
- Reduce broad file-level `@ts-nocheck` usage in demo fixtures and introduce minimal, low-risk typings so these demo entrypoints pass strict type checking without suppressions.

### Description
- Removed `// @ts-nocheck` pragmas from `demo/source-stack-fixture.tsx`, `demo/source-single-stack-fixture.tsx`, and `demo/oncall-span-fixture.tsx`.
- Added explicit parameter typing `firstMondayInMonth(baseDate: Date)` in each fixture helper to avoid `any` inference.
- Updated React root creation calls to use a non-null assertion `document.getElementById('root')!` so mount points are typed as non-null under strict checks.
- Changes are limited to demo fixture files and should not affect runtime behavior.

### Testing
- Ran `npm run type-check` (executes `tsc --noEmit`) and it completed successfully with no type errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7f9b282e4832cbaf68037dfb3e8ba)