### PR TITLE
fix: runtime guards on engine ingestion / mutation paths (#599 P0 1–5)

### DIFF
--- a/src/core/__tests__/eventModel.test.ts
+++ b/src/core/__tests__/eventModel.test.ts
@@ -162,4 +162,16 @@ describe('normalizeEvents', () => {
   it('returns empty array for empty input', () => {
     expect(normalizeEvents([])).toEqual([]);
   });
+
+  it('drops non-object entries (null / undefined / primitives) instead of throwing', () => {
+    const evs = normalizeEvents([
+      null,
+      undefined,
+      'oops',
+      42,
+      raw({ id: 'real' }),
+    ] as unknown as WorksCalendarEvent[]);
+    expect(evs).toHaveLength(1);
+    expect(evs[0]!.id).toBe('real');
+  });
 });

--- a/src/core/engine/CalendarEngine.ts
+++ b/src/core/engine/CalendarEngine.ts
@@ -68,9 +68,28 @@ import type { ApprovalStage } from '../../types/assets';
 
 // ─── Initial state ────────────────────────────────────────────────────────────
 
+/**
+ * Index events by `id`, dropping (and warning about) any without a usable
+ * string id. Events reach the engine via `normalizeEvents`, which assigns ids,
+ * so a bad id here means the host fed in something malformed (or skipped
+ * normalization). Indexing it would corrupt the map with an `undefined`/empty
+ * key and surface as ghost events everywhere; better to drop it loudly.
+ */
+function indexEventsById(events: ReadonlyArray<EngineEvent>): Map<string, EngineEvent> {
+  const map = new Map<string, EngineEvent>();
+  for (const ev of events) {
+    const id = (ev as { id?: unknown } | null | undefined)?.id;
+    if (typeof id === 'string' && id !== '') {
+      map.set(id, ev);
+    } else if (typeof console !== 'undefined') {
+      console.warn('[WorksCalendar] CalendarEngine: ignoring an event with a missing/invalid id:', ev);
+    }
+  }
+  return map;
+}
+
 export function createInitialState(init: CalendarEngineInit = {}): CalendarState {
-  const eventMap = new Map<string, EngineEvent>();
-  for (const ev of init.events ?? []) eventMap.set(ev.id, ev);
+  const eventMap = indexEventsById(init.events ?? []);
 
   const assignMap = new Map<string, Assignment>();
   for (const a of init.assignments ?? []) assignMap.set(a.id, a);
@@ -271,8 +290,7 @@ export class CalendarEngine {
    * Notifies subscribers once.
    */
   setEvents(events: ReadonlyArray<EngineEvent>): void {
-    const map = new Map<string, EngineEvent>(events.map(ev => [ev.id, ev]));
-    this._state = { ...this._state, events: map };
+    this._state = { ...this._state, events: indexEventsById(events) };
     this._notify();
   }
 

--- a/src/core/engine/__tests__/CalendarEngine.coverage.test.ts
+++ b/src/core/engine/__tests__/CalendarEngine.coverage.test.ts
@@ -72,6 +72,44 @@ describe('createInitialState — init.filter branch', () => {
   });
 });
 
+// ─── createInitialState / setEvents — malformed event ids ────────────────────
+
+describe('CalendarEngine — ingestion drops events with bad ids instead of corrupting the map', () => {
+  it('createInitialState skips events whose id is missing / not a string', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const state = createInitialState({
+      events: [
+        ev('ok-1'),
+        { id: undefined } as unknown as EngineEvent,
+        { id: null } as unknown as EngineEvent,
+        { id: '' } as unknown as EngineEvent,
+        { id: 42 } as unknown as EngineEvent,
+        ev('ok-2'),
+      ],
+    });
+    expect([...state.events.keys()].sort()).toEqual(['ok-1', 'ok-2']);
+    expect(state.events.has('undefined')).toBe(false);
+    expect(state.events.has('')).toBe(false);
+    expect(warn).toHaveBeenCalled();
+    warn.mockRestore();
+  });
+
+  it('does not throw when constructed with malformed events', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    expect(() => new CalendarEngine({ events: [{ id: undefined } as unknown as EngineEvent, ev('ok')] })).not.toThrow();
+    warn.mockRestore();
+  });
+
+  it('setEvents applies the same id guard', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const engine = new CalendarEngine();
+    engine.setEvents([ev('keep'), { id: '' } as unknown as EngineEvent, { id: undefined } as unknown as EngineEvent]);
+    expect([...engine.state.events.keys()]).toEqual(['keep']);
+    expect(warn).toHaveBeenCalled();
+    warn.mockRestore();
+  });
+});
+
 // ─── dispatch — no-change branch ─────────────────────────────────────────────
 
 describe('CalendarEngine.dispatch — same-state no-notify', () => {

--- a/src/core/eventModel.ts
+++ b/src/core/eventModel.ts
@@ -86,5 +86,8 @@ export function normalizeEvent(raw: WorksCalendarEvent): NormalizedEvent {
  */
 export function normalizeEvents(rawList: WorksCalendarEvent[] | null | undefined): NormalizedEvent[] {
   if (!Array.isArray(rawList)) return [];
-  return rawList.map(normalizeEvent);
+  // Drop non-object entries (a `null`/`undefined`/primitive that slipped in
+  // from a host array or source adapter) — `normalizeEvent` reads fields off
+  // its argument and would throw on them.
+  return rawList.filter((raw): raw is WorksCalendarEvent => raw != null && typeof raw === 'object').map(normalizeEvent);
 }

--- a/src/hooks/__tests__/useCalendarEngine.test.tsx
+++ b/src/hooks/__tests__/useCalendarEngine.test.tsx
@@ -1,0 +1,41 @@
+/**
+ * useCalendarEngine — runtime-guard regression tests.
+ *
+ * Covers the try/catch around the synchronous engine construction: a throw in
+ * `createInitialState` (malformed `events`/`pools`) must surface with context,
+ * not a bare/blank crash.
+ */
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { renderHook, cleanup } from '@testing-library/react';
+import { useCalendarEngine } from '../useCalendarEngine';
+import type { ResourcePool } from '../../core/pools/resourcePoolSchema';
+
+afterEach(() => cleanup());
+
+// Stable references — `useCalendarEngine` syncs `allNormalized` into the engine
+// in an effect keyed on its identity, so a fresh literal each render would loop.
+const NO_EVENTS: never[] = [];
+const ANNOUNCER_REF = { current: null };
+const RANGE = { start: new Date(2026, 0, 1), end: new Date(2026, 1, 1) };
+
+describe('useCalendarEngine — engine-init failures', () => {
+  it('mounts normally with no init data', () => {
+    const { result } = renderHook(() => useCalendarEngine({ allNormalized: NO_EVENTS, announcerRef: ANNOUNCER_REF, range: RANGE }));
+    expect(result.current.engine).toBeTruthy();
+    expect(result.current.undoManager).toBeTruthy();
+  });
+
+  it('rethrows an init failure with a "failed to initialize" message and the underlying cause', () => {
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    // A pool whose `id` getter throws — `createInitialState` reads `p.id`.
+    const poisonPool = {
+      get id(): string { throw new Error('poison-pool'); },
+    } as unknown as ResourcePool;
+
+    expect(() =>
+      renderHook(() => useCalendarEngine({ allNormalized: NO_EVENTS, rawPools: [poisonPool], announcerRef: ANNOUNCER_REF, range: RANGE })),
+    ).toThrow(/failed to initialize.*poison-pool/i);
+
+    errSpy.mockRestore();
+  });
+});

--- a/src/hooks/__tests__/useEventMutations.test.tsx
+++ b/src/hooks/__tests__/useEventMutations.test.tsx
@@ -1,0 +1,82 @@
+/**
+ * useEventMutations — runtime-guard regression tests.
+ *
+ * Covers the invalid-date guard in `handleEventSave`: an unparseable
+ * start/end must be rejected before it reaches the engine (where it would
+ * propagate into `date-fns` formatting and throw `RangeError`).
+ */
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { renderHook, act, cleanup } from '@testing-library/react';
+import { useEventMutations } from '../useEventMutations';
+import { CalendarEngine } from '../../core/engine/CalendarEngine';
+import type { MutationEventInput } from '../../types/engineOps';
+
+afterEach(() => cleanup());
+
+const NO_EVENTS: never[] = [];
+const OWNER_CFG = {};
+
+function setup() {
+  const applyEngineOp = vi.fn();
+  const applyWithRecurringCheck = vi.fn();
+  const engine = new CalendarEngine();
+  const getSavedEventPayload = vi.fn(() => null);
+  const setFormEvent = vi.fn();
+  const setInlineEditTarget = vi.fn();
+  const { result } = renderHook(() =>
+    useEventMutations({
+      applyEngineOp,
+      applyWithRecurringCheck,
+      getSavedEventPayload,
+      engine,
+      engineVer: 0,
+      expandedEvents: NO_EVENTS,
+      ownerConfig: OWNER_CFG,
+      inlineEditTarget: null,
+      setFormEvent,
+      setInlineEditTarget,
+    }),
+  );
+  return { result, applyEngineOp, applyWithRecurringCheck };
+}
+
+describe('useEventMutations — handleEventSave invalid-date guard', () => {
+  it('drops a save with an unparseable start date (no engine op, logs an error)', () => {
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const { result, applyEngineOp, applyWithRecurringCheck } = setup();
+
+    act(() => result.current.handleEventSave({ start: 'not a date', end: new Date(2026, 0, 1) } as MutationEventInput));
+
+    expect(applyEngineOp).not.toHaveBeenCalled();
+    expect(applyWithRecurringCheck).not.toHaveBeenCalled();
+    expect(errSpy).toHaveBeenCalled();
+    errSpy.mockRestore();
+  });
+
+  it('drops a save with an unparseable end date', () => {
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const { result, applyEngineOp } = setup();
+
+    act(() => result.current.handleEventSave({ start: new Date(2026, 0, 1), end: 'whenever' } as MutationEventInput));
+
+    expect(applyEngineOp).not.toHaveBeenCalled();
+    expect(errSpy).toHaveBeenCalled();
+    errSpy.mockRestore();
+  });
+
+  it('still creates an event when start/end are valid', () => {
+    const { result, applyEngineOp } = setup();
+
+    act(() =>
+      result.current.handleEventSave({
+        title: 'New thing',
+        start: new Date(2026, 0, 1, 9, 0),
+        end: new Date(2026, 0, 1, 10, 0),
+      } as MutationEventInput),
+    );
+
+    expect(applyEngineOp).toHaveBeenCalledTimes(1);
+    const [op] = applyEngineOp.mock.calls[0] as [{ type: string }];
+    expect(op.type).toBe('create');
+  });
+});

--- a/src/hooks/__tests__/useRealtimeEvents.test.ts
+++ b/src/hooks/__tests__/useRealtimeEvents.test.ts
@@ -126,4 +126,20 @@ describe('useRealtimeEvents', () => {
     );
     errorSpy.mockRestore();
   });
+
+  it('degrades to status="error" (no throw) when the Supabase client lacks channel()/from()', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    // A future SDK that moved/removed these methods.
+    const brokenClient = {} as unknown as Parameters<typeof useRealtimeEvents>[0]['supabaseClient'];
+
+    let result: { current: ReturnType<typeof useRealtimeEvents> } | undefined;
+    expect(() => {
+      ({ result } = renderHook(() => useRealtimeEvents({ supabaseClient: brokenClient, table: 'events' })));
+    }).not.toThrow();
+
+    expect(result!.current.status).toBe('error');
+    expect(result!.current.events).toEqual([]);
+    expect(warnSpy).toHaveBeenCalled();
+    warnSpy.mockRestore();
+  });
 });

