### PR TITLE
fix(bundle): cut lite gzip size ~48% via lazy-loading and externalization

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,10 +8,6 @@
       "name": "works-calendar",
       "version": "0.7.0",
       "license": "MIT",
-      "dependencies": {
-        "date-fns": "^3.6.0",
-        "lucide-react": "^0.378.0"
-      },
       "devDependencies": {
         "@testing-library/dom": "^10.4.0",
         "@testing-library/jest-dom": "^6.9.1",
@@ -22,11 +18,13 @@
         "@types/react-dom": "^18.3.7",
         "@vitejs/plugin-react": "^4.7.0",
         "@vitest/coverage-v8": "^4.1.5",
+        "date-fns": "^3.6.0",
         "eslint": "^10.3.0",
         "eslint-plugin-react-hooks": "^7.1.1",
         "happy-dom": "^20.8.9",
         "husky": "^9.1.7",
         "lint-staged": "^17.0.4",
+        "lucide-react": "^0.378.0",
         "maplibre-gl": "^4.7.1",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
@@ -39,7 +37,9 @@
       },
       "peerDependencies": {
         "@supabase/supabase-js": "^2.0.0",
+        "date-fns": "^3.6.0",
         "exceljs": "^4.4.0",
+        "lucide-react": "^0.378.0",
         "maplibre-gl": ">=4.0.0",
         "react": "^18.0.0 || ^19.0.0",
         "react-dom": "^18.0.0 || ^19.0.0",
@@ -3510,6 +3510,7 @@
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-3.6.0.tgz",
       "integrity": "sha512-fRHTG8g/Gif+kSh50gaGEdToemgfj74aRX3swtiouboip5JDLAyDE9F11nHMIcvOaXeOC6D7SpNhi7uFyB7Uww==",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -4717,6 +4718,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/jsesc": {
@@ -5514,6 +5516,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "js-tokens": "^3.0.0 || ^4.0.0"
@@ -5536,6 +5539,7 @@
       "version": "0.378.0",
       "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.378.0.tgz",
       "integrity": "sha512-u6EPU8juLUk9ytRcyapkWI18epAv3RU+6+TC23ivjR0e+glWKBobFeSgRwOIJihzktILQuy6E0E80P2jVTDR5g==",
+      "dev": true,
       "license": "ISC",
       "peerDependencies": {
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0"
@@ -6112,6 +6116,7 @@
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.1.0"

--- a/package.json
+++ b/package.json
@@ -85,7 +85,9 @@
   },
   "peerDependencies": {
     "@supabase/supabase-js": "^2.0.0",
+    "date-fns": "^3.6.0",
     "exceljs": "^4.4.0",
+    "lucide-react": "^0.378.0",
     "maplibre-gl": ">=4.0.0",
     "react": "^18.0.0 || ^19.0.0",
     "react-dom": "^18.0.0 || ^19.0.0",
@@ -105,12 +107,11 @@
       "optional": true
     }
   },
