### PR TITLE
refactor(types,a11y): tighten realtime + imperative-API types, broaden swipe nav, advertise key shortcuts

### DIFF
--- a/src/WorksCalendar.tsx
+++ b/src/WorksCalendar.tsx
@@ -33,10 +33,11 @@ import CalendarErrorBoundary     from './ui/CalendarErrorBoundary';
 import styles from './WorksCalendar.module.css';
 import './styles/family/index.css';
 
-// Phase 1 migration boundary
-type LooseValue = any; // eslint-disable-line @typescript-eslint/no-explicit-any
-
-
+// Views whose layout is a vertical calendar grid/list, so a horizontal
+// touch swipe unambiguously maps to "previous / next period". Timeline-style
+// views (timeline, base, assets) are intentionally excluded — they scroll
+// horizontally and a swipe there would fight the scroll container.
+const SWIPE_NAV_VIEWS = new Set(['month', 'week', 'day', 'agenda', 'schedule']);
 
 const WorksCalendarImpl = forwardRef<CalendarApi, WorksCalendarProps>(function WorksCalendarImpl(
   {
@@ -251,7 +252,7 @@ const WorksCalendarImpl = forwardRef<CalendarApi, WorksCalendarProps>(function W
     applyEngineOp, applyWithRecurringCheck, getSavedEventPayload, engine, engineVer,
     expandedEvents, visibleEvents, undoManager, announcerRef, sourceStore,
     onEventSave, onEventMove, onEventResize, onEventDelete, onEventGroupChange,
-    onAvailabilitySave, onScheduleSave, onEmployeeAction: onEmployeeAction as LooseValue,
+    onAvailabilitySave, onScheduleSave, onEmployeeAction,
     onEventClickProp, onDateSelect, onImport,
     configuredEmployees, devMode, showAddButton, perms,
     inlineEditTarget, setFormEvent, setInlineEditTarget, setSelectedEvent,
@@ -259,18 +260,18 @@ const WorksCalendarImpl = forwardRef<CalendarApi, WorksCalendarProps>(function W
     setAvailabilityState, setScheduleEditorState, setScheduleOpen,
   });
 
-  const api = useMemo(() => ({
-    navigateTo:       (date: LooseValue) => cal.setCurrentDate(date),
-    setView:          (v: LooseValue)    => cal.setView(v),
-    goToToday:        ()                 => cal.goToToday(),
-    openEvent:        (id: LooseValue)   => { const ev = expandedEvents.find((e: LooseValue) => e.id === id); if (ev) setSelectedEvent(ev); },
-    getVisibleEvents: ()                 => visibleEvents,
-    clearFilters:     ()                 => cal.clearFilters(),
-    addEvent:         (d = {})           => setFormEvent(d),
-    undo:             ()                 => undoManager.undo(),
-    redo:             ()                 => undoManager.redo(),
-    get canUndo()                        { return undoManager.canUndo; },
-    get canRedo()                        { return undoManager.canRedo; },
+  const api = useMemo((): CalendarApi => ({
+    navigateTo:       (date)  => cal.setCurrentDate(date),
+    setView:          (v)     => cal.setView(v),
+    goToToday:        ()      => cal.goToToday(),
+    openEvent:        (id)    => { const ev = expandedEvents.find(e => e.id === id); if (ev) setSelectedEvent(ev); },
+    getVisibleEvents: ()      => visibleEvents,
+    clearFilters:     ()      => cal.clearFilters(),
+    addEvent:         (d = {}) => setFormEvent(d),
+    undo:             ()      => undoManager.undo(),
+    redo:             ()      => undoManager.redo(),
+    get canUndo()             { return undoManager.canUndo; },
+    get canRedo()             { return undoManager.canRedo; },
   }), [cal, expandedEvents, visibleEvents, undoManager, setSelectedEvent, setFormEvent]);
 
   useImperativeHandle(ref, () => api, [api]);
@@ -284,7 +285,7 @@ const WorksCalendarImpl = forwardRef<CalendarApi, WorksCalendarProps>(function W
   const swipeAreaRef = useRef<HTMLDivElement | null>(null);
   useTouchSwipe({
     targetRef: swipeAreaRef,
-    enabled: cal.view === 'month' || cal.view === 'schedule',
+    enabled: SWIPE_NAV_VIEWS.has(cal.view),
     onSwipeLeft: () => cal.navigate(1),
     onSwipeRight: () => cal.navigate(-1),
   });
@@ -440,7 +441,7 @@ const WorksCalendarImpl = forwardRef<CalendarApi, WorksCalendarProps>(function W
             canRequestAsset={canRequestAsset}
             effectiveAssets={effectiveAssets}
             currentDate={cal.currentDate}
-            requirementTemplates={ownerCfg.config?.['requirementTemplates'] as LooseValue}
+            requirementTemplates={ownerCfg.config?.['requirementTemplates']}
             availabilityState={availabilityState}
             setAvailabilityState={setAvailabilityState}
             handleAvailabilitySave={handleAvailabilitySave}

--- a/src/hooks/useCalendarDataPipeline.ts
+++ b/src/hooks/useCalendarDataPipeline.ts
@@ -3,6 +3,7 @@ import { useFetchEvents } from './useFetchEvents';
 import { useSourceStore } from './useSourceStore';
 import { useSourceAggregator } from './useSourceAggregator';
 import { useRealtimeEvents } from './useRealtimeEvents';
+import type { SupabaseRealtimeClientLike } from './useRealtimeEvents';
 import { normalizeEvents } from '../core/eventModel';
 import { useCalendarEngine } from './useCalendarEngine';
 import { useTabScopedEvents } from './useTabScopedEvents';
@@ -71,11 +72,11 @@ export function useCalendarDataPipeline({
     sourceStore,
   });
 
-  const [supabaseClient, setSupabaseClient] = useState<unknown>(null);
+  const [supabaseClient, setSupabaseClient] = useState<SupabaseRealtimeClientLike | null>(null);
   useEffect(() => {
     if (!supabaseUrl || !supabaseKey) return;
     import('@supabase/supabase-js')
-      .then(({ createClient }) => setSupabaseClient(createClient(supabaseUrl, supabaseKey)))
+      .then(({ createClient }) => setSupabaseClient(createClient(supabaseUrl, supabaseKey) as unknown as SupabaseRealtimeClientLike))
       .catch(() => console.warn('[WorksCalendar] @supabase/supabase-js not installed.'));
   }, [supabaseUrl, supabaseKey]);
 
@@ -86,9 +87,15 @@ export function useCalendarDataPipeline({
   });
 
   const allNormalized = useMemo(() => {
-    const map = new Map();
+    // Heterogeneous inputs (host events, fetched events, CSV/ICS source rows,
+    // realtime rows) are reconciled by id here, then normalized into the
+    // canonical event shape.
+    const incoming = [
+      ...(rawEvents ?? []), ...fetchedEvents, ...sourceEvents, ...realtimeEvents,
+    ] as unknown as WorksCalendarEvent[];
+    const map = new Map<string, WorksCalendarEvent>();
     const noId: WorksCalendarEvent[] = [];
-    [...(rawEvents ?? []), ...fetchedEvents, ...sourceEvents, ...realtimeEvents].forEach(ev => {
+    incoming.forEach(ev => {
       if (ev.id != null) map.set(String(ev.id), ev);
       else noId.push(ev);
     });

--- a/src/hooks/useKeyboardShortcuts.ts
+++ b/src/hooks/useKeyboardShortcuts.ts
@@ -17,7 +17,11 @@
  */
 import { useEffect } from 'react';
 
-const VIEW_KEYS = {
+/**
+ * Single-digit keys that switch the active view. Exported so the toolbar can
+ * advertise the same bindings via `aria-keyshortcuts` (single source of truth).
+ */
+export const VIEW_SHORTCUT_KEYS = {
   '1': 'month',
   '2': 'week',
   '3': 'day',
@@ -63,9 +67,9 @@ export function useKeyboardShortcuts(api: {
       if (hasOpenModal()) return;
 
       // View switches: digits 1..6
-      if (Object.prototype.hasOwnProperty.call(VIEW_KEYS, e.key)) {
+      if (Object.prototype.hasOwnProperty.call(VIEW_SHORTCUT_KEYS, e.key)) {
         e.preventDefault();
-        setView?.(VIEW_KEYS[e.key as keyof typeof VIEW_KEYS]);
+        setView?.(VIEW_SHORTCUT_KEYS[e.key as keyof typeof VIEW_SHORTCUT_KEYS]);
         return;
       }
 

--- a/src/hooks/useRealtimeEvents.ts
+++ b/src/hooks/useRealtimeEvents.ts
@@ -57,7 +57,7 @@ export interface SupabaseRealtimeClientLike {
 }
 
 export function useRealtimeEvents({ supabaseClient, table, filter }: {
-  supabaseClient: SupabaseRealtimeClientLike | null | undefined;
+  supabaseClient: SupabaseRealtimeClientLike | null;
   table?: string | undefined;
   filter?: string | undefined;
 }): { events: RealtimeRow[]; status: RealtimeStatus } {

--- a/src/hooks/useRealtimeEvents.ts
+++ b/src/hooks/useRealtimeEvents.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-explicit-any -- TODO: remove as types are tightened */
 /**
  * useRealtimeEvents — subscribe to Supabase Realtime postgres_changes.
  * Returns live events and connection status.
@@ -13,12 +12,58 @@
 import { useState, useEffect, useRef } from 'react';
 
 type RealtimeStatus = 'disabled' | 'connecting' | 'live' | 'error';
-type RealtimeRow = any;
 
-export function useRealtimeEvents({ supabaseClient, table, filter }: { supabaseClient: any; table?: string | undefined; filter?: string | undefined }): { events: RealtimeRow[]; status: RealtimeStatus } {
+/**
+ * A row delivered by Realtime or the initial select. The concrete shape is
+ * consumer-defined (it mirrors their table columns); the hook only requires an
+ * `id` it can key on when reconciling INSERT/UPDATE/DELETE events.
+ */
+export interface RealtimeRow {
+  id: string | number;
+  [key: string]: unknown;
+}
+
+interface RealtimePayload {
+  eventType: string;
+  new: RealtimeRow;
+  old: RealtimeRow;
+}
+
+interface PostgresChangesFilter {
+  event: string;
+  schema: string;
+  table: string;
+  filter?: string;
+}
+
+/** The subset of the Supabase Realtime channel API this hook depends on. */
+interface RealtimeChannelLike {
+  on(
+    type: 'postgres_changes',
+    filter: PostgresChangesFilter,
+    callback: (payload: RealtimePayload) => void,
+  ): RealtimeChannelLike;
+  subscribe(callback?: (status: string) => void): RealtimeChannelLike;
+  unsubscribe(): void;
+}
+
+/** The subset of the Supabase client this hook depends on. */
+export interface SupabaseRealtimeClientLike {
+  channel(name: string): RealtimeChannelLike;
+  from(table: string): {
+    select(columns: string): Promise<{ data: RealtimeRow[] | null; error: unknown }>;
+  };
+  removeChannel?: (channel: RealtimeChannelLike) => void;
+}
+
+export function useRealtimeEvents({ supabaseClient, table, filter }: {
+  supabaseClient: SupabaseRealtimeClientLike | null | undefined;
+  table?: string | undefined;
+  filter?: string | undefined;
+}): { events: RealtimeRow[]; status: RealtimeStatus } {
   const [events, setEvents] = useState<RealtimeRow[]>([]);
   const [status, setStatus] = useState<RealtimeStatus>('disabled');
-  const channelRef = useRef<any>(null);
+  const channelRef = useRef<RealtimeChannelLike | null>(null);
 
   useEffect(() => {
     if (!supabaseClient || !table) {
@@ -30,23 +75,23 @@ export function useRealtimeEvents({ supabaseClient, table, filter }: { supabaseC
     setStatus('connecting');
 
     const chanName = `wc-rt-${table}-${filter ?? 'all'}`;
-    const pgFilter: { event: string; schema: string; table: any; filter?: any } = { event: '*', schema: 'public', table };
+    const pgFilter: PostgresChangesFilter = { event: '*', schema: 'public', table };
     if (filter) pgFilter.filter = filter;
 
     const channel = supabaseClient
       .channel(chanName)
-      .on('postgres_changes', pgFilter, (payload: any) => {
+      .on('postgres_changes', pgFilter, (payload) => {
         const { eventType, new: newRow, old: oldRow } = payload;
-        setEvents((prev: RealtimeRow[]) => {
+        setEvents((prev) => {
           switch (eventType) {
             case 'INSERT': return [...prev, newRow];
-            case 'UPDATE': return prev.map((e: RealtimeRow) => String(e.id) === String(newRow.id) ? newRow : e);
-            case 'DELETE': return prev.filter((e: RealtimeRow) => String(e.id) !== String(oldRow.id));
+            case 'UPDATE': return prev.map((e) => String(e.id) === String(newRow.id) ? newRow : e);
+            case 'DELETE': return prev.filter((e) => String(e.id) !== String(oldRow.id));
             default: return prev;
           }
         });
       })
-      .subscribe((s: string) => {
+      .subscribe((s) => {
         if (s === 'SUBSCRIBED')    setStatus('live');
         else if (s === 'CHANNEL_ERROR' || s === 'TIMED_OUT') setStatus('error');
       });
@@ -59,14 +104,14 @@ export function useRealtimeEvents({ supabaseClient, table, filter }: { supabaseC
     supabaseClient
       .from(table)
       .select('*')
-      .then(({ data, error }: { data: RealtimeRow[] | null; error: unknown }) => {
+      .then(({ data, error }) => {
         if (cancelled || error || !data) return;
-        setEvents((prev: RealtimeRow[]) => {
+        setEvents((prev) => {
           // prev may already contain INSERT payloads from the realtime channel.
           // Build a map keyed by id: initial data wins for rows it knows about,
           // but any realtime rows not in the initial fetch are preserved.
-          const map = new Map(data.map((r: RealtimeRow) => [String(r.id), r]));
-          prev.forEach((r: RealtimeRow) => { if (!map.has(String(r.id))) map.set(String(r.id), r); });
+          const map = new Map(data.map((r) => [String(r.id), r]));
+          prev.forEach((r) => { if (!map.has(String(r.id))) map.set(String(r.id), r); });
           return [...map.values()];
         });
       })
@@ -77,7 +122,7 @@ export function useRealtimeEvents({ supabaseClient, table, filter }: { supabaseC
       // removeChannel both unsubscribes the WebSocket and drops the channel
       // from supabaseClient.channels, which channel.unsubscribe() alone does
       // not — required to avoid registry buildup across mount/unmount cycles.
-      if (typeof supabaseClient?.removeChannel === 'function') {
+      if (typeof supabaseClient.removeChannel === 'function') {
         supabaseClient.removeChannel(channel);
       } else {
         channel.unsubscribe();

--- a/src/ui/CalendarToolbar.tsx
+++ b/src/ui/CalendarToolbar.tsx
@@ -9,7 +9,14 @@ import { ALL_VIEWS } from '../core/calendarViewConfig';
 import type { ViewDef } from '../core/calendarViewConfig';
 import { captureSavedViewFields } from '../core/viewScope';
 import { hasActiveFilters, buildActiveFilterPills, buildFilterSummary } from '../filters/filterState';
+import { VIEW_SHORTCUT_KEYS } from '../hooks/useKeyboardShortcuts';
 import styles from '../WorksCalendar.module.css';
+
+// view id → keyboard shortcut digit (inverse of VIEW_SHORTCUT_KEYS), used to
+// advertise the binding on each view button via aria-keyshortcuts.
+const VIEW_SHORTCUT_BY_ID: Record<string, string> = Object.fromEntries(
+  Object.entries(VIEW_SHORTCUT_KEYS).map(([key, id]) => [id, key]),
+);
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type LooseValue = any;
@@ -102,15 +109,17 @@ export default function CalendarToolbar({
                 className={styles['navBtn']}
                 onClick={() => cal.navigate(-1)}
                 aria-label="Previous"
+                aria-keyshortcuts="k ArrowLeft"
                 title={`Previous ${cal.view}`}
               >
                 <ChevronLeft size={18} aria-hidden="true" />
               </button>
-              <button className={styles['todayBtn']} onClick={cal.goToToday}>Today</button>
+              <button className={styles['todayBtn']} onClick={cal.goToToday} aria-keyshortcuts="t">Today</button>
               <button
                 className={styles['navBtn']}
                 onClick={() => cal.navigate(1)}
                 aria-label="Next"
+                aria-keyshortcuts="j ArrowRight"
                 title={`Next ${cal.view}`}
               >
                 <ChevronRight size={18} aria-hidden="true" />
@@ -131,6 +140,7 @@ export default function CalendarToolbar({
                 className={[styles['viewBtn'], cal.view === v.id && styles['activeView']].filter(Boolean).join(' ')}
                 onClick={() => cal.setView(v.id)}
                 aria-pressed={cal.view === v.id}
+                aria-keyshortcuts={VIEW_SHORTCUT_BY_ID[v.id]}
                 title={v.hint}
                 data-wc-view-button={v.id}
               >


### PR DESCRIPTION
- useRealtimeEvents: replace the `no-explicit-any` blanket with structural
  `SupabaseRealtimeClientLike` / `RealtimeRow` types
- WorksCalendar: drop the `LooseValue` alias; type the imperative `CalendarApi`
  object directly
- useTouchSwipe wiring: enable swipe-to-navigate on week/day/agenda in addition
  to month/schedule (timeline-style views stay excluded)
- CalendarToolbar: add `aria-keyshortcuts` to the prev/today/next and view
  buttons, sourced from a single exported `VIEW_SHORTCUT_KEYS` map

https://claude.ai/code/session_01CdMMGzZtvATq9JSyDkGPUg