### PR TITLE
refactor(#604): consolidate active-view resolution into one effect

### DIFF
--- a/src/WorksCalendar.tsx
+++ b/src/WorksCalendar.tsx
@@ -211,7 +211,7 @@ const WorksCalendarImpl = forwardRef<CalendarApi, WorksCalendarProps>(function W
     supabaseUrl, supabaseKey, supabaseTable, supabaseFilter,
     rawPools, businessHours, blockedWindows, onPoolsChange,
     configuredEmployees, effectiveAssets, selectedBaseIds,
-    assetRequestCategories, categoriesConfig, schema, activeSort,
+    assetRequestCategories, categoriesConfig, schema, activeSort, initialView,
   });
 
   const {

--- a/src/hooks/__tests__/useCalendarDataPipeline.viewResolution.test.ts
+++ b/src/hooks/__tests__/useCalendarDataPipeline.viewResolution.test.ts
@@ -1,0 +1,194 @@
+/**
+ * resolveActiveView — pure view-resolution logic (issue #604).
+ *
+ * The consolidated effect in `useCalendarDataPipeline` owns all active-view
+ * decisions. `resolveActiveView` is the pure core of that effect, covering:
+ *
+ *   Priority (first match wins on first resolution per calendarId):
+ *     1. initialView (if set and in enabledIds)
+ *     2. configDefault (if set and in enabledIds) — one-shot per calendarId
+ *     3. calView (if still in enabledIds)
+ *   Post-initial fallback (view became invalid after user navigation):
+ *     4. configDefault (if in enabledIds)
+ *     5. 'month'
+ */
+import { describe, it, expect } from 'vitest';
+import { resolveActiveView } from '../useCalendarDataPipeline';
+
+const ALWAYS_ON = new Set(['month', 'week', 'day', 'agenda', 'schedule']);
+
+function ids(...views: string[]): Set<string> {
+  return new Set(views);
+}
+
+describe('resolveActiveView — initial resolution (isNewCalendar = true)', () => {
+  it('returns initialView when set and enabled', () => {
+    expect(resolveActiveView({
+      enabledIds: ALWAYS_ON,
+      calView: 'month',
+      initialView: 'week',
+      configDefault: 'day',
+      isNewCalendar: true,
+    })).toBe('week');
+  });
+
+  it('skips initialView that is not in enabledIds and falls to configDefault', () => {
+    expect(resolveActiveView({
+      enabledIds: ids('month', 'week'),
+      calView: 'month',
+      initialView: 'schedule', // not enabled
+      configDefault: 'week',
+      isNewCalendar: true,
+    })).toBe('week');
+  });
+
+  it('returns configDefault when initialView is absent and configDefault is enabled', () => {
+    expect(resolveActiveView({
+      enabledIds: ids('month', 'week', 'day'),
+      calView: 'month',
+      initialView: undefined,
+      configDefault: 'day',
+      isNewCalendar: true,
+    })).toBe('day');
+  });
+
+  it('keeps calView when initialView and configDefault are absent but view is valid', () => {
+    expect(resolveActiveView({
+      enabledIds: ids('month', 'week'),
+      calView: 'week',
+      initialView: undefined,
+      configDefault: undefined,
+      isNewCalendar: true,
+    })).toBe('week');
+  });
+
+  it('falls through to month when calView is invalid and no initialView or configDefault', () => {
+    expect(resolveActiveView({
+      enabledIds: ids('month', 'week'),
+      calView: 'schedule', // not enabled
+      initialView: undefined,
+      configDefault: undefined,
+      isNewCalendar: true,
+    })).toBe('month');
+  });
+
+  it('falls through to month when configDefault is set but not in enabledIds', () => {
+    expect(resolveActiveView({
+      enabledIds: ids('month', 'week'),
+      calView: 'schedule', // not enabled
+      initialView: undefined,
+      configDefault: 'day',   // not enabled
+      isNewCalendar: true,
+    })).toBe('month');
+  });
+
+  it('inconsistent config: defaultView not in enabledViews — lands on calView (no flash)', () => {
+    // The key regression: old code would flash to defaultView then be overridden.
+    // Consolidated resolver goes directly to calView when defaultView is disabled.
+    expect(resolveActiveView({
+      enabledIds: ids('month', 'week'),
+      calView: 'month',
+      initialView: undefined,
+      configDefault: 'schedule', // disabled
+      isNewCalendar: true,
+    })).toBe('month');
+  });
+
+  it('inconsistent config: initialView not in enabledViews — falls to configDefault', () => {
+    expect(resolveActiveView({
+      enabledIds: ids('month', 'week'),
+      calView: 'day', // started here (useState)
+      initialView: 'day',   // not enabled
+      configDefault: 'week', // enabled
+      isNewCalendar: true,
+    })).toBe('week');
+  });
+});
+
+describe('resolveActiveView — post-initial fallback (isNewCalendar = false)', () => {
+  it('returns configDefault when calView became invalid', () => {
+    expect(resolveActiveView({
+      enabledIds: ids('month', 'week'),
+      calView: 'day', // was valid, now disabled
+      initialView: 'day',
+      configDefault: 'week',
+      isNewCalendar: false,
+    })).toBe('week');
+  });
+
+  it('returns month when calView invalid and configDefault is also not enabled', () => {
+    expect(resolveActiveView({
+      enabledIds: ids('month', 'week'),
+      calView: 'day',
+      initialView: 'day',
+      configDefault: 'schedule', // not enabled
+      isNewCalendar: false,
+    })).toBe('month');
+  });
+
+  it('returns month when calView invalid and no configDefault', () => {
+    expect(resolveActiveView({
+      enabledIds: ids('month'),
+      calView: 'week',
+      initialView: undefined,
+      configDefault: undefined,
+      isNewCalendar: false,
+    })).toBe('month');
+  });
+
+  it('does not re-apply initialView on post-initial resolution (respects user navigation)', () => {
+    // User navigated away from initialView ('week') to 'day'. 'day' is now disabled.
+    // Should NOT jump back to initialView — it should use configDefault/month.
+    expect(resolveActiveView({
+      enabledIds: ids('month', 'week'),
+      calView: 'day',
+      initialView: 'week',
+      configDefault: undefined,
+      isNewCalendar: false,
+    })).toBe('month');
+  });
+});
+
+describe('resolveActiveView — calendarId switch semantics', () => {
+  it('applies new calendarId defaultView on switch (isNewCalendar = true)', () => {
+    // User was on calA (view='week'), switches to calB with defaultView='schedule'.
+    expect(resolveActiveView({
+      enabledIds: ids('month', 'week', 'schedule'),
+      calView: 'week',
+      initialView: undefined,
+      configDefault: 'schedule',
+      isNewCalendar: true, // new calendar
+    })).toBe('schedule');
+  });
+
+  it('respects initialView over new calendarId defaultView', () => {
+    // Host passed initialView='week'; switching calendar should still land on 'week'.
+    expect(resolveActiveView({
+      enabledIds: ids('month', 'week', 'schedule'),
+      calView: 'week',
+      initialView: 'week',
+      configDefault: 'schedule',
+      isNewCalendar: true,
+    })).toBe('week');
+  });
+
+  it('keeps current view when new calendar has no defaultView and view is still valid', () => {
+    expect(resolveActiveView({
+      enabledIds: ids('month', 'week'),
+      calView: 'week',
+      initialView: undefined,
+      configDefault: undefined,
+      isNewCalendar: true,
+    })).toBe('week');
+  });
+
+  it('falls to month when new calendar has no defaultView and current view is not enabled', () => {
+    expect(resolveActiveView({
+      enabledIds: ids('month'),
+      calView: 'week', // not in new calendar's enabled set
+      initialView: undefined,
+      configDefault: undefined,
+      isNewCalendar: true,
+    })).toBe('month');
+  });
+});

--- a/src/hooks/useCalendarDataPipeline.ts
+++ b/src/hooks/useCalendarDataPipeline.ts
@@ -17,7 +17,6 @@ import { SCHEDULE_WORKFLOW_CATEGORIES } from '../core/scheduleModel';
 import type { AnnouncerRef } from '../ui/ScreenReaderAnnouncer';
 import type { CalendarView, WorksCalendarProps } from '../WorksCalendar.types';
 import type { WorksCalendarEvent } from '../types/events';
-import type { ViewId } from '../core/viewScope';
 import type { FilterField } from '../filters/filterSchema';
 import type { SortConfig } from '../types/grouping.ts';
 import type { CalObject } from './useCalendarSetup';
@@ -46,6 +45,44 @@ export interface UseCalendarDataPipelineInput {
   categoriesConfig: WorksCalendarProps['categoriesConfig'];
   schema: FilterField[];
   activeSort: SortConfig[] | null;
+  initialView: string | undefined;
+}
+
+/**
+ * Resolve the active calendar view from a priority-ordered list of candidates.
+ * Called from the consolidated view-resolution effect; exported for unit testing.
+ *
+ * Priority (first match wins):
+ *   1. `initialView` — if set and present in `enabledIds`
+ *   2. `configDefault` — if set, enabled, and this is the first resolution for the current
+ *      calendarId (`isNewCalendar`); prevents re-applying on every user navigation.
+ *   3. The current `calView` — if still enabled (no change needed).
+ *   4. `configDefault` as a general invalid-view fallback (even after initial application).
+ *   5. `'month'` (always-on view, guaranteed to exist).
+ *
+ * When `isNewCalendar` is false the caller has already done the initial
+ * resolution: we only need to recover from an invalid current view, so we
+ * skip priority #1 and #3 and jump straight to the fallback path.
+ */
+export function resolveActiveView({
+  enabledIds,
+  calView,
+  initialView,
+  configDefault,
+  isNewCalendar,
+}: {
+  enabledIds: Set<string>;
+  calView: string;
+  initialView: string | undefined;
+  configDefault: string | undefined;
+  isNewCalendar: boolean;
+}): string {
+  if (isNewCalendar) {
+    if (initialView && enabledIds.has(initialView)) return initialView;
+    if (configDefault && enabledIds.has(configDefault)) return configDefault;
+    if (enabledIds.has(calView)) return calView;
+  }
+  return configDefault && enabledIds.has(configDefault) ? configDefault : 'month';
 }
 
 export function useCalendarDataPipeline({
@@ -54,7 +91,7 @@ export function useCalendarDataPipeline({
   supabaseUrl, supabaseKey, supabaseTable, supabaseFilter,
   rawPools, businessHours, blockedWindows, onPoolsChange,
   configuredEmployees, effectiveAssets, selectedBaseIds,
-  assetRequestCategories, categoriesConfig, schema, activeSort,
+  assetRequestCategories, categoriesConfig, schema, activeSort, initialView,
 }: UseCalendarDataPipelineInput) {
   const range = useMemo(
     () => viewRange(cal.view, cal.currentDate, weekStartDay),
@@ -149,12 +186,25 @@ export function useCalendarDataPipeline({
       });
   }, [ownerCfg.config?.['display']?.enabledViews, locationLabel, assetsLabel]);
 
+  // Tracks the calendarId for which the initial view was last resolved.
+  // Using the calendarId (not a boolean) means a switch to a different
+  // calendar automatically re-arms without a separate effect.
+  const defaultViewAppliedForRef = useRef<string | null>(null);
   useEffect(() => {
-    if (VIEWS.some(v => v.id === cal.view)) return;
-    const fallback = (ownerCfg.config?.['display']?.defaultView as ViewId) ?? 'month';
-    const target = VIEWS.some(v => v.id === fallback) ? fallback : 'month';
+    const enabledIds = new Set<string>(VIEWS.map(v => v.id));
+    const configDefault = ownerCfg.config?.['display']?.defaultView as string | undefined;
+    const isNewCalendar = defaultViewAppliedForRef.current !== calendarId;
+
+    // Nothing to do: current view is valid and we have already done the
+    // initial resolution for this calendarId.
+    if (enabledIds.has(cal.view) && !isNewCalendar) return;
+
+    const target = resolveActiveView({
+      enabledIds, calView: cal.view, initialView, configDefault, isNewCalendar,
+    });
+    if (isNewCalendar) defaultViewAppliedForRef.current = calendarId;
     if (cal.view !== target) cal.setView(target);
-  }, [VIEWS, cal.view, ownerCfg.config?.['display']?.defaultView]);
+  }, [VIEWS, cal.view, initialView, calendarId, ownerCfg.config?.['display']?.defaultView]);
 
   const scopedEvents = useTabScopedEvents(cal.view, engineResult.expandedEvents, {
     employees: (configuredEmployees ?? []) as { id: string; base?: string | null }[],

--- a/src/hooks/useCalendarSetup.ts
+++ b/src/hooks/useCalendarSetup.ts
@@ -151,20 +151,6 @@ export function useCalendarSetup({
     onEmployeeDelete?.(id);
   }, [ownerCfg.updateConfig, onEmployeeDelete]);
 
-  const defaultViewApplied = useRef(false);
-  // Re-arm the one-shot default-view application when the host switches calendars
-  // (otherwise the new calendar's `display.defaultView` is never applied). Declared
-  // before the apply effect so it runs first on a `calendarId` change.
-  useEffect(() => { defaultViewApplied.current = false; }, [calendarId]);
-  useEffect(() => {
-    if (initialView) return;
-    const defaultView = ownerCfg.config?.['display']?.defaultView;
-    if (defaultView && !defaultViewApplied.current) {
-      defaultViewApplied.current = true;
-      setView(defaultView);
-    }
-  }, [ownerCfg.config?.['display']?.defaultView, initialView, setView]);
-
   return {
     ownerCfg, weekStartDay, rootStyle, rawTheme,
     effectiveTheme, themeFamily, themeMode, calendarTitle,


### PR DESCRIPTION
Replace two competing effects (useCalendarSetup's `defaultViewApplied` one-shot + useCalendarDataPipeline's invalid-view fallback) with a single resolver in `useCalendarDataPipeline`.

Problem the two-effect split caused: when `defaultView` (or `initialView`) is not in `enabledViews`, effect 1 would set the view and effect 2 would immediately override it, producing a visible flash and confusing logic.

Changes:
- `useCalendarDataPipeline`: add `initialView` to input; export pure `resolveActiveView` function (testable without the hook); replace the fallback effect with a consolidated resolver that tracks resolution per `calendarId` via `defaultViewAppliedForRef`.  Priority on first resolution: initialView > configDefault > calView > 'month'.  On subsequent renders the effect only fires when `cal.view` becomes invalid, using configDefault / 'month' as the fallback.
- `useCalendarSetup`: remove `defaultViewApplied` ref, the re-arm effect, and the apply effect — all superseded by the pipeline resolver.
- `WorksCalendar`: pass `initialView` down to `useCalendarDataPipeline`.
- New test: `useCalendarDataPipeline.viewResolution.test.ts` — 16 cases covering inconsistent-config (no flash), calendarId switch, post-initial fallback, and backward-compat (no initialView / no defaultView).
- All 4292 tests green.

https://claude.ai/code/session_011AaQfyb1RMTHHvBZS3J4kc

## Summary
Describe exactly what this PR changes.

## Scope
- Stage: 
- Planned PR number in sprint: 
- Target files/directories: 
- Why this slice is isolated: 

## Lessons Learned Check (REQUIRED)
Confirm these were actively used while building this PR:

- [ ] PR is intentionally small and isolated
- [ ] Boundary typing was prioritized over internal perfection
- [ ] No silent spread of `any`
- [ ] Advisory root `tsc` was used to catch integration issues
- [ ] I did not assume “looks typed” means “safe”
- [ ] I stopped and isolated typing cascades instead of expanding scope

## Definition of Done (ALL REQUIRED)
This PR is not done unless every box is checked.

- [ ] `npm run type-check:strict` passes
- [ ] Root advisory `tsc --noEmit` passes
- [ ] Tests pass for touched scope at minimum
- [ ] No uncontrolled increase in `any`
- [ ] All new types are intentional and named
- [ ] Public interfaces and exported functions are explicitly typed
- [ ] PR scope matches the sprint plan with no scope creep
- [ ] Any new `any` has an adjacent justification comment
- [ ] No file-wide `: any`
- [ ] No implicit `any` in exported functions

## What Was Typed
List exactly what was typed in this PR.

- 
- 
- 

## What Was Intentionally Left Loose
List anything intentionally not tightened yet.

- 
- 
- 

## `any` Ledger (REQUIRED)
- New `any` added: 
- Existing `any` removed: 
- Net change: 

For every new `any`, explain why it is required and why a safer type was not used yet.

1. 
2. 
3. 

## Boundary Notes
Document any public seams, caller-protection choices, or compatibility decisions.

- 
- 
- 

## Risk Level
- [ ] Low
- [ ] Medium
- [ ] High

Why:

## Validation Evidence
Paste the exact commands run and a short result summary.

```bash
npm run type-check:strict
npx tsc --noEmit -p tsconfig.json
```

Test commands run:

```bash
# paste commands here
```

## Stop Conditions Check
If any item below happened, explain how scope was reduced before merge.

- [ ] `any` started spreading across files
- [ ] Root `tsc` broke repeatedly
- [ ] Types required cross-module rewrites
- [ ] Scope was reduced to keep the PR reviewable

Notes:

## Reviewer Focus
What should reviewers look at first?

- 
- 
- 
