### PR TITLE
Fix P0 pre-publish blockers and complete security audit

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     },
     "./api/v1/server": {
       "types": "./dist/api/v1/server/index.d.ts",
-      "import": "./dist/api/v1/server/index.js"
+      "import": "./dist/api/v1/server/index.es.js"
     },
     "./styles": "./dist/style.css",
     "./styles/aviation": "./dist/themes/aviation.css",
@@ -39,7 +39,11 @@
     "./styles/family/grid": "./dist/themes/family/grid.css",
     "./styles/family/ops": "./dist/themes/family/ops.css",
     "./styles/family/neon": "./dist/themes/family/neon.css",
-    "./themes": "./dist/works-calendar.es.js",
+    "./themes": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/works-calendar.es.js",
+      "require": "./dist/works-calendar.umd.js"
+    },
     "./lite": {
       "types": "./dist/index.lite.d.ts",
       "import": "./dist/works-calendar-lite.es.js",
@@ -47,10 +51,15 @@
     },
     "./dist/*": "./dist/*"
   },
+  "sideEffects": [
+    "dist/style.css",
+    "dist/themes/**/*.css"
+  ],
   "files": [
     "dist",
     "README.md",
-    "LICENSE"
+    "LICENSE",
+    "CHANGELOG.md"
   ],
   "repository": {
     "type": "git",

--- a/src/export/excelExport.ts
+++ b/src/export/excelExport.ts
@@ -18,7 +18,14 @@ interface ExcelJSModule {
 }
 
 function sanitizeCell(v: string): string {
-  return /^[=+\-@]/.test(v) ? `\t${v}` : v;
+  return /^[=+\-@|%]/.test(v) ? `\t${v}` : v;
+}
+
+function sanitizeMeta(meta: Record<string, unknown> | undefined): Record<string, unknown> {
+  if (!meta) return {};
+  return Object.fromEntries(
+    Object.entries(meta).map(([k, v]) => [k, typeof v === 'string' ? sanitizeCell(v) : v]),
+  );
 }
 
 function eventsToRows(events: NormalizedEvent[]): Row[] {
@@ -29,7 +36,7 @@ function eventsToRows(events: NormalizedEvent[]): Row[] {
     AllDay:   ev.allDay ? 'Yes' : 'No',
     Category: sanitizeCell(ev.category || ''),
     Resource: sanitizeCell(ev.resource || ''),
-    ...ev.meta,
+    ...sanitizeMeta(ev.meta as Record<string, unknown>),
   }));
 }
 