--- a/src/hooks/useCalendarDataPipeline.ts
+++ b/src/hooks/useCalendarDataPipeline.ts
@@ -96,7 +96,11 @@ export function useCalendarDataPipeline({
     const map = new Map<string, WorksCalendarEvent>();
     const noId: WorksCalendarEvent[] = [];
     incoming.forEach(ev => {
-      if (ev.id != null) map.set(String(ev.id), ev);
+      // A null/undefined/primitive entry from any of the four sources would
+      // crash on `.id` here (and again in `normalizeEvent`) — skip it.
+      if (ev == null || typeof ev !== 'object') return;
+      const id = (ev as { id?: unknown }).id;
+      if (id != null && String(id) !== '') map.set(String(id), ev);
       else noId.push(ev);
     });
     return normalizeEvents([...map.values(), ...noId]);

--- a/src/hooks/useCalendarEngine.ts
+++ b/src/hooks/useCalendarEngine.ts
@@ -109,12 +109,22 @@ export function useCalendarEngine({
   const poolsSequenceRef = useRef(0);
 
   if (engineRef.current === null) {
-    const initState = rawPools && rawPools.length > 0 ? { pools: rawPools } : {};
-    engineRef.current = new CalendarEngine(
-      initialView ? { ...initState, view: initialView as AnyValue } : (rawPools && rawPools.length > 0 ? initState : undefined),
-    );
-    undoManagerRef.current = new UndoRedoManager(engineRef.current, { maxSize: 50 });
-    lastPoolsRef.current = engineRef.current.state.pools;
+    try {
+      const initState = rawPools && rawPools.length > 0 ? { pools: rawPools } : {};
+      engineRef.current = new CalendarEngine(
+        initialView ? { ...initState, view: initialView as AnyValue } : (rawPools && rawPools.length > 0 ? initState : undefined),
+      );
+      undoManagerRef.current = new UndoRedoManager(engineRef.current, { maxSize: 50 });
+      lastPoolsRef.current = engineRef.current.state.pools;
+    } catch (err) {
+      // Surface the underlying cause with context instead of a blank crash —
+      // a throw here usually means a malformed `events`/`pools` prop.
+      if (err instanceof Error) {
+        err.message = `WorksCalendar: the calendar engine failed to initialize (check the events/pools passed in) — ${err.message}`;
+        throw err;
+      }
+      throw new Error(`WorksCalendar: the calendar engine failed to initialize (check the events/pools passed in) — ${String(err)}`);
+    }
   }
 
   const engine      = engineRef.current;

--- a/src/hooks/useEventMutations.ts
+++ b/src/hooks/useEventMutations.ts
@@ -117,6 +117,15 @@ export function useEventMutations({
   const handleEventSave = useCallback((rawEv: MutationEventInput) => {
     const newStart = rawEv.start instanceof Date ? rawEv.start : new Date(rawEv.start ?? '');
     const newEnd   = rawEv.end   instanceof Date ? rawEv.end   : new Date(rawEv.end ?? '');
+    // Bail on an unparseable start/end before it reaches the engine — an
+    // Invalid Date there propagates into `date-fns` formatting of validation
+    // messages, which throws `RangeError` and crashes the next render.
+    if (Number.isNaN(newStart.getTime()) || Number.isNaN(newEnd.getTime())) {
+      if (typeof console !== 'undefined') {
+        console.error('[WorksCalendar] handleEventSave: ignoring an event with an invalid start/end date.', { start: rawEv.start, end: rawEv.end });
+      }
+      return;
+    }
     const recurringMasterId = rawEv._eventId ?? rawEv._seriesId ?? null;
     const eventId  = recurringMasterId ?? (rawEv.id ? String(rawEv.id) : null);
 

--- a/src/hooks/useRealtimeEvents.ts
+++ b/src/hooks/useRealtimeEvents.ts
@@ -72,6 +72,18 @@ export function useRealtimeEvents({ supabaseClient, table, filter }: {
       return;
     }
 
+    // Guard against Supabase SDK drift — if `channel()`/`from()` aren't where
+    // we expect (a major-version bump that moved them), degrade to no realtime
+    // instead of throwing out of the effect and blanking the calendar.
+    if (typeof supabaseClient.channel !== 'function' || typeof supabaseClient.from !== 'function') {
+      if (typeof console !== 'undefined') {
+        console.warn('[WorksCalendar] Supabase client is missing channel()/from() — realtime disabled (SDK version mismatch?).');
+      }
+      setStatus('error');
+      setEvents([]);
+      return;
+    }
+
     setStatus('connecting');
 
     const chanName = `wc-rt-${table}-${filter ?? 'all'}`;


### PR DESCRIPTION
## Summary

Runtime hardening — guards, not refactors. Closes the first batch of [#599](https://github.com/WorksCalendar/CalendarThatWorks/issues/599) (P0 1–5). Each fix is a few lines + an adversarial test.

| # | Path | Before | After |
|---|---|---|---|
| 1 | `CalendarEngine` ingestion (`createInitialState` + `setEvents`) | `eventMap.set(ev.id, ev)` — a missing/non-string id corrupts the map with an `undefined`/empty key → ghost events everywhere | `indexEventsById()` — index only when `id` is a non-empty string; drop + `console.warn` otherwise |
| 2 | `useCalendarEngine` engine init | `new CalendarEngine(...)` unwrapped → a throw in ingestion surfaces as a bare/blank crash | wrapped in try/catch that rethrows with `"…failed to initialize (check the events/pools passed in) — <cause>"`, preserving the original error/stack |
| 3 | `useRealtimeEvents` | calls `supabaseClient.channel()` / `.from()` with no presence check → an SDK that moved them throws out of the effect | feature-detect both; if missing → `status: 'error'`, no realtime, `console.warn` |
| 4 | `normalizeEvents` + `useCalendarDataPipeline` source merge | `incoming.forEach(ev => ev.id …)` / `.map(normalizeEvent)` crash on a `null`/primitive entry from a host array or source adapter | filter to objects before processing — at both the pipeline merge and the `normalizeEvents` chokepoint |
| 5 | `handleEventSave` | builds `new Date(rawEv.start ?? '')` with no NaN check → an Invalid Date reaches the engine, gets `date-fns`-formatted in a validation message, throws `RangeError`, crashes the next render | `if (Number.isNaN(newStart.getTime()) || …) { console.error(…); return; }` before anything reaches the engine |

**Not in this PR:** P0 #6 (delete of a non-existent id) and #7 (pool rejection) — I audited both on `main` and they're already handled (`applyWithRecurringCheck` routes the `{ id }` fallback through the non-recurring branch and the engine rejects unknown-id deletes gracefully; `resolvePoolForOp` already returns a normalized `OperationResult` with the violation shape the alert renders). Notes added to #599. The P1 items (8–12) and P2 (13–17) remain tracked there.

## Tests added

- `CalendarEngine.coverage.test.ts` — `createInitialState` / `new CalendarEngine` / `setEvents` skip events with missing/non-string ids; no `undefined` key; no throw.
- `eventModel.test.ts` — `normalizeEvents([null, undefined, 'x', 42, real])` → `[real]`, no throw.
- `useRealtimeEvents.test.ts` — a client missing `channel()`/`from()` → `status === 'error'`, no throw.
- `useCalendarEngine.test.tsx` *(new)* — mounts cleanly; a poison-`id`-getter pool → rethrows `/failed to initialize.*poison-pool/i`.
- `useEventMutations.test.tsx` *(new)* — `handleEventSave` with an unparseable start/end → no engine op, logs an error; still creates an event when start/end are valid.

## Test plan

- [x] `npm test` — 231 files, **4256 tests**, green.
- [x] `npm run type-check` (strict) — no new errors vs `main`.
- [x] `eslint src` — clean.
- [x] `npm run build` — succeeds.
- [ ] Smoke against a real host with deliberately bad input (paste corrupted CSV, pass `events: [null]`, etc.) — should warn/no-op, not blank.

https://claude.ai/code/session_01AKrYupUsUye3ShWYp2w6MW

---
_Generated by [Claude Code](https://claude.ai/code/session_01AKrYupUsUye3ShWYp2w6MW)_