### PR TITLE
chore(types): #596 sprint plan + sprint 1 — type the engine-op handler seam

### DIFF
--- a/docs/sprints/596-typing-the-engine-op-event-seam.md
+++ b/docs/sprints/596-typing-the-engine-op-event-seam.md
@@ -56,27 +56,32 @@ the engine-op/result/event types and adds:
   `getSavedEventPayload`, `emitEventSave`) to the shared signatures; type the
   `OperationResult` callbacks and `EventChange` handling.
 - `LooseValue` stays in those three files for the event/employee/config
-  parameters (Sprints 2–3).
-- Out of scope but noted: `useCalendarEngine.ts` still uses a private
-  `AnyValue = any` alias for the same shapes — not `LooseValue`, so not in #596's
-  literal scope, but it should adopt `EngineOpInput`/`OperationResult` in Sprint 2.
+  parameters (Sprint 3).
 
-### Sprint 2 — engine-op *literals* + `useCalendarEngine` adoption
+### Sprint 2 — `useCalendarEngine` adoption ✅
 
-- Adopt `EngineOpInput`/`OperationResult` in `useCalendarEngine.ts`
-  (`UseCalendarEngineResult`, `applyEngineOp`, `applyWithRecurringCheck`,
-  `getSavedEventPayload`, `opAnnouncement`), with the single
-  `op as unknown as EngineOperation` cast at `engine.applyMutation`.
-- Reconcile the op-literal shapes the hooks build (`resource` vs `resourceId`,
-  `Date | string` starts, `'inline-edit'` / `'template'` sources) — either
-  widen `EngineOpInput`, widen `OperationSource`, or fix the literal. No new
-  `any`.
+- Adopt the canonical types in `useCalendarEngine.ts`: `UseCalendarEngineResult`
+  exposes `applyEngineOp: EngineOpRunner`, `applyWithRecurringCheck:
+  RecurringOpRunner`, `getSavedEventPayload: GetSavedEventPayload`;
+  `opAnnouncement(op: EngineOpInput)`; the impls thread `EngineOpInput` /
+  `OperationResult`, with the single `op as unknown as EngineOperation` cast at
+  `engine.applyMutation` (the engine-adapter boundary) plus a narrowing cast for
+  the legacy event payload. The engine-op seam is now typed end-to-end:
+  `useCalendarEngine` → `useCalendarDataPipeline`/`WorksCalendar` →
+  `useCalendarMutations` → the three mutation hooks.
+- `useCalendarEngine.ts` still uses its private `AnyValue = any` for the event
+  *list* surface (`allNormalized`, `expandedEvents`, `approvalRequestEvents`,
+  `PendingAlert.violations`, …) — not `LooseValue`, not in #596's literal scope;
+  it gets cleaned up alongside the views (Sprints 4–5).
 
-### Sprint 3 — event-shape unification in the three hooks
+### Sprint 3 — event-shape unification in the three hooks + tighten `EngineOpInput`
 
 - Replace the remaining `LooseValue` in `useEventMutations.ts`,
   `useScheduleMutations.ts`, `useScheduleTemplates.ts` with `MutationEventInput`,
   `NormalizedEvent`, `EmployeeRecord`, `OwnerConfig`, etc.
+- Tighten `EngineOpInput` toward `EngineOperation` (reconcile `resource` vs
+  `resourceId` in patches, the extra op sources, `Date | string` starts) — either
+  widen the target types or fix the literal. No new `any`.
 - Where the public/engine types are genuinely too strict for what callers pass,
   loosen them (`?: T | undefined`) rather than scattering `as`.
 - **Remove `type LooseValue = any` + the `eslint-disable` from these three

--- a/docs/sprints/596-typing-the-engine-op-event-seam.md
+++ b/docs/sprints/596-typing-the-engine-op-event-seam.md
@@ -1,0 +1,108 @@
+# Sprint plan — issue #596: type the engine-op / event seam end-to-end
+
+Tracking issue: [#596](https://github.com/WorksCalendar/CalendarThatWorks/issues/596) —
+remove the remaining `type LooseValue = any` (and the file-level
+`eslint-disable @typescript-eslint/no-explicit-any`) from five files that
+currently bridge type mismatches across the mutation pipeline:
+
+| File | ~`LooseValue` uses | Nature |
+| --- | --- | --- |
+| `src/ui/CalendarModals.tsx` | ~56 | one big props interface |
+| `src/ui/CalendarViewGrid.tsx` | ~55 | one big props interface |
+| `src/hooks/useEventMutations.ts` | ~43 | engine-op + event-shape seam |
+| `src/hooks/useScheduleMutations.ts` | ~26 | engine-op + event-shape seam |
+| `src/hooks/useScheduleTemplates.ts` | ~24 | engine-op + template seam |
+
+The issue is *not* incrementable file-by-file (tightening one file cascades
+through `WorksCalendar.tsx` and the engine adapters), but it **is**
+incrementable layer-by-layer: keep `LooseValue` working as an escape hatch and
+tighten one seam at a time, each sprint landing `type-check` + `lint` + `test`
+green.
+
+## Canonical shapes
+
+- `EngineOperation` — `src/core/engine/schema/operationSchema.ts` (the engine's
+  authoritative mutation type)
+- `OperationResult` / `EventChange` — `src/core/engine/operations/operationResult.ts`
+- `EngineEvent` — `src/core/engine/schema/eventSchema.ts`
+- `WorksCalendarEvent` (public, loose) / `NormalizedEvent` (internal, strict) —
+  `src/types/events.ts`
+- `OwnerConfig`, `EmployeeRecord`, `EmployeeId`, `EmployeeActionInput`,
+  `AvailabilitySavePayload` — `src/WorksCalendar.types.ts`
+
+New shared module added in Sprint 1: **`src/types/engineOps.ts`** — re-exports
+the engine-op/result/event types and adds:
+
+- `EngineOpInput` — deliberately-loose hook→engine op shape (the hooks build
+  op-shaped literals; the engine normalises + validates). One `as` cast at the
+  engine-adapter boundary turns it into `EngineOperation`.
+- `EngineOpRunner` / `RecurringOpRunner` — the `applyEngineOp` /
+  `applyWithRecurringCheck` signatures.
+- `GetSavedEventPayload`, `EmitEventSave` — the post-mutation lookup signatures.
+- `MutationEventInput` — the "event-ish input" union the mutation hooks accept
+  (`NormalizedEvent | WorksCalendarEvent | Partial<WorksCalendarEvent>`).
+  *(Defined in Sprint 1, consumed from Sprint 3 on.)*
+- `isCreatedChange` / `isUpdatedChange` / `isDeletedChange` — `EventChange`
+  discriminant guards (needed because `Array.prototype.find` doesn't narrow a
+  union).
+
+## Sprints
+
+### Sprint 1 — canonical types + the engine-op handler seam ✅ (this PR)
+
+- Add `src/types/engineOps.ts`.
+- In `useEventMutations.ts`, `useScheduleMutations.ts`, `useScheduleTemplates.ts`:
+  retype the handler params (`applyEngineOp`, `applyWithRecurringCheck`,
+  `getSavedEventPayload`, `emitEventSave`) to the shared signatures; type the
+  `OperationResult` callbacks and `EventChange` handling.
+- `LooseValue` stays in those three files for the event/employee/config
+  parameters (Sprints 2–3).
+- Out of scope but noted: `useCalendarEngine.ts` still uses a private
+  `AnyValue = any` alias for the same shapes — not `LooseValue`, so not in #596's
+  literal scope, but it should adopt `EngineOpInput`/`OperationResult` in Sprint 2.
+
+### Sprint 2 — engine-op *literals* + `useCalendarEngine` adoption
+
+- Adopt `EngineOpInput`/`OperationResult` in `useCalendarEngine.ts`
+  (`UseCalendarEngineResult`, `applyEngineOp`, `applyWithRecurringCheck`,
+  `getSavedEventPayload`, `opAnnouncement`), with the single
+  `op as unknown as EngineOperation` cast at `engine.applyMutation`.
+- Reconcile the op-literal shapes the hooks build (`resource` vs `resourceId`,
+  `Date | string` starts, `'inline-edit'` / `'template'` sources) — either
+  widen `EngineOpInput`, widen `OperationSource`, or fix the literal. No new
+  `any`.
+
+### Sprint 3 — event-shape unification in the three hooks
+
+- Replace the remaining `LooseValue` in `useEventMutations.ts`,
+  `useScheduleMutations.ts`, `useScheduleTemplates.ts` with `MutationEventInput`,
+  `NormalizedEvent`, `EmployeeRecord`, `OwnerConfig`, etc.
+- Where the public/engine types are genuinely too strict for what callers pass,
+  loosen them (`?: T | undefined`) rather than scattering `as`.
+- **Remove `type LooseValue = any` + the `eslint-disable` from these three
+  files.**
+
+### Sprint 4 — `CalendarViewGrid.tsx`
+
+- Type the props (`cal`, `ownerCfg`, `perms`, the handler props, the event
+  arrays) from `useCalendarSetup` / `useOwnerConfig` / `usePermissions` /
+  `FilterField[]` / `NormalizedEvent[]`.
+- Fix the `WorksCalendar.tsx` caller cascade.
+- **Remove `LooseValue` + the `eslint-disable` from this file.**
+
+### Sprint 5 — `CalendarModals.tsx` + final sweep
+
+- Type the ~46-field `CalendarModalsProps` interface (events, config, the modal
+  state shapes, the handler signatures).
+- Fix the `WorksCalendar.tsx` caller cascade.
+- **Remove `LooseValue` + the `eslint-disable` from this file.**
+- Final audit: `git grep "LooseValue"` empty in the five files; no new `any`
+  introduced elsewhere; `npm run type-check && npm run lint && npm test && npm run build`
+  all green; CHANGELOG entry; close #596.
+
+## Done-when (from the issue)
+
+- No `type LooseValue = any` / `eslint-disable @typescript-eslint/no-explicit-any`
+  in the five files.
+- `npm run type-check`, `npm run lint`, `npm test`, `npm run build` all pass.
+- No new `any` introduced elsewhere.

--- a/docs/sprints/596-typing-the-engine-op-event-seam.md
+++ b/docs/sprints/596-typing-the-engine-op-event-seam.md
@@ -85,17 +85,32 @@ the engine-op/result/event types and adds:
   blobs, shape-validated downstream) and one in the adapter-reload path. **`LooseValue`
   + the `eslint-disable` removed from `useScheduleTemplates.ts`.**
 
-### Sprint 3b — `useEventMutations.ts` + `useScheduleMutations.ts` + tighten `EngineOpInput`
+### Sprint 3b — `useEventMutations.ts` ✅
 
-- Replace the remaining `LooseValue` in `useEventMutations.ts` /
-  `useScheduleMutations.ts` with `MutationEventInput`, `NormalizedEvent`,
-  `EmployeeRecord`, `OwnerConfig`, etc.
-- Tighten `EngineOpInput` toward `EngineOperation` (reconcile `resource` vs
-  `resourceId` in patches, the extra op sources, `Date | string` starts) — either
-  widen the target types or fix the literal. No new `any`.
+- `MutationEventInput` (the grab-bag "event-ish" interface — public fields +
+  normalisation markers + a few form-only fields + an index signature) replaces
+  the placeholder in `engineOps.ts`. `useEventMutations` types its event params
+  with it (`rawEv`, `proposed`, `inlineEditTarget.event`, `setFormEvent`,
+  `setInlineEditTarget`), drag handlers with `NormalizedEvent`, `engine` with
+  `CalendarEngine`, `ownerConfig` with `OwnerConfig`, callbacks with the public
+  `WorksCalendarEvent` shapes; new exported `InlineEventPatch`; a small
+  `asSavedEvent(EngineEvent): WorksCalendarEvent` helper (the engine-adapter
+  output is what host `onEventSave` consumes, and a `NormalizedEvent` isn't a
+  `WorksCalendarEvent` — it uses `null` where the public type uses `undefined`).
+  **`LooseValue` removed from `useEventMutations.ts`.**
+
+### Sprint 3c — `useScheduleMutations.ts`
+
+- Replace the remaining `LooseValue` in `useScheduleMutations.ts` with
+  `MutationEventInput`, `NormalizedEvent`, `EmployeeRecord`, `EmployeeId`,
+  `EmployeeActionInput`, `OwnerConfig`, etc.
 - Where the public/engine types are genuinely too strict for what callers pass,
   loosen them (`?: T | undefined`) rather than scattering `as`.
