### PR TITLE
chore(types): type OwnerConfig (drop Record&lt;string, any&gt;); document devMode

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ interface WorksCalendarEvent {
 | `initialView` | `'month' \| 'week' \| 'day' \| 'agenda' \| 'schedule' \| 'map'` | Starting view |
 | `theme` | `string` | Theme name (see Theming) |
 | `role` | `'owner' \| 'scheduler' \| 'viewer'` | Permission level — `'owner'` unlocks settings & config |
+| `devMode` | `boolean` | **Local development only.** When `true`, treats the user as an owner regardless of `role`, bypassing every role check. Never pass `true` in production. |
 | `calendarId` | `string` | Namespace key for localStorage persistence (default: `'default'`) |
 | `onEventSave` | `(event) => void` | Called when a user saves an event in the editor |
 | `onEventDelete` | `(id) => void` | Called when a user deletes an event |

--- a/src/WorksCalendar.tsx
+++ b/src/WorksCalendar.tsx
@@ -25,7 +25,7 @@ import FilterGroupSidebar        from './ui/FilterGroupSidebar';
 import CalendarModals            from './ui/CalendarModals';
 import CalendarToolbar           from './ui/CalendarToolbar';
 import CalendarViewGrid          from './ui/CalendarViewGrid';
-import SetupLanding              from './ui/SetupLanding';
+import SetupLanding, { type AssetTypeDef, type RequirementTemplate } from './ui/SetupLanding';
 import { CalendarLeftRail, CalendarRightPanel } from './ui/CalendarSideRails';
 import SavedFlash                from './ui/SavedFlash';
 import CalendarErrorBoundary     from './ui/CalendarErrorBoundary';
@@ -310,10 +310,10 @@ const WorksCalendarImpl = forwardRef<CalendarApi, WorksCalendarProps>(function W
           <SetupLanding
             onSkip={handleSetupSkip}
             onFinish={handleSetupFinish}
-            initialName={ownerCfg.config?.['title']}
+            initialName={ownerCfg.config?.['title'] ?? ''}
             initialTheme={ownerCfg.config?.['setup']?.preferredTheme ?? rawTheme}
-            initialAssetTypes={ownerCfg.config?.['assetTypes']}
-            initialRequirementTemplates={ownerCfg.config?.['requirementTemplates']}
+            initialAssetTypes={ownerCfg.config?.['assetTypes'] as AssetTypeDef[]}
+            initialRequirementTemplates={ownerCfg.config?.['requirementTemplates'] as Record<string, RequirementTemplate>}
           />
         </div>
       </CalendarErrorBoundary>

--- a/src/WorksCalendar.tsx
+++ b/src/WorksCalendar.tsx
@@ -310,7 +310,7 @@ const WorksCalendarImpl = forwardRef<CalendarApi, WorksCalendarProps>(function W
           <SetupLanding
             onSkip={handleSetupSkip}
             onFinish={handleSetupFinish}
-            initialName={ownerCfg.config?.['title'] ?? ''}
+            initialName={ownerCfg.config?.['title']}
             initialTheme={ownerCfg.config?.['setup']?.preferredTheme ?? rawTheme}
             initialAssetTypes={ownerCfg.config?.['assetTypes'] as AssetTypeDef[]}
             initialRequirementTemplates={ownerCfg.config?.['requirementTemplates'] as Record<string, RequirementTemplate>}

--- a/src/WorksCalendar.types.ts
+++ b/src/WorksCalendar.types.ts
@@ -29,6 +29,51 @@ export type ScheduleInstantiationLimits = {
 };
 
 type UnknownRecord = Record<string, unknown>;
+
+/**
+ * Persisted owner-configurable settings — the blob behind ConfigPanel, stored
+ * per `calendarId` (localStorage by default). A handful of well-known top-level
+ * keys are typed; everything else is surfaced as `unknown` through the index
+ * signature, so values read off ad-hoc keys should be narrowed with a cast or
+ * guard at the call site. Treat it as a loosely-validated bag, not a strict
+ * schema — the host app owns the source of truth.
+ */
+export type OwnerConfig = {
+  /** Calendar display name shown in the toolbar. */
+  title?: string;
+  /** Category name treated as "on-call" by the scheduling views. */
+  onCallCategory?: string;
+  /** First-run / setup wizard state (preferred theme, completion flag, …). */
+  setup?: { preferredTheme?: string; completed?: boolean; [key: string]: unknown };
+  /** Display preferences (start-of-week, default view, enabled views, …). */
+  display?: { weekStartDay?: number; defaultView?: string; enabledViews?: string[]; [key: string]: unknown };
+  /** Team registry — roles, bases, regions, member records and label overrides. */
+  team?: {
+    roles?: UnknownRecord[];
+    bases?: UnknownRecord[];
+    regions?: UnknownRecord[];
+    members?: EmployeeRecord[];
+    locationLabel?: string;
+    assetsLabel?: string;
+    [key: string]: unknown;
+  };
+  /** Owner-configured conflict rules consumed by `evaluateConflicts`. */
+  conflicts?: { enabled?: boolean; rules?: UnknownRecord[]; [key: string]: unknown };
+  /** Asset registry. */
+  assets?: unknown;
+  /** Asset-type definitions. */
+  assetTypes?: unknown;
+  /** Per-event-type requirement templates. */
+  requirementTemplates?: unknown;
+  /** Category definitions (colours, policies, …). */
+  categoriesConfig?: unknown;
+  /** Tiered approval workflow configuration. */
+  approvals?: UnknownRecord;
+  /** Custom theme token overrides. */
+  customTheme?: UnknownRecord;
+  [key: string]: unknown;
+};
+
 export type ScheduleTemplateAdapter = {
   listScheduleTemplates?: () => Promise<unknown>;
   createScheduleTemplate?: (template: UnknownRecord) => Promise<unknown>;
@@ -70,7 +115,14 @@ export type WorksCalendarProps = {
   scheduleInstantiationLimits?: ScheduleInstantiationLimits;
   onScheduleTemplateAnalytics?: (payload: UnknownRecord) => void;
   calendarId?: string;
-  onConfigSave?: (config: UnknownRecord) => void;
+  onConfigSave?: (config: OwnerConfig) => void;
+  /**
+   * Local development escape hatch. When `true`, the calendar treats the
+   * current user as an owner regardless of `role` — every role/permission
+   * check is bypassed. Intended only for local dev and demos; **never pass
+   * `true` in production**, where access must be gated by `role` (driven by
+   * the host app's auth).
+   */
   devMode?: boolean;
   notes?: UnknownRecord;
   onNoteSave?: (note: UnknownRecord) => void;

--- a/src/hooks/useCalendarDataPipeline.ts
+++ b/src/hooks/useCalendarDataPipeline.ts
@@ -155,7 +155,7 @@ export function useCalendarDataPipeline({
   const scopedEvents = useTabScopedEvents(cal.view, engineResult.expandedEvents, {
     employees: (configuredEmployees ?? []) as { id: string; base?: string | null }[],
     assets:    effectiveAssets ?? [],
-    bases:     configuredBases ?? [],
+    bases:     (configuredBases ?? []) as { id: string; name: string }[],
     selectedBaseIds,
   });
 
@@ -167,7 +167,7 @@ export function useCalendarDataPipeline({
 
   const resolvedAssetRequestCategories = useMemo(() => {
     if (!Array.isArray(assetRequestCategories) || assetRequestCategories.length === 0) return [];
-    const cfg = categoriesConfig ?? ownerCfg.config?.['categoriesConfig'];
+    const cfg = (categoriesConfig ?? ownerCfg.config?.['categoriesConfig']) as { categories?: unknown[] };
     const defs = (Array.isArray(cfg?.categories) ? cfg.categories : []) as Array<{ id: string; label?: string; color?: string }>;
     const byId = new Map(defs.map(d => [d.id, d]));
     return assetRequestCategories.map((id: string) => {

--- a/src/hooks/useCalendarSetup.ts
+++ b/src/hooks/useCalendarSetup.ts
@@ -74,13 +74,13 @@ export function useCalendarSetup({
     return [...configMembers, ...parentOnly];
   }, [employees, ownerCfg.config?.['team']?.members]);
 
-  const effectiveAssets = assets ?? ownerCfg.config?.['assets'];
+  const effectiveAssets = assets ?? (ownerCfg.config?.['assets'] as typeof assets);
   const resolveResourceLabel = useMemo(
-    () => makeResourceResolver({ employees: configuredEmployees, assets: effectiveAssets }),
+    () => makeResourceResolver({ employees: configuredEmployees, assets: effectiveAssets ?? [] }),
     [configuredEmployees, effectiveAssets],
   );
   const schema = useMemo(
-    () => filterSchema ?? buildDefaultFilterSchema({ employees: configuredEmployees, assets: effectiveAssets }),
+    () => filterSchema ?? buildDefaultFilterSchema({ employees: configuredEmployees, assets: effectiveAssets ?? [] }),
     [filterSchema, configuredEmployees, effectiveAssets],
   );
 

--- a/src/hooks/useOwnerConfig.ts
+++ b/src/hooks/useOwnerConfig.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-explicit-any -- TODO: remove as types are tightened */
 /**
  * useOwnerConfig — owner config state + role-derived edit access.
  *
@@ -6,12 +5,14 @@
  * `isOwner` is derived from the `role` prop (and `devMode`) — there is no
  * client-side password check, which on a browser-only library would be
  * obfuscation, not security.
+ *
+ * NOTE on `devMode`: it forces `isOwner` to `true` regardless of `role`. It is
+ * a local-development convenience only — host apps must never pass it `true` in
+ * production, where access has to be gated by `role`.
  */
 import { useState, useCallback, useEffect, useRef, type Dispatch, type SetStateAction } from 'react';
 import { loadConfig, saveConfig } from '../core/configSchema';
-import type { CalendarRole } from '../WorksCalendar.types';
-
-type OwnerConfig = Record<string, any>;
+import type { CalendarRole, OwnerConfig } from '../WorksCalendar.types';
 
 export function useOwnerConfig({ calendarId, role = 'admin', onConfigSave, devMode = false }: {
   calendarId: string;

--- a/src/ui/SetupLanding.tsx
+++ b/src/ui/SetupLanding.tsx
@@ -71,9 +71,9 @@ export type SetupLandingProps = {
   /** Called when owner skips the guide. Host marks setup.completed=true. */
   onSkip: () => void;
   /** Initial calendar name (from config.title). */
-  initialName?: string;
+  initialName?: string | undefined;
   /** Initial theme (from config.setup.preferredTheme). */
-  initialTheme?: string;
+  initialTheme?: string | undefined;
   /**
    * Initial asset types. When omitted, the wizard seeds a sensible default
    * list. Pass `config.assetTypes` so re-running setup on an already-

--- a/src/ui/__tests__/SetupLanding.initialName.test.tsx
+++ b/src/ui/__tests__/SetupLanding.initialName.test.tsx
@@ -1,0 +1,51 @@
+// @vitest-environment happy-dom
+/**
+ * Regression for the first-run wizard default calendar name.
+ *
+ * `SetupLandingProps.initialName` is intentionally typed `string | undefined`
+ * (not just `string`) so that — under `exactOptionalPropertyTypes` — callers
+ * can pass `undefined` (e.g. `ownerCfg.config?.title` when no title is set
+ * yet) and let the parameter default `'My Calendar'` apply. If `initialName`
+ * is narrowed back to `string`, a caller forced to substitute `?? ''` would
+ * bypass the default and the wizard would open with a blank name field on
+ * first run.
+ */
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import '@testing-library/jest-dom';
+
+import SetupLanding from '../SetupLanding';
+
+function startWizard() {
+  fireEvent.click(screen.getByRole('button', { name: /Start setup guide/i }));
+}
+
+describe('SetupLanding — initial calendar name default', () => {
+  it("defaults to 'My Calendar' when initialName is omitted", () => {
+    render(<SetupLanding onFinish={vi.fn()} onSkip={vi.fn()} />);
+    startWizard();
+
+    const input = screen.getByLabelText(/Calendar name/i) as HTMLInputElement;
+    expect(input.value).toBe('My Calendar');
+  });
+
+  it("defaults to 'My Calendar' when initialName is explicitly undefined", () => {
+    // This is the WorksCalendar.tsx call path when `ownerCfg.config?.title`
+    // is `undefined` (no saved title yet). Under exactOptionalPropertyTypes
+    // the prop type must include `| undefined` for this to even compile;
+    // the runtime behaviour we assert here is the parameter default kicking in.
+    render(<SetupLanding onFinish={vi.fn()} onSkip={vi.fn()} initialName={undefined} />);
+    startWizard();
+
+    const input = screen.getByLabelText(/Calendar name/i) as HTMLInputElement;
+    expect(input.value).toBe('My Calendar');
+  });
+
+  it('uses a saved title when initialName is provided', () => {
+    render(<SetupLanding onFinish={vi.fn()} onSkip={vi.fn()} initialName="Kitchen Schedule" />);
+    startWizard();
+
+    const input = screen.getByLabelText(/Calendar name/i) as HTMLInputElement;
+    expect(input.value).toBe('Kitchen Schedule');
+  });
+});


### PR DESCRIPTION
## Summary

Two of the type-hygiene items from the recent audit:

- **`OwnerConfig` is no longer `Record<string, any>`.** It's now a named type in `src/WorksCalendar.types.ts`: the well-known top-level keys (`title`, `team`, `display`, `setup`, `conflicts`, `assets`, `approvals`, …) are typed, the long tail stays `unknown` via an index signature, so reads off ad-hoc keys narrow with an explicit cast at the call site instead of silently being `any`. `useOwnerConfig.ts` drops the file-level `eslint-disable @typescript-eslint/no-explicit-any` and the `Record<string, any>` alias. The handful of downstream reads that relied on the old `any` (`WorksCalendar.tsx`, `useCalendarSetup.ts`, `useCalendarDataPipeline.ts`) now carry casts at the read boundary. `onConfigSave` is typed `(config: OwnerConfig) => void`.
- **`devMode` is now documented as a footgun.** JSDoc warning on the `WorksCalendarProps['devMode']` prop, a note in `useOwnerConfig`'s docblock, and a "Key props" row in the README — it forces owner access regardless of `role` and must never be `true` in production.

No behaviour change — this is purely types + docs.

(The remaining `LooseValue = any` aliases across ~10 UI/hook files are a separate, larger cleanup and are not touched here.)

## Test plan

- [x] `npm run type-check` — strict (`strict`, `strictNullChecks`, `exactOptionalPropertyTypes`, `noImplicitAny`, `noPropertyAccessFromIndexSignature`); no new errors vs `main`.
- [x] `eslint src` — clean.
- [x] `npm test` — full suite green (~4236 tests).
- [x] `npm run build` — succeeds.

https://claude.ai/code/session_01AKrYupUsUye3ShWYp2w6MW

---
_Generated by [Claude Code](https://claude.ai/code/session_01AKrYupUsUye3ShWYp2w6MW)_