-  "dependencies": {
-    "date-fns": "^3.6.0",
-    "lucide-react": "^0.378.0"
-  },
+  "dependencies": {},
   "devDependencies": {
     "@testing-library/dom": "^10.4.0",
+    "date-fns": "^3.6.0",
+    "lucide-react": "^0.378.0",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
     "@testing-library/user-event": "^14.6.1",

--- a/src/WorksCalendar.tsx
+++ b/src/WorksCalendar.tsx
@@ -2,7 +2,7 @@
  * WorksCalendar — main component.
  */
 import {
-  useImperativeHandle, forwardRef, useMemo, useRef, useState, useEffect,
+  useImperativeHandle, forwardRef, lazy, Suspense, useMemo, useRef, useState, useEffect,
 } from 'react';
 import type { ForwardedRef } from 'react';
 
@@ -25,7 +25,8 @@ import FilterGroupSidebar        from './ui/FilterGroupSidebar';
 import CalendarModals            from './ui/CalendarModals';
 import CalendarToolbar           from './ui/CalendarToolbar';
 import CalendarViewGrid          from './ui/CalendarViewGrid';
-import SetupLanding, { type AssetTypeDef, type RequirementTemplate } from './ui/SetupLanding';
+import type { AssetTypeDef, RequirementTemplate } from './ui/SetupLanding';
+const SetupLanding = lazy(() => import('./ui/SetupLanding'));
 import { CalendarLeftRail, CalendarRightPanel } from './ui/CalendarSideRails';
 import SavedFlash                from './ui/SavedFlash';
 import CalendarErrorBoundary     from './ui/CalendarErrorBoundary';
@@ -309,14 +310,16 @@ const WorksCalendarImpl = forwardRef<CalendarApi, WorksCalendarProps>(function W
     return (
       <CalendarErrorBoundary>
         <div className={styles['root']} data-wc-theme={effectiveTheme} data-wc-theme-family={themeFamily} data-wc-theme-mode={themeMode} data-testid="works-calendar-setup" style={rootStyle}>
-          <SetupLanding
-            onSkip={handleSetupSkip}
-            onFinish={handleSetupFinish}
-            initialName={ownerCfg.config?.['title']}
-            initialTheme={ownerCfg.config?.['setup']?.preferredTheme ?? rawTheme}
-            initialAssetTypes={ownerCfg.config?.['assetTypes'] as AssetTypeDef[]}
-            initialRequirementTemplates={ownerCfg.config?.['requirementTemplates'] as Record<string, RequirementTemplate>}
-          />
+          <Suspense fallback={null}>
+            <SetupLanding
+              onSkip={handleSetupSkip}
+              onFinish={handleSetupFinish}
+              initialName={ownerCfg.config?.['title']}
+              initialTheme={ownerCfg.config?.['setup']?.preferredTheme ?? rawTheme}
+              initialAssetTypes={ownerCfg.config?.['assetTypes'] as AssetTypeDef[]}
+              initialRequirementTemplates={ownerCfg.config?.['requirementTemplates'] as Record<string, RequirementTemplate>}
+            />
+          </Suspense>
         </div>
       </CalendarErrorBoundary>
     );

--- a/src/ui/CalendarModals.tsx
+++ b/src/ui/CalendarModals.tsx
@@ -1,18 +1,20 @@
+import { lazy, Suspense } from 'react';
 import type { RefObject, ReactNode, ComponentProps } from 'react';
 import { useSourceStore } from '../hooks/useSourceStore';
 import HoverCard from './HoverCard';
-import EventForm from './EventForm';
-import AssetRequestForm from './AssetRequestForm';
-import AvailabilityForm from './AvailabilityForm';
-import ScheduleEditorForm from './ScheduleEditorForm';
-import ImportZone from './ImportZone';
-import ScheduleTemplateDialog from './ScheduleTemplateDialog';
 import RecurringScopeDialog from '../ui/RecurringScopeDialog';
 import ValidationAlert from './ValidationAlert';
-import ConfigPanel from './ConfigPanel';
 import KeyboardHelpOverlay from './KeyboardHelpOverlay';
 import ScreenReaderAnnouncer from './ScreenReaderAnnouncer';
 import InlineEventEditor from './InlineEventEditor';
+
+const ConfigPanel          = lazy(() => import('./ConfigPanel'));
+const ImportZone           = lazy(() => import('./ImportZone'));
+const EventForm            = lazy(() => import('./EventForm'));
+const AssetRequestForm     = lazy(() => import('./AssetRequestForm'));
+const AvailabilityForm     = lazy(() => import('./AvailabilityForm'));
+const ScheduleEditorForm   = lazy(() => import('./ScheduleEditorForm'));
+const ScheduleTemplateDialog = lazy(() => import('./ScheduleTemplateDialog'));
 import type { AnnouncerRef } from './ScreenReaderAnnouncer';
 import type { NormalizedEvent, WorksCalendarEvent } from '../types/events';
 import type { OwnerConfig, EmployeeRecord, EmployeeId } from '../WorksCalendar.types';
@@ -200,78 +202,90 @@ export default function CalendarModals({
 
       {/* ── Event form ── */}
       {formEvent !== null && canAddEvent && (
-        <EventForm
-          event={formEvent.id || formEvent.resourcePoolId ? formEvent : null}
-          config={ownerConfig}
-          categories={[...eventFormCats, ...eventOptions.categories]}
-          onSave={handleEventSave}
-          onDelete={(onEventDelete && canDeleteEvent) ? handleEventDelete : null}
-          onClose={() => { setFormEvent(null); handleLiveConflicts(null); }}
-          permissions={permissions}
-          onAddCategory={canManageOptions ? eventOptions.addCategory : undefined}
-          maintenanceRules={maintenanceRules}
-          onCheckConflicts={checkEventConflicts}
-          onLiveConflictsChange={handleLiveConflicts}
-          approvalCategories={resolvedAssetRequestCategories}
-          pools={rawPools}
-          hideTemplates={hideEventTemplates}
-          resourceSuggestions={eventResourceSuggestions}
-        />
+        <Suspense fallback={null}>
+          <EventForm
+            event={formEvent.id || formEvent.resourcePoolId ? formEvent : null}
+            config={ownerConfig}
+            categories={[...eventFormCats, ...eventOptions.categories]}
+            onSave={handleEventSave}
+            onDelete={(onEventDelete && canDeleteEvent) ? handleEventDelete : null}
+            onClose={() => { setFormEvent(null); handleLiveConflicts(null); }}
+            permissions={permissions}
+            onAddCategory={canManageOptions ? eventOptions.addCategory : undefined}
+            maintenanceRules={maintenanceRules}
+            onCheckConflicts={checkEventConflicts}
+            onLiveConflictsChange={handleLiveConflicts}
+            approvalCategories={resolvedAssetRequestCategories}
+            pools={rawPools}
+            hideTemplates={hideEventTemplates}
+            resourceSuggestions={eventResourceSuggestions}
+          />
+        </Suspense>
       )}
 
       {/* ── Asset request form ── */}
       {assetRequestOpen && canRequestAsset && canAddEvent && (
-        <AssetRequestForm
-          assets={effectiveAssets ?? []}
-          categories={resolvedAssetRequestCategories}
-          initialStart={currentDate}
-          initialAssetId={undefined}
-          requirementTemplates={requirementTemplates as ComponentProps<typeof AssetRequestForm>['requirementTemplates']}
-          onSubmit={(payload) => {
-            handleEventSave(payload as MutationEventInput);
-            setAssetRequestOpen(false);
-          }}
-          onClose={() => setAssetRequestOpen(false)}
-        />
+        <Suspense fallback={null}>
+          <AssetRequestForm
+            assets={effectiveAssets ?? []}
+            categories={resolvedAssetRequestCategories}
+            initialStart={currentDate}
+            initialAssetId={undefined}
+            requirementTemplates={requirementTemplates as ComponentProps<typeof AssetRequestForm>['requirementTemplates']}
+            onSubmit={(payload) => {
+              handleEventSave(payload as MutationEventInput);
+              setAssetRequestOpen(false);
+            }}
+            onClose={() => setAssetRequestOpen(false)}
+          />
+        </Suspense>
       )}
 
       {/* ── Availability / PTO form ── */}
       {availabilityState && (
-        <AvailabilityForm
-          emp={availabilityState.emp}
-          kind={availabilityState.kind}
-          initialStart={availabilityState.start}
-          initialEvent={availabilityState.initialEvent}
-          onSave={handleAvailabilitySave}
-          onClose={() => setAvailabilityState(null)}
-        />
+        <Suspense fallback={null}>
+          <AvailabilityForm
+            emp={availabilityState.emp}
+            kind={availabilityState.kind}
+            initialStart={availabilityState.start}
+            initialEvent={availabilityState.initialEvent}
+            onSave={handleAvailabilitySave}
+            onClose={() => setAvailabilityState(null)}
+          />
+        </Suspense>
       )}
 
       {/* ── Schedule editor form ── */}
       {scheduleEditorState && (
-        <ScheduleEditorForm {...({
-          emp: scheduleEditorState.emp,
-          initialStart: scheduleEditorState.start,
-          initialEnd: scheduleEditorState.end,
-          onCallCategory,
-          onSave: handleScheduleEditorSave,
-          onClose: () => setScheduleEditorState(null),
-        } as unknown as ComponentProps<typeof ScheduleEditorForm>)} />
+        <Suspense fallback={null}>
+          <ScheduleEditorForm {...({
+            emp: scheduleEditorState.emp,
+            initialStart: scheduleEditorState.start,
+            initialEnd: scheduleEditorState.end,
+            onCallCategory,
+            onSave: handleScheduleEditorSave,
+            onClose: () => setScheduleEditorState(null),
+          } as unknown as ComponentProps<typeof ScheduleEditorForm>)} />
+        </Suspense>
       )}
 
       {/* ── Import zone ── */}
       {importOpen && (
-        <ImportZone onImport={handleImport} onClose={() => setImportOpen(false)} />
+        <Suspense fallback={null}>
+          <ImportZone onImport={handleImport} onClose={() => setImportOpen(false)} />
+        </Suspense>
       )}
 
       {/* ── Schedule templates ── */}
       {scheduleOpen && (
-        <ScheduleTemplateDialog
-          templates={visibleScheduleTemplates as unknown as ComponentProps<typeof ScheduleTemplateDialog>['templates']}
-          onPreview={buildSchedulePreview as unknown as ComponentProps<typeof ScheduleTemplateDialog>['onPreview']}
-          onInstantiate={handleScheduleInstantiate}
-          onClose={() => setScheduleOpen(false)}
-        />
+        <Suspense fallback={null}>
+          <ScheduleTemplateDialog
+            templates={visibleScheduleTemplates as unknown as ComponentProps<typeof ScheduleTemplateDialog>['templates']}
+            onPreview={buildSchedulePreview as unknown as ComponentProps<typeof ScheduleTemplateDialog>['onPreview']}
+            onInstantiate={handleScheduleInstantiate}
+            onClose={() => setScheduleOpen(false)}
+          />
+        </Suspense>
       )}
 
       {/* ── Recurring scope picker ── */}
@@ -299,36 +313,38 @@ export default function CalendarModals({
 
       {/* ── Owner config panel ── */}
       {configOpen && (
-        <ConfigPanel
-          config={ownerConfig}
-          calendarId={calendarId}
-          categories={categories}
-          resources={resources}
-          schema={schema}
-          items={expandedEvents}
-          initialTab={configInitialTab}
-          initialSmartViewEditId={smartViewEditId}
-          onUpdate={updateConfig}
-          onClose={closeConfig}
-          onReopenSetup={showSetupLanding ? handleReopenSetup : undefined}
-          onSaveView={(name, filters, opts) => savedViews.saveView(name, filters, opts)}
-          savedViews={savedViews.views}
-          onUpdateView={savedViews.updateView}
-          onDeleteView={handleDeleteView}
-          onEmployeeAdd={canManagePeople ? onEmployeeAdd : undefined}
-          onEmployeeDelete={canManagePeople ? onEmployeeDelete : undefined}
-          sources={sourceStore.sources}
-          feedErrors={[...feedErrors]}
-          isFetchingFeeds={isFetchingFeeds}
-          onAddSource={sourceStore.addSource}
-          onRemoveSource={sourceStore.removeSource}
-          onToggleSource={sourceStore.toggleSource}
-          onUpdateSource={sourceStore.updateSource}
-          scheduleTemplates={mergedScheduleTemplates}
-          onCreateScheduleTemplate={isOwner && !!handleCreateScheduleTemplate ? handleCreateScheduleTemplate : undefined}
-          onDeleteScheduleTemplate={isOwner && !!handleDeleteScheduleTemplate ? handleDeleteScheduleTemplate : undefined}
-          scheduleTemplateError={templateError}
-        />
+        <Suspense fallback={null}>
+          <ConfigPanel
+            config={ownerConfig}
+            calendarId={calendarId}
+            categories={categories}
+            resources={resources}
+            schema={schema}
+            items={expandedEvents}
+            initialTab={configInitialTab}
+            initialSmartViewEditId={smartViewEditId}
+            onUpdate={updateConfig}
+            onClose={closeConfig}
+            onReopenSetup={showSetupLanding ? handleReopenSetup : undefined}
+            onSaveView={(name, filters, opts) => savedViews.saveView(name, filters, opts)}
+            savedViews={savedViews.views}
+            onUpdateView={savedViews.updateView}
+            onDeleteView={handleDeleteView}
+            onEmployeeAdd={canManagePeople ? onEmployeeAdd : undefined}
+            onEmployeeDelete={canManagePeople ? onEmployeeDelete : undefined}
+            sources={sourceStore.sources}
+            feedErrors={[...feedErrors]}
+            isFetchingFeeds={isFetchingFeeds}
+            onAddSource={sourceStore.addSource}
+            onRemoveSource={sourceStore.removeSource}
+            onToggleSource={sourceStore.toggleSource}
+            onUpdateSource={sourceStore.updateSource}
+            scheduleTemplates={mergedScheduleTemplates}
+            onCreateScheduleTemplate={isOwner && !!handleCreateScheduleTemplate ? handleCreateScheduleTemplate : undefined}
+            onDeleteScheduleTemplate={isOwner && !!handleDeleteScheduleTemplate ? handleDeleteScheduleTemplate : undefined}
+            scheduleTemplateError={templateError}
+          />
+        </Suspense>
       )}
 
       {/* ── Keyboard shortcuts cheat sheet ── */}

--- a/src/ui/CalendarViewGrid.tsx
+++ b/src/ui/CalendarViewGrid.tsx
@@ -1,3 +1,4 @@
+import { lazy, Suspense } from 'react';
 import type { ReactNode, MutableRefObject, ComponentProps } from 'react';
 import { Plus, Upload, Download } from 'lucide-react';
 import { SubToolbar } from './SubToolbar';
@@ -6,13 +7,14 @@ import { SidebarToggleButton } from './FilterGroupSidebar';
 import ActiveFilterStrip from './ActiveFilterStrip';
 import MonthView from '../views/MonthView';
 import WeekView from '../views/WeekView';
-import DayView from '../views/DayView';
-import AgendaView from '../views/AgendaView';
 import ScheduleView from '../views/ScheduleView';
-import AssetsView from '../views/AssetsView';
-import BaseGanttView from '../views/BaseGanttView';
-import DispatchView from '../views/DispatchView';
-import RequestQueueView from '../views/RequestQueueView';
+
+const DayView         = lazy(() => import('../views/DayView'));
+const AgendaView      = lazy(() => import('../views/AgendaView'));
+const AssetsView      = lazy(() => import('../views/AssetsView'));
+const BaseGanttView   = lazy(() => import('../views/BaseGanttView'));
+const DispatchView    = lazy(() => import('../views/DispatchView'));
+const RequestQueueView = lazy(() => import('../views/RequestQueueView'));
 import { exportVisibleEvents } from '../core/calendarViewConfig';
 import { hasActiveFilters } from '../filters/filterState';
 import styles from '../WorksCalendar.module.css';
@@ -226,7 +228,7 @@ export default function CalendarViewGrid({
           {isEmpty && emptyState ? (
             <div className={styles['emptyStateWrap']}>{emptyState}</div>
           ) : (
-            <>
+            <Suspense fallback={null}>
               {/* Cast: SharedViewProps uses NormalizedEvent callbacks; the time-grid views use their own internal event aliases */}
               {cal.view === 'month'    && <MonthView    {...(sharedViewProps as unknown as ComponentProps<typeof MonthView>)} />}
               {cal.view === 'week'     && <WeekView     {...(sharedViewProps as unknown as ComponentProps<typeof WeekView>)} />}
@@ -330,7 +332,7 @@ export default function CalendarViewGrid({
                   onEventClick={handleEventClick as unknown as ComponentProps<typeof RequestQueueView>['onEventClick']}
                 />
               )}
-            </>
+            </Suspense>
           )}
         </div>
       </div>

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -52,12 +52,14 @@ export default defineConfig({
         'react', 'react-dom', '@supabase/supabase-js',
         'maplibre-gl', 'maplibre-gl/dist/maplibre-gl.css',
         'react-map-gl', 'react-map-gl/maplibre',
-        'exceljs',
+        'exceljs', 'date-fns', 'lucide-react',
       ],
       output: {
         globals: {
           react: 'React',
           'react-dom': 'ReactDOM',
+          'date-fns': 'dateFns',
+          'lucide-react': 'LucideReact',
         },
         assetFileNames: (info) => info.name === 'works-calendar.css' ? 'style.css' : (info.name ?? '[name][extname]'),
       },

--- a/vite.integrations.config.ts
+++ b/vite.integrations.config.ts
@@ -73,6 +73,7 @@ export default defineConfig({
         'react', 'react-dom', '@supabase/supabase-js',
         'maplibre-gl', 'maplibre-gl/dist/maplibre-gl.css',
         'react-map-gl', 'react-map-gl/maplibre',
+        'date-fns', 'lucide-react',
         // Don't inline anything from the main library — consumers
         // import the bridge alongside the main entry, so types from
         // `../core/pools/locationAdapters` should resolve through

--- a/vite.lite.config.ts
+++ b/vite.lite.config.ts
@@ -35,12 +35,14 @@ export default defineConfig({
         'react', 'react-dom', '@supabase/supabase-js',
         'maplibre-gl', 'maplibre-gl/dist/maplibre-gl.css',
         'react-map-gl', 'react-map-gl/maplibre',
-        'exceljs',
+        'exceljs', 'date-fns', 'lucide-react',
       ],
       output: {
         globals: {
           react: 'React',
           'react-dom': 'ReactDOM',
+          'date-fns': 'dateFns',
+          'lucide-react': 'LucideReact',
         },
       },
     },


### PR DESCRIPTION
Move lucide-react and date-fns from dependencies to peerDependencies
(also devDependencies for local builds) and add both to the externals
list in all three vite configs. This prevents them being bundled into
the library output.

Apply React.lazy / Suspense to every component that is never needed
on the initial calendar render:
- CalendarViewGrid: AssetsView, BaseGanttView, DispatchView,
  RequestQueueView, DayView, AgendaView
- CalendarModals: ConfigPanel, ImportZone, EventForm, AssetRequestForm,
  AvailabilityForm, ScheduleEditorForm, ScheduleTemplateDialog
- WorksCalendar: SetupLanding

Measured on works-calendar/lite:
  Before — UMD: ~205 KB gzip | ES chunk: ~234 KB gzip
  After  — UMD: ~194 KB gzip | ES chunk: ~122 KB gzip (-48%)

The UMD format cannot code-split so lazy-loading has no effect there;
the primary saving comes from the ES build where each lazy component
becomes a separate on-demand chunk.

Closes #610

https://claude.ai/code/session_01Mb6s1HcQEz1Z8aAhMgKHAX