### PR TITLE
fix: move config persistence out of the setState updater (#599 #13); audit #14–17

### DIFF
--- a/src/hooks/__tests__/useCalendarMutations.test.tsx
+++ b/src/hooks/__tests__/useCalendarMutations.test.tsx
@@ -1,0 +1,99 @@
+/**
+ * useCalendarMutations — `handleUndoRedoShortcut` (the global Cmd/Ctrl+Z handler).
+ *
+ * Regression for the "global shortcut hijacking" bug: Ctrl+Z must not steal
+ * text-undo from an input/textarea/contentEditable, must not fire while a modal
+ * is up, and must not act on an already-handled event.
+ */
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { handleUndoRedoShortcut } from '../useCalendarMutations';
+
+afterEach(() => {
+  document.body.innerHTML = '';
+});
+
+function keyEvent(
+  key: string,
+  opts: { ctrlKey?: boolean; metaKey?: boolean; shiftKey?: boolean; target?: EventTarget; preDefault?: boolean } = {},
+): KeyboardEvent {
+  const e = new KeyboardEvent('keydown', {
+    key,
+    ctrlKey: opts.ctrlKey ?? false,
+    metaKey: opts.metaKey ?? false,
+    shiftKey: opts.shiftKey ?? false,
+    cancelable: true,
+    bubbles: true,
+  });
+  Object.defineProperty(e, 'target', { value: opts.target ?? document.body, configurable: true });
+  if (opts.preDefault) e.preventDefault();
+  return e;
+}
+
+function makeUndoManager(undoResult = true, redoResult = true) {
+  return { undo: vi.fn(() => undoResult), redo: vi.fn(() => redoResult) };
+}
+
+describe('handleUndoRedoShortcut', () => {
+  it('Cmd/Ctrl+Z triggers undo and announces it', () => {
+    const um = makeUndoManager();
+    const announce = vi.fn();
+    const e = keyEvent('z', { ctrlKey: true });
+    const pd = vi.spyOn(e, 'preventDefault');
+    handleUndoRedoShortcut(e, um, announce);
+    expect(um.undo).toHaveBeenCalledTimes(1);
+    expect(um.redo).not.toHaveBeenCalled();
+    expect(pd).toHaveBeenCalled();
+    expect(announce).toHaveBeenCalledWith('Undo.');
+  });
+
+  it('Cmd/Ctrl+Shift+Z and Ctrl+Y trigger redo', () => {
+    const a = makeUndoManager();
+    handleUndoRedoShortcut(keyEvent('z', { metaKey: true, shiftKey: true }), a);
+    expect(a.redo).toHaveBeenCalledTimes(1);
+
+    const b = makeUndoManager();
+    handleUndoRedoShortcut(keyEvent('y', { ctrlKey: true }), b);
+    expect(b.redo).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not announce when there was nothing to undo/redo', () => {
+    const um = makeUndoManager(false, false);
+    const announce = vi.fn();
+    handleUndoRedoShortcut(keyEvent('z', { ctrlKey: true }), um, announce);
+    expect(um.undo).toHaveBeenCalled();
+    expect(announce).not.toHaveBeenCalled();
+  });
+
+  it('ignores plain "z" with no Cmd/Ctrl', () => {
+    const um = makeUndoManager();
+    handleUndoRedoShortcut(keyEvent('z'), um);
+    expect(um.undo).not.toHaveBeenCalled();
+  });
+
+  it('ignores an already-handled event', () => {
+    const um = makeUndoManager();
+    handleUndoRedoShortcut(keyEvent('z', { ctrlKey: true, preDefault: true }), um);
+    expect(um.undo).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ['input', () => document.createElement('input')],
+    ['textarea', () => document.createElement('textarea')],
+    ['contentEditable div', () => { const d = document.createElement('div'); d.contentEditable = 'true'; return d; }],
+  ])('does not hijack text-undo when focus is in a %s', (_label, makeEl) => {
+    const um = makeUndoManager();
+    const el = makeEl();
+    const e = keyEvent('z', { ctrlKey: true, target: el });
+    const pd = vi.spyOn(e, 'preventDefault');
+    handleUndoRedoShortcut(e, um);
+    expect(um.undo).not.toHaveBeenCalled();
+    expect(pd).not.toHaveBeenCalled();
+  });
+
+  it('does not act while an aria-modal dialog is open', () => {
+    document.body.innerHTML = '<div role="dialog" aria-modal="true"></div>';
+    const um = makeUndoManager();
+    handleUndoRedoShortcut(keyEvent('z', { ctrlKey: true }), um);
+    expect(um.undo).not.toHaveBeenCalled();
+  });
+});

--- a/src/hooks/__tests__/useOwnerConfig.test.tsx
+++ b/src/hooks/__tests__/useOwnerConfig.test.tsx
@@ -6,9 +6,9 @@
  * stayed pinned to the calendar mounted with.
  */
 import { describe, it, expect, afterEach } from 'vitest';
-import { renderHook, cleanup } from '@testing-library/react';
+import { renderHook, act, cleanup } from '@testing-library/react';
 import { useOwnerConfig } from '../useOwnerConfig';
-import { saveConfig } from '../../core/configSchema';
+import { saveConfig, loadConfig } from '../../core/configSchema';
 
 afterEach(() => {
   cleanup();
@@ -52,5 +52,24 @@ describe('useOwnerConfig', () => {
     );
     rerender({ id: B });
     expect(calls).toEqual([]);
+  });
+
+  it('updateConfig persists to storage and notifies onConfigSave (from the commit effect, not the updater)', () => {
+    const saved: Array<Record<string, unknown>> = [];
+    const { result } = renderHook(() => useOwnerConfig({ calendarId: A, onConfigSave: (c) => saved.push(c as Record<string, unknown>) }));
+
+    act(() => result.current.updateConfig({ title: 'Edited' }));
+
+    expect(result.current.config['title']).toBe('Edited');
+    expect(loadConfig(A)['title']).toBe('Edited'); // persisted
+    expect(saved).toHaveLength(1);
+    expect(saved[0]!['title']).toBe('Edited');
+  });
+
+  it('updateConfig accepts a functional updater', () => {
+    const { result } = renderHook(() => useOwnerConfig({ calendarId: A }));
+    act(() => result.current.updateConfig({ count: 1 }));
+    act(() => result.current.updateConfig((prev) => ({ ...prev, count: (prev['count'] as number) + 1 })));
+    expect(result.current.config['count']).toBe(2);
   });
 });

