### PR TITLE
test(coverage): cover multi-day blackout walk, corrupt-preset JSON, and parallel branch cycle guard

### DIFF
--- a/src/core/__tests__/conflictEngine.test.ts
+++ b/src/core/__tests__/conflictEngine.test.ts
@@ -619,6 +619,41 @@ describe('conflictEngine — policy-violation rule (#213)', () => {
     expect(result.violations).toEqual([]);
   });
 
+  it('flags blackout-dates on a middle day of a multi-day event', () => {
+    // Apr 10 → Apr 12; only Apr 11 (a day the event straddles but neither
+    // starts nor ends on) is blacked out.
+    const categories = categoryMap({ blackoutDates: ['2026-04-11'] });
+    const proposed: ConflictEvent = {
+      ...base,
+      start: new Date(Date.UTC(2026, 3, 10, 9, 0)),
+      end:   new Date(Date.UTC(2026, 3, 12, 9, 0)),
+    };
+    const result = evaluateConflicts({
+      proposed, events: [], rules: [rule], categories,
+      now: day(9, 0),
+    });
+    expect(result.violations).toHaveLength(1);
+    expect(result.violations[0].details!).toMatchObject({
+      type: 'policy-violation',
+      check: 'blackout-dates',
+      blackoutDate: '2026-04-11',
+    });
+  });
+
+  it('passes a multi-day event that straddles no blackout day', () => {
+    const categories = categoryMap({ blackoutDates: ['2026-04-20'] });
+    const proposed: ConflictEvent = {
+      ...base,
+      start: new Date(Date.UTC(2026, 3, 10, 9, 0)),
+      end:   new Date(Date.UTC(2026, 3, 12, 9, 0)),
+    };
+    const result = evaluateConflicts({
+      proposed, events: [], rules: [rule], categories,
+      now: day(9, 0),
+    });
+    expect(result.violations).toEqual([]);
+  });
+
   it('uses the resource timezone when deriving the blackout key', () => {
     // 2026-04-10 23:30 UTC is 2026-04-11 in Tokyo — only the Tokyo-side
     // blackout should fire.

--- a/src/core/__tests__/csvParser.test.ts
+++ b/src/core/__tests__/csvParser.test.ts
@@ -419,4 +419,9 @@ describe('presets', () => {
   it('returns empty array when no presets stored', () => {
     expect(loadPresets()).toEqual([]);
   });
+
+  it('returns empty array when stored presets are corrupt JSON', () => {
+    localStorage.setItem('wc-csv-presets', '{not valid json');
+    expect(loadPresets()).toEqual([]);
+  });
 });

--- a/src/core/workflow/__tests__/advance.parallel.test.ts
+++ b/src/core/workflow/__tests__/advance.parallel.test.ts
@@ -258,6 +258,37 @@ describe('advance — parallel with notify inside a branch', () => {
   })
 })
 
+describe('advance — parallel branch cycle guard', () => {
+  it('fails the workflow when a branch loops past its step limit', () => {
+    // `a-loop` is a notify node whose only outgoing edge points back to
+    // itself — the validator forbids this, but the interpreter must bail
+    // out with a "step limit" failure rather than spin forever.
+    const wf: Workflow = {
+      id: 'par-cycle',
+      version: 1,
+      trigger: 'on_submit',
+      startNodeId: 'fan',
+      nodes: [
+        { id: 'fan', type: 'parallel', branches: ['a-loop', 'b-approval'], mode: 'requireAll' },
+        { id: 'a-loop', type: 'notify', channel: 'slack' },
+        { id: 'b-approval', type: 'approval', assignTo: 'role:b' },
+        { id: 'join', type: 'join', pairedWith: 'fan' },
+        { id: 'done', type: 'terminal', outcome: 'finalized' },
+      ],
+      edges: [
+        { from: 'a-loop', to: 'a-loop', when: 'default' },
+        { from: 'b-approval', to: 'join', when: 'branch-completed' },
+        { from: 'join', to: 'done' },
+      ],
+    }
+    const r = advance({ workflow: wf, instance: null, action: { type: 'start' }, at: AT })
+    expect(r.ok).toBe(true)
+    if (!r.ok) return
+    expect(r.instance.status).toBe('failed')
+    expect(r.emit.some(e => e.type === 'workflow_failed' && /step limit/.test(e.reason))).toBe(true)
+  })
+})
+
 // ─── Helpers ──────────────────────────────────────────────────────────────
 
 function startParallel(wf: Workflow): WorkflowInstance {


### PR DESCRIPTION
- conflictEngine: flag a blackout that falls on a middle day of a multi-
  day event (and pass when it straddles none), exercising the per-day
  blackout walk.
- csvParser: loadPresets returns [] when localStorage holds corrupt JSON.
- advance: a parallel branch whose notify node edges back to itself fails
  the workflow with a "step limit" error instead of spinning.

https://claude.ai/code/session_01TmzzLKer2iSPpuJktAMU4i