### PR TITLE
refactor(types): replace AnyRecord with typed WorksCalendarConfig (#647)

### DIFF
--- a/src/WorksCalendar.types.ts
+++ b/src/WorksCalendar.types.ts
@@ -31,14 +31,14 @@ export type ScheduleInstantiationLimits = {
 type UnknownRecord = Record<string, unknown>;
 
 /**
- * Persisted owner-configurable settings — the blob behind ConfigPanel, stored
+ * Persisted host-configurable settings — the blob behind ConfigPanel, stored
  * per `calendarId` (localStorage by default). A handful of well-known top-level
  * keys are typed; everything else is surfaced as `unknown` through the index
  * signature, so values read off ad-hoc keys should be narrowed with a cast or
  * guard at the call site. Treat it as a loosely-validated bag, not a strict
  * schema — the host app owns the source of truth.
  */
-export type OwnerConfig = {
+export type WorksCalendarConfig = {
   /** Calendar display name shown in the toolbar. */
   title?: string;
   /** Category name treated as "on-call" by the scheduling views. */
@@ -46,11 +46,45 @@ export type OwnerConfig = {
   /** First-run / setup wizard state (preferred theme, completion flag, …). */
   setup?: { preferredTheme?: string; completed?: boolean; [key: string]: unknown };
   /** Display preferences (start-of-week, default view, enabled views, …). */
-  display?: { weekStartDay?: number; defaultView?: string; enabledViews?: string[]; [key: string]: unknown };
+  display?: {
+    weekStartDay?: number;
+    defaultView?: string;
+    enabledViews?: string[];
+    dayStart?: number;
+    dayEnd?: number;
+    showWeekNumbers?: boolean;
+    enlargeMonthRowOnHover?: boolean;
+    [key: string]: unknown;
+  };
+  /** Filter UI label overrides (group labels for Categories/People/Sources/More). */
+  filterUi?: {
+    groupLabels?: {
+      categories?: string;
+      resources?: string;
+      sources?: string;
+      more?: string;
+      [key: string]: unknown;
+    };
+    [key: string]: unknown;
+  };
+  /** Hover card field visibility toggles. */
+  hoverCard?: {
+    showTime?: boolean;
+    showCategory?: boolean;
+    showResource?: boolean;
+    showMeta?: boolean;
+    showNotes?: boolean;
+    [key: string]: unknown;
+  };
+  /** Per-category custom field definitions used by the EventForm. */
+  eventFields?: Record<string, UnknownRecord[]>;
   /** Team registry — roles, bases, regions, member records and label overrides. */
   team?: {
-    roles?: UnknownRecord[];
+    /** Display labels for role dropdowns (e.g. "Team Lead", "Software Engineer"). */
+    roles?: string[];
+    /** Named locations (bases / buildings / regions). Shape `{ id, name, regionId? }`. */
     bases?: UnknownRecord[];
+    /** Top-level regions that bases roll up to. Shape `{ id, name }`. */
     regions?: UnknownRecord[];
     members?: EmployeeRecord[];
     locationLabel?: string;
@@ -69,10 +103,18 @@ export type OwnerConfig = {
   categoriesConfig?: unknown;
   /** Tiered approval workflow configuration. */
   approvals?: UnknownRecord;
+  /** Owner-configurable request-form schema. */
+  requestForm?: { fields?: UnknownRecord[]; [key: string]: unknown };
   /** Custom theme token overrides. */
   customTheme?: UnknownRecord;
   [key: string]: unknown;
 };
+
+/**
+ * @deprecated Use `WorksCalendarConfig`. Retained as an alias for internal
+ * call sites that haven't migrated yet (and for the `useOwnerConfig` API).
+ */
+export type OwnerConfig = WorksCalendarConfig;
 
 export type ScheduleTemplateAdapter = {
   listScheduleTemplates?: () => Promise<unknown>;

--- a/src/index.lite.ts
+++ b/src/index.lite.ts
@@ -34,6 +34,7 @@ export type {
   ScheduleTemplateDraft,
   CalendarViewEvent,
   UpdateConfig,
+  WorksCalendarConfig,
 } from './types/ui';
 
 export { normalizeEvent, normalizeEvents } from './core/eventModel';

--- a/src/index.ts
+++ b/src/index.ts
@@ -56,6 +56,7 @@ export type {
   ScheduleTemplateDraft,
   CalendarViewEvent,
   UpdateConfig,
+  WorksCalendarConfig,
 } from './types/ui';
 
 export { WorksCalendar }                  from './WorksCalendar.tsx';

--- a/src/types/ui.ts
+++ b/src/types/ui.ts
@@ -2,9 +2,10 @@ import type { ReactNode } from 'react';
 import type { NormalizedEvent } from './events';
 import type { EventStatus, EventLifecycleState } from './events';
 import type { EventVisualPriority } from './view';
+import type { FilterField } from '../filters/filterSchema';
+import type { WorksCalendarConfig } from '../WorksCalendar.types';
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any -- transitional shared shape: consumers (ConfigPanel, CalendarModals) index untyped nested config fields; tightening this requires a deeper refactor of those consumers' config-shape inference.
-export type AnyRecord = Record<string, any>;
+export type { WorksCalendarConfig };
 
 /**
  * Loose callback prop type used by ConfigPanelProps for handler props that
@@ -54,7 +55,9 @@ export type CalendarContextValue = {
   displayTimezone?: string | undefined;
 };
 
-export type UpdateConfig = (updater: (current: AnyRecord) => AnyRecord) => void;
+export type UpdateConfig = (
+  updater: (current: WorksCalendarConfig) => WorksCalendarConfig,
+) => void;
 
 export type SavedViewFilters = Record<string, unknown>;
 
@@ -121,11 +124,11 @@ export type ConfigPanelTabId =
   | 'requestForm';
 
 export interface ConfigPanelProps {
-  config: AnyRecord;
+  config: WorksCalendarConfig;
   categories: string[];
   resources: string[];
-  schema: AnyRecord;
-  items: AnyRecord[];
+  schema: readonly FilterField[];
+  items: NormalizedEvent[];
   onUpdate: UpdateConfig;
   onClose: () => void;
   onSaveView?: SaveViewHandler | undefined;

--- a/src/ui/ConfigPanel.tsx
+++ b/src/ui/ConfigPanel.tsx
@@ -11,14 +11,16 @@ import {
   APPROVAL_ACTIONS,
 } from '../core/configSchema';
 import type {
-  AnyRecord,
   ConfigPanelProps,
   ConfigPanelTabId,
   SaveViewOptions,
   SavedViewDraft,
   SavedViewFilters,
   UpdateConfig,
+  WorksCalendarConfig,
 } from '../types/ui';
+import type { NormalizedEvent } from '../types/events';
+import type { FilterField } from '../filters/filterSchema';
 import { CONFLICT_RULE_TYPES } from '../core/conflictEngine.ts';
 import { DEFAULT_CATEGORIES } from '../types/assets.ts';
 import type { CategoryDef, CategoriesConfig } from '../types/assets.ts';
@@ -136,15 +138,15 @@ const SEARCH_INDEX: Array<{ label: string; keywords?: string; tabId: string }> =
 ];
 
 type ConfigPanelSectionProps = {
-  config: AnyRecord;
+  config: WorksCalendarConfig;
   onUpdate: UpdateConfig;
 };
 
 type SmartViewsTabProps = {
   categories: string[];
   resources: string[];
-  schema?: AnyRecord[] | AnyRecord | undefined;
-  items?: AnyRecord[] | undefined;
+  schema?: readonly FilterField[] | undefined;
+  items?: NormalizedEvent[] | undefined;
   onSaveView?: ConfigPanelProps['onSaveView'];
   savedViews?: SavedViewDraft[] | undefined;
   onUpdateView?: ConfigPanelProps['onUpdateView'];
@@ -165,7 +167,7 @@ type TemplateTabProps = {
 };
 
 type AssetsTabProps = ConfigPanelSectionProps & {
-  items?: AnyRecord[];
+  items?: NormalizedEvent[];
 };
 
 type TemplateVisibility = 'private' | 'team' | 'org';
@@ -954,7 +956,10 @@ export function TeamTab({ config, onUpdate, onEmployeeAdd, onEmployeeDelete }: T
 
   const updateTeam = (patch: TeamConfigPatch) => onUpdate(c => ({
     ...c,
-    team: { ...(c['team'] ?? {}), ...patch },
+    // TeamMemberDraft narrowly differs from EmployeeRecord on exact-optional
+    // fields (name?: string | undefined vs name?: string) but they're the same
+    // blob at runtime — see line 933 where we cast on the way in.
+    team: { ...(c['team'] ?? {}), ...patch } as NonNullable<WorksCalendarConfig['team']>,
     setup: { ...(c['setup'] ?? {}), completed: true },
   }));
 
@@ -1450,11 +1455,14 @@ function TemplateTab({ templates, onCreate, onDelete, error }: TemplateTabProps)
 
 /* ----- HoverCard tab ----- */
 function HoverCardTab({ config, onUpdate }: ConfigPanelSectionProps) {
-  const hc = config['hoverCard'];
+  const hc = config['hoverCard'] ?? {};
   type HoverCardFieldKey = 'showTime' | 'showCategory' | 'showResource' | 'showMeta' | 'showNotes';
 
   const toggle = (key: HoverCardFieldKey) =>
-    onUpdate(c => ({ ...c, hoverCard: { ...c['hoverCard'], [key]: !c['hoverCard'][key] } }));
+    onUpdate(c => {
+      const prev = c['hoverCard'] ?? {};
+      return { ...c, hoverCard: { ...prev, [key]: !prev[key] } };
+    });
 
   const fields: Array<{ key: HoverCardFieldKey; label: string }> = [
     { key: 'showTime',     label: 'Time' },
@@ -2079,9 +2087,9 @@ export function AssetsTab({ config, onUpdate, items = [] }: AssetsTabProps) {
 
 /* ----- Display tab ----- */
 function DisplayTab({ config, onUpdate }: ConfigPanelSectionProps) {
-  const d = config['display'];
+  const d = config['display'] ?? {};
   const labels = config['filterUi']?.groupLabels ?? {};
-  const set = (key: string, val: unknown) => onUpdate(c => ({ ...c, display: { ...c['display'], [key]: val } }));
+  const set = (key: string, val: unknown) => onUpdate(c => ({ ...c, display: { ...(c['display'] ?? {}), [key]: val } }));
   const setGroupLabel = (key: 'categories' | 'resources' | 'sources' | 'more', val: string) =>
     onUpdate(c => ({
       ...c,

--- a/src/ui/__tests__/ConfigPanel.initialTab.test.tsx
+++ b/src/ui/__tests__/ConfigPanel.initialTab.test.tsx
@@ -18,7 +18,7 @@ function mount(props = {}) {
   return render(
     <ConfigPanel
       config={DEFAULT_CONFIG}
-      schema={{ fields: [] }}
+      schema={[]}
       items={[]}
       categories={[]}
       resources={[]}

--- a/src/ui/__tests__/ConfigPanel.search.test.tsx
+++ b/src/ui/__tests__/ConfigPanel.search.test.tsx
@@ -18,7 +18,7 @@ function mount(props = {}) {
   return render(
     <ConfigPanel
       config={DEFAULT_CONFIG}
-      schema={{ fields: [] }}
+      schema={[]}
       items={[]}
       categories={[]}
       resources={[]}


### PR DESCRIPTION
ConfigPanel and CalendarModals previously indexed into config blobs typed
as `Record<string, any>` via the `AnyRecord` alias. Surface the real
shape: rename the existing `OwnerConfig` to `WorksCalendarConfig`, keep
`OwnerConfig` as a deprecated alias, and replace every `AnyRecord` usage
with the typed config (and proper `FilterField[]` / `NormalizedEvent[]`
types for `schema` and `items`).

Also exports `WorksCalendarConfig` from the public entries so hosts can
reference the same shape.