### PR TITLE
fix: bump explicit per-test timeouts to 60s for Windows compatibility

### DIFF
--- a/src/__tests__/WorksCalendar.poolBooking.integration.test.tsx
+++ b/src/__tests__/WorksCalendar.poolBooking.integration.test.tsx
@@ -76,7 +76,7 @@ describe('WorksCalendar — pool booking (end-to-end, #212)', () => {
     expect(['N121AB', 'N505CD']).toContain(saved.resource);
     // Audit trail preserves which pool the booking was drawn from.
     expect(saved.meta?.resolvedFromPoolId).toBe('fleet-west');
-  }, 30000);
+  }, 60000);
 
   it('passes a monotonic sequence counter to onPoolsChange on each emission (#386)', async () => {
     // Round-robin advances the cursor on every save, so every commit
@@ -120,5 +120,5 @@ describe('WorksCalendar — pool booking (end-to-end, #212)', () => {
       expect(sequences[i]).toBeGreaterThan(sequences[i - 1]!);
     }
     expect(sequences[0]).toBe(1);
-  }, 30000);
+  }, 60000);
 });

--- a/src/__tests__/WorksCalendar.recurringScopedEdit.test.tsx
+++ b/src/__tests__/WorksCalendar.recurringScopedEdit.test.tsx
@@ -138,7 +138,7 @@ describe('WorksCalendar recurring-event cluster (issues #149, #146, #150)', () =
     // from commit a5ffbc2 only the master update would be emitted.
     await waitFor(() => {
       expect(onEventSave.mock.calls.length).toBeGreaterThanOrEqual(2);
-    }, { timeout: 10000 });
+    }, { timeout: 30000 });
 
     const savedPayloads = onEventSave.mock.calls.map(([p]) => p);
     const masterUpdate = savedPayloads.find((p) => p.id === 'rec-master-1');
@@ -151,5 +151,5 @@ describe('WorksCalendar recurring-event cluster (issues #149, #146, #150)', () =
     expect(detached).toBeDefined();
     expect(detached.title).toBe('Daily Standup (edited only this)');
     expect(detached.rrule ?? null).toBeNull();
-  }, 15000);
+  }, 60000);
 });


### PR DESCRIPTION
The recurring scoped edit test had its own 15000ms override and a waitFor with timeout:10000 — both too tight on Windows where this test takes ~22s. Also bumped the two 30s overrides in poolBooking.integration to match.

https://claude.ai/code/session_01A3TQxurcdbRQByT6bX5G8o

## Summary
Describe exactly what this PR changes.

## Scope
- Stage: 
- Planned PR number in sprint: 
- Target files/directories: 
- Why this slice is isolated: 

## Lessons Learned Check (REQUIRED)
Confirm these were actively used while building this PR:

- [ ] PR is intentionally small and isolated
- [ ] Boundary typing was prioritized over internal perfection
- [ ] No silent spread of `any`
- [ ] Advisory root `tsc` was used to catch integration issues
- [ ] I did not assume “looks typed” means “safe”
- [ ] I stopped and isolated typing cascades instead of expanding scope

## Definition of Done (ALL REQUIRED)
This PR is not done unless every box is checked.

- [ ] `npm run type-check:strict` passes
- [ ] Root advisory `tsc --noEmit` passes
- [ ] Tests pass for touched scope at minimum
- [ ] No uncontrolled increase in `any`
- [ ] All new types are intentional and named
- [ ] Public interfaces and exported functions are explicitly typed
- [ ] PR scope matches the sprint plan with no scope creep
- [ ] Any new `any` has an adjacent justification comment
- [ ] No file-wide `: any`
- [ ] No implicit `any` in exported functions

## What Was Typed
List exactly what was typed in this PR.

- 
- 
- 

## What Was Intentionally Left Loose
List anything intentionally not tightened yet.

- 
- 
- 

## `any` Ledger (REQUIRED)
- New `any` added: 
- Existing `any` removed: 
- Net change: 

For every new `any`, explain why it is required and why a safer type was not used yet.

1. 
2. 
3. 

## Boundary Notes
Document any public seams, caller-protection choices, or compatibility decisions.

- 
- 
- 

## Risk Level
- [ ] Low
- [ ] Medium
- [ ] High

Why:

## Validation Evidence
Paste the exact commands run and a short result summary.

```bash
npm run type-check:strict
npx tsc --noEmit -p tsconfig.json
```

Test commands run:

```bash
# paste commands here
```

## Stop Conditions Check
If any item below happened, explain how scope was reduced before merge.

- [ ] `any` started spreading across files
- [ ] Root `tsc` broke repeatedly
- [ ] Types required cross-module rewrites
- [ ] Scope was reduced to keep the PR reviewable

Notes:

## Reviewer Focus
What should reviewers look at first?

- 
- 
- 
