### PR TITLE
fix(types): resolve all 15 pre-existing type errors

### DIFF
--- a/src/WorksCalendar.tsx
+++ b/src/WorksCalendar.tsx
@@ -26,6 +26,7 @@ import { useSavedFlash }      from './hooks/useSavedFlash';
 import { useEventOptions }    from './hooks/useEventOptions';
 import { useTouchSwipe }     from './hooks/useTouchSwipe';
 import { CalendarContext }    from './core/CalendarContext';
+import type { CalendarContextValue } from './types/ui';
 import { normalizeEvents }    from './core/eventModel';
 import type { ResourcePool } from './core/pools/resourcePoolSchema.ts';
 import { fromLegacyEvents }   from './core/engine/adapters/fromLegacyEvents.ts';
@@ -1241,7 +1242,7 @@ export const WorksCalendar = forwardRef<CalendarApi, WorksCalendarProps>(functio
     recurringPrompt,
   } = useCalendarEngine({
     allNormalized,
-    rawPools,
+    rawPools: rawPools ?? null,
     businessHours: ownerCfg.config?.['businessHours'] ?? businessHours,
     blockedWindows,
     announcerRef,
@@ -2309,8 +2310,10 @@ export const WorksCalendar = forwardRef<CalendarApi, WorksCalendarProps>(functio
   }, [inlineEditTarget, applyEngineOp, onEventDelete]);
 
   // ── Context value ────────────────────────────────────────────────────────
-  const ctxValue = useMemo(() => ({
-    renderEvent, renderHoverCard, colorRules, businessHours, emptyState,
+  const ctxValue = useMemo((): CalendarContextValue => ({
+    renderEvent:     renderEvent     as CalendarContextValue['renderEvent'],
+    renderHoverCard: renderHoverCard as CalendarContextValue['renderHoverCard'],
+    colorRules, businessHours, emptyState,
     permissions: perms,
     editMode,
     conflictingEventIds,
@@ -3049,7 +3052,7 @@ export const WorksCalendar = forwardRef<CalendarApi, WorksCalendarProps>(functio
             onConfirm={pendingAlert.onConfirm ? () => {
               const commit = pendingAlert.onConfirm;
               setPendingAlert(null);
-              commit();
+              if (commit) commit();
             } : null}
             onCancel={() => setPendingAlert(null)}
           />

--- a/src/hooks/useCalendarEngine.ts
+++ b/src/hooks/useCalendarEngine.ts
@@ -31,7 +31,7 @@ function opAnnouncement(op: AnyValue): string {
 }
 
 export type PendingAlert = {
-  violations: AnyValue[];
+  violations: readonly AnyValue[];
   isHard: boolean;
   onConfirm: (() => void) | null;
 };
@@ -46,10 +46,10 @@ export type UseCalendarEngineOptions = {
   /** Merged, normalised event list from all sources (static + fetch + ICS + realtime). */
   allNormalized: AnyValue[];
   /** Initial / controlled resource pools. */
-  rawPools?: ResourcePool[] | null;
+  rawPools?: ResourcePool[] | null | undefined;
   /** businessHours and blockedWindows forwarded to the engine's OperationContext. */
   businessHours?: AnyValue;
-  blockedWindows?: AnyValue[];
+  blockedWindows?: AnyValue[] | undefined;
   /** Ref to the ScreenReaderAnnouncer instance mounted in WorksCalendar. */
   announcerRef: React.RefObject<AnnouncerRef | null>;
   /** Current visible date range — drives occurrence expansion. */
@@ -57,7 +57,7 @@ export type UseCalendarEngineOptions = {
   /** Initial calendar view. Defaults to 'month'. */
   initialView?: string;
   /** Called whenever the engine commits a new pools snapshot (round-robin advance). */
-  onPoolsChange?: (pools: ResourcePool[], meta: { sequence: number }) => void;
+  onPoolsChange?: ((pools: ResourcePool[], meta: { sequence: number }) => void) | undefined;
 };
 
 export type UseCalendarEngineResult = {

--- a/src/types/ui.ts
+++ b/src/types/ui.ts
@@ -39,6 +39,7 @@ export type CalendarContextValue = {
   permissions?: PermissionCaps | undefined;
   editMode?: boolean | undefined;
   conflictingEventIds?: ReadonlySet<string> | undefined;
+  displayTimezone?: string | undefined;
 };
 
 export type UpdateConfig = (updater: (current: AnyRecord) => AnyRecord) => void;

--- a/src/views/AssetsView.tsx
+++ b/src/views/AssetsView.tsx
@@ -32,7 +32,7 @@ import { useResourceLocations } from '../hooks/useResourceLocations.ts';
 import { DEFAULT_CATEGORIES } from '../types/assets.ts';
 import AuditDrawer from './AuditDrawer';
 import ApprovalActionMenu, { allowedActionsFor } from '../ui/ApprovalActionMenu';
-import type { CalendarViewEvent } from '../types/ui';
+import type { CalendarViewEvent, ColorRule } from '../types/ui';
 import type { GroupByInput } from '../hooks/useNormalizedConfig';
 import type { AssetsZoomLevel, LocationData, LocationProvider } from '../types/assets';
 import type { ResourcePool } from '../core/pools/resourcePoolSchema';
@@ -258,7 +258,7 @@ function buildCategoryColorMap(categoriesConfig?: CategoryColorConfig): Map<stri
 function resolveAssetColor(
   ev: AssetsViewEvent,
   categoryColorMap: Map<string, string>,
-  colorRules: Record<string, unknown>[] | undefined,
+  colorRules: ReadonlyArray<Record<string, unknown> | ColorRule> | undefined,
 ): string | undefined {
   const ruleColor = resolveColor(ev as never, colorRules);
   if (ruleColor) return ruleColor;

--- a/src/views/DayView.tsx
+++ b/src/views/DayView.tsx
@@ -33,7 +33,7 @@ export default function DayView({
   const dayStart  = config?.display?.dayStart ?? 6;
   const dayEnd    = config?.display?.dayEnd   ?? 22;
   const pxPerHour = 64;
-  const bizHours  = ctx?.['businessHours'] ?? null;
+  const bizHours  = ctx?.businessHours ?? null;
 
   const gridRef            = useRef<HTMLDivElement | null>(null);
   const clickCandidateRef  = useRef<{ ev: CalendarViewEvent; startX: number; startY: number; moved: boolean } | null>(null);
@@ -97,7 +97,7 @@ export default function DayView({
   );
   const dayEvents = useMemo(() => layoutOverlaps(rawTimed), [rawTimed]);
 
-  const displayTz = ctx?.['displayTimezone'] ?? null;
+  const displayTz = ctx?.displayTimezone ?? null;
 
   const now     = new Date();
   const nowHour = displayTz ? hoursInTimezone(now, displayTz) : getHours(now) + getMinutes(now) / 60;
@@ -121,8 +121,10 @@ export default function DayView({
 
   function isBizHour(h: number) {
     if (!bizHours) return true;
-    const bizDays = bizHours.days ?? [1, 2, 3, 4, 5];
-    return bizDays.includes(currentDate.getDay()) && h >= bizHours.start && h < bizHours.end;
+    const bizDays = (bizHours?.['days'] as number[] | undefined) ?? [1, 2, 3, 4, 5];
+    return bizDays.includes(currentDate.getDay()) &&
+      h >= (bizHours?.['start'] as number) &&
+      h < (bizHours?.['end'] as number);
   }
 
   // ── Drag ────────────────────────────────────────────────────────────────

--- a/src/views/WeekView.tsx
+++ b/src/views/WeekView.tsx
@@ -11,6 +11,7 @@ import ApprovalDot from '../ui/ApprovalDot';
 import EventStatusBadge from '../ui/EventStatusBadge';
 import styles from './WeekView.module.css';
 import type { CalendarViewEvent } from '../types/ui';
+import type { NormalizedEvent } from '../types/events';
 
 const SPAN_H            = 28;
 const SPAN_GAP          = 3;
@@ -235,7 +236,7 @@ export default function WeekView({
     const ariaLabel = `${ev.title}, ${timeLabel}${ev.category ? `, ${ev.category}` : ''}`;
 
     const inner = ctx?.renderEvent
-      ? ctx.renderEvent(ev, { view: 'week', isCompact: false, onClick, color })
+      ? ctx.renderEvent(ev as unknown as NormalizedEvent, { view: 'week', isCompact: false, onClick, color })
       : null;
 
     return (

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -25,7 +25,6 @@ export default defineConfig({
       exclude: ['src/**/__tests__/**', 'src/**/*.test.*', 'src/test-setup.ts'],
       rollupTypes: true,
       outDir: 'dist',
-      skipDiagnostics: true,
     }),
     copyPublishAssetsPlugin(),
   ],


### PR DESCRIPTION
- useCalendarEngine: PendingAlert.violations narrowed to readonly AnyValue[] to match result.validation.violations (TS4104)
- WorksCalendar: rawPools normalised to null at hook call site to satisfy exactOptionalPropertyTypes (TS2379); ctxValue typed with explicit CalendarContextValue return on useMemo + casts for renderEvent/renderHoverCard prop→context boundary; pendingAlert.onConfirm guarded before invocation (TS2721)
- types/ui.ts: added displayTimezone to CalendarContextValue (TS7053)
- DayView: businessHours accessed via dot notation; sub-properties via bracket notation with number assertions; displayTimezone via dot notation (TS4111/TS18046)
- WeekView: ev cast through unknown at ctx.renderEvent call site (TS2345)
- AssetsView: resolveAssetColor colorRules param widened to ReadonlyArray (TS2345)
- vite.config.ts: removed defunct skipDiagnostics option from vite-plugin-dts (TS2353)

https://claude.ai/code/session_01AiznJXbNEReNa89DufyyZx

## Summary
Describe exactly what this PR changes.

## Scope
- Stage: 
- Planned PR number in sprint: 
- Target files/directories: 
- Why this slice is isolated: 

## Lessons Learned Check (REQUIRED)
Confirm these were actively used while building this PR:

- [ ] PR is intentionally small and isolated
- [ ] Boundary typing was prioritized over internal perfection
- [ ] No silent spread of `any`
- [ ] Advisory root `tsc` was used to catch integration issues
- [ ] I did not assume “looks typed” means “safe”
- [ ] I stopped and isolated typing cascades instead of expanding scope

## Definition of Done (ALL REQUIRED)
This PR is not done unless every box is checked.

- [ ] `npm run type-check:strict` passes
- [ ] Root advisory `tsc --noEmit` passes
- [ ] Tests pass for touched scope at minimum
- [ ] No uncontrolled increase in `any`
- [ ] All new types are intentional and named
- [ ] Public interfaces and exported functions are explicitly typed
- [ ] PR scope matches the sprint plan with no scope creep
- [ ] Any new `any` has an adjacent justification comment
- [ ] No file-wide `: any`
- [ ] No implicit `any` in exported functions

## What Was Typed
List exactly what was typed in this PR.

- 
- 
- 

## What Was Intentionally Left Loose
List anything intentionally not tightened yet.

- 
- 
- 

## `any` Ledger (REQUIRED)
- New `any` added: 
- Existing `any` removed: 
- Net change: 

For every new `any`, explain why it is required and why a safer type was not used yet.

1. 
2. 
3. 

## Boundary Notes
Document any public seams, caller-protection choices, or compatibility decisions.

- 
- 
- 

## Risk Level
- [ ] Low
- [ ] Medium
- [ ] High

Why:

## Validation Evidence
Paste the exact commands run and a short result summary.

```bash
npm run type-check:strict
npx tsc --noEmit -p tsconfig.json
```

Test commands run:

```bash
# paste commands here
```

## Stop Conditions Check
If any item below happened, explain how scope was reduced before merge.

- [ ] `any` started spreading across files
- [ ] Root `tsc` broke repeatedly
- [ ] Types required cross-module rewrites
- [ ] Scope was reduced to keep the PR reviewable

Notes:

## Reviewer Focus
What should reviewers look at first?

- 
- 
- 
