### PR TITLE
fix: address PR review feedback on bulk delete, timezone sync, mini c…

### DIFF
--- a/src/WorksCalendar.tsx
+++ b/src/WorksCalendar.tsx
@@ -257,6 +257,8 @@ const WorksCalendarImpl = forwardRef<CalendarApi, WorksCalendarProps>(function W
   const rootRef = useRef<HTMLDivElement>(null);
 
   const [internalTimezone, setInternalTimezone] = useState<string | undefined>(timezoneProp);
+  // Sync when the host changes the controlled prop (e.g. restoring a saved preference)
+  useEffect(() => { setInternalTimezone(timezoneProp); }, [timezoneProp]);
   const timezone = internalTimezone;
   const handleTimezoneChange = (tz: string) => { setInternalTimezone(tz); onTimezoneChange?.(tz); };
 
@@ -427,7 +429,16 @@ const WorksCalendarImpl = forwardRef<CalendarApi, WorksCalendarProps>(function W
                   totalCount={visibleEvents.length}
                   onSelectAll={() => selectAllEvents(visibleEvents)}
                   onDelete={() => {
-                    selectedEventIds.forEach(id => handleEventDelete(id));
+                    // Recurring events require a scope-confirmation dialog
+                    // (applyWithRecurringCheck stores a single prompt at a time),
+                    // so batching them overwrites earlier prompts. Only bulk-delete
+                    // non-recurring events; recurring ones must be deleted individually.
+                    const eventById = new Map(expandedEvents.map(e => [e.id, e]));
+                    for (const id of selectedEventIds) {
+                      const ev = eventById.get(id);
+                      if (!ev || ev._recurring || ev.rrule) continue;
+                      handleEventDelete(id);
+                    }
                     clearSelection();
                   }}
                   onClear={clearSelection}

--- a/src/ui/MiniCalendar.tsx
+++ b/src/ui/MiniCalendar.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback, useMemo } from 'react';
+import { useState, useCallback, useEffect, useMemo } from 'react';
 import {
   startOfMonth, endOfMonth, startOfWeek, endOfWeek,
   eachDayOfInterval, isSameMonth, isSameDay, isToday,
@@ -26,6 +26,18 @@ export default function MiniCalendar({
   eventDates = [],
 }: MiniCalendarProps) {
   const [viewMonth, setViewMonth] = useState(() => new Date(currentDate.getFullYear(), currentDate.getMonth(), 1));
+
+  // Keep the visible month in sync when the host navigates the main calendar
+  // to a different month (e.g. "Today" button, keyboard shortcuts). Only
+  // snaps when currentDate leaves the currently shown month so the user can
+  // still browse ahead in the mini calendar without being interrupted.
+  useEffect(() => {
+    setViewMonth(prev =>
+      isSameMonth(prev, currentDate)
+        ? prev
+        : new Date(currentDate.getFullYear(), currentDate.getMonth(), 1),
+    );
+  }, [currentDate]);
 
   const days = useMemo(() => {
     const monthStart = startOfMonth(viewMonth);


### PR DESCRIPTION
…alendar

- Bulk delete now skips recurring event instances; they require scope confirmation (applyWithRecurringCheck holds a single prompt at a time), so batching them would overwrite earlier prompts. Non-recurring events are still deleted immediately as before.

- internalTimezone now stays in sync with the timezone prop via useEffect so externally controlled updates (e.g. restoring a saved preference) are not ignored after mount.

- MiniCalendar.viewMonth now follows currentDate via useEffect: when the host navigates the main calendar to a different month the mini calendar snaps to match, while still allowing independent browsing when the user is already viewing the correct month.

https://claude.ai/code/session_017dDkZnWBapCCDDQwd7H3wG

## Summary
Describe exactly what this PR changes.

## Scope
- Stage: 
- Planned PR number in sprint: 
- Target files/directories: 
- Why this slice is isolated: 

## Lessons Learned Check (REQUIRED)
Confirm these were actively used while building this PR:

- [ ] PR is intentionally small and isolated
- [ ] Boundary typing was prioritized over internal perfection
- [ ] No silent spread of `any`
- [ ] Advisory root `tsc` was used to catch integration issues
- [ ] I did not assume “looks typed” means “safe”
- [ ] I stopped and isolated typing cascades instead of expanding scope

## Definition of Done (ALL REQUIRED)
This PR is not done unless every box is checked.

- [ ] `npm run type-check:strict` passes
- [ ] Root advisory `tsc --noEmit` passes
- [ ] Tests pass for touched scope at minimum
- [ ] No uncontrolled increase in `any`
- [ ] All new types are intentional and named
- [ ] Public interfaces and exported functions are explicitly typed
- [ ] PR scope matches the sprint plan with no scope creep
- [ ] Any new `any` has an adjacent justification comment
- [ ] No file-wide `: any`
- [ ] No implicit `any` in exported functions

## What Was Typed
List exactly what was typed in this PR.

- 
- 
- 

## What Was Intentionally Left Loose
List anything intentionally not tightened yet.

- 
- 
- 

## `any` Ledger (REQUIRED)
- New `any` added: 
- Existing `any` removed: 
- Net change: 

For every new `any`, explain why it is required and why a safer type was not used yet.

1. 
2. 
3. 

## Boundary Notes
Document any public seams, caller-protection choices, or compatibility decisions.

- 
- 
- 

## Risk Level
- [ ] Low
- [ ] Medium
- [ ] High

Why:

## Validation Evidence
Paste the exact commands run and a short result summary.

```bash
npm run type-check:strict
npx tsc --noEmit -p tsconfig.json
```

Test commands run:

```bash
# paste commands here
```

## Stop Conditions Check
If any item below happened, explain how scope was reduced before merge.

- [ ] `any` started spreading across files
- [ ] Root `tsc` broke repeatedly
- [ ] Types required cross-module rewrites
- [ ] Scope was reduced to keep the PR reviewable

Notes:

## Reviewer Focus
What should reviewers look at first?

- 
- 
- 
