### PR TITLE
fix(e2e): build all HTML entry points and use vite preview for CI smo…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,6 +93,9 @@ jobs:
 
       - name: Run E2E smoke tests
         run: npm run test:e2e:smoke
+        env:
+          E2E_BASE_URL: http://localhost:4173
+          E2E_WEB_SERVER_CMD: npm run preview -- --host localhost
 
       # Upload Playwright report + traces on failure so we can actually see
       # what broke without having to re-run locally. The report is emitted

--- a/vite.demo.config.ts
+++ b/vite.demo.config.ts
@@ -1,6 +1,7 @@
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 import { VitePWA } from 'vite-plugin-pwa';
+import { resolve } from 'path';
 
 // Set VITE_BASE=/CalendarThatWorks/ when building for GitHub Pages.
 // Defaults to '/' for local dev and preview.
@@ -75,6 +76,14 @@ export default defineConfig({
   build: {
     outDir: '../dist-demo',
     emptyOutDir: true,
+    rollupOptions: {
+      input: {
+        main:           resolve(__dirname, 'demo/index.html'),
+        embedHost:      resolve(__dirname, 'demo/embed-host.html'),
+        embedFrame:     resolve(__dirname, 'demo/embed-frame.html'),
+        regressionBugs: resolve(__dirname, 'demo/regression-bugs.html'),
+      },
+    },
   },
   server: {
     port: 3000,


### PR DESCRIPTION
…ke tests

The smoke tests were failing because:
1. Only index.html was being built — embed-host.html, embed-frame.html, and regression-bugs.html were never in dist-demo/, so vite preview couldn't serve them and the dev server was unpredictable in CI.
2. The CI was running npm run dev (Vite dev server) which compiles on-demand and can be slow/unreliable in ephemeral CI environments.

Fix:
- Add rollupOptions.input to vite.demo.config.ts listing all four HTML pages so they're all compiled and emitted to dist-demo/ during npm run build:demo.
- Update CI smoke test step to set E2E_BASE_URL=http://localhost:4173 and E2E_WEB_SERVER_CMD="npm run preview -- --host localhost" so the pre-built static files are served via vite preview (instant responses, no JIT compilation, deterministic port not shared with other CI services).

https://claude.ai/code/session_01AiznJXbNEReNa89DufyyZx

## Summary
Describe exactly what this PR changes.

## Scope
- Stage: 
- Planned PR number in sprint: 
- Target files/directories: 
- Why this slice is isolated: 

## Lessons Learned Check (REQUIRED)
Confirm these were actively used while building this PR:

- [ ] PR is intentionally small and isolated
- [ ] Boundary typing was prioritized over internal perfection
- [ ] No silent spread of `any`
- [ ] Advisory root `tsc` was used to catch integration issues
- [ ] I did not assume “looks typed” means “safe”
- [ ] I stopped and isolated typing cascades instead of expanding scope

## Definition of Done (ALL REQUIRED)
This PR is not done unless every box is checked.

- [ ] `npm run type-check:strict` passes
- [ ] Root advisory `tsc --noEmit` passes
- [ ] Tests pass for touched scope at minimum
- [ ] No uncontrolled increase in `any`
- [ ] All new types are intentional and named
- [ ] Public interfaces and exported functions are explicitly typed
- [ ] PR scope matches the sprint plan with no scope creep
- [ ] Any new `any` has an adjacent justification comment
- [ ] No file-wide `: any`
- [ ] No implicit `any` in exported functions

## What Was Typed
List exactly what was typed in this PR.

- 
- 
- 

## What Was Intentionally Left Loose
List anything intentionally not tightened yet.

- 
- 
- 

## `any` Ledger (REQUIRED)
- New `any` added: 
- Existing `any` removed: 
- Net change: 

For every new `any`, explain why it is required and why a safer type was not used yet.

1. 
2. 
3. 

## Boundary Notes
Document any public seams, caller-protection choices, or compatibility decisions.

- 
- 
- 

## Risk Level
- [ ] Low
- [ ] Medium
- [ ] High

Why:

## Validation Evidence
Paste the exact commands run and a short result summary.

```bash
npm run type-check:strict
npx tsc --noEmit -p tsconfig.json
```

Test commands run:

```bash
# paste commands here
```

## Stop Conditions Check
If any item below happened, explain how scope was reduced before merge.

- [ ] `any` started spreading across files
- [ ] Root `tsc` broke repeatedly
- [ ] Types required cross-module rewrites
- [ ] Scope was reduced to keep the PR reviewable

Notes:

## Reviewer Focus
What should reviewers look at first?

- 
- 
- 
