### PR TITLE
fix: raise global testTimeout to 60s and bump remaining 30s test time…

### DIFF
--- a/src/__tests__/WorksCalendar.scheduleModel.integration.test.tsx
+++ b/src/__tests__/WorksCalendar.scheduleModel.integration.test.tsx
@@ -88,7 +88,7 @@ describe('WorksCalendar schedule model integration', () => {
       const kinds = getKinds(visible);
       expect(kinds).toContain('open-shift');
     }, { timeout: 10000 });
-  }, 30000);
+  }, 60000);
 
   it('creates a PTO availability event and emits onAvailabilitySave', async () => {
     const apiRef = createRef<any>();
@@ -117,7 +117,7 @@ describe('WorksCalendar schedule model integration', () => {
       const ptoEvents = visible.filter((ev: ScheduleEventLike) => String(ev?.meta?.kind ?? '') === 'pto');
       expect(ptoEvents.length).toBeGreaterThan(0);
     });
-  }, 30000);
+  }, 60000);
 
   // Chain-heavy: two PTO submissions back-to-back means roughly 10 sequential
   // UI interactions (open menu → click Request PTO → fill start → fill end →
@@ -167,7 +167,7 @@ describe('WorksCalendar schedule model integration', () => {
       expect(String(mirrored[0]!.meta?.sourceShiftId ?? '')).toBe('shift-1');
       expect(String(mirrored[0]!.meta?.coveredEmployeeId ?? '')).toBe('emp-1');
     });
-  }, 30000);
+  }, 60000);
 
   it('clears linked schedule metadata and open/covering events when status is cleared', async () => {
     const apiRef = createRef<any>();
@@ -287,5 +287,5 @@ describe('WorksCalendar schedule model integration', () => {
       const coveringEvents = getByKind(visible, 'covering');
       expect(coveringEvents).toHaveLength(0);
     });
-  }, 30000);
+  }, 60000);
 });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -8,6 +8,7 @@ export default defineConfig({
     environment: 'happy-dom',
     setupFiles: ['./src/test-setup.ts'],
     css: true,
+    testTimeout: 60000,
     include: [
       'src/**/*.{test,spec}.{js,jsx,ts,tsx}',
       'demo/**/*.{test,spec}.{js,jsx,ts,tsx}',


### PR DESCRIPTION
…outs

All 13 failures on Windows were pure timeouts, not logic errors. The default 5000ms vitest timeout is too short for UI integration tests on slower Windows hardware. Setting testTimeout: 60000 globally covers all affected test files without patching each one individually.

Also bumps remaining 30s per-test overrides in scheduleModel.integration to 60s for consistency.

https://claude.ai/code/session_01A3TQxurcdbRQByT6bX5G8o

## Summary
Describe exactly what this PR changes.

## Scope
- Stage: 
- Planned PR number in sprint: 
- Target files/directories: 
- Why this slice is isolated: 

## Lessons Learned Check (REQUIRED)
Confirm these were actively used while building this PR:

- [ ] PR is intentionally small and isolated
- [ ] Boundary typing was prioritized over internal perfection
- [ ] No silent spread of `any`
- [ ] Advisory root `tsc` was used to catch integration issues
- [ ] I did not assume “looks typed” means “safe”
- [ ] I stopped and isolated typing cascades instead of expanding scope

## Definition of Done (ALL REQUIRED)
This PR is not done unless every box is checked.

- [ ] `npm run type-check:strict` passes
- [ ] Root advisory `tsc --noEmit` passes
- [ ] Tests pass for touched scope at minimum
- [ ] No uncontrolled increase in `any`
- [ ] All new types are intentional and named
- [ ] Public interfaces and exported functions are explicitly typed
- [ ] PR scope matches the sprint plan with no scope creep
- [ ] Any new `any` has an adjacent justification comment
- [ ] No file-wide `: any`
- [ ] No implicit `any` in exported functions

## What Was Typed
List exactly what was typed in this PR.

- 
- 
- 

## What Was Intentionally Left Loose
List anything intentionally not tightened yet.

- 
- 
- 

## `any` Ledger (REQUIRED)
- New `any` added: 
- Existing `any` removed: 
- Net change: 

For every new `any`, explain why it is required and why a safer type was not used yet.

1. 
2. 
3. 

## Boundary Notes
Document any public seams, caller-protection choices, or compatibility decisions.

- 
- 
- 

## Risk Level
- [ ] Low
- [ ] Medium
- [ ] High

Why:

## Validation Evidence
Paste the exact commands run and a short result summary.

```bash
npm run type-check:strict
npx tsc --noEmit -p tsconfig.json
```

Test commands run:

```bash
# paste commands here
```

## Stop Conditions Check
If any item below happened, explain how scope was reduced before merge.

- [ ] `any` started spreading across files
- [ ] Root `tsc` broke repeatedly
- [ ] Types required cross-module rewrites
- [ ] Scope was reduced to keep the PR reviewable

Notes:

## Reviewer Focus
What should reviewers look at first?

- 
- 
- 