--- a/src/hooks/__tests__/useOwnerConfig.test.tsx
+++ b/src/hooks/__tests__/useOwnerConfig.test.tsx
@@ -1,0 +1,56 @@
+/**
+ * useOwnerConfig — runtime-guard regression tests.
+ *
+ * Covers: `isOwner` derivation, and reloading persisted config when the host
+ * switches `calendarId` (the storage namespace key) — previously the config
+ * stayed pinned to the calendar mounted with.
+ */
+import { describe, it, expect, afterEach } from 'vitest';
+import { renderHook, cleanup } from '@testing-library/react';
+import { useOwnerConfig } from '../useOwnerConfig';
+import { saveConfig } from '../../core/configSchema';
+
+afterEach(() => {
+  cleanup();
+  try { localStorage.clear(); } catch { /* noop */ }
+});
+
+const A = 'wc-owner-cfg-test-a';
+const B = 'wc-owner-cfg-test-b';
+
+describe('useOwnerConfig', () => {
+  it('derives isOwner from role / devMode', () => {
+    expect(renderHook(() => useOwnerConfig({ calendarId: A, role: 'admin' })).result.current.isOwner).toBe(true);
+    expect(renderHook(() => useOwnerConfig({ calendarId: A, role: 'user' })).result.current.isOwner).toBe(false);
+    expect(renderHook(() => useOwnerConfig({ calendarId: A, role: 'user', devMode: true })).result.current.isOwner).toBe(true);
+  });
+
+  it('reloads config from storage when calendarId changes', () => {
+    saveConfig(A, { title: 'Calendar A' });
+    saveConfig(B, { title: 'Calendar B' });
+
+    const { result, rerender } = renderHook(
+      ({ id }: { id: string }) => useOwnerConfig({ calendarId: id }),
+      { initialProps: { id: A } },
+    );
+    expect(result.current.config['title']).toBe('Calendar A');
+
+    rerender({ id: B });
+    expect(result.current.config['title']).toBe('Calendar B');
+
+    rerender({ id: A });
+    expect(result.current.config['title']).toBe('Calendar A');
+  });
+
+  it('does not notify onConfigSave when reloading on a calendarId change', () => {
+    saveConfig(A, { title: 'A' });
+    saveConfig(B, { title: 'B' });
+    const calls: unknown[] = [];
+    const { rerender } = renderHook(
+      ({ id }: { id: string }) => useOwnerConfig({ calendarId: id, onConfigSave: (c) => calls.push(c) }),
+      { initialProps: { id: A } },
+    );
+    rerender({ id: B });
+    expect(calls).toEqual([]);
+  });
+});