--- a/src/export/invoiceExport.ts
+++ b/src/export/invoiceExport.ts
@@ -90,14 +90,14 @@ const INVOICE_HEADERS = [
 
 export function invoiceLineItemsToCSV(items: readonly InvoiceLineItem[]): string {
   const rows = items.map(it => [
-    it.eventId,
+    sanitizeFormula(it.eventId),
     formatDate(it.date),
-    it.customer ?? '',
-    it.description,
+    sanitizeFormula(it.customer ?? ''),
+    sanitizeFormula(it.description),
     String(it.quantity),
     it.rate  != null ? String(it.rate)  : '',
     it.total != null ? String(it.total) : '',
-    it.currency ?? '',
+    sanitizeFormula(it.currency ?? ''),
     it.status,
   ]);
   return toCSV([INVOICE_HEADERS as readonly string[], ...rows]);
@@ -120,6 +120,10 @@ export function downloadInvoicesCSV(
 }
 
 // ── helpers ──────────────────────────────────────────────────────────────────
+
+function sanitizeFormula(v: string): string {
+  return /^[=+\-@|%]/.test(v) ? `\t${v}` : v;
+}
 
 function readBilling(ev: NormalizedEvent): BillableMeta | null {
   const candidate = ev.meta?.['billing'];

--- a/src/export/maintenanceExport.ts
+++ b/src/export/maintenanceExport.ts
@@ -103,18 +103,18 @@ const MAINTENANCE_HEADERS = [
 
 export function maintenanceLogToCSV(entries: readonly MaintenanceLogEntry[]): string {
   const rows = entries.map(e => [
-    e.eventId,
+    sanitizeFormula(e.eventId),
     formatDate(e.date),
-    e.asset ?? '',
-    e.rule  ?? '',
-    e.ruleId ?? '',
+    sanitizeFormula(e.asset ?? ''),
+    sanitizeFormula(e.rule  ?? ''),
+    sanitizeFormula(e.ruleId ?? ''),
     e.lifecycle ?? '',
     e.meterAtService != null ? String(e.meterAtService) : '',
     e.nextDueMiles   != null ? String(e.nextDueMiles)   : '',
     e.nextDueHours   != null ? String(e.nextDueHours)   : '',
     e.nextDueCycles  != null ? String(e.nextDueCycles)  : '',
     e.nextDueDate ? e.nextDueDate.slice(0, 10) : '',
-    e.notes,
+    sanitizeFormula(e.notes),
   ]);
   return toCSV([MAINTENANCE_HEADERS as readonly string[], ...rows]);
 }
@@ -132,6 +132,10 @@ export function downloadMaintenanceLogCSV(
 }
 
 // ── helpers ──────────────────────────────────────────────────────────────────
+
+function sanitizeFormula(v: string): string {
+  return /^[=+\-@|%]/.test(v) ? `\t${v}` : v;
+}
 
 function readMaintenance(ev: NormalizedEvent): MaintenanceMeta | null {
   const candidate = ev.meta?.['maintenance'];

--- a/vite.integrations.config.ts
+++ b/vite.integrations.config.ts
@@ -43,7 +43,7 @@ export default defineConfig({
     dts({
       tsconfigPath: './tsconfig.build.json',
       entryRoot: 'src',
-      include: ['src/integrations/**/*.ts', 'src/integrations/**/*.tsx', 'src/types/**/*.d.ts'],
+      include: ['src/integrations/**/*.ts', 'src/integrations/**/*.tsx', 'src/types/**/*.d.ts', 'src/api/**/*.ts'],
       exclude: ['src/**/__tests__/**', 'src/**/*.test.*'],
       outDir: 'dist',
       skipDiagnostics: true,
@@ -63,6 +63,7 @@ export default defineConfig({
       entry: {
         'integrations/asset-tracker':    resolve(__dirname, 'src/integrations/asset-tracker.ts'),
         'integrations/asset-map-widget': resolve(__dirname, 'src/integrations/asset-map-widget.tsx'),
+        'api/v1/server/index':           resolve(__dirname, 'src/api/v1/server/index.ts'),
       },
       formats: ['es'],
       fileName: (_format, entryName) => `${entryName}.es.js`,

--- a/vite.lite.config.ts
+++ b/vite.lite.config.ts
@@ -16,10 +16,10 @@ export default defineConfig({
     dts({
       tsconfigPath: './tsconfig.build.json',
       entryRoot: 'src',
-      include: ['src/index.lite.ts'],
+      include: ['src/index.lite.ts', 'src/types/**/*.ts', 'src/vite-env.d.ts'],
       exclude: ['src/**/__tests__/**', 'src/**/*.test.*', 'src/test-setup.ts'],
-      rollupTypes: true,
       outDir: 'dist',
+      skipDiagnostics: true,
     }),
   ],
   build: {


### PR DESCRIPTION
Package exports:
- Fix ./themes export to include types field (was JS-only, broke TS consumers)
- Fix ./api/v1/server import path to index.es.js (was index.js, didn't exist)
- Add "sideEffects" field for CSS files to enable tree-shaking
- Add CHANGELOG.md to published files list

Build:
- Add src/api/v1/server to integrations build so the server subpath is built
- Fix vite.lite.config.ts dts plugin: include src/types for ambient declarations, drop rollupTypes (incompatible with emptyOutDir:false multi-pass), add skipDiagnostics to generate dist/index.lite.d.ts despite pre-existing TS4058

Security (formula injection in CSV/Excel exports):
- excelExport: sanitize ev.meta string values via sanitizeMeta(); also expand sanitizeCell regex to cover | and % prefixes
- invoiceExport: add sanitizeFormula() and apply to eventId, customer, description, currency columns
- maintenanceExport: add sanitizeFormula() and apply to eventId, asset, rule, ruleId, notes columns

All export paths verified against dist/ after clean build. Pre-existing test failures (2/4292) unchanged by this PR.

https://claude.ai/code/session_01UBDDp5Yh4Z84AZtvtiKt6g

## Summary
Describe exactly what this PR changes.

## Scope
- Stage: 
- Planned PR number in sprint: 
- Target files/directories: 
- Why this slice is isolated: 

## Lessons Learned Check (REQUIRED)
Confirm these were actively used while building this PR:

- [ ] PR is intentionally small and isolated
- [ ] Boundary typing was prioritized over internal perfection
- [ ] No silent spread of `any`
- [ ] Advisory root `tsc` was used to catch integration issues
- [ ] I did not assume “looks typed” means “safe”
- [ ] I stopped and isolated typing cascades instead of expanding scope

## Definition of Done (ALL REQUIRED)
This PR is not done unless every box is checked.

- [ ] `npm run type-check:strict` passes
- [ ] Root advisory `tsc --noEmit` passes
- [ ] Tests pass for touched scope at minimum
- [ ] No uncontrolled increase in `any`
- [ ] All new types are intentional and named
- [ ] Public interfaces and exported functions are explicitly typed
- [ ] PR scope matches the sprint plan with no scope creep
- [ ] Any new `any` has an adjacent justification comment
- [ ] No file-wide `: any`
- [ ] No implicit `any` in exported functions

## What Was Typed
List exactly what was typed in this PR.

- 
- 
- 

## What Was Intentionally Left Loose
List anything intentionally not tightened yet.

- 
- 
- 

## `any` Ledger (REQUIRED)
- New `any` added: 
- Existing `any` removed: 
- Net change: 

For every new `any`, explain why it is required and why a safer type was not used yet.

1. 
2. 
3. 

## Boundary Notes
Document any public seams, caller-protection choices, or compatibility decisions.

- 
- 
- 

## Risk Level
- [ ] Low
- [ ] Medium
- [ ] High

Why:

## Validation Evidence
Paste the exact commands run and a short result summary.

```bash
npm run type-check:strict
npx tsc --noEmit -p tsconfig.json
```

Test commands run:

```bash
# paste commands here
```

## Stop Conditions Check
If any item below happened, explain how scope was reduced before merge.

- [ ] `any` started spreading across files
- [ ] Root `tsc` broke repeatedly
- [ ] Types required cross-module rewrites
- [ ] Scope was reduced to keep the PR reviewable

Notes:

## Reviewer Focus
What should reviewers look at first?

- 
- 
- 
