### PR TITLE
refactor(types): replace LooseHandler with concrete handler signatures (#646)

### DIFF
--- a/src/types/ui.ts
+++ b/src/types/ui.ts
@@ -2,20 +2,10 @@ import type { ReactNode } from 'react';
 import type { NormalizedEvent } from './events';
 import type { EventStatus, EventLifecycleState } from './events';
 import type { EventVisualPriority } from './view';
+import type { EmployeeId, EmployeeRecord } from '../WorksCalendar.types';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any -- transitional shared shape: consumers (ConfigPanel, CalendarModals) index untyped nested config fields; tightening this requires a deeper refactor of those consumers' config-shape inference.
 export type AnyRecord = Record<string, any>;
-
-/**
- * Loose callback prop type used by ConfigPanelProps for handler props that
- * concrete callers may pass with a variety of concrete signatures
- * (e.g. (member: EmployeeRecord) => void, (id: string) => void). The
- * variance-tolerant signature avoids forcing every host to match a single
- * shape; the targeted disable is the smallest cost to keep the public prop
- * surface backward-compatible.
- */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any -- intentional permissive callable for transitional public prop surface
-export type LooseHandler = (...args: any[]) => void;
 
 // ─── Permissions ──────────────────────────────────────────────────────────────
 
@@ -89,12 +79,11 @@ export type SavedViewUpdateHandler = (
 ) => void;
 
 export type SourceDraft = {
-  id?: string | undefined;
+  id?: string;
   label?: string | undefined;
   enabled?: boolean | undefined;
-  type?: string | undefined;
+  type?: string;
   url?: string | undefined;
-  [k: string]: unknown;
 };
 
 export type ScheduleTemplateDraft = {
@@ -137,16 +126,16 @@ export interface ConfigPanelProps {
   /** True while iCal feeds are fetching; surfaced in SourcePanel as a
    *  small "Syncing…" affordance next to the iCal Feeds heading. */
   isFetchingFeeds?: boolean | undefined;
-  onAddSource?: LooseHandler | undefined;
-  onRemoveSource?: LooseHandler | undefined;
-  onToggleSource?: LooseHandler | undefined;
-  onUpdateSource?: LooseHandler | undefined;
+  onAddSource?: ((source: SourceDraft) => void) | undefined;
+  onRemoveSource?: ((id: string) => void) | undefined;
+  onToggleSource?: ((id: string) => void) | undefined;
+  onUpdateSource?: ((id: string, patch: SourceDraft) => void) | undefined;
   scheduleTemplates?: ScheduleTemplateDraft[] | undefined;
-  onCreateScheduleTemplate?: LooseHandler | undefined;
-  onDeleteScheduleTemplate?: LooseHandler | undefined;
+  onCreateScheduleTemplate?: ((template: ScheduleTemplateDraft) => void | Promise<void>) | undefined;
+  onDeleteScheduleTemplate?: ((templateId: string) => void | Promise<void>) | undefined;
   scheduleTemplateError?: string | null | undefined;
-  onEmployeeAdd?: LooseHandler | undefined;
-  onEmployeeDelete?: LooseHandler | undefined;
+  onEmployeeAdd?: ((member: EmployeeRecord) => void) | undefined;
+  onEmployeeDelete?: ((employeeId: EmployeeId) => void) | undefined;
   initialTab?: string | undefined;
   initialSmartViewEditId?: string | null | undefined;
   calendarId?: string | undefined;

--- a/src/ui/ConfigPanel.tsx
+++ b/src/ui/ConfigPanel.tsx
@@ -1040,7 +1040,7 @@ export function TeamTab({ config, onUpdate, onEmployeeAdd, onEmployeeDelete }: T
     const nextId = Math.max(0, ...teamMembers.map((member) => Number(member.id) || 0)) + 1;
     const newMember: TeamMemberDraft = { id: nextId, name: trimmed, color: '#8b5cf6', avatar: null };
     updateMembers([...teamMembers, newMember]);
-    onEmployeeAdd?.(newMember);
+    onEmployeeAdd?.({ id: nextId, name: trimmed, color: '#8b5cf6', avatar: null });
     setPendingName('');
     setIsAdding(false);
   };
@@ -1439,7 +1439,7 @@ function TemplateTab({ templates, onCreate, onDelete, error }: TemplateTabProps)
               {String(template['visibility'] ?? 'org')} · {(Array.isArray(template['entries']) ? template['entries'].length : 0)} entr{((Array.isArray(template['entries']) ? template['entries'].length : 0)) === 1 ? 'y' : 'ies'}
             </div>
           </div>
-          <button className={styles['removeBtn']} onClick={() => onDelete?.(template.id)} disabled={!onDelete}>
+          <button className={styles['removeBtn']} onClick={() => { if (template.id !== undefined) onDelete?.(template.id); }} disabled={!onDelete || template.id === undefined}>
             <Trash2 size={13} />
           </button>
         </div>


### PR DESCRIPTION
Every ConfigPanelProps callback previously typed as `LooseHandler`
(`(...args: any[]) => void`) now carries a precise signature: source
handlers take `SourceDraft` / `(id, patch)`, schedule template handlers
take `ScheduleTemplateDraft` and return `void | Promise<void>`, employee
handlers take `EmployeeRecord` / `EmployeeId`. Drops the `LooseHandler`
alias and its eslint-disable.

Tightening `SourceDraft` (drops the `[k: string]: unknown` index
signature; required-in-CalendarSource fields lose the `| undefined`
value) exposes two latent mismatches the looser type was hiding:
TeamTab's `commitPending` passed a `TeamMemberDraft` whose `name` was
`string | undefined` to a `name?: string` slot, and TemplateTab's delete
button forwarded `template.id` (`string | undefined`) into a `string`
handler. Both call sites now satisfy the precise contracts.

Breaking change for hosts whose handlers had the wrong shape — bundle
with the major-version bump tracked alongside #647.