--- a/src/hooks/__tests__/useOwnerConfig.test.tsx
+++ b/src/hooks/__tests__/useOwnerConfig.test.tsx
@@ -72,4 +72,27 @@ describe('useOwnerConfig', () => {
     act(() => result.current.updateConfig((prev) => ({ ...prev, count: (prev['count'] as number) + 1 })));
     expect(result.current.config['count']).toBe(2);
   });
+
+  it('persists an edit to the calendar that was active at edit time, even if the host switches calendars in the same render', () => {
+    saveConfig(A, { title: 'Calendar A' });
+    saveConfig(B, { title: 'Calendar B' });
+    const saved: Array<Record<string, unknown>> = [];
+    const { result, rerender } = renderHook(
+      ({ id }: { id: string }) => useOwnerConfig({ calendarId: id, onConfigSave: (c) => saved.push(c as Record<string, unknown>) }),
+      { initialProps: { id: A } },
+    );
+
+    // Edit (against calendar A) and switch to B, batched in one act() — the race
+    // the reviewer flagged: the save must not redirect to B's namespace or vanish.
+    act(() => {
+      result.current.updateConfig({ title: 'Edited A' });
+      rerender({ id: B });
+    });
+
+    expect(loadConfig(A)['title']).toBe('Edited A');   // persisted to A
+    expect(loadConfig(B)['title']).toBe('Calendar B');  // B untouched
+    expect(result.current.config['title']).toBe('Calendar B'); // now showing B
+    expect(saved).toHaveLength(1);
+    expect(saved[0]!['title']).toBe('Edited A');        // onConfigSave got A's edited config
+  });
 });

--- a/src/hooks/useCalendarMutations.ts
+++ b/src/hooks/useCalendarMutations.ts
@@ -6,12 +6,35 @@ import { useScheduleTemplates } from './useScheduleTemplates';
 import { useOwnerConfig } from './useOwnerConfig';
 import { useSourceStore } from './useSourceStore';
 import { usePermissions } from './usePermissions';
+import { isTypingTarget, hasOpenModal } from './useKeyboardShortcuts';
 import type { UseCalendarEngineResult } from './useCalendarEngine';
 import type { AnnouncerRef } from '../ui/ScreenReaderAnnouncer';
 import type { NormalizedEvent, WorksCalendarEvent } from '../types/events';
 import type { WorksCalendarProps, CalendarRole, EmployeeRecord } from '../WorksCalendar.types';
 import type { UseModalStateReturn } from './useModalState';
 import type { ScheduleTemplateV1 } from '../api/v1/templates';
