### PR TITLE
feat(month): native cursor-following pill drag; drop fluid-dnd dep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,14 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
-- **Fluid pill drag-and-drop** (`MonthView`): replaced the static ghost-pill
-  hover interaction with [fluid-dnd](https://github.com/carlosjorger/fluid-dnd)
-  for animated lift-follow-cursor-drop behaviour. Each day cell is now a
-  `DayCellPillList` component that runs an independent `useDragAndDrop` instance
-  inside the shared `wc-month-pills` droppable group, enabling smooth cross-day
-  moves. Multi-day span bars keep the existing pointer-event drag system.
-  New CSS classes `wc-pill-is-dragging` and `wc-pill-drop-target` control the
-  in-flight and drop-zone visual states.
+- **Pill drag-to-reschedule** (`MonthView`): single-day event pills can be
+  dragged onto another day cell to reschedule them. A clone of the pill follows
+  the cursor for the duration of the drag and the event "plants" on release
+  (`onEventMove`); the trailing click is suppressed so a drag doesn't also fire
+  `onEventClick`. Built on the same native pointer-event drag system already
+  used for multi-day span bars — no third-party drag library. `DayCellPillList`
+  is now a thin layout component.
 
 - **`FirebaseAdapter`** (`api/v1/adapters`): Firestore real-time backend adapter.
   Supports both the Firebase JS SDK v8 namespaced API and the v9 modular API

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,6 @@
       "license": "MIT",
       "dependencies": {
         "date-fns": "^3.6.0",
-        "fluid-dnd": "^2.6.3",
         "lucide-react": "^0.378.0"
       },
       "devDependencies": {
@@ -4177,12 +4176,6 @@
       "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/fluid-dnd": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/fluid-dnd/-/fluid-dnd-2.6.3.tgz",
-      "integrity": "sha512-KLqOBEWw8uP24qIx8V5xzJDzoyKJ8jR7Hie5ERevzxlsBhtLbuk6OYhrZ8+EQyrXrgjyIdFebAneFQbc/eeKmw==",
-      "license": "MIT"
     },
     "node_modules/fs-constants": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -98,7 +98,6 @@
   },
   "dependencies": {
     "date-fns": "^3.6.0",
-    "fluid-dnd": "^2.6.3",
     "lucide-react": "^0.378.0"
   },
   "devDependencies": {

--- a/src/test-setup.ts
+++ b/src/test-setup.ts
@@ -1,15 +1,1 @@
 import '@testing-library/jest-dom';
-import { vi } from 'vitest';
-import { useRef, useState } from 'react';
-
-// fluid-dnd sets up MutationObservers + event listeners on every droppable
-// element. In a month-view test environment that mounts ~35 day cells, this
-// causes excessive DOM overhead and test timeouts. Mock the hook to a simple
-// pass-through so tests stay fast while still exercising rendering logic.
-vi.mock('fluid-dnd/react', () => ({
-  useDragAndDrop: <T,>(items: T[]) => {
-    const ref = useRef<HTMLDivElement | null>(null);
-    const [localItems, setLocalItems] = useState<T[]>(items);
-    return [ref, localItems, setLocalItems, () => {}, () => {}] as const;
-  },
-}));

--- a/src/ui/DayCellPillList.tsx
+++ b/src/ui/DayCellPillList.tsx
@@ -1,71 +1,27 @@
-import { useRef, useEffect, type ReactNode } from 'react';
-import { useDragAndDrop } from 'fluid-dnd/react';
-import { isSameDay, startOfDay } from 'date-fns';
+import type { ReactNode } from 'react';
 import type { NormalizedEvent } from '../types/events';
-import type { DragEndEventData } from 'fluid-dnd';
 
 type Props = {
-  day: Date;
   events: NormalizedEvent[];
   maxPills: number;
   spansHeight: number;
-  canDrag: boolean;
-  onEventMove?: ((ev: NormalizedEvent, newStart: Date, newEnd: Date) => void) | undefined;
-  /** Called with the event and its fluid-dnd slot index; must include data-index={dataIndex} on root. */
-  renderPill: (ev: NormalizedEvent, dataIndex: number) => ReactNode;
+  /** Renders a single pill. The returned element must carry its own React key. */
+  renderPill: (ev: NormalizedEvent) => ReactNode;
   containerClass: string;
-  /** Optional ghost pill node for span-bar drag preview (non-fluid-dnd drag). */
+  /** Optional ghost pill node shown while a drag targets this cell. */
   ghostNode?: ReactNode | undefined;
 };
 
 /**
- * Renders a single day cell's event pills as a fluid-dnd droppable list.
- * All DayCellPillList instances share droppableGroup "wc-month-pills" so
- * events can be dragged across day cells with fluid animations.
+ * Lays out a single day cell's event pills (up to `maxPills`). Reserves
+ * `spansHeight` of top padding for MonthView's absolutely-positioned spans
+ * layer. Drag-to-reschedule is owned by MonthView's pointer drag — the pills
+ * carry an `onPointerDown` from `renderPill`; this component just renders them.
  */
-export function DayCellPillList({
-  day, events, maxPills, spansHeight, canDrag,
-  onEventMove, renderPill, containerClass, ghostNode,
-}: Props) {
-  const isDraggingRef = useRef(false);
-  // Block one prop sync after a cross-container drop while the parent confirms the move.
-  const pendingDropRef = useRef(false);
-
-  const [containerRef, localItems, setLocalItems] = useDragAndDrop<NormalizedEvent, HTMLDivElement>(
-    events,
-    {
-      droppableGroup: 'wc-month-pills',
-      animationDuration: 220,
-      draggingClass: 'wc-pill-is-dragging',
-      droppableClass: 'wc-pill-drop-target',
-      isDraggable: () => canDrag,
-      onDragStart: () => { isDraggingRef.current = true; },
-      onDragEnd: ({ value }: DragEndEventData<NormalizedEvent>) => {
-        isDraggingRef.current = false;
-        if (isSameDay(value.start, day) || !onEventMove) return;
-        pendingDropRef.current = true;
-        const durationMs = value.end.getTime() - value.start.getTime();
-        const newStart = new Date(startOfDay(day));
-        if (!value.allDay) {
-          newStart.setHours(value.start.getHours(), value.start.getMinutes(), 0, 0);
-        }
-        onEventMove(value, newStart, new Date(newStart.getTime() + durationMs));
-      },
-    },
-  );
-
-  useEffect(() => {
-    if (isDraggingRef.current) return;
-    if (pendingDropRef.current) {
-      pendingDropRef.current = false;
-      return;
-    }
-    setLocalItems(events);
-  }, [events, setLocalItems]);
-
+export function DayCellPillList({ events, maxPills, spansHeight, renderPill, containerClass, ghostNode }: Props) {
   return (
-    <div ref={containerRef} className={containerClass} style={{ paddingTop: spansHeight }}>
-      {localItems.slice(0, maxPills).map((ev, idx) => renderPill(ev, idx))}
+    <div className={containerClass} style={{ paddingTop: spansHeight }}>
+      {events.slice(0, maxPills).map((ev) => renderPill(ev))}
       {ghostNode}
     </div>
   );

--- a/src/views/MonthView.module.css
+++ b/src/views/MonthView.module.css
@@ -348,22 +348,3 @@
   }
 }
 
-/* ── fluid-dnd pill drag states ─────────────────────────────────────────────
- * These are global class names injected by DayCellPillList via fluid-dnd's
- * draggingClass / droppableClass config. CSS Modules :global() lets them
- * escape the hash so fluid-dnd (which uses document.querySelectorAll) can
- * still find the droppable containers by the group class it adds itself.  */
-:global(.wc-pill-is-dragging) {
-  cursor: grabbing !important;
-  opacity: 0.92 !important;
-  box-shadow: 0 6px 20px rgba(0, 0, 0, 0.3) !important;
-  border-radius: 4px;
-}
-
-:global(.wc-pill-drop-target) {
-  outline: 1.5px dashed var(--wc-accent, #6366f1);
-  outline-offset: -1px;
-  background: color-mix(in srgb, var(--wc-accent, #6366f1) 10%, transparent) !important;
-  border-radius: 4px;
-  transition: background 100ms ease, outline 100ms ease;
-}

--- a/src/views/MonthView.tsx
+++ b/src/views/MonthView.tsx
@@ -151,12 +151,62 @@ export default function MonthView({
   // ── Drag state ───────────────────────────────────────────────────────────
   const dragRef    = useRef<{ ev: NormalizedEvent; moved: boolean; targetDay: Date | null } | null>(null); // { ev, moved, targetDay }
   const [dragTarget, setDragTarget] = useState<Date | null>(null); // Date | null
+  // Tears down the cursor-following ghost + its pointermove listener. Null when no drag is in flight.
+  const ghostCleanupRef = useRef<(() => void) | null>(null);
+  // Set briefly after a drag that moved an event so the trailing synthetic `click` doesn't also fire onEventClick.
+  const justDraggedRef = useRef(false);
 
   function startPillDrag(ev: NormalizedEvent, e: ReactPointerEvent<HTMLElement>) {
     if (e.button !== 0 || !ctx?.permissions?.canDrag) return;
     e.preventDefault();
     e.stopPropagation();
     dragRef.current = { ev, moved: false, targetDay: null };
+    spawnDragGhost(e.currentTarget, e.clientX, e.clientY);
+  }
+
+  /**
+   * Clones the pressed pill into a fixed-position node that tracks the cursor
+   * until the drag ends. Plain DOM, not React: each pointer move is a single
+   * transform write rather than a re-render, and React never has to reconcile
+   * a node it doesn't own. Drop detection + commit stay with the existing cell
+   * `onPointerEnter` / grid `onPointerUp` handlers.
+   */
+  function spawnDragGhost(sourceEl: HTMLElement, clientX: number, clientY: number) {
+    ghostCleanupRef.current?.();
+    if (typeof document === 'undefined') return;
+    const rect  = sourceEl.getBoundingClientRect();
+    const ghost = sourceEl.cloneNode(true) as HTMLElement;
+    ghost.removeAttribute('data-index');
+    ghost.removeAttribute('id');
+    ghost.removeAttribute('data-wc-event-id');
+    ghost.setAttribute('data-wc-drag-ghost', '');
+    ghost.setAttribute('aria-hidden', 'true');
+    Object.assign(ghost.style, {
+      position: 'fixed', left: '0', top: '0', margin: '0', boxSizing: 'border-box',
+      width: `${rect.width}px`, height: `${rect.height}px`,
+      pointerEvents: 'none', zIndex: '2147483646', willChange: 'transform',
+      transition: 'none', transform: `translate(${rect.left}px, ${rect.top}px)`,
+      opacity: '0.92', boxShadow: '0 6px 20px rgba(0, 0, 0, 0.3)', borderRadius: '4px',
+    });
+    document.body.appendChild(ghost);
+    document.body.style.cursor = 'grabbing';
+    const offsetX = clientX - rect.left;
+    const offsetY = clientY - rect.top;
+    const onMove = (me: PointerEvent) => {
+      ghost.style.transform = `translate(${me.clientX - offsetX}px, ${me.clientY - offsetY}px)`;
+    };
+    window.addEventListener('pointermove', onMove);
+    ghostCleanupRef.current = () => {
+      window.removeEventListener('pointermove', onMove);
+      ghost.remove();
+      document.body.style.cursor = '';
+      ghostCleanupRef.current = null;
+    };
+  }
+
+  function flagJustDragged() {
+    justDraggedRef.current = true;
+    window.setTimeout(() => { justDraggedRef.current = false; }, 0);
   }
 
   function handleCellPointerEnter(day: Date) {
@@ -168,10 +218,12 @@ export default function MonthView({
   }
 
   function commitDrag() {
+    ghostCleanupRef.current?.();
     const d = dragRef.current;
     dragRef.current = null;
     setDragTarget(null);
     if (!d || !d.moved || !d.targetDay) return;
+    flagJustDragged(); // any drag that left the source pill should swallow the trailing click
     if (isSameDay(d.targetDay, d.ev.start)) return;
 
     // Bail before invoking onEventMove if the source event is missing a
@@ -195,9 +247,13 @@ export default function MonthView({
   }
 
   function cancelDrag() {
+    ghostCleanupRef.current?.();
     dragRef.current = null;
     setDragTarget(null);
   }
+
+  // Drop the cursor ghost + its listener if MonthView unmounts mid-drag.
+  useEffect(() => () => { ghostCleanupRef.current?.(); }, []);
 
   // ── Data ─────────────────────────────────────────────────────────────────
   const { weeks, dayNames } = useMemo(() => {
@@ -316,7 +372,17 @@ export default function MonthView({
   }, [popoverState]);
 
   // ── Renderers ─────────────────────────────────────────────────────────────
-  function renderPill(ev: NormalizedEvent, extra: { onAfterClick?: () => void } = {}, weekIdx: number | null = null, dataIndex?: number) {
+  function renderPill(ev: NormalizedEvent, extra: { onAfterClick?: () => void } = {}, weekIdx: number | null = null) {
+    // Pills inside a day cell (weekIdx set) are drag-to-reschedule handles;
+    // pills in the overflow popover are not.
+    const dragProps = weekIdx != null
+      ? { onPointerDown: (e: ReactPointerEvent<HTMLElement>) => startPillDrag(ev, e) }
+      : {};
+    const handleClick = (e: ReactMouseEvent<HTMLElement>) => {
+      e.stopPropagation();
+      if (justDraggedRef.current) return; // a drag just ended — don't also "click" the pill
+      onClick();
+    };
     const color       = resolveColor(ev, ctx?.colorRules);
     const onClick     = () => { onEventClick?.(ev); extra.onAfterClick?.(); };
     const isDimmed    = dragRef.current?.ev?.id === ev.id && dragTarget !== null;
@@ -342,14 +408,14 @@ export default function MonthView({
       if (custom != null) {
         return (
           <div key={ev.id}
-            data-index={dataIndex}
+            {...dragProps}
             className={[styles['eventPill'], statusClass, isDimmed && styles['dragging']].filter(Boolean).join(' ')}
             role="button"
             tabIndex={0}
             data-wc-event-id={ev.id}
             data-wc-priority={ev.visualPriority ?? undefined}
             data-wc-conflicting={isConflicting ? 'true' : undefined}
-            onClick={e => { e.stopPropagation(); onClick(); }}
+            onClick={handleClick}
             onKeyDown={e => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); e.stopPropagation(); onClick(); } }}
             onMouseEnter={handlePillMouseEnter}
             onMouseLeave={handlePillMouseLeave}
@@ -367,7 +433,7 @@ export default function MonthView({
 
     return (
       <button key={ev.id}
-        data-index={dataIndex}
+        {...dragProps}
         className={[
           styles['eventPill'],
           statusClass,
@@ -384,7 +450,7 @@ export default function MonthView({
           minHeight:  display.large ? '26px' : undefined,
           height:     display.large ? '26px' : undefined,
         }}
-        onClick={e => { e.stopPropagation(); onClick(); }}
+        onClick={handleClick}
         onMouseEnter={handlePillMouseEnter}
         onMouseLeave={handlePillMouseLeave}
         aria-label={ev.lifecycle ? `${ariaLabel}, lifecycle ${ev.lifecycle}` : ariaLabel}
@@ -525,13 +591,10 @@ export default function MonthView({
 
                         {/* paddingTop reserves space for the absolutely-positioned spansLayer */}
                         <DayCellPillList
-                          day={day}
                           events={daySingles}
                           maxPills={MAX_PILLS}
                           spansHeight={spansHeight}
-                          canDrag={Boolean(ctx?.permissions?.canDrag)}
-                          onEventMove={onEventMove}
-                          renderPill={(ev, idx) => renderPill(ev, {}, wi, idx)}
+                          renderPill={(ev) => renderPill(ev, {}, wi)}
                           containerClass={styles['events']}
                           ghostNode={isDropTarget ? renderGhostPill() : null}
                         />
@@ -572,7 +635,7 @@ export default function MonthView({
                               top:    lane * (SPAN_H + SPAN_GAP),
                               height: SPAN_H,
                             }}
-                            onClick={e => { e.stopPropagation(); onEventClick?.(ev); }}
+                            onClick={e => { e.stopPropagation(); if (justDraggedRef.current) return; onEventClick?.(ev); }}
                             onPointerDown={e => startPillDrag(ev, e)}
                             onMouseEnter={(e) => {
                               if (enlargeMonthRowOnHover) setHoveredWeekIdx(wi);

--- a/src/views/__tests__/MonthView.test.tsx
+++ b/src/views/__tests__/MonthView.test.tsx
@@ -152,6 +152,100 @@ describe('MonthView — multi-day / allDay event span bars', () => {
   });
 });
 
+// ─── Pill drag-to-reschedule (native pointer drag) ────────────────────────────
+
+describe('MonthView — pill drag-to-reschedule', () => {
+  function withDrag(props: Record<string, any> = {}) {
+    return render(
+      <CalendarContext.Provider value={{ permissions: { canDrag: true } } as any}>
+        <MonthView currentDate={currentDate} events={[]} {...props} />
+      </CalendarContext.Provider>,
+    );
+  }
+
+  it('moves a single-day event to the day cell where the drag is released', () => {
+    const onEventMove = vi.fn();
+    const events = [
+      { id: 'e1', title: 'Standup', start: new Date(2026, 3, 15, 9, 30), end: new Date(2026, 3, 15, 10, 0) },
+    ];
+    withDrag({ events, onEventMove });
+
+    const pill = screen.getByRole('button', { name: /Standup/i });
+    const target = screen.getByRole('gridcell', { name: /April 20/i });
+
+    fireEvent.pointerDown(pill, { button: 0, pointerId: 1, clientX: 5, clientY: 5 });
+    // A cursor-following clone is spawned on <body> while dragging.
+    expect(document.querySelector('[data-wc-drag-ghost]')).not.toBeNull();
+    fireEvent.pointerMove(document, { pointerId: 1, clientX: 40, clientY: 40 });
+    fireEvent.pointerEnter(target);
+    fireEvent.pointerUp(target);
+
+    expect(onEventMove).toHaveBeenCalledOnce();
+    const [movedEv, newStart, newEnd] = onEventMove.mock.calls[0] as [unknown, Date, Date];
+    expect(movedEv).toBe(events[0]);
+    expect(newStart.getFullYear()).toBe(2026);
+    expect(newStart.getMonth()).toBe(3);
+    expect(newStart.getDate()).toBe(20);
+    expect(newStart.getHours()).toBe(9); // time-of-day preserved for timed events
+    expect(newStart.getMinutes()).toBe(30);
+    expect(newEnd.getTime() - newStart.getTime()).toBe(30 * 60_000);
+    // The clone is torn down once the drag ends.
+    expect(document.querySelector('[data-wc-drag-ghost]')).toBeNull();
+    expect(document.body.style.cursor).toBe('');
+  });
+
+  it('does not move (or fire onEventClick) when released on the source day', () => {
+    const onEventMove = vi.fn();
+    const onEventClick = vi.fn();
+    const events = [
+      { id: 'e1', title: 'Standup', start: d(2026, 4, 15), end: d(2026, 4, 15) },
+    ];
+    withDrag({ events, onEventMove, onEventClick });
+
+    const pill = screen.getByRole('button', { name: /Standup/i });
+    const sameDay = screen.getByRole('gridcell', { name: /April 15/i });
+
+    fireEvent.pointerDown(pill, { button: 0, pointerId: 1, clientX: 5, clientY: 5 });
+    fireEvent.pointerEnter(sameDay);
+    fireEvent.pointerUp(sameDay);
+    fireEvent.click(pill); // the synthetic click that follows a press-release
+
+    expect(onEventMove).not.toHaveBeenCalled();
+    expect(onEventClick).not.toHaveBeenCalled(); // suppressed because a drag just happened
+    expect(document.querySelector('[data-wc-drag-ghost]')).toBeNull();
+  });
+
+  it('still fires onEventClick for a plain click on a pill', () => {
+    const onEventClick = vi.fn();
+    const events = [
+      { id: 'e1', title: 'Standup', start: d(2026, 4, 15), end: d(2026, 4, 15) },
+    ];
+    withDrag({ events, onEventClick });
+    fireEvent.click(screen.getByRole('button', { name: /Standup/i }));
+    expect(onEventClick).toHaveBeenCalledOnce();
+    expect(onEventClick).toHaveBeenCalledWith(events[0]);
+  });
+
+  it('does not start a drag when canDrag is false', () => {
+    const onEventMove = vi.fn();
+    const events = [
+      { id: 'e1', title: 'Standup', start: d(2026, 4, 15), end: d(2026, 4, 15) },
+    ];
+    render(
+      <CalendarContext.Provider value={{ permissions: { canDrag: false } } as any}>
+        <MonthView currentDate={currentDate} events={events as any} onEventMove={onEventMove} />
+      </CalendarContext.Provider>,
+    );
+    const pill = screen.getByRole('button', { name: /Standup/i });
+    const target = screen.getByRole('gridcell', { name: /April 20/i });
+    fireEvent.pointerDown(pill, { button: 0, pointerId: 1, clientX: 5, clientY: 5 });
+    expect(document.querySelector('[data-wc-drag-ghost]')).toBeNull();
+    fireEvent.pointerEnter(target);
+    fireEvent.pointerUp(target);
+    expect(onEventMove).not.toHaveBeenCalled();
+  });
+});
+
 // ─── Date selection ───────────────────────────────────────────────────────────
 
 describe('MonthView — date selection', () => {


### PR DESCRIPTION
## Summary

- Single-day event pills in `MonthView` can be dragged onto another day cell to reschedule. A clone of the pressed pill follows the cursor for the duration of the drag (plain DOM — no per-move re-render, nothing for React to reconcile) and the event "plants" on release via `onEventMove`; the trailing synthetic `click` is suppressed so a drag doesn't also fire `onEventClick`.
- Reuses the pointer-event drag system already powering multi-day span bars (cell `onPointerEnter` picks the target day, grid `onPointerUp` commits) — so the **`fluid-dnd` dependency is removed entirely**.
- `DayCellPillList` becomes a thin layout component; the dead `wc-pill-is-dragging` / `wc-pill-drop-target` CSS and the `fluid-dnd` test mock are removed; the CHANGELOG `[Unreleased]` entry is updated to describe the native approach.

This replaces the abandoned vendored-`fluid-dnd` exploration — same goal ("pills follow the cursor, plant on drop, no unmaintained dependency") with far less code and risk surface.

## Test plan

- [x] `npm test` — full suite green (228 files, 4241 tests; +4 new `MonthView` tests covering drag-to-another-day, same-day no-op + click suppression, plain click, and the `canDrag` gate).
- [x] `npm run type-check` / `eslint` — clean (no new errors).
- [x] `npm run build` — succeeds; lite bundle ~10 kB smaller.
- [ ] Manual browser pass: confirm the ghost tracks the cursor pixel-for-pixel and the drop highlights/commits correctly (happy-dom has no layout, so the visual side isn't covered by unit tests).

https://claude.ai/code/session_01AKrYupUsUye3ShWYp2w6MW

---
_Generated by [Claude Code](https://claude.ai/code/session_01AKrYupUsUye3ShWYp2w6MW)_