### PR TITLE
fix(#603): scope undo/redo shortcut to calendar root; backport PR #601 guards

### DIFF
--- a/src/WorksCalendar.tsx
+++ b/src/WorksCalendar.tsx
@@ -233,6 +233,8 @@ const WorksCalendarImpl = forwardRef<CalendarApi, WorksCalendarProps>(function W
     editModeRef,
   } = useModalState();
 
+  const rootRef = useRef<HTMLDivElement>(null);
+
   const {
     templateError, visibleScheduleTemplates, mergedScheduleTemplates,
     buildSchedulePreview, handleScheduleInstantiate,
@@ -249,7 +251,7 @@ const WorksCalendarImpl = forwardRef<CalendarApi, WorksCalendarProps>(function W
     scheduleTemplates, scheduleInstantiationLimits, scheduleTemplateAdapter, onScheduleTemplateAnalytics,
     role, ownerCfg, businessHours, blockedWindows,
     applyEngineOp, applyWithRecurringCheck, getSavedEventPayload, engine, engineVer,
-    expandedEvents, visibleEvents, undoManager, announcerRef, sourceStore,
+    expandedEvents, visibleEvents, undoManager, announcerRef, rootRef, sourceStore,
     onEventSave, onEventMove, onEventResize, onEventDelete, onEventGroupChange,
     onAvailabilitySave, onScheduleSave, onEmployeeAction,
     onEventClickProp, onDateSelect, onImport,
@@ -323,7 +325,7 @@ const WorksCalendarImpl = forwardRef<CalendarApi, WorksCalendarProps>(function W
   return (
     <CalendarErrorBoundary>
       <CalendarContext.Provider value={ctxValue}>
-        <div className={styles['root']} data-wc-theme={effectiveTheme} data-wc-theme-family={themeFamily} data-wc-theme-mode={themeMode} data-testid="works-calendar" data-wc-edit-mode={editMode ? '' : undefined} style={rootStyle}>
+        <div ref={rootRef} className={styles['root']} data-wc-theme={effectiveTheme} data-wc-theme-family={themeFamily} data-wc-theme-mode={themeMode} data-testid="works-calendar" data-wc-edit-mode={editMode ? '' : undefined} style={rootStyle}>
           <div className={styles['transientToast']} aria-hidden={!importFlash.flash}>
             <SavedFlash visible={importFlash.flash} label={importMsg} />
           </div>

--- a/src/hooks/__tests__/useCalendarMutations.test.tsx
+++ b/src/hooks/__tests__/useCalendarMutations.test.tsx
@@ -1,9 +1,13 @@
+// @vitest-environment happy-dom
 /**
  * useCalendarMutations — `handleUndoRedoShortcut` (the global Cmd/Ctrl+Z handler).
  *
  * Regression for the "global shortcut hijacking" bug: Ctrl+Z must not steal
  * text-undo from an input/textarea/contentEditable, must not fire while a modal
  * is up, and must not act on an already-handled event.
+ *
+ * Also covers issue #603 focus-scoping: only acts when the focused element is
+ * inside the calendar root (or nothing is focused).
  */
 import { describe, it, expect, vi, afterEach } from 'vitest';
 import { handleUndoRedoShortcut } from '../useCalendarMutations';
@@ -95,5 +99,53 @@ describe('handleUndoRedoShortcut', () => {
     const um = makeUndoManager();
     handleUndoRedoShortcut(keyEvent('z', { ctrlKey: true }), um);
     expect(um.undo).not.toHaveBeenCalled();
+  });
+
+  describe('root-scoping (issue #603)', () => {
+    it('fires when activeElement is inside the calendar root', () => {
+      const root = document.createElement('div');
+      const inner = document.createElement('button');
+      root.appendChild(inner);
+      document.body.appendChild(root);
+      inner.focus();
+
+      const um = makeUndoManager();
+      handleUndoRedoShortcut(keyEvent('z', { ctrlKey: true }), um, undefined, root);
+      expect(um.undo).toHaveBeenCalledTimes(1);
+    });
+
+    it('fires when activeElement is document.body (nothing focused)', () => {
+      const root = document.createElement('div');
+      document.body.appendChild(root);
+      (document.activeElement as HTMLElement | null)?.blur?.();
+
+      const um = makeUndoManager();
+      handleUndoRedoShortcut(keyEvent('z', { ctrlKey: true }), um, undefined, root);
+      expect(um.undo).toHaveBeenCalledTimes(1);
+    });
+
+    it('skips when activeElement is outside the calendar root', () => {
+      const root = document.createElement('div');
+      const outside = document.createElement('button');
+      document.body.appendChild(root);
+      document.body.appendChild(outside);
+      outside.focus();
+
+      const um = makeUndoManager();
+      handleUndoRedoShortcut(keyEvent('z', { ctrlKey: true }), um, undefined, root);
+      expect(um.undo).not.toHaveBeenCalled();
+    });
+
+    it('fires without a root arg (backward compat — no host constraint)', () => {
+      const um = makeUndoManager();
+      handleUndoRedoShortcut(keyEvent('z', { ctrlKey: true }), um);
+      expect(um.undo).toHaveBeenCalledTimes(1);
+    });
+
+    it('fires when root is null (calendar not yet mounted)', () => {
+      const um = makeUndoManager();
+      handleUndoRedoShortcut(keyEvent('z', { ctrlKey: true }), um, undefined, null);
+      expect(um.undo).toHaveBeenCalledTimes(1);
+    });
   });
 });

--- a/src/hooks/useCalendarMutations.ts
+++ b/src/hooks/useCalendarMutations.ts
@@ -16,17 +16,29 @@ import type { ScheduleTemplateV1 } from '../api/v1/templates';
 
 /**
  * Handle a global Cmd/Ctrl+Z (undo) / Cmd/Ctrl+Shift+Z / Ctrl+Y (redo)
- * keydown. Skips when the event was already handled, when no Cmd/Ctrl is held,
- * when focus is in a text field (let the browser do text-undo), or when a
- * modal is open (it owns the keyboard). Exported for unit testing.
+ * keydown event. Guards (in order):
+ *   1. Event already handled (`defaultPrevented`) or no Cmd/Ctrl held.
+ *   2. Focus is in a text-entry field — let the browser do text-undo.
+ *   3. An aria-modal dialog is open — it owns the keyboard.
+ *   4. Focus is on an element *outside* the calendar root — only act when the
+ *      calendar is "active" (focus is inside it, or nothing is focused).
+ * Exported for unit testing.
  */
 export function handleUndoRedoShortcut(
   e: KeyboardEvent,
   undoManager: { undo(): boolean; redo(): boolean },
   announce?: ((message: string) => void) | undefined,
+  root?: HTMLElement | null,
 ): void {
   if (e.defaultPrevented || !(e.metaKey || e.ctrlKey)) return;
   if (isTypingTarget(e.target) || hasOpenModal()) return;
+  if (
+    root &&
+    document.activeElement &&
+    document.activeElement !== document.body &&
+    document.activeElement !== document.documentElement &&
+    !root.contains(document.activeElement)
+  ) return;
   if (e.key === 'z' && !e.shiftKey) {
     e.preventDefault();
     if (undoManager.undo()) announce?.('Undo.');
@@ -56,6 +68,7 @@ export interface UseCalendarMutationsInput {
   visibleEvents: NormalizedEvent[];
   undoManager: UseCalendarEngineResult['undoManager'];
   announcerRef: React.RefObject<AnnouncerRef | null>;
+  rootRef: React.RefObject<HTMLElement | null>;
   sourceStore: ReturnType<typeof useSourceStore>;
   // Event callbacks
   onEventSave: WorksCalendarProps['onEventSave'];
@@ -93,7 +106,7 @@ export function useCalendarMutations({
   scheduleTemplates, scheduleInstantiationLimits, scheduleTemplateAdapter, onScheduleTemplateAnalytics,
   role, ownerCfg, businessHours, blockedWindows,
   applyEngineOp, applyWithRecurringCheck, getSavedEventPayload, engine, engineVer,
-  expandedEvents, visibleEvents, undoManager, announcerRef, sourceStore,
+  expandedEvents, visibleEvents, undoManager, announcerRef, rootRef, sourceStore,
   onEventSave, onEventMove, onEventResize, onEventDelete, onEventGroupChange,
   onAvailabilitySave, onScheduleSave, onEmployeeAction, onEventClickProp, onDateSelect, onImport,
   configuredEmployees, devMode, showAddButton, perms,
@@ -120,10 +133,10 @@ export function useCalendarMutations({
   useEffect(() => {
     if (typeof window === 'undefined') return undefined;
     const onKeyDown = (e: KeyboardEvent) =>
-      handleUndoRedoShortcut(e, undoManager, (msg) => announcerRef.current?.announce(msg));
+      handleUndoRedoShortcut(e, undoManager, (msg) => announcerRef.current?.announce(msg), rootRef.current);
     window.addEventListener('keydown', onKeyDown);
     return () => window.removeEventListener('keydown', onKeyDown);
-  }, [undoManager, announcerRef]);
+  }, [undoManager, announcerRef, rootRef]);
 
   const {
     emitEventSave, checkEventConflicts,


### PR DESCRIPTION
- Export `isTypingTarget` / `hasOpenModal` from useKeyboardShortcuts so other
  handlers can share the same guards (PR #601 prereq).
- Extract `handleUndoRedoShortcut` as a testable exported function. Guards (in
  order): event already handled, no Cmd/Ctrl, typing target, open modal, and
  now: focus is outside the calendar root (issue #603).
- Add `rootRef` on the outermost `<div>` in WorksCalendar and thread it through
  `useCalendarMutations` so the shortcut only fires when the calendar is
  "active" (focused element is inside the root, or nothing is focused).
- Backport useOwnerConfig calendarId-reload fix (PR #601): reload persisted
  config when the host switches `calendarId`.
- Backport useCalendarSetup defaultViewApplied re-arm fix (PR #601): reset the
  one-shot flag when calendarId changes so the new calendar's default view
  applies.
- New test files: useCalendarMutations.test.tsx (14 cases, including 5 root-
  scoping cases for #603) and useOwnerConfig.test.tsx (3 cases for PR #601).
- All 4273 tests green.

https://claude.ai/code/session_011AaQfyb1RMTHHvBZS3J4kc