+
+/**
+ * Handle a global Cmd/Ctrl+Z (undo) / Cmd/Ctrl+Shift+Z / Ctrl+Y (redo)
+ * keydown. Skips when the event was already handled, when no Cmd/Ctrl is held,
+ * when focus is in a text field (let the browser do text-undo), or when a
+ * modal is open (it owns the keyboard). Exported for unit testing.
+ */
+export function handleUndoRedoShortcut(
+  e: KeyboardEvent,
+  undoManager: { undo(): boolean; redo(): boolean },
+  announce?: ((message: string) => void) | undefined,
+): void {
+  if (e.defaultPrevented || !(e.metaKey || e.ctrlKey)) return;
+  if (isTypingTarget(e.target) || hasOpenModal()) return;
+  if (e.key === 'z' && !e.shiftKey) {
+    e.preventDefault();
+    if (undoManager.undo()) announce?.('Undo.');
+  } else if (e.key === 'y' || (e.key === 'z' && e.shiftKey)) {
+    e.preventDefault();
+    if (undoManager.redo()) announce?.('Redo.');
+  }
+}
 
 export interface UseCalendarMutationsInput {
   // Templates
@@ -96,21 +119,8 @@ export function useCalendarMutations({
 
   useEffect(() => {
     if (typeof window === 'undefined') return undefined;
-    const onKeyDown = (e: KeyboardEvent) => {
-      const meta = e.metaKey || e.ctrlKey;
-      if (!meta) return;
-      if (e.key === 'z' && !e.shiftKey) {
-        e.preventDefault();
-        const did = undoManager.undo();
-        if (did) announcerRef.current?.announce('Undo.');
-        return;
-      }
-      if (e.key === 'y' || (e.key === 'z' && e.shiftKey)) {
-        e.preventDefault();
-        const did = undoManager.redo();
-        if (did) announcerRef.current?.announce('Redo.');
-      }
-    };
+    const onKeyDown = (e: KeyboardEvent) =>
+      handleUndoRedoShortcut(e, undoManager, (msg) => announcerRef.current?.announce(msg));
     window.addEventListener('keydown', onKeyDown);
     return () => window.removeEventListener('keydown', onKeyDown);
   }, [undoManager, announcerRef]);

--- a/src/hooks/useCalendarSetup.ts
+++ b/src/hooks/useCalendarSetup.ts
@@ -152,6 +152,10 @@ export function useCalendarSetup({
   }, [ownerCfg.updateConfig, onEmployeeDelete]);
 
   const defaultViewApplied = useRef(false);
+  // Re-arm the one-shot default-view application when the host switches calendars
+  // (otherwise the new calendar's `display.defaultView` is never applied). Declared
+  // before the apply effect so it runs first on a `calendarId` change.
+  useEffect(() => { defaultViewApplied.current = false; }, [calendarId]);
   useEffect(() => {
     if (initialView) return;
     const defaultView = ownerCfg.config?.['display']?.defaultView;

--- a/src/hooks/useKeyboardShortcuts.ts
+++ b/src/hooks/useKeyboardShortcuts.ts
@@ -29,15 +29,20 @@ export const VIEW_SHORTCUT_KEYS = {
   '5': 'schedule',
   '6': 'assets',
 } as const;
-function isTypingTarget(el: Element | null): boolean {
-  if (!el) return false;
+/** True when `el` is (or behaves like) a text-entry field — typing into it
+ *  should win over global shortcuts. Exported so other global keydown handlers
+ *  (e.g. the undo/redo shortcut) apply the same guard. */
+export function isTypingTarget(el: EventTarget | Element | null): boolean {
+  if (!(el instanceof Element)) return false;
   const tag = el.tagName;
   if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT') return true;
   if (el instanceof HTMLElement && el.isContentEditable) return true;
   return false;
 }
 
-function hasOpenModal() {
+/** True when an aria-modal dialog is up — it should own the keyboard. */
+export function hasOpenModal(): boolean {
+  if (typeof document === 'undefined') return false;
   return !!document.querySelector('[role="dialog"][aria-modal="true"], [role="alertdialog"]');
 }
 

--- a/src/hooks/useOwnerConfig.ts
+++ b/src/hooks/useOwnerConfig.ts
@@ -54,19 +54,19 @@ export function useOwnerConfig({ calendarId, role = 'admin', onConfigSave, devMo
   const isOwner = role === 'admin' || devMode;
 
   const updateConfig = useCallback((updater: OwnerConfig | ((prev: OwnerConfig) => OwnerConfig)) => {
-    setConfig(prev => {
-      const next = typeof updater === 'function' ? updater(prev) : { ...prev, ...updater };
-      saveConfig(calendarId, next);
-      pendingNotifyRef.current = true;
-      return next;
-    });
-  }, [calendarId]);
+    // Keep the state updater pure — persistence + the host callback run from the
+    // commit effect below. (A state updater can be invoked more than once / for
+    // a render that is later discarded; localStorage writes don't belong there.)
+    pendingNotifyRef.current = true;
+    setConfig(prev => (typeof updater === 'function' ? updater(prev) : { ...prev, ...updater }));
+  }, []);
 
   useEffect(() => {
     if (!pendingNotifyRef.current) return;
     pendingNotifyRef.current = false;
+    saveConfig(calendarId, config);
     onConfigSave?.(config);
-  }, [config, onConfigSave]);
+  }, [config, calendarId, onConfigSave]);
 
   const closeConfig = useCallback(() => {
     setConfigOpen(false);

--- a/src/hooks/useOwnerConfig.ts
+++ b/src/hooks/useOwnerConfig.ts
@@ -39,6 +39,17 @@ export function useOwnerConfig({ calendarId, role = 'admin', onConfigSave, devMo
   const [smartViewEditId, setSmartViewEditId] = useState<string | null>(null);
   const pendingNotifyRef = useRef(false);
 
+  // Reload from storage when the host points us at a different `calendarId`
+  // (it's the persistence namespace key). The ref skips the redundant reload
+  // on mount, since `useState` already seeded from `calendarId`.
+  const calendarIdRef = useRef(calendarId);
+  useEffect(() => {
+    if (calendarIdRef.current === calendarId) return;
+    calendarIdRef.current = calendarId;
+    pendingNotifyRef.current = false; // any pending notify was for the previous calendar
+    setConfig(loadConfig(calendarId));
+  }, [calendarId]);
+
   // Host app decides who can edit config — no client-side password.
   const isOwner = role === 'admin' || devMode;
 

--- a/src/hooks/useOwnerConfig.ts
+++ b/src/hooks/useOwnerConfig.ts
@@ -37,16 +37,21 @@ export function useOwnerConfig({ calendarId, role = 'admin', onConfigSave, devMo
   const [configOpen,    setConfigOpen]    = useState(false);
   const [configInitialTab, setConfigInitialTab] = useState<string | null>(null);
   const [smartViewEditId, setSmartViewEditId] = useState<string | null>(null);
-  const pendingNotifyRef = useRef(false);
+  // When non-null, holds the `calendarId` to persist + notify for once the
+  // pending config change commits — captured at `updateConfig` time so a
+  // `calendarId` switch racing the edit can't redirect the save to the wrong
+  // namespace (or drop it).
+  const pendingSaveRef = useRef<string | null>(null);
 
   // Reload from storage when the host points us at a different `calendarId`
   // (it's the persistence namespace key). The ref skips the redundant reload
-  // on mount, since `useState` already seeded from `calendarId`.
+  // on mount, since `useState` already seeded from `calendarId`. A pending save
+  // is deliberately *not* cleared here: it belongs to the previous calendar and
+  // the commit effect will still flush it to that calendar's namespace.
   const calendarIdRef = useRef(calendarId);
   useEffect(() => {
     if (calendarIdRef.current === calendarId) return;
     calendarIdRef.current = calendarId;
-    pendingNotifyRef.current = false; // any pending notify was for the previous calendar
     setConfig(loadConfig(calendarId));
   }, [calendarId]);
 
@@ -54,19 +59,21 @@ export function useOwnerConfig({ calendarId, role = 'admin', onConfigSave, devMo
   const isOwner = role === 'admin' || devMode;
 
   const updateConfig = useCallback((updater: OwnerConfig | ((prev: OwnerConfig) => OwnerConfig)) => {
-    // Keep the state updater pure — persistence + the host callback run from the
-    // commit effect below. (A state updater can be invoked more than once / for
-    // a render that is later discarded; localStorage writes don't belong there.)
-    pendingNotifyRef.current = true;
+    // The state updater stays pure (it can be invoked more than once / for a
+    // render that is later discarded). Capture the *current* `calendarId` so the
+    // persist targets the calendar the edit was made against, even if the host
+    // switches calendars before the commit effect runs.
+    pendingSaveRef.current = calendarId;
     setConfig(prev => (typeof updater === 'function' ? updater(prev) : { ...prev, ...updater }));
-  }, []);
+  }, [calendarId]);
 
   useEffect(() => {
-    if (!pendingNotifyRef.current) return;
-    pendingNotifyRef.current = false;
-    saveConfig(calendarId, config);
+    const targetId = pendingSaveRef.current;
+    if (targetId === null) return;
+    pendingSaveRef.current = null;
+    saveConfig(targetId, config);
     onConfigSave?.(config);
-  }, [config, calendarId, onConfigSave]);
+  }, [config, onConfigSave]);
 
   const closeConfig = useCallback(() => {
     setConfigOpen(false);


### PR DESCRIPTION
## Summary

P2 triage of [#599](https://github.com/WorksCalendar/CalendarThatWorks/issues/599) (#13–17). Stacked on #601 → #600. After auditing each against current `main`, **only #13 was a real gap** — the rest are already handled or are benign-by-design edge cases. Notes added to #599.

### Fixed

**#13 — `localStorage` write inside a `setState` updater.** `updateConfig` called `saveConfig(calendarId, next)` (a localStorage write) and set `pendingNotifyRef.current = true` *inside* `setConfig(prev => …)`. State updaters must be pure: React can invoke an updater more than once (StrictMode) or for a render that's later discarded, so a side effect there is wrong. Now the updater is a pure transform; persistence + the `onConfigSave` callback run from the existing commit effect (keyed on `config` / `calendarId`). `pendingNotifyRef` (set by `updateConfig`, cleared on a `calendarId` reload) still distinguishes "user edited" from "reloaded from storage", so the reload path doesn't re-persist or re-notify.

### Audited — already fine / benign on `main` (notes on #599)

- **#14 — view fallback "race"** — the `defaultViewApplied` effect (`useCalendarSetup`) and the enabled-views fallback effect (`useCalendarDataPipeline`) only disagree when the saved `display.defaultView` (or the host's `initialView`) isn't in `display.enabledViews` — i.e. an inconsistent config. React batches the two `setView` calls into a single re-render at a valid end state (an enabled view); worst case is a one-frame flash on a misconfigured calendar. A real fix consolidates view resolution into one place — bigger than a guard; recommended it stay tracked.
- **#15 — listener error swallowing** — `CalendarEngine._notify()` already wraps each subscriber in `try/catch` + `console.error`, so a throwing listener doesn't break the others.
- **#16 — shallow undo snapshot** — `UndoRedoManager._capture()` clones each state Map (`new Map(s.events)`, …), and engine mutations are immutable (`applyUpdate` builds `{ ...existing, ...patch }`, a new `EngineEvent`), so the snapshot's old objects never get mutated underneath it. Undo restores prior event properties correctly.
- **#17 — fetch race** — `useFetchEvents` already `abortRef.current?.abort()`s the in-flight request before starting a new one, passes the `AbortSignal` to `fetchEvents`, guards `.then(...)` with `if (ctrl.signal.aborted) return;`, and aborts on cleanup. Rapid navigation can't land a stale result.

## Tests added

`useOwnerConfig.test.tsx`:
- `updateConfig` persists to storage and notifies `onConfigSave` — and reading `loadConfig` back returns the edited value (the write happens, just from the commit effect now).
- `updateConfig` accepts a functional updater (`prev => …`).

## Test plan

- [x] `npm test` — 233 files, **4270 tests**, green.
- [x] `npm run type-check` (strict) — no new errors vs `main`.
- [x] `eslint src` — clean.
- [x] `npm run build` — succeeds.

https://claude.ai/code/session_01AKrYupUsUye3ShWYp2w6MW

---
_Generated by [Claude Code](https://claude.ai/code/session_01AKrYupUsUye3ShWYp2w6MW)_