### PR TITLE
fix: style fluid-dnd temp-child placeholder and clear stuck isDraggin…

### DIFF
--- a/src/ui/DayCellPillList.tsx
+++ b/src/ui/DayCellPillList.tsx
@@ -52,10 +52,20 @@ export function DayCellPillList({
   );
 
   useEffect(() => {
-    if (!isDraggingRef.current) {
-      setLocalItems(events);
+    if (isDraggingRef.current) {
+      // When an item is dragged cross-container, onDragEnd only fires on the
+      // destination. The source container's ref stays true until we detect that
+      // fluid-dnd's localItems and the parent's events have re-aligned (same IDs),
+      // meaning the drag is fully resolved from this container's perspective.
+      const localSet = new Set(localItems.map(e => e.id));
+      const eventsSet = new Set(events.map(e => e.id));
+      const aligned = localSet.size === eventsSet.size &&
+        [...localSet].every(id => eventsSet.has(id));
+      if (!aligned) return;
+      isDraggingRef.current = false;
     }
-  }, [events, setLocalItems]);
+    setLocalItems(events);
+  }, [events, localItems, setLocalItems]);
 
   return (
     <div ref={containerRef} className={containerClass} style={{ paddingTop: spansHeight }}>

--- a/src/views/MonthView.module.css
+++ b/src/views/MonthView.module.css
@@ -367,3 +367,13 @@
   border-radius: 4px;
   transition: background 100ms ease, outline 100ms ease;
 }
+
+/* fluid-dnd inserts a bare .temp-child element as a placeholder while a pill
+ * is being dragged (both in source and destination containers). Without
+ * styling it appears as an unstyled white box — give it a ghost-pill look. */
+.events :global(.temp-child) {
+  background: color-mix(in srgb, var(--wc-accent, #6366f1) 18%, transparent) !important;
+  border: 1.5px dashed color-mix(in srgb, var(--wc-accent, #6366f1) 55%, transparent) !important;
+  border-radius: var(--wc-radius-sm, 4px) !important;
+  opacity: 0.75 !important;
+}


### PR DESCRIPTION
…gRef

White box during cross-container pill drag was fluid-dnd's .temp-child placeholder element — a bare DOM node injected into both source and destination containers with no visual styles. Added ghost-pill CSS inside .events to give it a semi-transparent accent-color appearance.

Also fixed a stuck isDraggingRef on the source container: fluid-dnd only fires onDragEnd on the destination, leaving the source ref permanently true after a cross-container drag. The useEffect now detects re-alignment between localItems and events (same IDs) and auto-clears the flag, restoring normal parent-prop syncing for subsequent updates.

https://claude.ai/code/session_01FpkBbzBbeGYTL3MaETa5kk

## Summary
Describe exactly what this PR changes.

## Scope
- Stage: 
- Planned PR number in sprint: 
- Target files/directories: 
- Why this slice is isolated: 

## Lessons Learned Check (REQUIRED)
Confirm these were actively used while building this PR:

- [ ] PR is intentionally small and isolated
- [ ] Boundary typing was prioritized over internal perfection
- [ ] No silent spread of `any`
- [ ] Advisory root `tsc` was used to catch integration issues
- [ ] I did not assume “looks typed” means “safe”
- [ ] I stopped and isolated typing cascades instead of expanding scope

## Definition of Done (ALL REQUIRED)
This PR is not done unless every box is checked.

- [ ] `npm run type-check:strict` passes
- [ ] Root advisory `tsc --noEmit` passes
- [ ] Tests pass for touched scope at minimum
- [ ] No uncontrolled increase in `any`
- [ ] All new types are intentional and named
- [ ] Public interfaces and exported functions are explicitly typed
- [ ] PR scope matches the sprint plan with no scope creep
- [ ] Any new `any` has an adjacent justification comment
- [ ] No file-wide `: any`
- [ ] No implicit `any` in exported functions

## What Was Typed
List exactly what was typed in this PR.

- 
- 
- 

## What Was Intentionally Left Loose
List anything intentionally not tightened yet.

- 
- 
- 

## `any` Ledger (REQUIRED)
- New `any` added: 
- Existing `any` removed: 
- Net change: 

For every new `any`, explain why it is required and why a safer type was not used yet.

1. 
2. 
3. 

## Boundary Notes
Document any public seams, caller-protection choices, or compatibility decisions.

- 
- 
- 

## Risk Level
- [ ] Low
- [ ] Medium
- [ ] High

Why:

## Validation Evidence
Paste the exact commands run and a short result summary.

```bash
npm run type-check:strict
npx tsc --noEmit -p tsconfig.json
```

Test commands run:

```bash
# paste commands here
```

## Stop Conditions Check
If any item below happened, explain how scope was reduced before merge.

- [ ] `any` started spreading across files
- [ ] Root `tsc` broke repeatedly
- [ ] Types required cross-module rewrites
- [ ] Scope was reduced to keep the PR reviewable

Notes:

## Reviewer Focus
What should reviewers look at first?

- 
- 
- 
