### PR TITLE
fix: resolve 5 pre-existing test failures with root-cause fixes

### DIFF
--- a/src/__tests__/WorksCalendar.scheduleModel.integration.test.tsx
+++ b/src/__tests__/WorksCalendar.scheduleModel.integration.test.tsx
@@ -66,8 +66,8 @@ describe('WorksCalendar schedule model integration', () => {
   async function requestPtoForAlex() {
     fireEvent.click(await screen.findByRole('button', { name: 'Actions for Alex Rivera' }));
     fireEvent.click(await screen.findByRole('button', { name: 'Request PTO' }));
-    fireEvent.change(screen.getByLabelText('Start *'), { target: { value: '2026-04-01' } });
-    fireEvent.change(screen.getByLabelText('End *'), { target: { value: '2026-04-02' } });
+    fireEvent.change(await screen.findByLabelText('Start *'), { target: { value: '2026-04-01' } });
+    fireEvent.change(await screen.findByLabelText('End *'), { target: { value: '2026-04-02' } });
     fireEvent.click(await screen.findByRole('button', { name: 'Save PTO Request' }));
   }
 

--- a/src/__tests__/WorksCalendar.scheduleTemplates.test.tsx
+++ b/src/__tests__/WorksCalendar.scheduleTemplates.test.tsx
@@ -57,7 +57,7 @@ describe('WorksCalendar schedule template flow', () => {
     );
 
     fireEvent.click(screen.getByRole('button', { name: 'Add schedule from template' }));
-    fireEvent.click(screen.getByRole('button', { name: 'Create schedule' }));
+    fireEvent.click(await screen.findByRole('button', { name: 'Create schedule' }));
 
     await waitFor(() => expect(onEventSave).toHaveBeenCalledTimes(1));
     expect(onEventSave).toHaveBeenCalledWith(

--- a/src/core/safeLocalStorage.ts
+++ b/src/core/safeLocalStorage.ts
@@ -26,7 +26,12 @@ export function safeRemoveLocalStorage(key: string): boolean {
 
 export function safeLocalStorageKeys(): string[] {
   try {
-    return Object.keys(localStorage).filter(k => k.startsWith('wc-'));
+    const keys: string[] = [];
+    for (let i = 0; i < localStorage.length; i++) {
+      const k = localStorage.key(i);
+      if (k !== null) keys.push(k);
+    }
+    return keys;
   } catch {
     return [];
   }


### PR DESCRIPTION
- safeLocalStorageKeys: enumerate via localStorage.length + key(i) instead of Object.keys(), which happy-dom does not implement for localStorage; also drop the wc- prefix filter to match the function's documented contract
- WorksCalendar.scheduleModel: await findByLabelText (was synchronous getByLabelText) inside requestPtoForAlex so the lazy-loaded EventForm has time to mount before the field interaction
- WorksCalendar.scheduleTemplates: await findByRole for the "Create schedule" button so the lazy-loaded ScheduleTemplateDialog is present in the DOM

No test expectations were changed; all fixes are in production code or test setup steps that were racing against React.lazy Suspense resolution.

https://claude.ai/code/session_01Mb6s1HcQEz1Z8aAhMgKHAX

## Summary
Describe exactly what this PR changes.

## Scope
- Stage: 
- Planned PR number in sprint: 
- Target files/directories: 
- Why this slice is isolated: 

## Lessons Learned Check (REQUIRED)
Confirm these were actively used while building this PR:

- [ ] PR is intentionally small and isolated
- [ ] Boundary typing was prioritized over internal perfection
- [ ] No silent spread of `any`
- [ ] Advisory root `tsc` was used to catch integration issues
- [ ] I did not assume “looks typed” means “safe”
- [ ] I stopped and isolated typing cascades instead of expanding scope

## Definition of Done (ALL REQUIRED)
This PR is not done unless every box is checked.

- [ ] `npm run type-check:strict` passes
- [ ] Root advisory `tsc --noEmit` passes
- [ ] Tests pass for touched scope at minimum
- [ ] No uncontrolled increase in `any`
- [ ] All new types are intentional and named
- [ ] Public interfaces and exported functions are explicitly typed
- [ ] PR scope matches the sprint plan with no scope creep
- [ ] Any new `any` has an adjacent justification comment
- [ ] No file-wide `: any`
- [ ] No implicit `any` in exported functions

## What Was Typed
List exactly what was typed in this PR.

- 
- 
- 

## What Was Intentionally Left Loose
List anything intentionally not tightened yet.

- 
- 
- 

## `any` Ledger (REQUIRED)
- New `any` added: 
- Existing `any` removed: 
- Net change: 

For every new `any`, explain why it is required and why a safer type was not used yet.

1. 
2. 
3. 

## Boundary Notes
Document any public seams, caller-protection choices, or compatibility decisions.

- 
- 
- 

## Risk Level
- [ ] Low
- [ ] Medium
- [ ] High

Why:

## Validation Evidence
Paste the exact commands run and a short result summary.

```bash
npm run type-check:strict
npx tsc --noEmit -p tsconfig.json
```

Test commands run:

```bash
# paste commands here
```

## Stop Conditions Check
If any item below happened, explain how scope was reduced before merge.

- [ ] `any` started spreading across files
- [ ] Root `tsc` broke repeatedly
- [ ] Types required cross-module rewrites
- [ ] Scope was reduced to keep the PR reviewable

Notes:

## Reviewer Focus
What should reviewers look at first?

- 
- 
- 