-- **Remove `type LooseValue = any` + the `eslint-disable` from these two files.**
+- **Remove `type LooseValue = any` + the `eslint-disable` from this file.**
+
+> `EngineOpInput` keeps `event` / `patch` as `unknown` (not tightened toward
+> `EngineOperation`) — that's not required by the "done when" and the loose op
+> shape is `unknown`, not `any`. A later polish could tighten it.
 
 ### Sprint 4 — `CalendarViewGrid.tsx`
 

--- a/docs/sprints/596-typing-the-engine-op-event-seam.md
+++ b/docs/sprints/596-typing-the-engine-op-event-seam.md
@@ -74,18 +74,28 @@ the engine-op/result/event types and adds:
   `PendingAlert.violations`, …) — not `LooseValue`, not in #596's literal scope;
   it gets cleaned up alongside the views (Sprints 4–5).
 
-### Sprint 3 — event-shape unification in the three hooks + tighten `EngineOpInput`
+### Sprint 3a — `useScheduleTemplates.ts` ✅
 
-- Replace the remaining `LooseValue` in `useEventMutations.ts`,
-  `useScheduleMutations.ts`, `useScheduleTemplates.ts` with `MutationEventInput`,
-  `NormalizedEvent`, `EmployeeRecord`, `OwnerConfig`, etc.
+- Type the template surface: `scheduleTemplates: readonly ScheduleTemplateV1[]`,
+  `engine: { state: { events: ReadonlyMap<string, EngineEvent> } }`, `role:
+  CalendarRole`, the request/result via `ScheduleInstantiationRequestV1` /
+  `ScheduleInstantiationResultV1` / `CalendarEventV1`; new exported
+  `SchedulePreviewResult` / `SchedulePreviewConflict`. One boundary cast in
+  `useCalendarMutations` (`scheduleTemplates as ScheduleTemplateV1[]` — host-supplied
+  blobs, shape-validated downstream) and one in the adapter-reload path. **`LooseValue`
+  + the `eslint-disable` removed from `useScheduleTemplates.ts`.**
+
+### Sprint 3b — `useEventMutations.ts` + `useScheduleMutations.ts` + tighten `EngineOpInput`
+
+- Replace the remaining `LooseValue` in `useEventMutations.ts` /
+  `useScheduleMutations.ts` with `MutationEventInput`, `NormalizedEvent`,
+  `EmployeeRecord`, `OwnerConfig`, etc.
 - Tighten `EngineOpInput` toward `EngineOperation` (reconcile `resource` vs
   `resourceId` in patches, the extra op sources, `Date | string` starts) — either
   widen the target types or fix the literal. No new `any`.
 - Where the public/engine types are genuinely too strict for what callers pass,
   loosen them (`?: T | undefined`) rather than scattering `as`.
-- **Remove `type LooseValue = any` + the `eslint-disable` from these three
-  files.**
+- **Remove `type LooseValue = any` + the `eslint-disable` from these two files.**
 
 ### Sprint 4 — `CalendarViewGrid.tsx`
 

--- a/docs/sprints/596-typing-the-engine-op-event-seam.md
+++ b/docs/sprints/596-typing-the-engine-op-event-seam.md
@@ -99,14 +99,25 @@ the engine-op/result/event types and adds:
   `WorksCalendarEvent` — it uses `null` where the public type uses `undefined`).
   **`LooseValue` removed from `useEventMutations.ts`.**
 
-### Sprint 3c — `useScheduleMutations.ts`
+### Sprint 3c — `useScheduleMutations.ts` ✅
 
-- Replace the remaining `LooseValue` in `useScheduleMutations.ts` with
-  `MutationEventInput`, `NormalizedEvent`, `EmployeeRecord`, `EmployeeId`,
-  `EmployeeActionInput`, `OwnerConfig`, etc.
-- Where the public/engine types are genuinely too strict for what callers pass,
-  loosen them (`?: T | undefined`) rather than scattering `as`.
-- **Remove `type LooseValue = any` + the `eslint-disable` from this file.**
+- `useScheduleMutations` types its event params with `NormalizedEvent` (the
+  shift-status / coverage-assign handlers) and `MutationEventInput` (the
+  availability / schedule-editor save handlers), `expandedEvents` with
+  `NormalizedEvent[]`, `configuredEmployees` with `EmployeeRecord[]`, the
+  callbacks with `EmployeeId` / `EmployeeActionInput` / `AvailabilitySavePayload`
+  / `WorksCalendarEvent`, `ownerConfig` with `OwnerConfig`, and the modal-state
+  setters with `Record<string, unknown> | null`.
+- `ShiftEventLike` / `OverlapEventLike` (the "loose event" types in
+  `core/scheduleMutations.ts` / `core/scheduleOverlap.ts`) get `_eventId?: string
+  | undefined` so a `NormalizedEvent` assigns to them under
+  `exactOptionalPropertyTypes` — a small loosening of "...Like" types that are
+  meant to accept normalised events.
+- `Date > Date` comparisons replaced with `.getTime()`; a couple of boundary
+  casts (the `actionPayload.sourceShift` bag, the saved payload → host
+  availability bag, `meta` index reads).
+- **`LooseValue` + the `eslint-disable` removed from `useScheduleMutations.ts`.**
+  All three mutation hooks are now `LooseValue`-free.
 
 > `EngineOpInput` keeps `event` / `patch` as `unknown` (not tightened toward
 > `EngineOperation`) — that's not required by the "done when" and the loose op

