### PR TITLE
fix: treat explicit null colors as empty string in safeColor

### DIFF
--- a/src/core/themeSchema.ts
+++ b/src/core/themeSchema.ts
@@ -51,7 +51,8 @@ export function normalizeCustomTheme(theme: ThemeObject | null | undefined): The
 
 const SAFE_COLOR = /^(#[0-9a-fA-F]{3,8}|rgb\(|rgba\(|hsl\(|hsla\(|transparent|currentColor|inherit|initial)$/;
 
-function safeColor(value: string | undefined, fallback: string): string {
+function safeColor(value: string | null | undefined, fallback: string): string {
+  if (value === null) return '';
   if (!value) return fallback;
   const v = value.trim();
   if (SAFE_COLOR.test(v) || v.startsWith('rgb(') || v.startsWith('rgba(') || v.startsWith('hsl(') || v.startsWith('hsla(')) return v;


### PR DESCRIPTION
When null color values pass through normalizeCustomTheme (mergeTheme
preserves null since it only skips undefined), safeColor was falling
back to the default color via `!value`. Adding an explicit null check
returns '' instead, matching the documented ?? semantics.

Fixes #611

https://claude.ai/code/session_01D2bvTHTvtsdm4d7nn7TeSf