### PR TITLE
chore(types): drop LooseValue=any in 5 files (toolbar, modal state, side rails, …)

### DIFF
--- a/src/core/calendarViewConfig.ts
+++ b/src/core/calendarViewConfig.ts
@@ -3,11 +3,12 @@ import {
   startOfWeek, endOfWeek, addDays,
 } from 'date-fns';
 import type { ViewId } from './viewScope';
+import type { NormalizedEvent } from '../types/events';
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-type LooseValue = any;
+/** Minimal shape `opAnnouncement` reads off an engine operation. */
+type AnnouncedOp = { type?: string; event?: { title?: string } };
 
-export function opAnnouncement(op: LooseValue): string {
+export function opAnnouncement(op: AnnouncedOp): string {
   switch (op.type) {
     case 'create': return `Event "${op.event?.title ?? 'Untitled'}" created.`;
     case 'update': return 'Event updated.';
@@ -39,8 +40,8 @@ export const DEFAULT_SCHEDULE_INSTANTIATION_LIMITS = {
   createMax: 200,
 };
 
-let exportToExcelFn: LooseValue = null;
-export async function exportVisibleEvents(events: LooseValue): Promise<void> {
+let exportToExcelFn: ((events: NormalizedEvent[]) => Promise<void>) | null = null;
+export async function exportVisibleEvents(events: NormalizedEvent[]): Promise<void> {
   if (!exportToExcelFn) {
     ({ exportToExcel: exportToExcelFn } = await import('../export/excelExport.js'));
   }
@@ -48,7 +49,7 @@ export async function exportVisibleEvents(events: LooseValue): Promise<void> {
 }
 
 /** Compute the visible [start, end] range for a given view + date. */
-export function viewRange(view: LooseValue, date: LooseValue, weekStartDay: 0 | 1 | 2 | 3 | 4 | 5 | 6 = 0) {
+export function viewRange(view: string, date: Date, weekStartDay: 0 | 1 | 2 | 3 | 4 | 5 | 6 = 0) {
   switch (view) {
     case 'week':
       return { start: startOfWeek(date, { weekStartsOn: weekStartDay }), end: endOfWeek(date, { weekStartsOn: weekStartDay }) };

--- a/src/hooks/useModalState.ts
+++ b/src/hooks/useModalState.ts
@@ -1,14 +1,52 @@
-/* eslint-disable @typescript-eslint/no-explicit-any -- TODO: remove as types are tightened */
 import { useState, useCallback, useRef } from 'react';
 import { useSavedFlash } from './useSavedFlash';
+import type { NormalizedEvent } from '../types/events';
+import type { EmployeeRecord } from '../WorksCalendar.types';
 
-type LooseValue = any;
+/**
+ * Draft event the user is composing in the editor / new-event form. Loose by
+ * design — accepts the public `WorksCalendarEvent` shape, the internal
+ * `NormalizedEvent`, and the partial drafts the toolbar / pool / cell-click
+ * paths build, plus a handful of form-only fields (e.g. `resourcePoolId`).
+ */
+export interface FormEventDraft {
+  /** Accepts both the public `WorksCalendarEvent` shape (`id?: string | undefined`)
+   *  and the internal `NormalizedEvent` shape (`id: string`). */
+  id?: string | undefined;
+  /** Set when launching the form from a resource-pool row. */
+  resourcePoolId?: string | null;
+  start?: Date | string | undefined;
+  end?: Date | string | undefined;
+  resource?: string | undefined;
+}
+
+/** Anchor for the in-place pill editor popover. */
+export interface InlineEditTarget {
+  event: NormalizedEvent;
+  x: number;
+  y: number;
+}
+
+/** Modal state for the PTO / Unavailable picker. */
+export interface AvailabilityModalState {
+  emp: EmployeeRecord;
+  kind: string;
+  start: Date | string;
+  initialEvent?: NormalizedEvent | null;
+}
+
+/** Modal state for the shift / on-call editor. */
+export interface ScheduleEditorModalState {
+  emp: EmployeeRecord;
+  start: Date;
+  end: Date;
+}
 
 export interface UseModalStateReturn {
-  selectedEvent: LooseValue | null;
-  setSelectedEvent: (ev: LooseValue | null) => void;
-  formEvent: LooseValue | null;
-  setFormEvent: (ev: LooseValue | null) => void;
+  selectedEvent: NormalizedEvent | null;
+  setSelectedEvent: (ev: NormalizedEvent | null) => void;
+  formEvent: FormEventDraft | null;
+  setFormEvent: (ev: FormEventDraft | null) => void;
   conflictingEventIds: ReadonlySet<string>;
   handleLiveConflicts: (ids: readonly string[] | null) => void;
   assetRequestOpen: boolean;
@@ -20,25 +58,25 @@ export interface UseModalStateReturn {
   importFlash: ReturnType<typeof useSavedFlash>;
   scheduleOpen: boolean;
   setScheduleOpen: (v: boolean) => void;
-  availabilityState: LooseValue | null;
-  setAvailabilityState: (v: LooseValue | null) => void;
-  scheduleEditorState: LooseValue | null;
-  setScheduleEditorState: (v: LooseValue | null) => void;
+  availabilityState: AvailabilityModalState | null;
+  setAvailabilityState: (v: AvailabilityModalState | null) => void;
+  scheduleEditorState: ScheduleEditorModalState | null;
+  setScheduleEditorState: (v: ScheduleEditorModalState | null) => void;
   pillHoverTitle: boolean;
   setPillHoverTitle: (v: boolean) => void;
   editMode: boolean;
   setEditMode: React.Dispatch<React.SetStateAction<boolean>>;
   helpOpen: boolean;
   setHelpOpen: (v: boolean) => void;
-  inlineEditTarget: LooseValue | null;
-  setInlineEditTarget: (v: LooseValue | null) => void;
+  inlineEditTarget: InlineEditTarget | null;
+  setInlineEditTarget: (v: InlineEditTarget | null) => void;
   lastClickCoordsRef: React.MutableRefObject<{ x: number; y: number }>;
   editModeRef: React.MutableRefObject<boolean>;
 }
 
 export function useModalState(): UseModalStateReturn {
-  const [selectedEvent, setSelectedEvent] = useState<LooseValue | null>(null);
-  const [formEvent, setFormEvent] = useState<LooseValue | null>(null);
+  const [selectedEvent, setSelectedEvent] = useState<NormalizedEvent | null>(null);
+  const [formEvent, setFormEvent] = useState<FormEventDraft | null>(null);
 
   const [conflictingEventIds, setConflictingEventIds] = useState<ReadonlySet<string>>(
     () => new Set(),
@@ -60,12 +98,12 @@ export function useModalState(): UseModalStateReturn {
   const [importMsg, setImportMsg] = useState('');
   const importFlash = useSavedFlash(2500);
   const [scheduleOpen, setScheduleOpen] = useState(false);
-  const [availabilityState, setAvailabilityState] = useState<LooseValue | null>(null);
-  const [scheduleEditorState, setScheduleEditorState] = useState<LooseValue | null>(null);
+  const [availabilityState, setAvailabilityState] = useState<AvailabilityModalState | null>(null);
+  const [scheduleEditorState, setScheduleEditorState] = useState<ScheduleEditorModalState | null>(null);
   const [pillHoverTitle, setPillHoverTitle] = useState(false);
   const [editMode, setEditMode] = useState(false);
   const [helpOpen, setHelpOpen] = useState(false);
-  const [inlineEditTarget, setInlineEditTarget] = useState<LooseValue | null>(null);
+  const [inlineEditTarget, setInlineEditTarget] = useState<InlineEditTarget | null>(null);
 
   const lastClickCoordsRef = useRef({ x: 0, y: 0 });
   const editModeRef = useRef(false);

--- a/src/hooks/useSavedViewsManager.ts
+++ b/src/hooks/useSavedViewsManager.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-explicit-any -- TODO: remove as types are tightened */
 import { useState, useRef, useCallback, useEffect } from 'react';
 import { deserializeFilters } from './useSavedViews';
 import { captureSavedViewFields } from '../core/viewScope';
@@ -6,7 +5,18 @@ import type { GroupByInput } from './useNormalizedConfig';
 import type { SortConfig } from '../types/grouping';
 import type { AssetsZoomLevel } from '../types/assets';
 
-type LooseValue = any;
+/** Persisted saved view as read by `handleApplyView`. */
+interface SavedViewRecord {
+  id: string;
+  filters?: Record<string, unknown> | null;
+  view?: string;
+  groupBy?: GroupByInput | null;
+  sort?: SortConfig[] | null;
+  showAllGroups?: boolean;
+  zoomLevel?: AssetsZoomLevel;
+  collapsedGroups?: string[];
+  selectedBaseIds?: string[];
+}
 
 interface CalHandle {
   view: string;
@@ -42,9 +52,9 @@ export interface UseSavedViewsManagerParams {
 export interface UseSavedViewsManagerReturn {
   savedViewActiveId: string | null;
   savedViewDirty: boolean;
-  handleApplyView: (savedView: LooseValue) => void;
+  handleApplyView: (savedView: SavedViewRecord) => void;
   handleClearFilters: () => void;
-  handleDeleteView: (id: LooseValue) => void;
+  handleDeleteView: (id: string) => void;
   handleSidebarSaveView: (name: string, color: string | null) => void;
 }
 
@@ -92,7 +102,7 @@ export function useSavedViewsManager({
     if (savedViewActiveId) setSavedViewDirty(true);
   }, [cal.filters, cal.view, activeGroupBy, activeSort, activeShowAllGroups, activeAssetsZoom, activeAssetsCollapsed, selectedBaseIds]);
 
-  const handleApplyView = useCallback((savedView: LooseValue) => {
+  const handleApplyView = useCallback((savedView: SavedViewRecord) => {
     if (savedView.id === savedViewActiveId) {
       setSavedViewActiveId(null);
       setSavedViewDirty(false);
@@ -123,7 +133,7 @@ export function useSavedViewsManager({
     setSavedViewDirty(false);
   }, [cal]);
 
-  const handleDeleteView = useCallback((id: LooseValue) => {
+  const handleDeleteView = useCallback((id: string) => {
     savedViews.deleteView(id);
     if (savedViewActiveId === id) {
       setSavedViewActiveId(null);

--- a/src/ui/CalendarSideRails.tsx
+++ b/src/ui/CalendarSideRails.tsx
@@ -1,16 +1,23 @@
+import type { Dispatch, ReactNode, SetStateAction } from 'react';
 import { Bookmark, Filter, Settings } from 'lucide-react';
-import { LeftRail } from './LeftRail';
+import { LeftRail, type LeftRailAction } from './LeftRail';
 import { RightPanel, RightPanelSection, CrewOnShiftList } from './RightPanel';
 import { MapPeekWidget } from './MapPeekWidget';
 import { isScheduleWorkflowEvent } from '../core/scheduleModel';
+import type { NormalizedEvent } from '../types/events';
+import type { EmployeeRecord } from '../WorksCalendar.types';
+import type { SidebarTab } from './FilterGroupSidebar';
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-type LooseValue = any;
+/** Slice of `useOwnerConfig`'s return that the rails need. */
+interface OwnerCfgSlice {
+  isOwner: boolean;
+  setConfigOpen: Dispatch<SetStateAction<boolean>>;
+}
 
 interface CalendarLeftRailProps {
-  ownerCfg: LooseValue;
-  leftRailExtras: LooseValue;
-  setSidebarInitialTab: LooseValue;
+  ownerCfg: OwnerCfgSlice;
+  leftRailExtras: readonly LeftRailAction[] | undefined;
+  setSidebarInitialTab: Dispatch<SetStateAction<SidebarTab>>;
   setSidebarOpen: (v: boolean) => void;
 }
 
@@ -21,7 +28,7 @@ export function CalendarLeftRail({ ownerCfg, leftRailExtras, setSidebarInitialTa
         { id: 'saved-views', label: 'Saved views', hint: 'Manage your view library', icon: <Bookmark size={18} aria-hidden="true" />, onClick: () => { setSidebarInitialTab('saved'); setSidebarOpen(true); } },
         { id: 'focus', label: 'Focus filters', hint: 'Narrow the calendar by region, base, role, or category', icon: <Filter size={18} aria-hidden="true" />, onClick: () => { setSidebarInitialTab('focus'); setSidebarOpen(true); } },
         ...(ownerCfg.isOwner ? [{ id: 'settings', label: 'Settings', hint: 'Calendar configuration', icon: <Settings size={18} aria-hidden="true" />, onClick: () => ownerCfg.setConfigOpen(true) }] : []),
-        ...(leftRailExtras ?? []).filter((extra: LooseValue) => !['saved-views', 'focus', 'settings'].includes(extra.id)),
+        ...(leftRailExtras ?? []).filter((extra) => !['saved-views', 'focus', 'settings'].includes(extra.id)),
       ]}
     />
   );
@@ -29,13 +36,13 @@ export function CalendarLeftRail({ ownerCfg, leftRailExtras, setSidebarInitialTa
 
 interface CalendarRightPanelProps {
   showMapWidget: boolean;
-  expandedEvents: LooseValue[];
-  handleEventClick: LooseValue;
-  onMapWidgetOpenChange: LooseValue;
-  mapStyle: LooseValue;
-  configuredEmployees: LooseValue[];
-  onShiftIds: LooseValue;
-  rightPanelExtras: LooseValue;
+  expandedEvents: readonly NormalizedEvent[];
+  handleEventClick: (event: NormalizedEvent) => void;
+  onMapWidgetOpenChange: ((open: boolean) => void) | undefined;
+  mapStyle: string | undefined;
+  configuredEmployees: EmployeeRecord[];
+  onShiftIds: ReadonlySet<string>;
+  rightPanelExtras: ReactNode;
 }
 
 export function CalendarRightPanel({
@@ -47,7 +54,7 @@ export function CalendarRightPanel({
       {showMapWidget && (
         <RightPanelSection title="Region map">
           <MapPeekWidget
-            events={(expandedEvents as LooseValue[]).filter(ev => !isScheduleWorkflowEvent(ev)) as never}
+            events={expandedEvents.filter(ev => !isScheduleWorkflowEvent(ev)) as never}
             onEventClick={handleEventClick as never}
             {...(onMapWidgetOpenChange ? { onOpenChange: onMapWidgetOpenChange } : {})}
             {...(mapStyle ? { mapStyle } : {})}

--- a/src/ui/CalendarToolbar.tsx
+++ b/src/ui/CalendarToolbar.tsx
@@ -1,3 +1,4 @@
+import type { Dispatch, SetStateAction } from 'react';
 import { format, startOfWeek, endOfWeek } from 'date-fns';
 import { ChevronLeft, ChevronRight, Sparkles } from 'lucide-react';
 import { AppHeader } from './AppHeader';
@@ -9,6 +10,15 @@ import type { ViewDef } from '../core/calendarViewConfig';
 import { captureSavedViewFields } from '../core/viewScope';
 import { hasActiveFilters, buildActiveFilterPills, buildFilterSummary } from '../filters/filterState';
 import { VIEW_SHORTCUT_KEYS } from '../hooks/useKeyboardShortcuts';
+import { useCalendarSetup } from '../hooks/useCalendarSetup';
+import { useOwnerConfig } from '../hooks/useOwnerConfig';
+import { useSavedViews } from '../hooks/useSavedViews';
+import type { InlineEditTarget } from '../hooks/useModalState';
+import type { CalendarApi, WorksCalendarProps } from '../WorksCalendar.types';
+import type { NormalizedEvent } from '../types/events';
+import type { FilterField } from '../filters/filterSchema';
+import type { SidebarTab } from './FilterGroupSidebar';
+import type { GroupByInput } from '../hooks/useNormalizedConfig';
 import styles from '../WorksCalendar.module.css';
 
 // view id → keyboard shortcut digit (inverse of VIEW_SHORTCUT_KEYS), used to
@@ -17,16 +27,19 @@ const VIEW_SHORTCUT_BY_ID: Record<string, string> = Object.fromEntries(
   Object.entries(VIEW_SHORTCUT_KEYS).map(([key, id]) => [id, key]),
 );
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-type LooseValue = any;
+type CalendarHandle = ReturnType<typeof useCalendarSetup>['cal'];
+type OwnerCfgHandle = ReturnType<typeof useOwnerConfig>;
+type SavedViewsHandle = ReturnType<typeof useSavedViews>;
+type SavedViewArg = Parameters<SavedViewsHandle['saveView']>[2];
+type CaptureCtx = Parameters<typeof captureSavedViewFields>[1];
 
 export interface CalendarToolbarProps {
-  cal: LooseValue;
-  ownerCfg: LooseValue;
-  api: LooseValue;
-  renderToolbar?: LooseValue;
-  renderSavedViewsBar?: LooseValue;
-  renderFilterBar?: LooseValue;
+  cal: CalendarHandle;
+  ownerCfg: OwnerCfgHandle;
+  api: CalendarApi;
+  renderToolbar?: WorksCalendarProps['renderToolbar'];
+  renderSavedViewsBar?: WorksCalendarProps['renderSavedViewsBar'];
+  renderFilterBar?: WorksCalendarProps['renderFilterBar'];
   focusChips?: FocusChipDef[] | boolean | undefined;
   logoSrc?: string | undefined;
   logoAlt?: string | undefined;
@@ -34,24 +47,24 @@ export interface CalendarToolbarProps {
   calendarTitle: string;
   fetchLoading: boolean;
   editMode: boolean;
-  setEditMode: LooseValue;
-  setInlineEditTarget: LooseValue;
+  setEditMode: Dispatch<SetStateAction<boolean>>;
+  setInlineEditTarget: (target: InlineEditTarget | null) => void;
   setHelpOpen: (v: boolean) => void;
-  savedViews: LooseValue;
+  savedViews: SavedViewsHandle;
   savedViewActiveId: string | null;
   savedViewDirty: boolean;
-  handleApplyView: LooseValue;
-  handleDeleteView: LooseValue;
-  handleClearFilters: LooseValue;
-  savedViewCaptureCtx: LooseValue;
-  activeGroupBy: LooseValue;
+  handleApplyView: (savedView: { id: string; [key: string]: unknown }) => void;
+  handleDeleteView: (id: string) => void;
+  handleClearFilters: () => void;
+  savedViewCaptureCtx: CaptureCtx;
+  activeGroupBy: GroupByInput | null;
   VIEWS: readonly ViewDef[];
   setSidebarOpen: (v: boolean) => void;
-  setSidebarInitialTab: LooseValue;
+  setSidebarInitialTab: Dispatch<SetStateAction<SidebarTab>>;
   handleScopeClick: () => void;
-  schema: LooseValue;
-  filterBarSchema: LooseValue;
-  scopedEvents: LooseValue;
+  schema: FilterField[];
+  filterBarSchema: FilterField[];
+  scopedEvents: readonly NormalizedEvent[];
   locationLabel: string;
   assetsLabel: string;
   weekStartDay: 0 | 1 | 2 | 3 | 4 | 5 | 6;
@@ -191,9 +204,9 @@ export default function CalendarToolbar({
             activeId:    savedViewActiveId,
             isDirty:     savedViewDirty,
             applyView:   handleApplyView,
-            saveView:    (name: LooseValue, opts: LooseValue) => savedViews.saveView(name, cal.filters, { view: cal.view, ...captureSavedViewFields(cal.view, savedViewCaptureCtx), ...opts }),
+            saveView:    (name: string, opts: SavedViewArg) => savedViews.saveView(name, cal.filters, { view: cal.view, ...captureSavedViewFields(cal.view, savedViewCaptureCtx), ...opts }),
             updateView:  savedViews.updateView,
-            resaveView:  (id: LooseValue) => savedViews.resaveView(id, cal.filters, cal.view, activeGroupBy, captureSavedViewFields(cal.view, savedViewCaptureCtx)),
+            resaveView:  (id: string) => savedViews.resaveView(id, cal.filters, cal.view, activeGroupBy, captureSavedViewFields(cal.view, savedViewCaptureCtx)),
             deleteView:  handleDeleteView,
             toggleStripVisibility: savedViews.toggleStripVisibility,
             clearFilters: cal.clearFilters,
@@ -201,7 +214,7 @@ export default function CalendarToolbar({
             currentFilters: cal.filters,
             currentView:    cal.view,
             schema,
-            buildFilterSummary: (filters: LooseValue) => buildFilterSummary(filters, schema),
+            buildFilterSummary: (filters: Record<string, unknown>) => buildFilterSummary(filters, schema),
           })
         : (() => {
           const resolvedFocusChips: FocusChipDef[] | null = focusChips
@@ -213,7 +226,7 @@ export default function CalendarToolbar({
               <FocusChips
                 chips={resolvedFocusChips}
                 activeCategories={activeCategories}
-                onCategoriesChange={(next: LooseValue) => cal.setFilter('categories', next)}
+                onCategoriesChange={(next: Set<string>) => cal.setFilter('categories', next)}
               />
               <button
                 type="button"
@@ -241,15 +254,15 @@ export default function CalendarToolbar({
               hasActiveFilters={hasActiveFilters(cal.filters, schema)}
               tailSlot={tailSlot}
               onApply={handleApplyView}
-              onAdd={({ name, color }: { name: LooseValue; color: LooseValue }) =>
+              onAdd={({ name, color }: { name: string; color: string | null }) =>
                 savedViews.saveView(name, cal.filters, { color, view: cal.view, ...captureSavedViewFields(cal.view, savedViewCaptureCtx) })
               }
-              onResave={(id: LooseValue) => savedViews.resaveView(id, cal.filters, cal.view, activeGroupBy, captureSavedViewFields(cal.view, savedViewCaptureCtx))}
+              onResave={(id: string) => savedViews.resaveView(id, cal.filters, cal.view, activeGroupBy, captureSavedViewFields(cal.view, savedViewCaptureCtx))}
               onUpdate={savedViews.updateView}
               onDelete={handleDeleteView}
               onToggleVisibility={savedViews.toggleStripVisibility}
               onClearFilters={handleClearFilters}
-              onEditConditions={ownerCfg.isOwner ? (id: LooseValue) => ownerCfg.openConfigToTab('smartViews', { smartViewEditId: id }) : undefined}
+              onEditConditions={ownerCfg.isOwner ? (id: string) => ownerCfg.openConfigToTab('smartViews', { smartViewEditId: id }) : undefined}
             />
           );
         })()


### PR DESCRIPTION
## Summary

First slice of the `LooseValue = any` cleanup flagged in the audit. Each of these files previously aliased `type LooseValue = any` behind a file-level `eslint-disable @typescript-eslint/no-explicit-any`; that alias and the disable comment are gone, and the values they typed get real types instead.

- **`core/calendarViewConfig.ts`** — `opAnnouncement` takes a small `AnnouncedOp` shape; `exportToExcelFn` / `exportVisibleEvents` take `NormalizedEvent[]`; `viewRange` is `(view: string, date: Date, …)`.
- **`hooks/useSavedViewsManager.ts`** — new local `SavedViewRecord` interface for `handleApplyView`; `handleDeleteView(id: string)`.
- **`hooks/useModalState.ts`** — named, exported shapes: `FormEventDraft`, `InlineEditTarget`, `AvailabilityModalState`, `ScheduleEditorModalState`. `selectedEvent: NormalizedEvent | null`.
- **`ui/CalendarSideRails.tsx`** — a small `OwnerCfgSlice`; `LeftRailAction[]` for `leftRailExtras`; `NormalizedEvent` / `EmployeeRecord` / `SidebarTab` used directly. Drops a cast on `expandedEvents.filter(...)`.
- **`ui/CalendarToolbar.tsx`** — prop types derived from the source hooks (`ReturnType<typeof useCalendarSetup>['cal']`, `useOwnerConfig`, `useSavedViews`) and shared types (`CalendarApi`, `WorksCalendarProps`, `FilterField`, `SidebarTab`, `GroupByInput`).

No behaviour change. ~65 of the ~270 `LooseValue` usages across the codebase are gone.

## What's still using `LooseValue = any`

Punted to a follow-up to keep this PR reviewable — these handle engine-op payloads / event mutation logic and the cascade is bigger:

- `ui/CalendarModals.tsx` (~56 uses)
- `ui/CalendarViewGrid.tsx` (~55)
- `hooks/useEventMutations.ts` (~43)
- `hooks/useScheduleMutations.ts` (~26)
- `hooks/useScheduleTemplates.ts` (~24)

## Test plan

- [x] `npm test` — full suite green (~4236 tests).
- [x] `npm run type-check` (strict, incl. `exactOptionalPropertyTypes`, `noPropertyAccessFromIndexSignature`) — no new errors vs `main`.
- [x] `eslint src` — clean.
- [x] `npm run build` — succeeds.

https://claude.ai/code/session_01AKrYupUsUye3ShWYp2w6MW

---
_Generated by [Claude Code](https://claude.ai/code/session_01AKrYupUsUye3ShWYp2w6MW)_