### PR TITLE
fix: scope the global undo shortcut; reload config on calendarId change (#599 P1)

### DIFF
--- a/src/hooks/__tests__/useCalendarMutations.test.tsx
+++ b/src/hooks/__tests__/useCalendarMutations.test.tsx
@@ -1,0 +1,99 @@
+/**
+ * useCalendarMutations — `handleUndoRedoShortcut` (the global Cmd/Ctrl+Z handler).
+ *
+ * Regression for the "global shortcut hijacking" bug: Ctrl+Z must not steal
+ * text-undo from an input/textarea/contentEditable, must not fire while a modal
+ * is up, and must not act on an already-handled event.
+ */
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { handleUndoRedoShortcut } from '../useCalendarMutations';
+
+afterEach(() => {
+  document.body.innerHTML = '';
+});
+
+function keyEvent(
+  key: string,
+  opts: { ctrlKey?: boolean; metaKey?: boolean; shiftKey?: boolean; target?: EventTarget; preDefault?: boolean } = {},
+): KeyboardEvent {
+  const e = new KeyboardEvent('keydown', {
+    key,
+    ctrlKey: opts.ctrlKey ?? false,
+    metaKey: opts.metaKey ?? false,
+    shiftKey: opts.shiftKey ?? false,
+    cancelable: true,
+    bubbles: true,
+  });
+  Object.defineProperty(e, 'target', { value: opts.target ?? document.body, configurable: true });
+  if (opts.preDefault) e.preventDefault();
+  return e;
+}
+
+function makeUndoManager(undoResult = true, redoResult = true) {
+  return { undo: vi.fn(() => undoResult), redo: vi.fn(() => redoResult) };
+}
+
+describe('handleUndoRedoShortcut', () => {
+  it('Cmd/Ctrl+Z triggers undo and announces it', () => {
+    const um = makeUndoManager();
+    const announce = vi.fn();
+    const e = keyEvent('z', { ctrlKey: true });
+    const pd = vi.spyOn(e, 'preventDefault');
+    handleUndoRedoShortcut(e, um, announce);
+    expect(um.undo).toHaveBeenCalledTimes(1);
+    expect(um.redo).not.toHaveBeenCalled();
+    expect(pd).toHaveBeenCalled();
+    expect(announce).toHaveBeenCalledWith('Undo.');
+  });
+
+  it('Cmd/Ctrl+Shift+Z and Ctrl+Y trigger redo', () => {
+    const a = makeUndoManager();
+    handleUndoRedoShortcut(keyEvent('z', { metaKey: true, shiftKey: true }), a);
+    expect(a.redo).toHaveBeenCalledTimes(1);
+
+    const b = makeUndoManager();
+    handleUndoRedoShortcut(keyEvent('y', { ctrlKey: true }), b);
+    expect(b.redo).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not announce when there was nothing to undo/redo', () => {
+    const um = makeUndoManager(false, false);
+    const announce = vi.fn();
+    handleUndoRedoShortcut(keyEvent('z', { ctrlKey: true }), um, announce);
+    expect(um.undo).toHaveBeenCalled();
+    expect(announce).not.toHaveBeenCalled();
+  });
+
+  it('ignores plain "z" with no Cmd/Ctrl', () => {
+    const um = makeUndoManager();
+    handleUndoRedoShortcut(keyEvent('z'), um);
+    expect(um.undo).not.toHaveBeenCalled();
+  });
+
+  it('ignores an already-handled event', () => {
+    const um = makeUndoManager();
+    handleUndoRedoShortcut(keyEvent('z', { ctrlKey: true, preDefault: true }), um);
+    expect(um.undo).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ['input', () => document.createElement('input')],
+    ['textarea', () => document.createElement('textarea')],
+    ['contentEditable div', () => { const d = document.createElement('div'); d.contentEditable = 'true'; return d; }],
+  ])('does not hijack text-undo when focus is in a %s', (_label, makeEl) => {
+    const um = makeUndoManager();
+    const el = makeEl();
+    const e = keyEvent('z', { ctrlKey: true, target: el });
+    const pd = vi.spyOn(e, 'preventDefault');
+    handleUndoRedoShortcut(e, um);
+    expect(um.undo).not.toHaveBeenCalled();
+    expect(pd).not.toHaveBeenCalled();
+  });
+
+  it('does not act while an aria-modal dialog is open', () => {
+    document.body.innerHTML = '<div role="dialog" aria-modal="true"></div>';
+    const um = makeUndoManager();
+    handleUndoRedoShortcut(keyEvent('z', { ctrlKey: true }), um);
+    expect(um.undo).not.toHaveBeenCalled();
+  });
+});

--- a/src/hooks/__tests__/useOwnerConfig.test.tsx
+++ b/src/hooks/__tests__/useOwnerConfig.test.tsx
@@ -1,0 +1,56 @@
+/**
+ * useOwnerConfig — runtime-guard regression tests.
+ *
+ * Covers: `isOwner` derivation, and reloading persisted config when the host
+ * switches `calendarId` (the storage namespace key) — previously the config
+ * stayed pinned to the calendar mounted with.
+ */
+import { describe, it, expect, afterEach } from 'vitest';
+import { renderHook, cleanup } from '@testing-library/react';
+import { useOwnerConfig } from '../useOwnerConfig';
+import { saveConfig } from '../../core/configSchema';
+
+afterEach(() => {
+  cleanup();
+  try { localStorage.clear(); } catch { /* noop */ }
+});
+
+const A = 'wc-owner-cfg-test-a';
+const B = 'wc-owner-cfg-test-b';
+
+describe('useOwnerConfig', () => {
+  it('derives isOwner from role / devMode', () => {
+    expect(renderHook(() => useOwnerConfig({ calendarId: A, role: 'admin' })).result.current.isOwner).toBe(true);
+    expect(renderHook(() => useOwnerConfig({ calendarId: A, role: 'user' })).result.current.isOwner).toBe(false);
+    expect(renderHook(() => useOwnerConfig({ calendarId: A, role: 'user', devMode: true })).result.current.isOwner).toBe(true);
+  });
+
+  it('reloads config from storage when calendarId changes', () => {
+    saveConfig(A, { title: 'Calendar A' });
+    saveConfig(B, { title: 'Calendar B' });
+
+    const { result, rerender } = renderHook(
+      ({ id }: { id: string }) => useOwnerConfig({ calendarId: id }),
+      { initialProps: { id: A } },
+    );
+    expect(result.current.config['title']).toBe('Calendar A');
+
+    rerender({ id: B });
+    expect(result.current.config['title']).toBe('Calendar B');
+
+    rerender({ id: A });
+    expect(result.current.config['title']).toBe('Calendar A');
+  });
+
+  it('does not notify onConfigSave when reloading on a calendarId change', () => {
+    saveConfig(A, { title: 'A' });
+    saveConfig(B, { title: 'B' });
+    const calls: unknown[] = [];
+    const { rerender } = renderHook(
+      ({ id }: { id: string }) => useOwnerConfig({ calendarId: id, onConfigSave: (c) => calls.push(c) }),
+      { initialProps: { id: A } },
+    );
+    rerender({ id: B });
+    expect(calls).toEqual([]);
+  });
+});

--- a/src/hooks/useCalendarMutations.ts
+++ b/src/hooks/useCalendarMutations.ts
@@ -6,12 +6,35 @@ import { useScheduleTemplates } from './useScheduleTemplates';
 import { useOwnerConfig } from './useOwnerConfig';
 import { useSourceStore } from './useSourceStore';
 import { usePermissions } from './usePermissions';
+import { isTypingTarget, hasOpenModal } from './useKeyboardShortcuts';
 import type { UseCalendarEngineResult } from './useCalendarEngine';
 import type { AnnouncerRef } from '../ui/ScreenReaderAnnouncer';
 import type { NormalizedEvent, WorksCalendarEvent } from '../types/events';
 import type { WorksCalendarProps, CalendarRole, EmployeeRecord } from '../WorksCalendar.types';
 import type { UseModalStateReturn } from './useModalState';
 import type { ScheduleTemplateV1 } from '../api/v1/templates';
+
+/**
+ * Handle a global Cmd/Ctrl+Z (undo) / Cmd/Ctrl+Shift+Z / Ctrl+Y (redo)
+ * keydown. Skips when the event was already handled, when no Cmd/Ctrl is held,
+ * when focus is in a text field (let the browser do text-undo), or when a
+ * modal is open (it owns the keyboard). Exported for unit testing.
+ */
+export function handleUndoRedoShortcut(
+  e: KeyboardEvent,
+  undoManager: { undo(): boolean; redo(): boolean },
+  announce?: ((message: string) => void) | undefined,
+): void {
+  if (e.defaultPrevented || !(e.metaKey || e.ctrlKey)) return;
+  if (isTypingTarget(e.target) || hasOpenModal()) return;
+  if (e.key === 'z' && !e.shiftKey) {
+    e.preventDefault();
+    if (undoManager.undo()) announce?.('Undo.');
+  } else if (e.key === 'y' || (e.key === 'z' && e.shiftKey)) {
+    e.preventDefault();
+    if (undoManager.redo()) announce?.('Redo.');
+  }
+}
 
 export interface UseCalendarMutationsInput {
   // Templates
@@ -96,21 +119,8 @@ export function useCalendarMutations({
 
   useEffect(() => {
     if (typeof window === 'undefined') return undefined;
-    const onKeyDown = (e: KeyboardEvent) => {
-      const meta = e.metaKey || e.ctrlKey;
-      if (!meta) return;
-      if (e.key === 'z' && !e.shiftKey) {
-        e.preventDefault();
-        const did = undoManager.undo();
-        if (did) announcerRef.current?.announce('Undo.');
-        return;
-      }
-      if (e.key === 'y' || (e.key === 'z' && e.shiftKey)) {
-        e.preventDefault();
-        const did = undoManager.redo();
-        if (did) announcerRef.current?.announce('Redo.');
-      }
-    };
+    const onKeyDown = (e: KeyboardEvent) =>
+      handleUndoRedoShortcut(e, undoManager, (msg) => announcerRef.current?.announce(msg));
     window.addEventListener('keydown', onKeyDown);
     return () => window.removeEventListener('keydown', onKeyDown);
   }, [undoManager, announcerRef]);

--- a/src/hooks/useCalendarSetup.ts
+++ b/src/hooks/useCalendarSetup.ts
@@ -152,6 +152,10 @@ export function useCalendarSetup({
   }, [ownerCfg.updateConfig, onEmployeeDelete]);
 
   const defaultViewApplied = useRef(false);
+  // Re-arm the one-shot default-view application when the host switches calendars
+  // (otherwise the new calendar's `display.defaultView` is never applied). Declared
+  // before the apply effect so it runs first on a `calendarId` change.
+  useEffect(() => { defaultViewApplied.current = false; }, [calendarId]);
   useEffect(() => {
     if (initialView) return;
     const defaultView = ownerCfg.config?.['display']?.defaultView;

--- a/src/hooks/useKeyboardShortcuts.ts
+++ b/src/hooks/useKeyboardShortcuts.ts
@@ -29,15 +29,20 @@ export const VIEW_SHORTCUT_KEYS = {
   '5': 'schedule',
   '6': 'assets',
 } as const;
-function isTypingTarget(el: Element | null): boolean {
-  if (!el) return false;
+/** True when `el` is (or behaves like) a text-entry field — typing into it
+ *  should win over global shortcuts. Exported so other global keydown handlers
+ *  (e.g. the undo/redo shortcut) apply the same guard. */
+export function isTypingTarget(el: EventTarget | Element | null): boolean {
+  if (!(el instanceof Element)) return false;
   const tag = el.tagName;
   if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT') return true;
   if (el instanceof HTMLElement && el.isContentEditable) return true;
   return false;
 }
 
-function hasOpenModal() {
+/** True when an aria-modal dialog is up — it should own the keyboard. */
+export function hasOpenModal(): boolean {
+  if (typeof document === 'undefined') return false;
   return !!document.querySelector('[role="dialog"][aria-modal="true"], [role="alertdialog"]');
 }
 

--- a/src/hooks/useOwnerConfig.ts
+++ b/src/hooks/useOwnerConfig.ts
@@ -39,6 +39,17 @@ export function useOwnerConfig({ calendarId, role = 'admin', onConfigSave, devMo
   const [smartViewEditId, setSmartViewEditId] = useState<string | null>(null);
   const pendingNotifyRef = useRef(false);
 
+  // Reload from storage when the host points us at a different `calendarId`
+  // (it's the persistence namespace key). The ref skips the redundant reload
+  // on mount, since `useState` already seeded from `calendarId`.
+  const calendarIdRef = useRef(calendarId);
+  useEffect(() => {
+    if (calendarIdRef.current === calendarId) return;
+    calendarIdRef.current = calendarId;
+    pendingNotifyRef.current = false; // any pending notify was for the previous calendar
+    setConfig(loadConfig(calendarId));
+  }, [calendarId]);
+
   // Host app decides who can edit config — no client-side password.
   const isOwner = role === 'admin' || devMode;
 


### PR DESCRIPTION
## Summary

P1 batch of [#599](https://github.com/WorksCalendar/CalendarThatWorks/issues/599). Stacked on #600 (P0) — touches different files, merges independently. Two fixes, plus three items audited as already-fine.

### Fixed

**#10 — global undo shortcut hijacking.** The `window`-level Cmd/Ctrl+Z (undo) / Cmd/Ctrl+Shift+Z / Ctrl+Y (redo) handler in `useCalendarMutations` had no target/state guards — pressing Ctrl+Z while editing text in any input on the page (host's or the calendar's) would `preventDefault()` the native text-undo *and* fire a calendar event-undo. It now bails when:
- the event was already handled (`e.defaultPrevented`),
- focus is in an `<input>` / `<textarea>` / `<select>` / `contentEditable` element,
- an `aria-modal` dialog is open (it owns the keyboard).

Extracted to a pure `handleUndoRedoShortcut(e, undoManager, announce?)` (exported, unit-tested). `isTypingTarget` and `hasOpenModal` are now exported from `useKeyboardShortcuts` so both global keydown handlers share one definition of "don't steal this key".

**#11 — `calendarId` switch.** `useOwnerConfig` only read persisted config in the `useState` initializer, so changing `calendarId` (the storage namespace key) at runtime kept showing the old calendar's config; and `useCalendarSetup`'s one-shot `defaultViewApplied` ref never re-armed. Now: `useOwnerConfig` reloads `loadConfig(calendarId)` on a `calendarId` change (ref-guarded to skip the redundant mount-time reload; doesn't trigger `onConfigSave`), and `useCalendarSetup` resets `defaultViewApplied` on a `calendarId` change so the new calendar's `display.defaultView` is applied.

### Audited — already fine on `main` (notes added to #599)

- **#8 (undo race)** — `UndoRedoManager.undo()`/`.redo()` return `false` on an empty stack; they don't throw. The "a polling `fetchEvents` clears the undo history" behaviour is intentional: a prop-driven `setEvents` replaces the event set, which invalidates the snapshot-based undo stack (undoing would otherwise clobber the refreshed data). Content-aware echo-detection / debouncing would be a design enhancement, not a guard.
- **#9 (keyboard listener leak)** — both global keydown handlers (`useKeyboardShortcuts`, the undo one in `useCalendarMutations`) already `removeEventListener` in their effect cleanup. No leak.
- **#12 (SSR mount delay)** — the `window`/`document` accesses in `WorksCalendar` and the hooks are all inside `useEffect` callbacks / event handlers (client-only), and the few render-time reads are guarded (`typeof window === 'undefined' ? … : …`). SSR-safe.

### Not in this PR

Full focus-scoping of the undo shortcut (only act when the calendar root contains the focused element) — needs a root ref threaded through `useCalendarMutations`; left as a follow-up. The current guard covers the harmful case (text editing) and modals.

## Tests added

- `useCalendarMutations.test.tsx` *(new)* — `handleUndoRedoShortcut`: Ctrl+Z → undo + announce; Shift+Z / Ctrl+Y → redo; no announce when nothing to undo; ignores plain `z`; ignores already-handled events; **does not hijack text-undo from input/textarea/contentEditable**; doesn't act with a modal open.
- `useOwnerConfig.test.tsx` *(new)* — `isOwner` derivation; **reloads config when `calendarId` changes** (round-trip A→B→A); doesn't notify `onConfigSave` on the reload.

## Test plan

- [x] `npm test` — 233 files, **4268 tests**, green.
- [x] `npm run type-check` (strict) — no new errors vs `main`.
- [x] `eslint src` — clean.
- [x] `npm run build` — succeeds.
- [ ] Smoke: type in a host `<input>`, hit Ctrl+Z → text-undo works, no calendar undo; switch `calendarId` at runtime → config + default view update.

https://claude.ai/code/session_01AKrYupUsUye3ShWYp2w6MW

---
_Generated by [Claude Code](https://claude.ai/code/session_01AKrYupUsUye3ShWYp2w6MW)_