--- a/src/core/scheduleMutations.ts
+++ b/src/core/scheduleMutations.ts
@@ -4,7 +4,8 @@ type MutableMeta = Record<string, unknown>;
 
 type ShiftEventLike = {
   id?: string;
-  _eventId?: string;
+  // `| undefined` so NormalizedEvent (whose `_eventId?: string | undefined`) assigns under exactOptionalPropertyTypes.
+  _eventId?: string | undefined;
   title?: string;
   start?: unknown;
   end?: unknown;

--- a/src/core/scheduleOverlap.ts
+++ b/src/core/scheduleOverlap.ts
@@ -33,7 +33,8 @@ export function intervalsOverlap(aStart: Date, aEnd: Date, bStart: Date, bEnd: D
 
 type OverlapEventLike = {
   id?: string;
-  _eventId?: string;
+  // `| undefined` so NormalizedEvent (whose `_eventId?: string | undefined`) assigns under exactOptionalPropertyTypes.
+  _eventId?: string | undefined;
   resource?: unknown;
   employeeId?: unknown;
   start?: unknown;

--- a/src/hooks/useCalendarEngine.ts
+++ b/src/hooks/useCalendarEngine.ts
@@ -14,13 +14,25 @@ import { occurrenceToLegacy, toLegacyEvent } from '../core/engine/adapters/toLeg
 import type { ResourcePool }    from '../core/pools/resourcePoolSchema.ts';
 import type { OperationContext } from '../core/engine/validation/validationTypes';
 import type { AnnouncerRef }    from '../ui/ScreenReaderAnnouncer';
+import type { WorksCalendarEvent } from '../types/events';
+import type {
+  EngineOpInput,
+  EngineOperation,
+  EngineOpRunner,
+  GetSavedEventPayload,
+  OperationResult,
+  RecurringOpRunner,
+} from '../types/engineOps';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type AnyValue = any;
 
-function opAnnouncement(op: AnyValue): string {
+function opAnnouncement(op: EngineOpInput): string {
   switch (op.type) {
-    case 'create':       return `Event "${op.event?.title ?? 'Untitled'}" created.`;
+    case 'create': {
+      const title = (op.event as { title?: unknown } | null | undefined)?.title;
+      return `Event "${String(title ?? 'Untitled')}" created.`;
+    }
     case 'update':       return 'Event updated.';
     case 'delete':       return 'Event deleted.';
     case 'move':         return 'Event moved.';
@@ -70,20 +82,11 @@ export type UseCalendarEngineResult = {
   /** All master events that carry an approvalStage — unwindowed. */
   approvalRequestEvents: AnyValue[];
   /** Submit a mutation op through the engine, handling soft/hard violations. */
-  applyEngineOp: (op: AnyValue, onAccepted: AnyValue) => void;
+  applyEngineOp: EngineOpRunner;
   /** Wrap a mutation op with a recurring-scope dialog for recurring events. */
-  applyWithRecurringCheck: (
-    ev: AnyValue,
-    makeOp: (scope: string) => AnyValue,
-    onAccepted: AnyValue,
-    actionLabel: string,
-  ) => void;
+  applyWithRecurringCheck: RecurringOpRunner;
   /** Look up the post-mutation engine state for a given event id. */
-  getSavedEventPayload: (
-    eventId: AnyValue,
-    fallbackEvent?: AnyValue,
-    fallbackPatch?: AnyValue,
-  ) => AnyValue | null;
+  getSavedEventPayload: GetSavedEventPayload;
   pendingAlert: PendingAlert | null;
   setPendingAlert: (alert: PendingAlert | null) => void;
   recurringPrompt: RecurringPrompt | null;
@@ -183,45 +186,49 @@ export function useCalendarEngine({
   const [recurringPrompt, setRecurringPrompt] = useState<RecurringPrompt | null>(null);
 
   // ── getSavedEventPayload ──────────────────────────────────────────────────
-  const getSavedEventPayload = useCallback(
-    (eventId: AnyValue, fallbackEvent: AnyValue = null, fallbackPatch: AnyValue = null) => {
+  const getSavedEventPayload: GetSavedEventPayload = useCallback(
+    (eventId: unknown, fallbackEvent: unknown = null, fallbackPatch: unknown = null): WorksCalendarEvent | null => {
       const normalizedId = eventId == null ? '' : String(eventId);
       if (normalizedId) {
         const saved = engine.state.events.get(normalizedId);
-        if (saved) return toLegacyEvent(saved);
+        // Engine-adapter boundary: the legacy event shape is what host onEventSave handlers consume.
+        if (saved) return toLegacyEvent(saved) as unknown as WorksCalendarEvent;
       }
       if (!fallbackEvent) return null;
-      return fallbackPatch ? { ...fallbackEvent, ...fallbackPatch } : fallbackEvent;
+      const base = fallbackEvent as Record<string, unknown>;
+      return (fallbackPatch ? { ...base, ...(fallbackPatch as Record<string, unknown>) } : base) as unknown as WorksCalendarEvent;
     },
     [engine],
   );
 
   // ── applyEngineOp ─────────────────────────────────────────────────────────
-  const applyEngineOp = useCallback(
-    (op: AnyValue, onAccepted: AnyValue) => {
+  const applyEngineOp: EngineOpRunner = useCallback(
+    (op: EngineOpInput, onAccepted?: (result: OperationResult) => void) => {
       const ctx = opCtxRef.current;
       if (ctx === null) return;
 
       const preSnap = undoManager.captureSnapshot();
-      const result  = engine.applyMutation(op, ctx);
+      // Engine-adapter boundary: the loose hook-built op is normalised + validated by the engine.
+      const engineOp = op as unknown as EngineOperation;
+      const result  = engine.applyMutation(engineOp, ctx);
 
       if (result.status === 'accepted' || result.status === 'accepted-with-warnings') {
         undoManager.record(preSnap, op.type);
         announcerRef.current?.announce(opAnnouncement(op));
         engineMutationPendingRef.current = Math.max(1, result.changes.length);
-        onAccepted(result);
+        onAccepted?.(result);
 
       } else if (result.status === 'pending-confirmation') {
         setPendingAlert({
           violations: result.validation.violations,
           isHard: false,
           onConfirm: () => {
-            const confirmed = engine.applyMutation(op, ctx, { overrideSoftViolations: true });
+            const confirmed = engine.applyMutation(engineOp, ctx, { overrideSoftViolations: true });
             if (confirmed.status === 'accepted' || confirmed.status === 'accepted-with-warnings') {
               undoManager.record(preSnap, op.type);
               announcerRef.current?.announce(opAnnouncement(op));
               engineMutationPendingRef.current = Math.max(1, confirmed.changes.length);
-              onAccepted(confirmed);
+              onAccepted?.(confirmed);
             }
           },
         });
@@ -234,14 +241,15 @@ export function useCalendarEngine({
   );
 
   // ── applyWithRecurringCheck ───────────────────────────────────────────────
-  const applyWithRecurringCheck = useCallback(
+  const applyWithRecurringCheck: RecurringOpRunner = useCallback(
     (
-      ev: AnyValue,
-      makeOp: (scope: string) => AnyValue,
-      onAccepted: AnyValue,
+      ev: unknown,
+      makeOp: (scope: string) => EngineOpInput,
+      onAccepted: (result: OperationResult) => void,
       actionLabel: string,
     ) => {
-      if (!ev._recurring) {
+      const evObj = ev as { _recurring?: unknown; start?: Date | string | number | undefined };
+      if (!evObj._recurring) {
         applyEngineOp(makeOp('series'), onAccepted);
         return;
       }
@@ -253,7 +261,7 @@ export function useCalendarEngine({
             {
               ...makeOp(scope),
               scope,
-              occurrenceDate: ev.start instanceof Date ? ev.start : new Date(ev.start),
+              occurrenceDate: evObj.start instanceof Date ? evObj.start : new Date(evObj.start ?? ''),
             },
             onAccepted,
           );

--- a/src/hooks/useCalendarMutations.ts
+++ b/src/hooks/useCalendarMutations.ts
@@ -11,6 +11,7 @@ import type { AnnouncerRef } from '../ui/ScreenReaderAnnouncer';
 import type { NormalizedEvent, WorksCalendarEvent } from '../types/events';
 import type { WorksCalendarProps, CalendarRole, EmployeeRecord } from '../WorksCalendar.types';
 import type { UseModalStateReturn } from './useModalState';
+import type { ScheduleTemplateV1 } from '../api/v1/templates';
 
 export interface UseCalendarMutationsInput {
   // Templates
@@ -82,9 +83,11 @@ export function useCalendarMutations({
     buildSchedulePreview, handleScheduleInstantiate,
     handleCreateScheduleTemplate, handleDeleteScheduleTemplate,
   } = useScheduleTemplates({
-    scheduleTemplates: scheduleTemplates ?? [], scheduleInstantiationLimits, scheduleTemplateAdapter, onScheduleTemplateAnalytics,
+    // Host-supplied template blobs; shape-validated by canViewScheduleTemplate / instantiateScheduleTemplate.
+    scheduleTemplates: (scheduleTemplates ?? []) as unknown as ScheduleTemplateV1[],
+    scheduleInstantiationLimits, scheduleTemplateAdapter, onScheduleTemplateAnalytics,
     role, isOwner: ownerCfg.isOwner,
-    engine: engine as unknown as { state: { events: Map<string, unknown> } },
+    engine,
     ownerBusinessHours: ownerCfg.config?.['businessHours'],
     businessHours, blockedWindows: blockedWindows ?? [],
     applyEngineOp, getSavedEventPayload, onEventSave,

--- a/src/hooks/useEventMutations.ts
+++ b/src/hooks/useEventMutations.ts
@@ -7,6 +7,7 @@ import type { CalendarEngine } from '../core/engine/CalendarEngine';
 import { createId } from '../core/createId';
 import type { WorksCalendarEvent, NormalizedEvent } from '../types/events';
 import type { OwnerConfig } from '../WorksCalendar.types';
+import type { FormEventDraft, InlineEditTarget } from './useModalState';
 import { isCreatedChange } from '../types/engineOps';
 import type {
   EngineOpInput,
@@ -43,9 +44,9 @@ type UseEventMutationsParams = {
   onEventDelete?: ((eventId: string) => void) | undefined;
   onEventGroupChange?: ((event: WorksCalendarEvent, patch: Record<string, unknown>) => void) | undefined;
   ownerConfig: OwnerConfig;
-  inlineEditTarget: { event: MutationEventInput; x: number; y: number } | null;
-  setFormEvent: (ev: MutationEventInput | null) => void;
-  setInlineEditTarget: (target: { event: MutationEventInput; x: number; y: number } | null) => void;
+  inlineEditTarget: InlineEditTarget | null;
+  setFormEvent: (ev: FormEventDraft | null) => void;
+  setInlineEditTarget: (target: InlineEditTarget | null) => void;
 };
 
 export function useEventMutations({

--- a/src/hooks/useEventMutations.ts
+++ b/src/hooks/useEventMutations.ts
@@ -2,29 +2,50 @@ import { useCallback } from 'react';
 import { evaluateConflicts } from '../core/conflictEngine';
 import type { ConflictEvent, ConflictRule } from '../core/conflictEngine';
 import { occurrenceToLegacy, toLegacyEvent } from '../core/engine/adapters/toLegacyEvents';
+import type { EngineEvent } from '../core/engine/schema/eventSchema';
+import type { CalendarEngine } from '../core/engine/CalendarEngine';
 import { createId } from '../core/createId';
+import type { WorksCalendarEvent, NormalizedEvent } from '../types/events';
+import type { OwnerConfig } from '../WorksCalendar.types';
 import { isCreatedChange } from '../types/engineOps';
-import type { EngineOpInput, EngineOpRunner, RecurringOpRunner, GetSavedEventPayload } from '../types/engineOps';
+import type {
+  EngineOpInput,
+  EngineOpRunner,
+  RecurringOpRunner,
+  GetSavedEventPayload,
+  MutationEventInput,
+} from '../types/engineOps';
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-type LooseValue = any;
+/** A NormalizedEvent isn't assignable to WorksCalendarEvent (it uses `null`
+ *  where the public type uses `undefined`); the engine-adapter output is what
+ *  host `onEventSave` handlers actually consume. */
+function asSavedEvent(ev: EngineEvent): WorksCalendarEvent {
+  return toLegacyEvent(ev) as unknown as WorksCalendarEvent;
+}
+
+/** Patch applied by the inline event editor. */
+export interface InlineEventPatch {
+  title?: string | undefined;
+  color?: string | undefined;
+  meta?: Record<string, unknown> | undefined;
+}
 
 type UseEventMutationsParams = {
   applyEngineOp: EngineOpRunner;
   applyWithRecurringCheck: RecurringOpRunner;
   getSavedEventPayload: GetSavedEventPayload;
-  engine: LooseValue;
+  engine: CalendarEngine;
   engineVer: number;
-  expandedEvents: LooseValue[];
-  onEventSave?: ((event: LooseValue) => void) | undefined;
-  onEventMove?: ((event: LooseValue, newStart: Date, newEnd: Date) => void) | undefined;
-  onEventResize?: ((event: LooseValue, newStart: Date, newEnd: Date) => void) | undefined;
+  expandedEvents: NormalizedEvent[];
+  onEventSave?: ((event: WorksCalendarEvent) => void) | undefined;
+  onEventMove?: ((event: WorksCalendarEvent, newStart: Date, newEnd: Date) => void) | undefined;
+  onEventResize?: ((event: WorksCalendarEvent, newStart: Date, newEnd: Date) => void) | undefined;
   onEventDelete?: ((eventId: string) => void) | undefined;
-  onEventGroupChange?: ((event: LooseValue, patch: LooseValue) => void) | undefined;
-  ownerConfig: LooseValue;
-  inlineEditTarget: { event: LooseValue; x: number; y: number } | null;
-  setFormEvent: (ev: LooseValue) => void;
-  setInlineEditTarget: (target: LooseValue) => void;
+  onEventGroupChange?: ((event: WorksCalendarEvent, patch: Record<string, unknown>) => void) | undefined;
+  ownerConfig: OwnerConfig;
+  inlineEditTarget: { event: MutationEventInput; x: number; y: number } | null;
+  setFormEvent: (ev: MutationEventInput | null) => void;
+  setInlineEditTarget: (target: { event: MutationEventInput; x: number; y: number } | null) => void;
 };
 
 export function useEventMutations({
@@ -32,7 +53,7 @@ export function useEventMutations({
   applyWithRecurringCheck,
   getSavedEventPayload,
   engine,
-  engineVer,  
+  engineVer,
   expandedEvents,
   onEventSave,
   onEventMove,
@@ -58,14 +79,15 @@ export function useEventMutations({
   // into another month would miss every conflict outside the visible window.
   // Instead, re-expand over a window that hugs the proposed event's interval,
   // padded by the largest min-rest rule.
-  const checkEventConflicts = useCallback((proposed: LooseValue) => {
-    const conflictsCfg = ownerConfig?.['conflicts'] ?? {};
-    const rules = (conflictsCfg.rules ?? []) as ConflictRule[];
-    const enabled = conflictsCfg.enabled !== false;
+  const checkEventConflicts = useCallback((proposed: MutationEventInput) => {
+    const conflictsCfg = ownerConfig.conflicts;
+    // Host-supplied rule blobs from OwnerConfig; shape-validated by evaluateConflicts.
+    const rules = (conflictsCfg?.rules ?? []) as unknown as ConflictRule[];
+    const enabled = conflictsCfg?.enabled !== false;
     if (!enabled || rules.length === 0) return null;
 
-    const proposedStart = proposed.start instanceof Date ? proposed.start : new Date(proposed.start);
-    const proposedEnd   = proposed.end   instanceof Date ? proposed.end   : new Date(proposed.end);
+    const proposedStart = proposed.start instanceof Date ? proposed.start : new Date(proposed.start ?? '');
+    const proposedEnd   = proposed.end   instanceof Date ? proposed.end   : new Date(proposed.end ?? '');
     if (Number.isNaN(proposedStart.getTime()) || Number.isNaN(proposedEnd.getTime())) {
       return null;
     }
@@ -83,16 +105,17 @@ export function useEventMutations({
     const events = engine.getOccurrencesInRange(windowStart, windowEnd).map(occurrenceToLegacy);
 
     return evaluateConflicts({
-      proposed: proposed as ConflictEvent,
+      // Pre-save check: the form draft / live occurrences are treated as ConflictEvents.
+      proposed: proposed as unknown as ConflictEvent,
       events:   events as unknown as ConflictEvent[],
       rules,
       enabled,
     });
   }, [ownerConfig, engine, engineVer]);
 
-  const handleEventSave = useCallback((rawEv: LooseValue) => {
-    const newStart = rawEv.start instanceof Date ? rawEv.start : new Date(rawEv.start);
-    const newEnd   = rawEv.end   instanceof Date ? rawEv.end   : new Date(rawEv.end);
+  const handleEventSave = useCallback((rawEv: MutationEventInput) => {
+    const newStart = rawEv.start instanceof Date ? rawEv.start : new Date(rawEv.start ?? '');
+    const newEnd   = rawEv.end   instanceof Date ? rawEv.end   : new Date(rawEv.end ?? '');
     const recurringMasterId = rawEv._eventId ?? rawEv._seriesId ?? null;
     const eventId  = recurringMasterId ?? (rawEv.id ? String(rawEv.id) : null);
 
@@ -154,9 +177,9 @@ export function useEventMutations({
         if (result.changes.length > 1) {
           result.changes.forEach((change) => {
             if (change.type === 'created') {
-              onEventSave?.(toLegacyEvent(change.event) as LooseValue);
+              onEventSave?.(asSavedEvent(change.event));
             } else if (change.type === 'updated') {
-              onEventSave?.(toLegacyEvent(change.after) as LooseValue);
+              onEventSave?.(asSavedEvent(change.after));
             }
           });
         } else {
@@ -169,7 +192,7 @@ export function useEventMutations({
     );
   }, [applyEngineOp, applyWithRecurringCheck, getSavedEventPayload, onEventSave, engine, setFormEvent]);
 
-  const handleEventMove = useCallback((ev: LooseValue, newStart: LooseValue, newEnd: LooseValue) => {
+  const handleEventMove = useCallback((ev: NormalizedEvent, newStart: Date, newEnd: Date) => {
     const raw = ev._raw ?? ev;
     const id  = ev._eventId ?? String(ev.id);
     applyWithRecurringCheck(
@@ -177,11 +200,11 @@ export function useEventMutations({
       (_scope) => ({ type: 'move', id, newStart, newEnd, source: 'drag' }),
       (result) => {
         if (onEventMove) {
-          onEventMove(ev, newStart, newEnd);
+          onEventMove(ev as unknown as WorksCalendarEvent, newStart, newEnd);
         } else if (result.changes.length > 1) {
           result.changes.forEach((change) => {
-            if (change.type === 'created') onEventSave?.(toLegacyEvent(change.event) as LooseValue);
-            else if (change.type === 'updated') onEventSave?.(toLegacyEvent(change.after) as LooseValue);
+            if (change.type === 'created') onEventSave?.(asSavedEvent(change.event));
+            else if (change.type === 'updated') onEventSave?.(asSavedEvent(change.after));
           });
         } else {
           const savedPayload = getSavedEventPayload(id, raw, { start: newStart, end: newEnd });
@@ -192,7 +215,7 @@ export function useEventMutations({
     );
   }, [applyWithRecurringCheck, getSavedEventPayload, onEventMove, onEventSave]);
 
-  const handleEventResize = useCallback((ev: LooseValue, newStart: LooseValue, newEnd: LooseValue) => {
+  const handleEventResize = useCallback((ev: NormalizedEvent, newStart: Date, newEnd: Date) => {
     const raw = ev._raw ?? ev;
     const id  = ev._eventId ?? String(ev.id);
     applyWithRecurringCheck(
@@ -200,11 +223,11 @@ export function useEventMutations({
       (_scope) => ({ type: 'resize', id, newStart, newEnd, source: 'resize' }),
       (result) => {
         if (onEventResize) {
-          onEventResize(ev, newStart, newEnd);
+          onEventResize(ev as unknown as WorksCalendarEvent, newStart, newEnd);
         } else if (result.changes.length > 1) {
           result.changes.forEach((change) => {
-            if (change.type === 'created') onEventSave?.(toLegacyEvent(change.event) as LooseValue);
-            else if (change.type === 'updated') onEventSave?.(toLegacyEvent(change.after) as LooseValue);
+            if (change.type === 'created') onEventSave?.(asSavedEvent(change.event));
+            else if (change.type === 'updated') onEventSave?.(asSavedEvent(change.after));
           });
         } else {
           const savedPayload = getSavedEventPayload(id, raw, { start: newStart, end: newEnd });
@@ -215,31 +238,31 @@ export function useEventMutations({
     );
   }, [applyWithRecurringCheck, getSavedEventPayload, onEventResize, onEventSave]);
 
-  const handleEventGroupChange = useCallback((ev: LooseValue, patch: LooseValue) => {
+  const handleEventGroupChange = useCallback((ev: NormalizedEvent, patch: Record<string, unknown>) => {
     if (!patch || typeof patch !== 'object') return;
     const raw = ev._raw ?? ev;
     const id  = ev._eventId ?? String(ev.id);
     applyEngineOp(
       { type: 'group-change', id, patch, source: 'drag' },
       () => {
-        if (onEventGroupChange) onEventGroupChange(ev, patch);
+        if (onEventGroupChange) onEventGroupChange(ev as unknown as WorksCalendarEvent, patch);
         else emitEventSave(id, raw, patch);
       },
     );
   }, [applyEngineOp, emitEventSave, onEventGroupChange]);
 
-  const handleEventDelete = useCallback((id: LooseValue) => {
-    const ev      = expandedEvents.find((e: LooseValue) => String(e.id) === String(id)) ?? { id };
-    const eventId = ev._eventId ?? String(id);
+  const handleEventDelete = useCallback((id: string) => {
+    const found   = expandedEvents.find(e => String(e.id) === String(id));
+    const eventId = found?._eventId ?? String(id);
     applyWithRecurringCheck(
-      ev,
+      found ?? { id },
       (_scope) => ({ type: 'delete', id: eventId, source: 'form' }),
       () => { onEventDelete?.(id); setFormEvent(null); },
       'Delete',
     );
   }, [applyWithRecurringCheck, expandedEvents, onEventDelete, setFormEvent]);
 
-  const handleInlineSave = useCallback((patch: LooseValue) => {
+  const handleInlineSave = useCallback((patch: InlineEventPatch) => {
     const ev = inlineEditTarget?.event;
     if (!ev) return;
     const eventId = ev._eventId ?? String(ev.id);

--- a/src/hooks/useEventMutations.ts
+++ b/src/hooks/useEventMutations.ts
@@ -3,19 +3,16 @@ import { evaluateConflicts } from '../core/conflictEngine';
 import type { ConflictEvent, ConflictRule } from '../core/conflictEngine';
 import { occurrenceToLegacy, toLegacyEvent } from '../core/engine/adapters/toLegacyEvents';
 import { createId } from '../core/createId';
+import { isCreatedChange } from '../types/engineOps';
+import type { EngineOpInput, EngineOpRunner, RecurringOpRunner, GetSavedEventPayload } from '../types/engineOps';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type LooseValue = any;
 
 type UseEventMutationsParams = {
-  applyEngineOp: (op: LooseValue, callback?: (result: LooseValue) => void) => void;
-  applyWithRecurringCheck: (
-    ev: LooseValue,
-    opFactory: (scope: LooseValue) => LooseValue,
-    callback: (result: LooseValue) => void,
-    actionLabel: string,
-  ) => void;
-  getSavedEventPayload: (id: LooseValue, fallback?: LooseValue, patch?: LooseValue) => LooseValue;
+  applyEngineOp: EngineOpRunner;
+  applyWithRecurringCheck: RecurringOpRunner;
+  getSavedEventPayload: GetSavedEventPayload;
   engine: LooseValue;
   engineVer: number;
   expandedEvents: LooseValue[];
@@ -47,7 +44,7 @@ export function useEventMutations({
   setFormEvent,
   setInlineEditTarget,
 }: UseEventMutationsParams) {
-  const emitEventSave = useCallback((eventId: LooseValue, fallbackEvent: LooseValue = null, fallbackPatch: LooseValue = null) => {
+  const emitEventSave = useCallback((eventId: unknown, fallbackEvent: unknown = null, fallbackPatch: unknown = null) => {
     const savedPayload = getSavedEventPayload(eventId, fallbackEvent, fallbackPatch);
     if (savedPayload) onEventSave?.(savedPayload);
   }, [getSavedEventPayload, onEventSave]);
@@ -106,7 +103,7 @@ export function useEventMutations({
 
     if (!eventId) {
       const createdId = String(rawEv.id ?? createId('event'));
-      const op = {
+      const op: EngineOpInput = {
         type:  'create',
         event: {
           id:             createdId,
@@ -125,9 +122,9 @@ export function useEventMutations({
         },
         source: 'form',
       };
-      applyEngineOp(op, (result: LooseValue) => {
-        const createdChange = result?.changes?.find((c: LooseValue) => c.type === 'created');
-        const engineId = createdChange?.event?.id ?? createdId;
+      applyEngineOp(op, (result) => {
+        const createdChange = result.changes.find(isCreatedChange);
+        const engineId = createdChange?.event.id ?? createdId;
         const savedPayload = getSavedEventPayload(engineId, rawEv, { id: engineId });
         if (savedPayload) onEventSave?.(savedPayload);
         setFormEvent(null);
@@ -137,7 +134,7 @@ export function useEventMutations({
 
     applyWithRecurringCheck(
       rawEv,
-      (_scope: LooseValue) => ({
+      (_scope) => ({
         type:  'update',
         id:    eventId,
         patch: {
@@ -153,9 +150,9 @@ export function useEventMutations({
         },
         source: 'form',
       }),
-      (result: LooseValue) => {
-        if (result?.changes?.length > 1) {
-          result.changes.forEach((change: LooseValue) => {
+      (result) => {
+        if (result.changes.length > 1) {
+          result.changes.forEach((change) => {
             if (change.type === 'created') {
               onEventSave?.(toLegacyEvent(change.event) as LooseValue);
             } else if (change.type === 'updated') {
@@ -177,12 +174,12 @@ export function useEventMutations({
     const id  = ev._eventId ?? String(ev.id);
     applyWithRecurringCheck(
       ev,
-      (_scope: LooseValue) => ({ type: 'move', id, newStart, newEnd, source: 'drag' }),
-      (result: LooseValue) => {
+      (_scope) => ({ type: 'move', id, newStart, newEnd, source: 'drag' }),
+      (result) => {
         if (onEventMove) {
           onEventMove(ev, newStart, newEnd);
-        } else if (result?.changes?.length > 1) {
-          result.changes.forEach((change: LooseValue) => {
+        } else if (result.changes.length > 1) {
+          result.changes.forEach((change) => {
             if (change.type === 'created') onEventSave?.(toLegacyEvent(change.event) as LooseValue);
             else if (change.type === 'updated') onEventSave?.(toLegacyEvent(change.after) as LooseValue);
           });
@@ -200,12 +197,12 @@ export function useEventMutations({
     const id  = ev._eventId ?? String(ev.id);
     applyWithRecurringCheck(
       ev,
-      (_scope: LooseValue) => ({ type: 'resize', id, newStart, newEnd, source: 'resize' }),
-      (result: LooseValue) => {
+      (_scope) => ({ type: 'resize', id, newStart, newEnd, source: 'resize' }),
+      (result) => {
         if (onEventResize) {
           onEventResize(ev, newStart, newEnd);
-        } else if (result?.changes?.length > 1) {
-          result.changes.forEach((change: LooseValue) => {
+        } else if (result.changes.length > 1) {
+          result.changes.forEach((change) => {
             if (change.type === 'created') onEventSave?.(toLegacyEvent(change.event) as LooseValue);
             else if (change.type === 'updated') onEventSave?.(toLegacyEvent(change.after) as LooseValue);
           });
@@ -236,7 +233,7 @@ export function useEventMutations({
     const eventId = ev._eventId ?? String(id);
     applyWithRecurringCheck(
       ev,
-      (_scope: LooseValue) => ({ type: 'delete', id: eventId, source: 'form' }),
+      (_scope) => ({ type: 'delete', id: eventId, source: 'form' }),
       () => { onEventDelete?.(id); setFormEvent(null); },
       'Delete',
     );

--- a/src/hooks/useModalState.ts
+++ b/src/hooks/useModalState.ts
@@ -39,7 +39,8 @@ export interface AvailabilityModalState {
 export interface ScheduleEditorModalState {
   emp: EmployeeRecord;
   start: Date;
-  end: Date;
+  /** Omitted when launched from the employee "schedule" action (the form picks an end). */
+  end?: Date | undefined;
 }
 
 export interface UseModalStateReturn {

--- a/src/hooks/useScheduleMutations.ts
+++ b/src/hooks/useScheduleMutations.ts
@@ -18,6 +18,7 @@ import type {
   AvailabilitySavePayload,
   OwnerConfig,
 } from '../WorksCalendar.types';
+import type { AvailabilityModalState, ScheduleEditorModalState } from './useModalState';
 import type { EngineOpInput, EngineOpRunner, EmitEventSave, GetSavedEventPayload, MutationEventInput } from '../types/engineOps';
 
 type UseScheduleMutationsParams = {
@@ -31,8 +32,8 @@ type UseScheduleMutationsParams = {
   onScheduleSave?: ((payload: WorksCalendarEvent) => void) | undefined;
   onEmployeeAction?: ((employeeId: EmployeeId, action: EmployeeActionInput) => void) | undefined;
   ownerConfig: OwnerConfig;
-  setAvailabilityState: (state: Record<string, unknown> | null) => void;
-  setScheduleEditorState: (state: Record<string, unknown> | null) => void;
+  setAvailabilityState: (state: AvailabilityModalState | null) => void;
+  setScheduleEditorState: (state: ScheduleEditorModalState | null) => void;
 };
 
 export function useScheduleMutations({
@@ -202,7 +203,7 @@ export function useScheduleMutations({
     const sourceShift = actionPayload['sourceShift'] as { start?: unknown; end?: unknown; allDay?: unknown; meta?: Record<string, unknown> } | null | undefined;
     const AVAILABILITY_ACTIONS = new Set(['pto', 'unavailable', 'availability']);
     if (AVAILABILITY_ACTIONS.has(action)) {
-      const initialEvent = action === 'availability'
+      const initialEvent: NormalizedEvent | null = action === 'availability'
         ? expandedEvents
           .filter((ev) => {
             const e: { kind?: unknown; category?: unknown; resource?: unknown; resourceId?: unknown; employeeId?: unknown; meta?: Record<string, unknown> } = ev;
@@ -218,13 +219,14 @@ export function useScheduleMutations({
           })
           .map((ev) => ({ ...ev, id: ev._eventId ?? ev.id }))[0] ?? null
         : sourceShift
-          ? {
+          // Seed object for the AvailabilityForm — not a full NormalizedEvent.
+          ? ({
             title: action === 'pto' ? 'PTO' : 'Unavailable',
             start: sourceShift.start,
             end: sourceShift.end,
             allDay: sourceShift.allDay ?? true,
             meta: sourceShift.meta ?? {},
-          }
+          } as unknown as NormalizedEvent)
           : null;
       const initialStart = sourceShift?.start
         ? new Date(sourceShift.start as string | number | Date)

--- a/src/hooks/useScheduleMutations.ts
+++ b/src/hooks/useScheduleMutations.ts
@@ -10,14 +10,15 @@ import {
 import { detectShiftConflicts, buildOpenShiftEvent } from '../core/scheduleOverlap';
 import { normalizeScheduleKind, SCHEDULE_KINDS } from '../core/scheduleModel';
 import { createId } from '../core/createId';
+import type { EngineOpInput, EngineOpRunner, EmitEventSave, GetSavedEventPayload } from '../types/engineOps';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type LooseValue = any;
 
 type UseScheduleMutationsParams = {
-  applyEngineOp: (op: LooseValue, callback?: (result: LooseValue) => void) => void;
-  emitEventSave: (eventId: LooseValue, fallbackEvent?: LooseValue, fallbackPatch?: LooseValue) => void;
-  getSavedEventPayload: (id: LooseValue, fallback?: LooseValue, patch?: LooseValue) => LooseValue;
+  applyEngineOp: EngineOpRunner;
+  emitEventSave: EmitEventSave;
+  getSavedEventPayload: GetSavedEventPayload;
   expandedEvents: LooseValue[];
   configuredEmployees: LooseValue[];
   onEventDelete?: ((eventId: string) => void) | undefined;
@@ -238,7 +239,7 @@ export function useScheduleMutations({
     const availabilityId = existingAvailability
       ? String(existingAvailability._eventId ?? existingAvailability.id)
       : String(availEv.id ?? createId('avail'));
-    const saveOp = existingAvailability
+    const saveOp: EngineOpInput = existingAvailability
       ? {
         type: 'update',
         id: availabilityId,

--- a/src/hooks/useScheduleMutations.ts
+++ b/src/hooks/useScheduleMutations.ts
@@ -10,24 +10,29 @@ import {
 import { detectShiftConflicts, buildOpenShiftEvent } from '../core/scheduleOverlap';
 import { normalizeScheduleKind, SCHEDULE_KINDS } from '../core/scheduleModel';
 import { createId } from '../core/createId';
-import type { EngineOpInput, EngineOpRunner, EmitEventSave, GetSavedEventPayload } from '../types/engineOps';
-
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-type LooseValue = any;
+import type { NormalizedEvent, WorksCalendarEvent } from '../types/events';
+import type {
+  EmployeeRecord,
+  EmployeeId,
+  EmployeeActionInput,
+  AvailabilitySavePayload,
+  OwnerConfig,
+} from '../WorksCalendar.types';
+import type { EngineOpInput, EngineOpRunner, EmitEventSave, GetSavedEventPayload, MutationEventInput } from '../types/engineOps';
 
 type UseScheduleMutationsParams = {
   applyEngineOp: EngineOpRunner;
   emitEventSave: EmitEventSave;
   getSavedEventPayload: GetSavedEventPayload;
-  expandedEvents: LooseValue[];
-  configuredEmployees: LooseValue[];
+  expandedEvents: NormalizedEvent[];
+  configuredEmployees: EmployeeRecord[];
   onEventDelete?: ((eventId: string) => void) | undefined;
-  onAvailabilitySave?: ((payload: LooseValue) => void) | undefined;
-  onScheduleSave?: ((payload: LooseValue) => void) | undefined;
-  onEmployeeAction?: ((employeeId: LooseValue, action: LooseValue) => void) | undefined;
-  ownerConfig: LooseValue;
-  setAvailabilityState: (state: LooseValue) => void;
-  setScheduleEditorState: (state: LooseValue) => void;
+  onAvailabilitySave?: ((payload: AvailabilitySavePayload) => void) | undefined;
+  onScheduleSave?: ((payload: WorksCalendarEvent) => void) | undefined;
+  onEmployeeAction?: ((employeeId: EmployeeId, action: EmployeeActionInput) => void) | undefined;
+  ownerConfig: OwnerConfig;
+  setAvailabilityState: (state: Record<string, unknown> | null) => void;
+  setScheduleEditorState: (state: Record<string, unknown> | null) => void;
 };
 
 export function useScheduleMutations({
@@ -44,7 +49,7 @@ export function useScheduleMutations({
   setAvailabilityState,
   setScheduleEditorState,
 }: UseScheduleMutationsParams) {
-  const handleShiftStatusChange = useCallback((ev: LooseValue, status: LooseValue) => {
+  const handleShiftStatusChange = useCallback((ev: NormalizedEvent, status: string | null | undefined) => {
     const eventId = resolveEventId(ev);
     if (!eventId) return;
     const linkedOpenShifts = findLinkedOpenShifts(expandedEvents, ev);
@@ -72,7 +77,7 @@ export function useScheduleMutations({
     }
   }, [applyEngineOp, emitEventSave, expandedEvents, onEventDelete]);
 
-  const handleCoverageAssign = useCallback((ev: LooseValue, coveringEmployeeId: LooseValue) => {
+  const handleCoverageAssign = useCallback((ev: NormalizedEvent, coveringEmployeeId: string | number | null | undefined) => {
     const eventId = resolveEventId(ev);
     if (!eventId) return;
     const normalizedCoveringEmployeeId = String(coveringEmployeeId ?? '');
@@ -82,7 +87,7 @@ export function useScheduleMutations({
     const mirroredCoverage = findLinkedMirroredCoverage(expandedEvents, ev);
 
     if (!normalizedCoveringEmployeeId) {
-      const clearedMeta = { ...(ev.meta ?? {}), coveredBy: null as LooseValue };
+      const clearedMeta = { ...ev.meta, coveredBy: null };
       applyEngineOp(
         { type: 'update', id: eventId, patch: { meta: clearedMeta }, source: 'api' },
         () => emitEventSave(eventId, ev, { meta: clearedMeta }),
@@ -93,7 +98,7 @@ export function useScheduleMutations({
         if (openId) {
           const openMeta = {
             ...(primaryOpenShift.meta ?? {}),
-            coveredBy: null as LooseValue,
+            coveredBy: null,
             status: 'open',
           };
           applyEngineOp(
@@ -150,15 +155,15 @@ export function useScheduleMutations({
     // 3. Create or update the mirrored on-call event on the covering employee's row.
     //    Clamp to the PTO request window (meta.requestStart/End) when available so
     //    the coverage bar only spans the days actually needing coverage.
-    const onCallCat = ownerConfig?.['onCallCategory'] ?? 'on-call';
+    const onCallCat = ownerConfig.onCallCategory ?? 'on-call';
     const shiftStart = ev.start instanceof Date ? ev.start : new Date(ev.start);
     const shiftEnd   = ev.end   instanceof Date ? ev.end   : new Date(ev.end);
-    const requestStart = ev.meta?.requestStart ? new Date(ev.meta.requestStart) : shiftStart;
-    const requestEnd   = ev.meta?.requestEnd   ? new Date(ev.meta.requestEnd)   : shiftEnd;
-    const mirrorStart = requestStart > shiftStart ? requestStart : shiftStart;
-    const mirrorEnd   = requestEnd   < shiftEnd   ? requestEnd   : shiftEnd;
+    const requestStart = ev.meta['requestStart'] ? new Date(ev.meta['requestStart'] as string | number | Date) : shiftStart;
+    const requestEnd   = ev.meta['requestEnd']   ? new Date(ev.meta['requestEnd']   as string | number | Date) : shiftEnd;
+    const mirrorStart = requestStart.getTime() > shiftStart.getTime() ? requestStart : shiftStart;
+    const mirrorEnd   = requestEnd.getTime()   < shiftEnd.getTime()   ? requestEnd   : shiftEnd;
     const mirroredPatch = {
-      title:    `Covering: ${ev.title ?? 'Shift'}`,
+      title:    `Covering: ${ev.title}`,
       start:    mirrorStart,
       end:      mirrorEnd,
       category: onCallCat,
@@ -166,7 +171,7 @@ export function useScheduleMutations({
       meta: {
         kind:              SCHEDULE_KINDS.COVERING,
         sourceShiftId:     eventId,
-        coveredEmployeeId: String(ev.resource ?? ev.employeeId ?? ''),
+        coveredEmployeeId: String((ev.resource ?? (ev as { employeeId?: unknown }).employeeId) ?? ''),
       },
     };
     const existingMirror = mirroredCoverage[0];
@@ -187,54 +192,58 @@ export function useScheduleMutations({
     }
   }, [applyEngineOp, emitEventSave, expandedEvents, onEventDelete, ownerConfig]);
 
-  const handleEmployeeAction = useCallback((empId: LooseValue, actionInput: LooseValue) => {
-    const emp = configuredEmployees.find((e: LooseValue) => String(e.id) === String(empId)) ?? { id: empId, name: empId };
-    const actionPayload = typeof actionInput === 'string'
+  const handleEmployeeAction = useCallback((empId: EmployeeId, actionInput: string | EmployeeActionInput) => {
+    const emp = configuredEmployees.find(e => String(e.id) === String(empId)) ?? { id: empId, name: String(empId) };
+    const actionPayload: EmployeeActionInput = typeof actionInput === 'string'
       ? { type: actionInput }
       : (actionInput ?? {});
     const action = actionPayload.type;
     if (!action) return;
+    const sourceShift = actionPayload['sourceShift'] as { start?: unknown; end?: unknown; allDay?: unknown; meta?: Record<string, unknown> } | null | undefined;
     const AVAILABILITY_ACTIONS = new Set(['pto', 'unavailable', 'availability']);
     if (AVAILABILITY_ACTIONS.has(action)) {
       const initialEvent = action === 'availability'
         ? expandedEvents
-          .filter((ev: LooseValue) => {
-            const evKind = normalizeScheduleKind(ev?.kind ?? ev?.meta?.kind);
-            const evCat  = String(ev?.category ?? '').toLowerCase();
-            const resourceId = String(ev?.resource ?? ev?.resourceId ?? ev?.employeeId ?? '');
+          .filter((ev) => {
+            const e: { kind?: unknown; category?: unknown; resource?: unknown; resourceId?: unknown; employeeId?: unknown; meta?: Record<string, unknown> } = ev;
+            const evKind = normalizeScheduleKind(e.kind ?? e.meta?.['kind']);
+            const evCat  = String(e.category ?? '').toLowerCase();
+            const resourceId = String((e.resource ?? e.resourceId ?? e.employeeId) ?? '');
             return resourceId === String(empId) && (evKind === 'availability' || evCat === 'availability');
           })
-          .sort((a: LooseValue, b: LooseValue) => {
-            const aStart = a?.start ? new Date(a.start).getTime() : 0;
-            const bStart = b?.start ? new Date(b.start).getTime() : 0;
+          .sort((a, b) => {
+            const aStart = a.start ? a.start.getTime() : 0;
+            const bStart = b.start ? b.start.getTime() : 0;
             return bStart - aStart;
           })
-          .map((ev: LooseValue) => ({ ...ev, id: ev?._eventId ?? ev?.id }))[0] ?? null
-        : actionPayload.sourceShift
+          .map((ev) => ({ ...ev, id: ev._eventId ?? ev.id }))[0] ?? null
+        : sourceShift
           ? {
             title: action === 'pto' ? 'PTO' : 'Unavailable',
-            start: actionPayload.sourceShift.start,
-            end: actionPayload.sourceShift.end,
-            allDay: actionPayload.sourceShift.allDay ?? true,
-            meta: actionPayload.sourceShift.meta ?? {},
+            start: sourceShift.start,
+            end: sourceShift.end,
+            allDay: sourceShift.allDay ?? true,
+            meta: sourceShift.meta ?? {},
           }
           : null;
-      const initialStart = actionPayload.sourceShift?.start
-        ? new Date(actionPayload.sourceShift.start)
+      const initialStart = sourceShift?.start
+        ? new Date(sourceShift.start as string | number | Date)
         : new Date();
       setAvailabilityState({ emp, kind: action, start: initialStart, initialEvent });
     } else if (action === 'schedule') {
       setScheduleEditorState({ emp, start: new Date() });
     }
-    onEmployeeAction?.(empId, actionInput);
+    // The host callback contractually wants an object; passing the raw input through
+    // preserves legacy behaviour when a plain action string was supplied.
+    onEmployeeAction?.(empId, actionInput as EmployeeActionInput);
   }, [configuredEmployees, expandedEvents, onEmployeeAction, setAvailabilityState, setScheduleEditorState]);
 
   /** Save an availability/PTO event through the engine then notify the host.
    *  Also runs overlap detection: any uncovered shift overlapping the PTO/
    *  unavailable window automatically gets an open-shift event created. */
-  const handleAvailabilitySave = useCallback((availEv: LooseValue) => {
+  const handleAvailabilitySave = useCallback((availEv: MutationEventInput) => {
     const existingAvailability = expandedEvents.find(
-      (ev: LooseValue) => String(ev._eventId ?? ev.id) === String(availEv.id),
+      ev => String(ev._eventId ?? ev.id) === String(availEv.id),
     );
     const availabilityId = existingAvailability
       ? String(existingAvailability._eventId ?? existingAvailability.id)
@@ -260,16 +269,17 @@ export function useScheduleMutations({
 
     applyEngineOp(saveOp, () => {
       const savedPayload = getSavedEventPayload(availabilityId, availEv, { id: availabilityId });
-      if (savedPayload) onAvailabilitySave?.(savedPayload);
+      // The saved engine payload is forwarded to the host's looser availability-save bag.
+      if (savedPayload) onAvailabilitySave?.(savedPayload as unknown as AvailabilitySavePayload);
     });
 
-    const isLeave = availEv.kind === 'pto' || availEv.kind === 'unavailable';
-    if (isLeave) {
-      const onCallCat = ownerConfig?.['onCallCategory'] ?? 'on-call';
+    if (availEv.kind === 'pto' || availEv.kind === 'unavailable') {
+      const leaveKind = availEv.kind;
+      const onCallCat = ownerConfig.onCallCategory ?? 'on-call';
       const { conflictingEvents } = detectShiftConflicts({
-        employeeId:    String(availEv.employeeId ?? availEv.resource ?? ''),
-        requestStart:  availEv.start instanceof Date ? availEv.start : new Date(availEv.start),
-        requestEnd:    availEv.end   instanceof Date ? availEv.end   : new Date(availEv.end),
+        employeeId:    String((availEv.employeeId ?? availEv.resource) ?? ''),
+        requestStart:  availEv.start instanceof Date ? availEv.start : new Date(availEv.start ?? ''),
+        requestEnd:    availEv.end   instanceof Date ? availEv.end   : new Date(availEv.end ?? ''),
         allEvents:     expandedEvents,
         onCallCategory: onCallCat,
       });
@@ -283,10 +293,10 @@ export function useScheduleMutations({
           applyEngineOp({ type: 'delete', id: duplicateId, source: 'api' }, () => onEventDelete?.(duplicateId));
         });
 
-        const openShiftPatch = buildOpenShiftPatch(existingOpenShifts[0], shiftEv, availEv.kind);
+        const openShiftPatch = buildOpenShiftPatch(existingOpenShifts[0], shiftEv, leaveKind);
         const openShift = existingOpenShifts[0]
           ? { ...existingOpenShifts[0], ...openShiftPatch }
-          : buildOpenShiftEvent({ shiftEvent: shiftEv, reason: availEv.kind });
+          : buildOpenShiftEvent({ shiftEvent: shiftEv, reason: leaveKind });
 
         if (existingOpenShifts[0]) {
           const openId = resolveEventId(existingOpenShifts[0]);
@@ -305,9 +315,9 @@ export function useScheduleMutations({
 
         const updatedMeta = {
           ...(shiftEv.meta ?? {}),
-          shiftStatus:  availEv.kind,
+          shiftStatus:  leaveKind,
           openShiftId:  openShift['id'],
-          coveredBy:    null as LooseValue,
+          coveredBy:    null,
           requestStart: availEv.start instanceof Date ? availEv.start.toISOString() : String(availEv.start),
           requestEnd:   availEv.end   instanceof Date ? availEv.end.toISOString()   : String(availEv.end),
         };
@@ -321,9 +331,9 @@ export function useScheduleMutations({
     setAvailabilityState(null);
   }, [applyEngineOp, emitEventSave, getSavedEventPayload, onAvailabilitySave, onEventDelete, expandedEvents, ownerConfig, setAvailabilityState]);
 
-  const handleScheduleEditorSave = useCallback((shiftEvOrArr: LooseValue) => {
+  const handleScheduleEditorSave = useCallback((shiftEvOrArr: MutationEventInput | MutationEventInput[]) => {
     const events = Array.isArray(shiftEvOrArr) ? shiftEvOrArr : [shiftEvOrArr];
-    events.forEach((ev: LooseValue, index: number) => {
+    events.forEach((ev, index) => {
       const scheduleId = String(ev.id ?? createId(`shift-${index}`));
       applyEngineOp(
         { type: 'create', event: { ...ev, id: scheduleId }, source: 'api' },

--- a/src/hooks/useScheduleTemplates.ts
+++ b/src/hooks/useScheduleTemplates.ts
@@ -7,6 +7,7 @@ import type { LegacyEvent } from '../core/engine/adapters/fromLegacyEvents';
 import { validateOperation } from '../core/engine/validation/validateOperation';
 import type { OperationContext } from '../core/engine/validation/validationTypes';
 import { createId } from '../core/createId';
+import type { EngineOpRunner, GetSavedEventPayload } from '../types/engineOps';
 
 type LooseValue = any;
 
@@ -28,8 +29,8 @@ export interface UseScheduleTemplatesParams {
   ownerBusinessHours: unknown;
   businessHours?: unknown;
   blockedWindows?: LooseValue[] | undefined;
-  applyEngineOp: (op: LooseValue, callback?: () => void) => void;
-  getSavedEventPayload: (id: string, ev: LooseValue, context: LooseValue) => LooseValue;
+  applyEngineOp: EngineOpRunner;
+  getSavedEventPayload: GetSavedEventPayload;
   onEventSave?: ((event: LooseValue) => void) | undefined;
   onInstantiateSuccess: () => void;
 }

--- a/src/hooks/useScheduleTemplates.ts
+++ b/src/hooks/useScheduleTemplates.ts
@@ -1,20 +1,43 @@
-/* eslint-disable @typescript-eslint/no-explicit-any -- TODO: remove as types are tightened */
 import { useState, useMemo, useCallback, useEffect, useRef } from 'react';
 import { canViewScheduleTemplate, instantiateScheduleTemplate } from '../api/v1/templates';
+import type {
+  ScheduleTemplateV1,
+  ScheduleInstantiationRequestV1,
+  ScheduleInstantiationResultV1,
+} from '../api/v1/templates';
 import type { CalendarEventV1 } from '../api/v1/types';
 import { fromLegacyEvents } from '../core/engine/adapters/fromLegacyEvents';
 import type { LegacyEvent } from '../core/engine/adapters/fromLegacyEvents';
 import { validateOperation } from '../core/engine/validation/validateOperation';
-import type { OperationContext } from '../core/engine/validation/validationTypes';
+import type { OperationContext, ValidationResult } from '../core/engine/validation/validationTypes';
+import type { EngineEvent } from '../core/engine/schema/eventSchema';
 import { createId } from '../core/createId';
+import type { WorksCalendarEvent } from '../types/events';
+import type { CalendarRole } from '../WorksCalendar.types';
 import type { EngineOpRunner, GetSavedEventPayload } from '../types/engineOps';
-
-type LooseValue = any;
 
 const DEFAULT_LIMITS = { previewMax: 200, createMax: 200 };
 
+/** A schedule entry that would violate engine rules at the chosen anchor. */
+export interface SchedulePreviewConflict {
+  index: number;
+  title: string;
+  severity: ValidationResult['severity'];
+  violations: ReadonlyArray<{ rule?: string | undefined; message?: string | undefined }>;
+}
+
+/** Result of `buildSchedulePreview`: the events the template would create, the
+ *  ones that would conflict, and a user-facing error string (empty on success). */
+export interface SchedulePreviewResult {
+  generated: readonly CalendarEventV1[];
+  conflicts: readonly SchedulePreviewConflict[];
+  error: string;
+}
+
 export interface UseScheduleTemplatesParams {
-  scheduleTemplates: LooseValue[];
+  /** Host-supplied static schedule templates (validated by `canViewScheduleTemplate`
+   *  / `instantiateScheduleTemplate` before use). */
+  scheduleTemplates: readonly ScheduleTemplateV1[];
   scheduleInstantiationLimits?: { previewMax?: number; createMax?: number } | undefined;
   scheduleTemplateAdapter?: {
     listScheduleTemplates?: () => Promise<unknown>;
@@ -23,26 +46,26 @@ export interface UseScheduleTemplatesParams {
     [key: string]: unknown;
   } | undefined;
   onScheduleTemplateAnalytics?: ((payload: Record<string, unknown>) => void) | undefined;
-  role?: string | undefined;
+  role?: CalendarRole | undefined;
   isOwner: boolean;
-  engine: { state: { events: Map<string, LooseValue> } };
+  engine: { state: { events: ReadonlyMap<string, EngineEvent> } };
   ownerBusinessHours: unknown;
   businessHours?: unknown;
-  blockedWindows?: LooseValue[] | undefined;
+  blockedWindows?: readonly unknown[] | undefined;
   applyEngineOp: EngineOpRunner;
   getSavedEventPayload: GetSavedEventPayload;
-  onEventSave?: ((event: LooseValue) => void) | undefined;
+  onEventSave?: ((event: WorksCalendarEvent) => void) | undefined;
   onInstantiateSuccess: () => void;
 }
 
 export interface UseScheduleTemplatesReturn {
   templateError: string;
-  visibleScheduleTemplates: LooseValue[];
-  mergedScheduleTemplates: LooseValue[];
-  buildSchedulePreview: (request: LooseValue) => LooseValue;
-  handleScheduleInstantiate: (request: LooseValue) => void;
-  handleCreateScheduleTemplate: (template: LooseValue) => Promise<void>;
-  handleDeleteScheduleTemplate: (templateId: LooseValue) => Promise<void>;
+  visibleScheduleTemplates: ScheduleTemplateV1[];
+  mergedScheduleTemplates: ScheduleTemplateV1[];
+  buildSchedulePreview: (request: ScheduleInstantiationRequestV1) => SchedulePreviewResult;
+  handleScheduleInstantiate: (request: ScheduleInstantiationRequestV1) => void;
+  handleCreateScheduleTemplate: (template: Record<string, unknown>) => Promise<void>;
+  handleDeleteScheduleTemplate: (templateId: string) => Promise<void>;
 }
 
 export function useScheduleTemplates({
@@ -61,7 +84,7 @@ export function useScheduleTemplates({
   onEventSave,
   onInstantiateSuccess,
 }: UseScheduleTemplatesParams): UseScheduleTemplatesReturn {
-  const [remoteTemplates, setRemoteTemplates] = useState<LooseValue[]>([]);
+  const [remoteTemplates, setRemoteTemplates] = useState<ScheduleTemplateV1[]>([]);
   const [templateError, setTemplateError] = useState('');
 
   const resolvedLimits = useMemo(() => ({
@@ -81,7 +104,8 @@ export function useScheduleTemplates({
     if (!scheduleTemplateAdapter?.listScheduleTemplates) return;
     try {
       const templates = await scheduleTemplateAdapter.listScheduleTemplates();
-      setRemoteTemplates(Array.isArray(templates) ? templates : []);
+      // Host-supplied template blobs from the adapter; shape-validated downstream.
+      setRemoteTemplates(Array.isArray(templates) ? (templates as ScheduleTemplateV1[]) : []);
       setTemplateError('');
     } catch {
       setTemplateError('Unable to load schedule templates from adapter.');
@@ -90,15 +114,15 @@ export function useScheduleTemplates({
 
   useEffect(() => { reloadRemoteTemplates(); }, [reloadRemoteTemplates]);
 
-  const mergedScheduleTemplates = useMemo(() => {
+  const mergedScheduleTemplates = useMemo<ScheduleTemplateV1[]>(() => {
     const combined = [...scheduleTemplates, ...remoteTemplates];
-    const byId = new Map();
-    combined.forEach(t => { if (t?.id) byId.set(t.id, t); });
+    const byId = new Map<string, ScheduleTemplateV1>();
+    combined.forEach(t => { if (t.id) byId.set(t.id, t); });
     return Array.from(byId.values());
   }, [scheduleTemplates, remoteTemplates]);
 
-  const visibleScheduleTemplates = useMemo(
-    () => mergedScheduleTemplates.filter(t => canViewScheduleTemplate(t, { role: role as LooseValue, isOwner })),
+  const visibleScheduleTemplates = useMemo<ScheduleTemplateV1[]>(
+    () => mergedScheduleTemplates.filter(t => canViewScheduleTemplate(t, role !== undefined ? { role, isOwner } : { isOwner })),
     [mergedScheduleTemplates, isOwner, role],
   );
 
@@ -107,16 +131,16 @@ export function useScheduleTemplates({
   const previewCtxRef = useRef({ engine, ownerBusinessHours, businessHours, blockedWindows });
   previewCtxRef.current = { engine, ownerBusinessHours, businessHours, blockedWindows };
 
-  const buildSchedulePreview = useCallback((request: LooseValue): LooseValue => {
+  const buildSchedulePreview = useCallback((request: ScheduleInstantiationRequestV1): SchedulePreviewResult => {
     const { engine: eng, ownerBusinessHours: ownerBH, businessHours: bh, blockedWindows: bw } = previewCtxRef.current;
     const startedAt = Date.now();
-    const template = visibleScheduleTemplates.find((t: LooseValue) => t.id === request.templateId);
+    const template = visibleScheduleTemplates.find(t => t.id === request.templateId);
     if (!template) return { generated: [], conflicts: [], error: 'Selected template was not found.' };
     if (!Array.isArray(template.entries) || template.entries.length === 0) {
       return { generated: [], conflicts: [], error: 'Selected template does not have valid entries.' };
     }
 
-    const anchor = request?.anchor instanceof Date ? request.anchor : new Date(request?.anchor);
+    const anchor = request.anchor instanceof Date ? request.anchor : new Date(request.anchor);
     if (Number.isNaN(anchor.getTime())) {
       return { generated: [], conflicts: [], error: 'Enter a valid anchor date/time.' };
     }
@@ -145,12 +169,12 @@ export function useScheduleTemplates({
       blockedWindows: bw ?? [],
     } as unknown as OperationContext;
     const seededEvents = [...eng.state.events.values()];
-    const conflicts: LooseValue[] = [];
+    const conflicts: SchedulePreviewConflict[] = [];
 
     generated.forEach((ev, index) => {
-      const start = ev.start instanceof Date || typeof ev.start === 'string'
-        ? ev.start : new Date(ev.start as number);
-      const end = ev.end instanceof Date || typeof ev.end === 'string'
+      const start: Date | string = ev.start instanceof Date || typeof ev.start === 'string'
+        ? ev.start : new Date(ev.start);
+      const end: Date | string = ev.end instanceof Date || typeof ev.end === 'string'
         ? ev.end : new Date(ev.end as number);
       const legacy: LegacyEvent[] = [{
         id: `preview:${template.id}:${index}`,
@@ -163,7 +187,7 @@ export function useScheduleTemplates({
         status: typeof ev.status === 'string' ? ev.status : 'confirmed',
         rrule: typeof ev.rrule === 'string' ? ev.rrule : null,
         exdates: Array.isArray(ev.exdates) ? ev.exdates : [],
-        meta: typeof ev.meta === 'object' && ev.meta ? ev.meta as Record<string, unknown> : {},
+        meta: typeof ev.meta === 'object' && ev.meta ? ev.meta : {},
       }];
       const previewEvent = fromLegacyEvents(legacy)[0];
       if (previewEvent === undefined) return;
@@ -172,9 +196,9 @@ export function useScheduleTemplates({
       if (validation.violations.length > 0) {
         conflicts.push({
           index,
-          title: ev.title ?? '(untitled)',
+          title: ev.title,
           severity: validation.severity,
-          violations: validation.violations.map((v: LooseValue) => ({
+          violations: validation.violations.map(v => ({
             rule: typeof v.rule === 'string' ? v.rule : undefined,
             message: typeof v.message === 'string' ? v.message : undefined,
           })),
@@ -196,22 +220,22 @@ export function useScheduleTemplates({
     return { generated: normalizedPreview, conflicts, error: '' };
   }, [resolvedLimits.previewMax, trackAnalytics, visibleScheduleTemplates]);
 
-  const handleScheduleInstantiate = useCallback((request: LooseValue) => {
+  const handleScheduleInstantiate = useCallback((request: ScheduleInstantiationRequestV1) => {
     const startedAt = Date.now();
-    const template = visibleScheduleTemplates.find((t: LooseValue) => t.id === request.templateId);
+    const template = visibleScheduleTemplates.find(t => t.id === request.templateId);
     if (!template || !Array.isArray(template.entries) || template.entries.length === 0) {
       trackAnalytics('schedule_instantiate_failed', {
         reason: 'template-missing-or-invalid',
-        templateId: request?.templateId ?? null,
+        templateId: request.templateId ?? null,
       });
       return;
     }
-    const anchor = request?.anchor instanceof Date ? request.anchor : new Date(request?.anchor);
+    const anchor = request.anchor instanceof Date ? request.anchor : new Date(request.anchor);
     if (Number.isNaN(anchor.getTime())) {
       trackAnalytics('schedule_instantiate_failed', { reason: 'invalid-anchor', templateId: template.id });
       return;
     }
-    let result;
+    let result: ScheduleInstantiationResultV1;
     try {
       result = instantiateScheduleTemplate(template, request);
     } catch {
@@ -225,7 +249,7 @@ export function useScheduleTemplates({
       });
       return;
     }
-    result.generated.forEach((ev: LooseValue, index: number) => {
+    result.generated.forEach((ev, index) => {
       if (ev.start == null || ev.end == null) return;
       const start = ev.start instanceof Date ? ev.start : new Date(ev.start);
       const end   = ev.end   instanceof Date ? ev.end   : new Date(ev.end);
@@ -235,7 +259,7 @@ export function useScheduleTemplates({
           type: 'create',
           event: {
             id: templateEventId,
-            title: ev.title ?? '(untitled)',
+            title: ev.title,
             start, end,
             allDay: ev.allDay ?? false,
             resourceId: ev.resource ?? null,
@@ -262,7 +286,7 @@ export function useScheduleTemplates({
     onInstantiateSuccess();
   }, [applyEngineOp, getSavedEventPayload, onEventSave, resolvedLimits.createMax, trackAnalytics, visibleScheduleTemplates, onInstantiateSuccess]);
 
-  const handleCreateScheduleTemplate = useCallback(async (template: LooseValue) => {
+  const handleCreateScheduleTemplate = useCallback(async (template: Record<string, unknown>) => {
     if (!scheduleTemplateAdapter?.createScheduleTemplate) return;
     try {
       await scheduleTemplateAdapter.createScheduleTemplate(template);
@@ -273,7 +297,7 @@ export function useScheduleTemplates({
     }
   }, [reloadRemoteTemplates, scheduleTemplateAdapter]);
 
-  const handleDeleteScheduleTemplate = useCallback(async (templateId: LooseValue) => {
+  const handleDeleteScheduleTemplate = useCallback(async (templateId: string) => {
     if (!scheduleTemplateAdapter?.deleteScheduleTemplate) return;
     try {
       await scheduleTemplateAdapter.deleteScheduleTemplate(templateId);

--- a/src/types/engineOps.ts
+++ b/src/types/engineOps.ts
@@ -1,0 +1,146 @@
+/**
+ * Shared types for the engine-op / mutation seam — the boundary where the
+ * calendar's mutation hooks (`useEventMutations`, `useScheduleMutations`,
+ * `useScheduleTemplates`) build op-shaped literals, hand them to the engine,
+ * and receive `OperationResult`s back.
+ *
+ * Re-exported here so those hooks depend on one stable module instead of
+ * reaching across the full `core/engine/...` path, and so the loose
+ * hook-side op shape (`EngineOpInput`) lives next to the strict engine-side
+ * one (`EngineOperation`). Introduced for issue #596.
+ */
+import type {
+  EngineOperation,
+  RecurringEditScope,
+  OperationSource,
+} from '../core/engine/schema/operationSchema';
+import type {
+  OperationResult,
+  EventChange,
+  OperationStatus,
+} from '../core/engine/operations/operationResult';
+import type { EngineEvent } from '../core/engine/schema/eventSchema';
+import type { NormalizedEvent, WorksCalendarEvent } from './events';
+
+export type {
+  EngineOperation,
+  RecurringEditScope,
+  OperationSource,
+  OperationResult,
+  EventChange,
+  OperationStatus,
+  EngineEvent,
+};
+
+/**
+ * The loose op shape the mutation hooks construct. Intentionally wider than
+ * {@link EngineOperation}: `event` / `patch` are `unknown` because the hooks
+ * forward partially-built, mixed-shape event literals (public `start: string`,
+ * `resource` vs `resourceId`, …) and `source` is a plain string
+ * (some call sites use sources like `'inline-edit'` / `'template'` that aren't
+ * in {@link OperationSource}). The engine normalises and validates; a single
+ * `as unknown as EngineOperation` cast bridges the two at the
+ * `engine.applyMutation` call.
+ *
+ * Tightening this toward {@link EngineOperation} is Sprint 2 of #596.
+ */
+export type EngineOpInput =
+  | { type: 'create'; event: unknown; source?: string | undefined }
+  | {
+      type: 'update';
+      id: string;
+      patch: unknown;
+      scope?: string | undefined;
+      occurrenceDate?: Date | undefined;
+      source?: string | undefined;
+    }
+  | {
+      type: 'delete';
+      id: string;
+      scope?: string | undefined;
+      occurrenceDate?: Date | undefined;
+      source?: string | undefined;
+    }
+  | {
+      type: 'move';
+      id: string;
+      newStart: Date;
+      newEnd: Date;
+      scope?: string | undefined;
+      occurrenceDate?: Date | undefined;
+      source?: string | undefined;
+    }
+  | {
+      type: 'resize';
+      id: string;
+      newStart: Date;
+      newEnd: Date;
+      scope?: string | undefined;
+      occurrenceDate?: Date | undefined;
+      source?: string | undefined;
+    }
+  | {
+      type: 'group-change';
+      id: string;
+      patch: unknown;
+      scope?: string | undefined;
+      occurrenceDate?: Date | undefined;
+      source?: string | undefined;
+    };
+
+/** Submit a mutation op through the engine; the callback receives the
+ *  post-validate/mutate result. Mirrors `useCalendarEngine`'s `applyEngineOp`. */
+export type EngineOpRunner = (
+  op: EngineOpInput,
+  onAccepted?: (result: OperationResult) => void,
+) => void;
+
+/** Wrap a mutation op with the recurring-scope dialog for recurring events.
+ *  `opFactory` builds the op for the scope the user picks. */
+export type RecurringOpRunner = (
+  ev: unknown,
+  opFactory: (scope: string) => EngineOpInput,
+  onAccepted: (result: OperationResult) => void,
+  actionLabel: string,
+) => void;
+
+/** Look up the post-mutation engine state for an event id, falling back to a
+ *  caller-supplied event (optionally merged with a patch) when the engine
+ *  doesn't have it. Mirrors `useCalendarEngine`'s `getSavedEventPayload`. */
+export type GetSavedEventPayload = (
+  eventId: unknown,
+  fallbackEvent?: unknown,
+  fallbackPatch?: unknown,
+) => WorksCalendarEvent | null;
+
+/** Resolve an event id to its saved payload and forward it to the host's
+ *  `onEventSave`. Defined by `useEventMutations`, reused by `useScheduleMutations`. */
+export type EmitEventSave = (
+  eventId: unknown,
+  fallbackEvent?: unknown,
+  fallbackPatch?: unknown,
+) => void;
+
+/** The "event-ish input" the mutation hooks accept: a normalized internal
+ *  event, a public-API event, or a partial form draft. Adopted from Sprint 3. */
+export type MutationEventInput = NormalizedEvent | WorksCalendarEvent | Partial<WorksCalendarEvent>;
+
+/** `Array.prototype.find` doesn't narrow a discriminated union, so the hooks
+ *  use these guards when pulling a specific change out of `OperationResult.changes`. */
+export function isCreatedChange(
+  change: EventChange,
+): change is Extract<EventChange, { type: 'created' }> {
+  return change.type === 'created';
+}
+
+export function isUpdatedChange(
+  change: EventChange,
+): change is Extract<EventChange, { type: 'updated' }> {
+  return change.type === 'updated';
+}
+
+export function isDeletedChange(
+  change: EventChange,
+): change is Extract<EventChange, { type: 'deleted' }> {
+  return change.type === 'deleted';
+}

--- a/src/types/engineOps.ts
+++ b/src/types/engineOps.ts
@@ -128,9 +128,40 @@ export type EmitEventSave = (
   fallbackPatch?: unknown,
 ) => void;
 
-/** The "event-ish input" the mutation hooks accept: a normalized internal
- *  event, a public-API event, or a partial form draft. Adopted from Sprint 3. */
-export type MutationEventInput = NormalizedEvent | WorksCalendarEvent | Partial<WorksCalendarEvent>;
+/**
+ * The grab-bag "event-ish" value the mutation hooks accept: a public
+ * {@link WorksCalendarEvent}, an internal {@link NormalizedEvent}, a partial
+ * form draft, or an engine occurrence — carrying a mix of public fields,
+ * normalisation markers (`_raw`, `_eventId`, `_seriesId`, `_recurring`), and a
+ * few form-only fields (`resourcePoolId`, `kind`, `employeeId`). Every field is
+ * optional and the index signature accepts the rest; call sites narrow / coerce
+ * before use. `NormalizedEvent` is assignable to this.
+ */
+export interface MutationEventInput {
+  id?: string | number | undefined;
+  title?: string | undefined;
+  start?: Date | string | number | undefined;
+  end?: Date | string | number | undefined;
+  allDay?: boolean | undefined;
+  category?: string | null | undefined;
+  color?: string | null | undefined;
+  resource?: string | null | undefined;
+  resourceId?: string | null | undefined;
+  resourcePoolId?: string | null | undefined;
+  status?: string | undefined;
+  rrule?: string | null | undefined;
+  exdates?: ReadonlyArray<Date | string> | undefined;
+  meta?: Record<string, unknown> | undefined;
+  kind?: string | undefined;
+  employeeId?: string | number | undefined;
+  /** Original event the host supplied, attached by the normaliser. */
+  _raw?: WorksCalendarEvent | undefined;
+  /** Series-master id for occurrences — use this for mutations. */
+  _eventId?: string | undefined;
+  _seriesId?: string | undefined;
+  _recurring?: boolean | undefined;
+  [key: string]: unknown;
+}
 
 /** `Array.prototype.find` doesn't narrow a discriminated union, so the hooks
  *  use these guards when pulling a specific change out of `OperationResult.changes`. */

--- a/src/types/engineOps.ts
+++ b/src/types/engineOps.ts
@@ -40,12 +40,19 @@ export type {
  * (some call sites use sources like `'inline-edit'` / `'template'` that aren't
  * in {@link OperationSource}). The engine normalises and validates; a single
  * `as unknown as EngineOperation` cast bridges the two at the
- * `engine.applyMutation` call.
+ * `engine.applyMutation` call (see `useCalendarEngine`).
  *
- * Tightening this toward {@link EngineOperation} is Sprint 2 of #596.
+ * Tightening this toward {@link EngineOperation} (reconciling `resource` vs
+ * `resourceId`, the extra op sources, `Date | string` starts) is Sprint 3 of #596.
  */
 export type EngineOpInput =
-  | { type: 'create'; event: unknown; source?: string | undefined }
+  | {
+      type: 'create';
+      event: unknown;
+      scope?: string | undefined;
+      occurrenceDate?: Date | undefined;
+      source?: string | undefined;
+    }
   | {
       type: 'update';
       id: string;


### PR DESCRIPTION
## Summary

Builds [#596](https://github.com/WorksCalendar/CalendarThatWorks/issues/596) ("type the engine-op / event seam end-to-end — remove remaining `LooseValue = any`") into a multi-sprint plan and lands **sprint 1**.

### Sprint plan — `docs/sprints/596-typing-the-engine-op-event-seam.md`

The issue isn't incrementable file-by-file (tightening one file cascades through `WorksCalendar.tsx` and the engine adapters), but it *is* incrementable layer-by-layer — keep `LooseValue` working as an escape hatch and tighten one seam at a time, each sprint landing `type-check` + `lint` + `test` + `build` green:

1. **Canonical types + engine-op handler seam** — this PR
2. **Engine-op *literals* + `useCalendarEngine` adoption** — tighten `EngineOpInput` → `EngineOperation`; reconcile `resource`/`resourceId`, `Date | string` starts, `'inline-edit'`/`'template'` sources; add the single `op as unknown as EngineOperation` cast at `engine.applyMutation`
3. **Event-shape unification in the 3 mutation hooks** — `MutationEventInput` / `NormalizedEvent` / `EmployeeRecord` / `OwnerConfig`; **remove `LooseValue` + the `eslint-disable` from `useEventMutations` / `useScheduleMutations` / `useScheduleTemplates`**
4. **`CalendarViewGrid.tsx`** props (`cal` / `ownerCfg` / `perms` / handlers / event arrays) + the `WorksCalendar.tsx` caller cascade; remove `LooseValue` + `eslint-disable`
5. **`CalendarModals.tsx`** props + caller cascade + final sweep (no `LooseValue` in the five files, no new `any`, CHANGELOG, close #596)

### Sprint 1 changes

- **New `src/types/engineOps.ts`** — re-exports `EngineOperation` / `OperationResult` / `EventChange` / `EngineEvent` / `RecurringEditScope` / `OperationSource` / `OperationStatus`, plus:
  - `EngineOpInput` — the deliberately-loose hook→engine op shape (`event`/`patch` are `unknown`; `source` is a plain string — some call sites use sources like `'inline-edit'`/`'template'` that aren't in `OperationSource`). The engine normalises + validates; one cast bridges it to `EngineOperation` (in sprint 2).
  - `EngineOpRunner`, `RecurringOpRunner`, `GetSavedEventPayload`, `EmitEventSave`
  - `MutationEventInput` (adopted from sprint 3)
  - `isCreatedChange` / `isUpdatedChange` / `isDeletedChange` — `EventChange` discriminant guards (`Array.prototype.find` doesn't narrow a union)
- **`useEventMutations` / `useScheduleMutations` / `useScheduleTemplates`** now type `applyEngineOp` / `applyWithRecurringCheck` / `getSavedEventPayload` / `emitEventSave` and the `OperationResult` callbacks via that module instead of `LooseValue`. `LooseValue` stays for the event/employee/config params (sprints 2–3). `LooseValue` use count: `useEventMutations` 43→25, `useScheduleMutations` 26→23, `useScheduleTemplates` 24→22.

> Note: `useCalendarEngine.ts` still uses a private `AnyValue = any` for the same shapes — not `LooseValue`, so technically outside #596's literal scope, but sprint 2 has it adopt `EngineOpInput` / `OperationResult` for the "end-to-end" goal.

## Test plan

- [x] `npm run type-check`
- [x] `npm run lint`
- [x] `npm test` — 229 files / 4246 tests passing
- [x] `npm run build`

https://claude.ai/code/session_01AUBYQ42nmQTfakU5V1AZzM

---
_Generated by [Claude Code](https://claude.ai/code/session_01AUBYQ42nmQTfakU5V1AZzM)_