### PR TITLE
fix(types): clean up test-file type errors so tsc -p tsconfig.json pa…

### DIFF
--- a/src/__tests__/WorksCalendar.poolBooking.integration.test.tsx
+++ b/src/__tests__/WorksCalendar.poolBooking.integration.test.tsx
@@ -114,7 +114,7 @@ describe('WorksCalendar — pool booking (end-to-end, #212)', () => {
 
     // Every call carries (pools, { sequence }); sequences must be
     // strictly increasing across the run.
-    const sequences = onPoolsChange.mock.calls.map(([, meta]: [unknown, { sequence?: number }]) => meta?.sequence as number);
+    const sequences = onPoolsChange.mock.calls.map(([, meta]) => (meta as { sequence?: number })?.sequence as number);
     expect(sequences.length).toBeGreaterThan(0);
     for (let i = 1; i < sequences.length; i++) {
       expect(sequences[i]).toBeGreaterThan(sequences[i - 1]!);

--- a/src/__tests__/WorksCalendar.recurringScopedEdit.test.tsx
+++ b/src/__tests__/WorksCalendar.recurringScopedEdit.test.tsx
@@ -140,7 +140,7 @@ describe('WorksCalendar recurring-event cluster (issues #149, #146, #150)', () =
       expect(onEventSave.mock.calls.length).toBeGreaterThanOrEqual(2);
     }, { timeout: 30000 });
 
-    const savedPayloads = onEventSave.mock.calls.map(([p]: [unknown]) => p);
+    const savedPayloads = onEventSave.mock.calls.map(([p]) => p);
     const masterUpdate = savedPayloads.find((p) => p.id === 'rec-master-1');
     const detached     = savedPayloads.find((p) => p.id !== 'rec-master-1');
 

--- a/src/__tests__/WorksCalendar.scheduleModel.integration.test.tsx
+++ b/src/__tests__/WorksCalendar.scheduleModel.integration.test.tsx
@@ -218,7 +218,7 @@ describe('WorksCalendar schedule model integration', () => {
       expect(onEventSave.mock.calls.length).toBeGreaterThan(0);
       expect(onEventDelete.mock.calls.length).toBeGreaterThan(0);
       const savedShiftWithCoverage = onEventSave.mock.calls
-        .map(([payload]: [unknown]) => payload)
+        .map(([payload]) => payload)
         .find(
           (payload) => String(payload?.id ?? '') === 'shift-1'
             && String(payload?.meta?.coveredBy ?? '') === 'emp-2'

--- a/src/api/v1/__tests__/sync.test.ts
+++ b/src/api/v1/__tests__/sync.test.ts
@@ -568,7 +568,7 @@ describe('SyncManager', () => {
     const localEv = await manager.createEvent(ev({ id: undefined }));
     await flushPromises();
     // The temp id should still have the event since server.id was undefined
-    expect(manager.events.has(localEv.id)).toBe(true);
+    expect(manager.events.has(localEv.id!)).toBe(true);
   });
 
   it('_dispatchDelete does not rollback when rollback is null', async () => {

--- a/src/api/v1/__tests__/templates.test.ts
+++ b/src/api/v1/__tests__/templates.test.ts
@@ -79,7 +79,7 @@ describe('instantiateScheduleTemplate', () => {
       { ...template, entries: [{ title: 'T', startOffsetMinutes: 0, durationMinutes: 0 }] },
       { anchor: new Date('2026-04-20T08:00:00.000Z') },
     );
-    const diff = result.generated[0].end!.getTime() - result.generated[0].start!.getTime();
+    const diff = new Date(result.generated[0].end!).getTime() - new Date(result.generated[0].start!).getTime();
     expect(diff).toBe(60_000);
   });
 

--- a/src/core/__tests__/scheduleMutations.test.ts
+++ b/src/core/__tests__/scheduleMutations.test.ts
@@ -85,7 +85,7 @@ describe('scheduleMutations helpers', () => {
   });
 
   it('findLinkedOpenShifts returns empty when shiftEvent has no id', () => {
-    const found = findLinkedOpenShifts([openShift], { id: undefined, _eventId: undefined });
+    const found = findLinkedOpenShifts([openShift], {});
     expect(found).toHaveLength(0);
   });
 
@@ -160,7 +160,7 @@ describe('scheduleMutations helpers', () => {
 
   it('findLinkedMirroredCoverage returns empty when shiftEvent has no id', () => {
     // Covers the if (!shiftId) return [] branch in findLinkedMirroredCoverage
-    const found = findLinkedMirroredCoverage([mirror], { id: undefined, _eventId: undefined });
+    const found = findLinkedMirroredCoverage([mirror], {});
     expect(found).toHaveLength(0);
   });
 
@@ -179,7 +179,7 @@ describe('scheduleMutations helpers', () => {
 
   it('buildOpenShiftPatch uses "Shift" fallback when title is absent', () => {
     // Covers shiftEvent?.title ?? 'Shift' fallback
-    const noTitle = { ...shift, title: undefined };
+    const { title: _title, ...noTitle } = shift;
     const patch = buildOpenShiftPatch(openShift, noTitle, 'pto');
     expect(patch.title).toBe('Open: Shift');
   });

--- a/src/core/__tests__/themeSchema.test.ts
+++ b/src/core/__tests__/themeSchema.test.ts
@@ -49,25 +49,25 @@ describe('mergeTheme', () => {
     const base = { colors: { accent: '#000', bg: '#fff' } };
     const patch = { colors: { accent: '#f00' } };
     const result = mergeTheme(base, patch);
-    expect(result.colors.accent).toBe('#f00');
-    expect(result.colors.bg).toBe('#fff');
+    expect(result['colors'].accent).toBe('#f00');
+    expect(result['colors'].bg).toBe('#fff');
   });
 
   it('does not merge arrays — replaces them', () => {
     const base = { items: [1, 2, 3] };
     const patch = { items: [4, 5] };
     const result = mergeTheme(base, patch);
-    expect(result.items).toEqual([4, 5]);
+    expect(result['items']).toEqual([4, 5]);
   });
 
   it('skips patch keys with undefined value', () => {
     const result = mergeTheme({ a: 1 }, { a: undefined });
-    expect(result.a).toBe(1);
+    expect(result['a']).toBe(1);
   });
 
   it('adds new keys from patch', () => {
     const result = mergeTheme({ a: 1 }, { b: 2 });
-    expect(result.b).toBe(2);
+    expect(result['b']).toBe(2);
   });
 
   it('handles patch key whose base value is missing (nested)', () => {
@@ -81,7 +81,7 @@ describe('mergeTheme', () => {
 describe('normalizeCustomTheme', () => {
   it('returns defaults when called with null', () => {
     const result = normalizeCustomTheme(null);
-    expect(result.colors).toBeDefined();
+    expect(result['colors']).toBeDefined();
     expect((result as any).typography.baseSize).toBe(14);
   });
 

--- a/src/core/config/__tests__/profilePresets.test.ts
+++ b/src/core/config/__tests__/profilePresets.test.ts
@@ -322,7 +322,7 @@ describe('cleanUndefined — branch coverage', () => {
   it('drops keys that are explicitly undefined in the merged output (bid=22 FALSE)', () => {
     // Passing a base with an explicitly-undefined key forces cleanUndefined to
     // visit a key where o[k] === undefined and skip it (the FALSE branch).
-    const base = Object.assign({} as CalendarConfig, { resourceTypes: undefined })
+    const base = { resourceTypes: undefined } as unknown as CalendarConfig
     const out = applyProfilePreset('custom', base)
     expect(out).not.toHaveProperty('resourceTypes')
     expect(out.profile).toBe('custom')

--- a/src/core/engine/__tests__/CalendarEngine.coverage.test.ts
+++ b/src/core/engine/__tests__/CalendarEngine.coverage.test.ts
@@ -82,7 +82,7 @@ describe('CalendarEngine.dispatch — same-state no-notify', () => {
     // An unknown operation type falls through to the default case in applyOperation,
     // which returns the original state reference unchanged — so dispatch skips _notify().
     const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
-    engine.dispatch({ type: 'UNKNOWN_NO_OP' } as Parameters<typeof engine.dispatch>[0]);
+    engine.dispatch({ type: 'UNKNOWN_NO_OP' } as unknown as Parameters<typeof engine.dispatch>[0]);
     consoleSpy.mockRestore();
     expect(listener).not.toHaveBeenCalled();
   });
@@ -362,7 +362,7 @@ describe('CalendarEngine._emitBookingLifecycle — actor / reason on create/dele
     const stage: ApprovalStage = {
       stage: 'requested',
       updatedAt: new Date().toISOString(),
-      history: [{ action: 'request', at: new Date().toISOString(), actor: 'alice' }],
+      history: [{ action: 'submit', at: new Date().toISOString(), actor: 'alice' }],
     };
 
     engine.applyMutation({
@@ -372,7 +372,7 @@ describe('CalendarEngine._emitBookingLifecycle — actor / reason on create/dele
         start: new Date(2026, 3, 21, 9, 0),
         end:   new Date(2026, 3, 21, 10, 0),
         meta: { approvalStage: stage },
-      } as Omit<EngineEvent, 'id'>,
+      } as unknown as Omit<EngineEvent, 'id'>,
     });
 
     await flush();

--- a/src/core/engine/__tests__/operations.test.ts
+++ b/src/core/engine/__tests__/operations.test.ts
@@ -21,16 +21,16 @@ function emptyFilter(): FilterState {
 
 function makeState(overrides: Partial<CalendarState> = {}): CalendarState {
   return {
-    events:       new Map(),
-    assignments:  new Map(),
-    dependencies: new Map(),
-    exceptions:   new Map(),
-    pools:        new Map(),
-    selection:    new Set(),
-    cursor:       d(2026, 1, 5),
-    view:         'month' as CalendarView,
-    filter:       emptyFilter(),
-    config:       {},
+    events:            new Map(),
+    assignments:       new Map(),
+    dependencies:      new Map(),
+    resourceCalendars: new Map(),
+    pools:             new Map(),
+    selection:         new Set(),
+    cursor:            d(2026, 1, 5),
+    view:              'month' as CalendarView,
+    filter:            emptyFilter(),
+    config:            {},
     ...overrides,
   };
 }

--- a/src/core/engine/engineConfig.ts
+++ b/src/core/engine/engineConfig.ts
@@ -73,9 +73,14 @@ export const DEFAULT_RUNTIME_CONFIG: Readonly<EngineRuntimeConfig> = {
   features: DEFAULT_FEATURE_FLAGS,
 };
 
-/** Merge a partial config override onto the defaults. */
+/**
+ * Merge a partial config override onto the defaults. `features` may itself
+ * be partial — supplied flags are layered onto {@link DEFAULT_FEATURE_FLAGS}.
+ */
 export function mergeRuntimeConfig(
-  override: Partial<EngineRuntimeConfig> = {},
+  override: Partial<Omit<EngineRuntimeConfig, 'features'>> & {
+    readonly features?: Partial<EngineFeatureFlags>;
+  } = {},
 ): EngineRuntimeConfig {
   return {
     ...DEFAULT_RUNTIME_CONFIG,

--- a/src/core/engine/recurrence/__tests__/expandOccurrences.test.ts
+++ b/src/core/engine/recurrence/__tests__/expandOccurrences.test.ts
@@ -12,8 +12,9 @@ import { makeEvent } from '../../schema/eventSchema'
 const rangeStart = new Date('2026-06-10T00:00:00Z')
 const rangeEnd   = new Date('2026-06-11T00:00:00Z')
 
-function singleEv(overrides: Parameters<typeof makeEvent>[1] = {}) {
+function singleEv(overrides: Partial<Parameters<typeof makeEvent>[1]> = {}) {
   return makeEvent('ev-test', {
+    title: 'Test event',
     start: new Date('2026-06-10T09:00:00Z'),
     end:   new Date('2026-06-10T10:00:00Z'),
     ...overrides,

--- a/src/core/engine/validation/__tests__/validateEventConstraints.test.ts
+++ b/src/core/engine/validation/__tests__/validateEventConstraints.test.ts
@@ -58,7 +58,7 @@ describe('validateEventConstraints', () => {
     expect(result!.rule).toBe('event-constraint');
     expect(result!.severity).toBe('hard');
     expect(result!.message).toMatch(/Event constraint violated/i);
-    expect(result!.details?.constraintType).toBe('must-start-on');
+    expect(result!.details?.['constraintType']).toBe('must-start-on');
   });
 
   it('returns null for must-start-on when start matches exactly', () => {
@@ -73,7 +73,7 @@ describe('validateEventConstraints', () => {
     const ctx: OperationContext = { events: [ev] };
     const result = validateEventConstraints({ ...base, event: ev }, ctx);
     expect(result!.severity).toBe('soft');
-    expect(result!.details?.constraintType).toBe('snet');
+    expect(result!.details?.['constraintType']).toBe('snet');
   });
 
   it('looks up event from ctx.events using event id (canonical)', () => {
@@ -101,6 +101,6 @@ describe('validateEventConstraints', () => {
     ]);
     const ctx: OperationContext = { events: [ev] };
     const result = validateEventConstraints({ ...base, event: ev }, ctx);
-    expect(result!.details?.constraintType).toBe('snet');
+    expect(result!.details?.['constraintType']).toBe('snet');
   });
 });

--- a/src/core/workflow/__tests__/advance.test.ts
+++ b/src/core/workflow/__tests__/advance.test.ts
@@ -893,7 +893,7 @@ describe('advance — walkBranchForward notify node paths', () => {
       id: 'notify-to-join', version: 1, trigger: 'on_submit', startNodeId: 'par',
       nodes: [
         { id: 'par',     type: 'parallel', mode: 'requireAll', branches: ['b1_ntf'] },
-        { id: 'b1_ntf',  type: 'notify', message: 'branch alert', channel: 'slack' },
+        { id: 'b1_ntf',  type: 'notify', channel: 'slack' },
         { id: 'join',    type: 'join', pairedWith: 'par' },
         { id: 'done',    type: 'terminal', outcome: 'finalized' },
       ],
@@ -916,7 +916,7 @@ describe('advance — walkBranchForward notify node paths', () => {
       id: 'notify-then-approval', version: 1, trigger: 'on_submit', startNodeId: 'par',
       nodes: [
         { id: 'par',    type: 'parallel', mode: 'requireAll', branches: ['b1_ntf'] },
-        { id: 'b1_ntf', type: 'notify', message: 'heads-up', channel: 'slack' },
+        { id: 'b1_ntf', type: 'notify', channel: 'slack' },
         { id: 'b1_apv', type: 'approval', assignTo: 'role:x' },
         { id: 'join',   type: 'join', pairedWith: 'par' },
         { id: 'done',   type: 'terminal', outcome: 'finalized' },
@@ -1032,7 +1032,7 @@ describe('advance — applyBranchAction: intermediate node after branch approval
       nodes: [
         { id: 'par',   type: 'parallel', mode: 'requireAll', branches: ['b1'] },
         { id: 'b1',    type: 'approval', assignTo: 'role:x' },
-        { id: 'b1_ntf', type: 'notify', message: 'step', channel: 'slack' },
+        { id: 'b1_ntf', type: 'notify', channel: 'slack' },
         { id: 'join',  type: 'join', pairedWith: 'par' },
         { id: 'done',  type: 'terminal', outcome: 'finalized' },
       ],

--- a/src/filters/__tests__/filterSchema.test.ts
+++ b/src/filters/__tests__/filterSchema.test.ts
@@ -452,7 +452,7 @@ describe('viewScopedSchema', () => {
     // when a categories field already has static options set
     const schemaWithOptions = baseSchema.map(f =>
       f.key === 'categories'
-        ? { ...f, options: [{ value: 'PTO', label: 'PTO' }], getOptions: undefined }
+        ? { ...f, options: [{ value: 'PTO', label: 'PTO' }] }
         : f,
     );
     const result = viewScopedSchema(schemaWithOptions, 'schedule');

--- a/src/hooks/__tests__/useSavedWorkflows.test.ts
+++ b/src/hooks/__tests__/useSavedWorkflows.test.ts
@@ -88,7 +88,7 @@ describe('useSavedWorkflows — save / update / delete', () => {
     // (i.e. must not contain the name "for A") — asserting no
     // cross-contamination even in the intermediate render pass.
     const bWrites = setSpy.mock.calls.filter(
-      ([key]: [string]) => key === 'wc-saved-workflows-cal-b',
+      ([key]) => key === 'wc-saved-workflows-cal-b',
     )
     for (const [, value] of bWrites) {
       expect(value as string).not.toContain('for A')

--- a/src/integrations/__tests__/asset-tracker.test.ts
+++ b/src/integrations/__tests__/asset-tracker.test.ts
@@ -92,7 +92,8 @@ describe('asset-tracker integration subpath', () => {
 
   it('omits optional fields when position has no altitude/heading/speed', () => {
     const minimal: AssetTrackerPosition = {
-      id: 'bus-1', lat: 37.77, lon: -122.42, timestamp: 1714329600, source: 'gps',
+      id: 'bus-1', lat: 37.77, lon: -122.42, altitude: null, heading: null, speed: null,
+      timestamp: 1714329600, source: 'gps', label: 'Bus 1',
     }
     const registry: AssetTrackerLikeRegistry = { getById: () => minimal }
     const integration = createAssetTrackerIntegration(registry, { nowSeconds: () => 1714329660 })
@@ -105,7 +106,8 @@ describe('asset-tracker integration subpath', () => {
 
   it('omits upstream meta when position.meta is absent', () => {
     const noMeta: AssetTrackerPosition = {
-      id: 'van-1', lat: 37.77, lon: -122.42, timestamp: 1714329600, source: 'gps',
+      id: 'van-1', lat: 37.77, lon: -122.42, altitude: null, heading: null, speed: null,
+      timestamp: 1714329600, source: 'gps', label: 'Van 1',
     }
     const registry: AssetTrackerLikeRegistry = { getById: () => noMeta }
     const integration = createAssetTrackerIntegration(registry, { nowSeconds: () => 1714329660 })


### PR DESCRIPTION
…sses

The CI type-check uses tsconfig.build.json (which excludes tests), so a batch of test files had accumulated type errors under the full tsconfig.json — index-signature property access, exactOptionalPropertyTypes violations, loose mock.calls tuple annotations, and a few stale shapes.

- Bracket-notation access for index-signature props (themeSchema, validateEventConstraints).
- Drop `: [unknown]` / `: [string]` tuple annotations on mock.calls callbacks so destructured args infer `any` (recurringScopedEdit, scheduleModel, poolBooking, useSavedWorkflows).
- Avoid explicit-undefined props under exactOptionalPropertyTypes (scheduleMutations, profilePresets, filterSchema, asset-tracker).
- Give makeEvent/makeState helpers their required fields; remove the non-existent `exceptions` key; supply `resourceCalendars`.
- Remove the unsupported `message` field from WorkflowNotifyNode literals.
- `mergeRuntimeConfig` now accepts a partial `features` override, matching what its implementation already does (and what the test exercises).

No behavior changes; full suite + lint + both type-checks pass.

https://claude.ai/code/session_01TmzzLKer2iSPpuJktAMU4i

## Summary
Describe exactly what this PR changes.

## Scope
- Stage: 
- Planned PR number in sprint: 
- Target files/directories: 
- Why this slice is isolated: 

## Lessons Learned Check (REQUIRED)
Confirm these were actively used while building this PR:

- [ ] PR is intentionally small and isolated
- [ ] Boundary typing was prioritized over internal perfection
- [ ] No silent spread of `any`
- [ ] Advisory root `tsc` was used to catch integration issues
- [ ] I did not assume “looks typed” means “safe”
- [ ] I stopped and isolated typing cascades instead of expanding scope

## Definition of Done (ALL REQUIRED)
This PR is not done unless every box is checked.

- [ ] `npm run type-check:strict` passes
- [ ] Root advisory `tsc --noEmit` passes
- [ ] Tests pass for touched scope at minimum
- [ ] No uncontrolled increase in `any`
- [ ] All new types are intentional and named
- [ ] Public interfaces and exported functions are explicitly typed
- [ ] PR scope matches the sprint plan with no scope creep
- [ ] Any new `any` has an adjacent justification comment
- [ ] No file-wide `: any`
- [ ] No implicit `any` in exported functions

## What Was Typed
List exactly what was typed in this PR.

- 
- 
- 

## What Was Intentionally Left Loose
List anything intentionally not tightened yet.

- 
- 
- 

## `any` Ledger (REQUIRED)
- New `any` added: 
- Existing `any` removed: 
- Net change: 

For every new `any`, explain why it is required and why a safer type was not used yet.

1. 
2. 
3. 

## Boundary Notes
Document any public seams, caller-protection choices, or compatibility decisions.

- 
- 
- 

## Risk Level
- [ ] Low
- [ ] Medium
- [ ] High

Why:

## Validation Evidence
Paste the exact commands run and a short result summary.

```bash
npm run type-check:strict
npx tsc --noEmit -p tsconfig.json
```

Test commands run:

```bash
# paste commands here
```

## Stop Conditions Check
If any item below happened, explain how scope was reduced before merge.

- [ ] `any` started spreading across files
- [ ] Root `tsc` broke repeatedly
- [ ] Types required cross-module rewrites
- [ ] Scope was reduced to keep the PR reviewable

Notes:

## Reviewer Focus
What should reviewers look at first?

- 
- 
- 
