### PR TITLE
docs: add Reminders, CalendarSources, and OfflineSupport pages (closes #619, #620, #621)

### DIFF
--- a/docs/CalendarSources.md
+++ b/docs/CalendarSources.md
@@ -1,0 +1,188 @@
+# Calendar Sources
+
+CalendarThatWorks supports multiple concurrent calendar sources — iCal (ICS) feeds and imported CSV datasets. Each source has its own color, and sources can be toggled on or off without a page reload. The `CalendarLegend` component renders a color-dot toggle list so users can show or hide individual calendars.
+
+## How sources are stored
+
+Sources are managed by `useSourceStore`, which persists them to `localStorage` under the key `wc-sources-<calendarId>`. Each calendar instance (identified by its `calendarId` prop) has its own independent store.
+
+On first load, the store automatically migrates any legacy `wc-feeds-<calendarId>` entries to the new unified format.
+
+### Source types
+
+| Type | Description |
+|---|---|
+| `'ics'` | iCal feed fetched by URL at a configurable `refreshInterval` |
+| `'csv'` | Pre-parsed event dataset imported by the user |
+
+```ts
+// ICS source shape
+{
+  id: string;
+  type: 'ics';
+  label: string;
+  color: string;         // hex color applied to all events from this feed
+  enabled: boolean;
+  url: string;
+  refreshInterval: number; // milliseconds; default 300 000 (5 min)
+  addedAt: string;         // ISO timestamp
+}
+
+// CSV source shape
+{
+  id: string;
+  type: 'csv';
+  label: string;
+  color: string;
+  enabled: boolean;
+  events: WorksCalendarEvent[];
+  importedAt?: string;
+  addedAt: string;
+}
+```
+
+## The `showCalendarLegend` prop
+
+Set `showCalendarLegend={true}` to render a color-dot toggle list at the bottom of the built-in sidebar. The legend shows all sources (ICS and CSV) and lets users toggle visibility and cycle through preset colors.
+
+```tsx
+<WorksCalendar
+  calendarId="my-app"
+  events={myEvents}
+  icalFeeds={[{ url: 'https://example.com/calendar.ics', label: 'Work' }]}
+  showCalendarLegend={true}
+/>
+```
+
+## How source colors propagate onto events
+
+Color assignment flows through `useSourceAggregator`:
+
+1. The aggregator builds two lookup maps from `sourceStore.sources`: `sourceColorById` (id → color) and `labelToSourceId` (label → id).
+2. For each ICS event, it resolves the source ID — store-managed feeds use their UUID (looked up by label); prop-level `icalFeeds` fall back to the label string as `_sourceId`.
+3. When a matching `sourceColorById` entry exists, the event's `color` field is overwritten with the source color. This value ends up on `NormalizedEvent.color`.
+4. CSV source events receive their source color the same way.
+
+The resolved `_sourceId` is stable across label renames for store-managed sources, because the store UUID is used rather than the mutable label string.
+
+### Source ID resolution summary
+
+| Feed origin | `_sourceId` value |
+|---|---|
+| Store-managed ICS feed | Store UUID (`src_…`) |
+| Prop-level `icalFeeds` | Feed's `label` string |
+| CSV source | Store UUID (`src_…`) |
+
+## Toggling a source
+
+Calling `toggleSource(id)` flips the `enabled` flag in the store. On the next render cycle, `useSourceAggregator` re-derives its active source lists, the aggregated event stream updates, and the calendar re-renders — all in one pass. There is no debounce or animation delay.
+
+## `LegendSource` type
+
+```ts
+interface LegendSource {
+  id: string;
+  label: string;
+  color: string;
+  enabled: boolean;
+  eventCount?: number; // optional count badge shown in the legend
+}
+```
+
+## `CalendarLegend` standalone export
+
+`CalendarLegend` is exported as a named component for use outside the built-in sidebar:
+
+```ts
+import { CalendarLegend } from 'calendarthatworks';
+import type { LegendSource } from 'calendarthatworks';
+```
+
+### Props
+
+| Prop | Type | Required | Description |
+|---|---|---|---|
+| `sources` | `LegendSource[]` | Yes | List of sources to display |
+| `onToggle` | `(id: string) => void` | Yes | Called when a source label is clicked |
+| `onColorChange` | `(id: string, color: string) => void` | No | Called when the color dot is clicked; cycles through preset colors |
+
+`CalendarLegend` renders nothing when `sources` is empty.
+
+## Working examples
+
+### Using `showCalendarLegend` (simplest)
+
+```tsx
+import { WorksCalendar } from 'calendarthatworks';
+
+export default function App() {
+  return (
+    <WorksCalendar
+      calendarId="team-calendar"
+      events={myEvents}
+      icalFeeds={[
+        { url: 'https://example.com/work.ics',     label: 'Work',     refreshInterval: 300_000 },
+        { url: 'https://example.com/personal.ics', label: 'Personal', refreshInterval: 600_000 },
+      ]}
+      showCalendarLegend={true}
+    />
+  );
+}
+```
+
+### Using `CalendarLegend` outside the sidebar
+
+```tsx
+import { useState } from 'react';
+import { WorksCalendar, CalendarLegend } from 'calendarthatworks';
+import type { LegendSource } from 'calendarthatworks';
+
+const initialSources: LegendSource[] = [
+  { id: 'work',     label: 'Work',     color: '#3b82f6', enabled: true },
+  { id: 'personal', label: 'Personal', color: '#10b981', enabled: true },
+];
+
+export default function App() {
+  const [sources, setSources] = useState(initialSources);
+
+  function toggle(id: string) {
+    setSources(prev =>
+      prev.map(s => s.id === id ? { ...s, enabled: !s.enabled } : s)
+    );
+  }
+
+  function changeColor(id: string, color: string) {
+    setSources(prev =>
+      prev.map(s => s.id === id ? { ...s, color } : s)
+    );
+  }
+
+  // Filter events based on enabled sources
+  const visibleEvents = myEvents.filter(ev =>
+    sources.find(s => s.id === ev._sourceId)?.enabled !== false
+  );
+
+  return (
+    <div style={{ display: 'flex', gap: '1rem' }}>
+      <aside>
+        <CalendarLegend
+          sources={sources}
+          onToggle={toggle}
+          onColorChange={changeColor}
+        />
+      </aside>
+      <WorksCalendar
+        calendarId="team-calendar"
+        events={visibleEvents}
+      />
+    </div>
+  );
+}
+```
+
+## References
+
+- `src/hooks/useSourceAggregator.ts`
+- `src/hooks/useSourceStore.ts`
+- `src/ui/CalendarLegend.tsx`
+- `docs/diagrams/level3i.mmd` / `level3i.png`

--- a/docs/OfflineSupport.md
+++ b/docs/OfflineSupport.md
@@ -1,0 +1,142 @@
+# Offline Support
+
+CalendarThatWorks includes a lightweight offline indicator that reacts to the browser's network status. It is purely presentational — the calendar does not buffer writes or retry requests itself. Retry and queue logic is the responsibility of the host data adapter.
+
+## The `showOfflineIndicator` prop
+
+Set `showOfflineIndicator={true}` to enable a slide-in banner that appears when the browser reports it is offline. The banner dismisses automatically when connectivity is restored.
+
+```tsx
+<WorksCalendar
+  events={events}
+  showOfflineIndicator={true}
+/>
+```
+
+## `useNetworkStatus`
+
+`useNetworkStatus` is exported as a standalone hook for use anywhere in your application:
+
+```ts
+import { useNetworkStatus } from 'calendarthatworks/hooks';
+
+const { isOnline, isInitializing } = useNetworkStatus();
+```
+
+### Return value
+
+```ts
+interface NetworkStatus {
+  isOnline: boolean;
+  isInitializing: boolean; // true until first client-side effect fires
+}
+```
+
+The hook subscribes to the browser's `online` and `offline` events — no polling. It returns immediately on every re-render with the current connectivity state. Listeners are cleaned up on unmount, so there is no accumulation across React strict-mode double-mounts.
+
+### SSR behavior
+
+`useNetworkStatus` is SSR-safe. On the server and during the first render:
+
+- `isOnline` defaults to `true` (the only safe assumption without a real browser).
+- `isInitializing` is `true` when `navigator` is not available (server-side), and becomes `false` after the first client-side effect fires.
+
+**The `OfflineIndicator` banner and any UI driven by `isInitializing` should render nothing during this window** to prevent a hydration mismatch between server HTML (which assumes online) and client HTML (which may already know the state).
+
+```tsx
+const { isOnline, isInitializing } = useNetworkStatus();
+
+if (isInitializing) return null; // avoid hydration mismatch
+if (!isOnline) return <OfflineBanner />;
+return null;
+```
+
+## `OfflineIndicator` standalone export
+
+`OfflineIndicator` is exported as a named component for use outside `<WorksCalendar>`:
+
+```ts
+import { OfflineIndicator } from 'calendarthatworks';
+```
+
+It calls `useNetworkStatus` internally and renders a `role="status"` / `aria-live="polite"` banner when offline. No props are required.
+
+```tsx
+export default function Layout({ children }) {
+  return (
+    <>
+      <OfflineIndicator />
+      <main>{children}</main>
+    </>
+  );
+}
+```
+
+## What the indicator does NOT do
+
+The offline indicator is intentionally thin:
+
+- It does **not** block or queue write operations.
+- It does **not** retry failed requests.
+- It does **not** cache event data for offline reads.
+- It does **not** integrate with `SyncManager` or `SyncQueue` — retry on reconnect is entirely the host's responsibility.
+
+The relationship to `SyncManager` / `SyncQueue` is deliberately decoupled: the indicator tells the user they are offline; the host data adapter decides what to do about it.
+
+## Relationship to `SyncManager` / `SyncQueue`
+
+If your application has a sync layer (e.g., `SyncManager` + `SyncQueue`), wire it up independently:
+
+```ts
+const { isOnline } = useNetworkStatus();
+
+useEffect(() => {
+  if (isOnline) {
+    syncQueue.flush(); // retry queued operations on reconnect
+  }
+}, [isOnline]);
+```
+
+The calendar's offline indicator and your sync layer react to the same browser events but are otherwise independent.
+
+## Working example
+
+```tsx
+import { WorksCalendar, OfflineIndicator, useNetworkStatus } from 'calendarthatworks';
+
+// Option A: built-in indicator inside the calendar
+export function SimpleExample() {
+  return (
+    <WorksCalendar
+      events={events}
+      showOfflineIndicator={true}
+    />
+  );
+}
+
+// Option B: standalone indicator + custom offline behavior
+export function AdvancedExample() {
+  const { isOnline, isInitializing } = useNetworkStatus();
+
+  return (
+    <div>
+      {/* Renders its own offline banner */}
+      <OfflineIndicator />
+
+      {!isInitializing && !isOnline && (
+        <p className="warning">
+          You're offline. New events will sync when you reconnect.
+        </p>
+      )}
+
+      <WorksCalendar events={events} />
+    </div>
+  );
+}
+```
+
+## References
+
+- `src/hooks/useNetworkStatus.ts`
+- `src/ui/OfflineIndicator.tsx`
+- `docs/diagrams/level3j.mmd` / `level3j.png`

--- a/docs/Reminders.md
+++ b/docs/Reminders.md
@@ -1,0 +1,137 @@
+# Reminders
+
+CalendarThatWorks supports per-event reminders via two delivery methods: browser push notifications and a host-supplied callback. Reminders are configured on individual events and scheduled by the `useReminders` hook.
+
+## ReminderDef
+
+```ts
+interface ReminderDef {
+  minutesBefore: number;  // minutes before event start to fire
+  method: 'browser' | 'callback';
+}
+```
+
+- **`'browser'`** — fires a [Web Notification](https://developer.mozilla.org/en-US/docs/Web/API/Notifications_API). Requires the user to grant permission.
+- **`'callback'`** — invokes the `onReminder` prop on `<WorksCalendar>` instead of showing a system notification.
+
+## Attaching reminders to events
+
+Add a `reminders` array to any event:
+
+```ts
+const events = [
+  {
+    id: '1',
+    title: 'Team standup',
+    start: '2024-11-01T09:00:00',
+    end:   '2024-11-01T09:30:00',
+    reminders: [
+      { minutesBefore: 10, method: 'browser' },
+      { minutesBefore: 5,  method: 'callback' },
+    ],
+  },
+];
+```
+
+## The `onReminder` prop
+
+When a reminder with `method: 'callback'` fires, the `onReminder` prop is called:
+
+```ts
+type ReminderCallback = (event: WorksCalendarEvent, reminder: ReminderDef) => void;
+```
+
+```tsx
+<WorksCalendar
+  events={events}
+  onReminder={(event, reminder) => {
+    console.log(`Reminder: ${event.title} starts in ${reminder.minutesBefore} min`);
+    // send a push notification, play a sound, show a toast, etc.
+  }}
+/>
+```
+
+## Browser permission flow
+
+For `method: 'browser'`, the calendar calls `Notification.requestPermission()` once — the first time a browser reminder is registered. The request is not re-issued on subsequent renders or page loads. If the user denies permission, browser reminders silently do nothing; callback reminders are unaffected.
+
+## Key behaviors
+
+### Reminders fire against `expandedEvents` (pre-filter)
+
+Timers are scheduled against the full expanded event list **before** any active filters are applied. This means a reminder fires even when its event is currently hidden by a filter (e.g., a category filter or source toggle). This is intentional: a hidden event is still a real event on your calendar.
+
+### Timers are rebuilt on page load
+
+`useReminders` re-registers all timers whenever the events array changes and clears them all on unmount. There is **no service-worker persistence** — if the tab is closed and reopened, reminders that already fired are gone, and any future reminders are re-scheduled from the new page load time.
+
+### Past reminders are silently skipped
+
+If `eventStart − minutesBefore` is less than 1 second from now (already passed, or effectively immediate), the reminder is skipped. This prevents notification spam when you reload a page near the start time of an event.
+
+### All-day events are skipped
+
+All-day events have no meaningful fire time, so their reminders are never scheduled.
+
+## Working example
+
+```tsx
+import { WorksCalendar } from 'calendarthatworks';
+import type { WorksCalendarEvent, ReminderDef } from 'calendarthatworks';
+
+const events: WorksCalendarEvent[] = [
+  {
+    id: '1',
+    title: 'Weekly planning',
+    start: new Date(Date.now() + 60 * 60 * 1000), // 1 hour from now
+    end:   new Date(Date.now() + 90 * 60 * 1000),
+    reminders: [
+      { minutesBefore: 15, method: 'browser' },   // → Web Notification
+      { minutesBefore: 5,  method: 'callback' },  // → onReminder
+    ],
+  },
+];
+
+function handleReminder(event: WorksCalendarEvent, reminder: ReminderDef) {
+  // Example: show a custom toast
+  showToast(`${event.title} starts in ${reminder.minutesBefore} min`);
+}
+
+export default function App() {
+  return (
+    <WorksCalendar
+      events={events}
+      onReminder={handleReminder}
+    />
+  );
+}
+```
+
+## Using `useReminders` standalone
+
+`useReminders` is exported for cases where you manage your own event list outside `<WorksCalendar>`:
+
+```ts
+import { useReminders } from 'calendarthatworks/hooks';
+
+useReminders(normalizedEvents, onReminder);
+```
+
+It takes an array of `NormalizedEvent` (the internal shape produced by `useNormalizedEvents`) and an optional `ReminderCallback`. The hook is effect-only — it returns nothing.
+
+## Limitations
+
+| Limitation | Detail |
+|---|---|
+| No persistence across page loads | Timers use `setTimeout`; closing the tab cancels all pending reminders. |
+| No service-worker support | There is no background delivery mechanism. |
+| Past reminders skipped silently | Reminders < 1 s away at schedule time are dropped with no error or log. |
+| All-day events not supported | Only timed events produce reminder timers. |
+| Browser permission is one-time | Once denied by the user, `'browser'` reminders are permanently silent until the user manually re-enables them in browser settings. |
+
+## References
+
+- `src/hooks/useReminders.ts`
+- `src/types/events.ts` — `ReminderDef`, `WorksCalendarEvent`, `NormalizedEvent`
+- `src/ui/EventFormSections/RemindersSection.tsx`
+- `docs/diagrams/level3h.mmd` / `level3h.png`


### PR DESCRIPTION
Covers useReminders / ReminderDef / onReminder, the multi-calendar source
color system / CalendarLegend / showCalendarLegend, and useNetworkStatus /
OfflineIndicator / showOfflineIndicator — each with type definitions, key
behaviors, limitations, and working code examples grounded in the Tier 3
source files and level-3h/3i/3j data flow diagrams.

https://claude.ai/code/session_01JBYNTfgMmLTtpPs9nBAH7r