### PR TITLE
packaging(attw): resolve attw warnings, enforce in CI (#648)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,12 @@ jobs:
       - name: Unit tests
         run: npm test
 
+      - name: Build library
+        run: npm run build
+
+      - name: Package check (attw)
+        run: npm run package:check
+
   e2e:
     runs-on: ubuntu-latest
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 ### Added
 
 - `npm run package:check` script using `@arethetypeswrong/cli` to verify the
-  `exports` map and catch type-resolution regressions before publish.
+  `exports` map and catch type-resolution regressions before publish. The
+  check now runs in CI and as part of `prepublishOnly`.
+- `engines.node` set to `>=18` to document the supported runtime range.
+
+### Changed
+
+- **ESM-only distribution.** The package now ships only ES modules. The
+  `require` condition and UMD bundles (`works-calendar.umd.js`,
+  `works-calendar-lite.umd.js`) have been removed from `package.json#exports`
+  and the Vite build configs. CommonJS consumers should switch to dynamic
+  `import()`. Node 18+ has supported ESM natively for several releases; the
+  README already advertised the library as ESM-only.
+- Subpath type declarations (`./integrations/*`, `./api/v1/server`, `./lite`)
+  now rewrite cross-tree imports to the package root and add explicit `.js`
+  extensions to relative specifiers so they resolve cleanly under `node16`
+  and bundler module-resolution modes.
+- CSS-only entrypoints (`./styles`, `./styles/family/*`, etc.) now use the
+  `{ "default": "./dist/<file>.css" }` form for clarity. They are excluded
+  from `attw` since they intentionally resolve to `.css` rather than JS.
 
 ### Verified
 

--- a/package.json
+++ b/package.json
@@ -4,14 +4,12 @@
   "description": "Drop-in embeddable React calendar with filtering, scheduling workflows, themes, and external-form support.",
   "license": "MIT",
   "type": "module",
-  "main": "./dist/works-calendar.umd.js",
   "module": "./dist/works-calendar.es.js",
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/works-calendar.es.js",
-      "require": "./dist/works-calendar.umd.js"
+      "import": "./dist/works-calendar.es.js"
     },
     "./integrations/asset-tracker": {
       "types": "./dist/integrations/asset-tracker.d.ts",
@@ -25,31 +23,60 @@
       "types": "./dist/api/v1/server/index.d.ts",
       "import": "./dist/api/v1/server/index.es.js"
     },
-    "./styles": "./dist/style.css",
-    "./styles/aviation": "./dist/themes/aviation.css",
-    "./styles/soft": "./dist/themes/soft.css",
-    "./styles/minimal": "./dist/themes/minimal.css",
-    "./styles/corporate": "./dist/themes/corporate.css",
-    "./styles/forest": "./dist/themes/forest.css",
-    "./styles/ocean": "./dist/themes/ocean.css",
-    "./styles/family": "./dist/themes/family/index.css",
-    "./styles/family/canvas": "./dist/themes/family/canvas.css",
-    "./styles/family/corporate": "./dist/themes/family/corporate.css",
-    "./styles/family/industrial": "./dist/themes/family/industrial.css",
-    "./styles/family/grid": "./dist/themes/family/grid.css",
-    "./styles/family/ops": "./dist/themes/family/ops.css",
-    "./styles/family/neon": "./dist/themes/family/neon.css",
+    "./styles": {
+      "default": "./dist/style.css"
+    },
+    "./styles/aviation": {
+      "default": "./dist/themes/aviation.css"
+    },
+    "./styles/soft": {
+      "default": "./dist/themes/soft.css"
+    },
+    "./styles/minimal": {
+      "default": "./dist/themes/minimal.css"
+    },
+    "./styles/corporate": {
+      "default": "./dist/themes/corporate.css"
+    },
+    "./styles/forest": {
+      "default": "./dist/themes/forest.css"
+    },
+    "./styles/ocean": {
+      "default": "./dist/themes/ocean.css"
+    },
+    "./styles/family": {
+      "default": "./dist/themes/family/index.css"
+    },
+    "./styles/family/canvas": {
+      "default": "./dist/themes/family/canvas.css"
+    },
+    "./styles/family/corporate": {
+      "default": "./dist/themes/family/corporate.css"
+    },
+    "./styles/family/industrial": {
+      "default": "./dist/themes/family/industrial.css"
+    },
+    "./styles/family/grid": {
+      "default": "./dist/themes/family/grid.css"
+    },
+    "./styles/family/ops": {
+      "default": "./dist/themes/family/ops.css"
+    },
+    "./styles/family/neon": {
+      "default": "./dist/themes/family/neon.css"
+    },
     "./themes": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/works-calendar.es.js",
-      "require": "./dist/works-calendar.umd.js"
+      "import": "./dist/works-calendar.es.js"
     },
     "./lite": {
       "types": "./dist/index.lite.d.ts",
-      "import": "./dist/works-calendar-lite.es.js",
-      "require": "./dist/works-calendar-lite.umd.js"
+      "import": "./dist/works-calendar-lite.es.js"
     },
     "./dist/*": "./dist/*"
+  },
+  "engines": {
+    "node": ">=18"
   },
   "sideEffects": [
     "dist/style.css",
@@ -81,10 +108,10 @@
     "type-check:watch": "tsc --noEmit --project tsconfig.build.json --watch",
     "lint": "eslint src",
     "lint:fix": "eslint src --fix",
-    "package:check": "attw --pack .",
+    "package:check": "attw --pack . --profile esm-only --exclude-entrypoints ./styles ./styles/aviation ./styles/soft ./styles/minimal ./styles/corporate ./styles/forest ./styles/ocean ./styles/family ./styles/family/canvas ./styles/family/corporate ./styles/family/industrial ./styles/family/grid ./styles/family/ops ./styles/family/neon",
     "ci": "npm run type-check && npm run lint && npm run test",
     "prepare": "husky",
-    "prepublishOnly": "npm run ci && npm run build"
+    "prepublishOnly": "npm run ci && npm run build && npm run package:check"
   },
   "peerDependencies": {
     "@supabase/supabase-js": "^2.0.0",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -43,9 +43,8 @@ export default defineConfig({
   build: {
     lib: {
       entry: resolve(__dirname, 'src/index.ts'),
-      name: 'WorksCalendar',
-      formats: ['es', 'umd'],
-      fileName: (format) => `works-calendar.${format}.js`,
+      formats: ['es'],
+      fileName: () => 'works-calendar.es.js',
     },
     rollupOptions: {
       external: [
@@ -55,12 +54,6 @@ export default defineConfig({
         'exceljs', 'date-fns', 'lucide-react',
       ],
       output: {
-        globals: {
-          react: 'React',
-          'react-dom': 'ReactDOM',
-          'date-fns': 'dateFns',
-          'lucide-react': 'LucideReact',
-        },
         assetFileNames: (info) => info.name === 'works-calendar.css' ? 'style.css' : (info.name ?? '[name][extname]'),
       },
     },

--- a/vite.integrations.config.ts
+++ b/vite.integrations.config.ts
@@ -20,19 +20,35 @@ import { readFileSync, writeFileSync, globSync } from 'fs';
  * entry — those relative paths don't resolve. Rewrite them to import
  * from the package root so consumers' tsc finds the types via the
  * main types pointer.
+ *
+ * Also append `.js` to remaining relative imports without extensions
+ * so node16 ESM resolution succeeds on the per-file declarations.
  */
 const rewritePackageImportsPlugin = (): Plugin => ({
   name: 'rewrite-subpath-types',
   closeBundle() {
-    const files = globSync('dist/integrations/**/*.d.ts');
+    const files = [
+      ...globSync('dist/integrations/**/*.d.ts'),
+      ...globSync('dist/api/**/*.d.ts'),
+      ...globSync('dist/types/**/*.d.ts'),
+    ];
+    const importLike = /(from\s+|import\s*\(\s*)(['"])([^'"]+)\2/g;
     for (const file of files) {
       const before = readFileSync(file, 'utf8');
-      // Match `from '...src-tree-path...'` (relative path traversing
-      // out of dist/integrations/) and rewrite to `from 'works-calendar'`.
-      const after = before.replace(
-        /from\s+['"](\.\.\/(?:[^'"]*\/)?(?:core|hooks|providers|types|ui|views)\/[^'"]+)['"]/g,
-        "from 'works-calendar'",
-      );
+      const after = before.replace(importLike, (match, prefix, quote, spec) => {
+        // Rewrite cross-tree relative imports into the main library
+        // (which ships rolled-up types via dist/index.d.ts).
+        if (/^\.\.\/(?:[^/]+\/)*?(?:core|hooks|providers|types|ui|views)\//.test(spec)) {
+          return `${prefix}${quote}works-calendar${quote}`;
+        }
+        // Leave non-relative specifiers alone.
+        if (!spec.startsWith('.')) return match;
+        // Already has an extension — leave it.
+        if (/\.(?:js|mjs|cjs|d\.ts|d\.cts|d\.mts|json)$/.test(spec)) return match;
+        // node16/nodenext ESM requires explicit extensions on relative
+        // imports — append `.js` so resolution succeeds.
+        return `${prefix}${quote}${spec}.js${quote}`;
+      });
       if (after !== before) writeFileSync(file, after, 'utf8');
     }
   },
@@ -43,7 +59,7 @@ export default defineConfig({
     dts({
       tsconfigPath: './tsconfig.build.json',
       entryRoot: 'src',
-      include: ['src/integrations/**/*.ts', 'src/integrations/**/*.tsx', 'src/types/**/*.d.ts', 'src/api/**/*.ts'],
+      include: ['src/integrations/**/*.ts', 'src/integrations/**/*.tsx', 'src/api/**/*.ts'],
       exclude: ['src/**/__tests__/**', 'src/**/*.test.*'],
       outDir: 'dist',
       skipDiagnostics: true,

--- a/vite.lite.config.ts
+++ b/vite.lite.config.ts
@@ -17,6 +17,11 @@ import { readFileSync, writeFileSync } from 'fs';
  * that aren't shipped per-file from this build. Rewrite each relative
  * import in `dist/index.lite.d.ts` to the package root so TypeScript
  * resolves the types via the main entry's rolled-up declarations.
+ *
+ * The rolled-up `dist/index.d.ts` has no `default` export — every
+ * symbol that the source re-exports via `export { default as Foo }`
+ * surfaces as a named export there. Strip the `default as` aliasing
+ * during the rewrite so the lite re-exports resolve to those names.
  */
 const rewriteLiteImportsPlugin = (): Plugin => ({
   name: 'rewrite-lite-types',
@@ -24,8 +29,11 @@ const rewriteLiteImportsPlugin = (): Plugin => ({
     const file = 'dist/index.lite.d.ts';
     const before = readFileSync(file, 'utf8');
     const after = before.replace(
-      /(from\s+|import\s*\(\s*)(['"])(\.\/?[^'"]+)\2/g,
-      (_match, prefix, quote) => `${prefix}${quote}works-calendar${quote}`,
+      /(export|import)(\s+type)?\s*\{([^}]*)\}\s*from\s*(['"])(\.[^'"]*)\4/g,
+      (_match, kind, typeMod, names, quote) => {
+        const cleaned = names.replace(/\bdefault\s+as\s+/g, '');
+        return `${kind}${typeMod ?? ''} {${cleaned}} from ${quote}works-calendar${quote}`;
+      },
     );
     if (after !== before) writeFileSync(file, after, 'utf8');
   },

--- a/vite.lite.config.ts
+++ b/vite.lite.config.ts
@@ -1,14 +1,35 @@
 /**
- * Lite-entry build — appends works-calendar-lite.{es,umd}.js and index.lite.d.ts
+ * Lite-entry build — appends works-calendar-lite.es.js and index.lite.d.ts
  * to the dist/ directory produced by the main vite.config.ts build.
  *
  * Run after the main build:
  *   vite build && vite build --config vite.lite.config.ts
  */
-import { defineConfig } from 'vite';
+import { defineConfig, type Plugin } from 'vite';
 import react from '@vitejs/plugin-react';
 import dts from 'vite-plugin-dts';
 import { resolve } from 'path';
+import { readFileSync, writeFileSync } from 'fs';
+
+/**
+ * The lite entry's emitted `.d.ts` re-exports symbols from sibling
+ * source paths (e.g. `./WorksCalendar.tsx`, `./views/ScheduleView`)
+ * that aren't shipped per-file from this build. Rewrite each relative
+ * import in `dist/index.lite.d.ts` to the package root so TypeScript
+ * resolves the types via the main entry's rolled-up declarations.
+ */
+const rewriteLiteImportsPlugin = (): Plugin => ({
+  name: 'rewrite-lite-types',
+  closeBundle() {
+    const file = 'dist/index.lite.d.ts';
+    const before = readFileSync(file, 'utf8');
+    const after = before.replace(
+      /(from\s+|import\s*\(\s*)(['"])(\.\/?[^'"]+)\2/g,
+      (_match, prefix, quote) => `${prefix}${quote}works-calendar${quote}`,
+    );
+    if (after !== before) writeFileSync(file, after, 'utf8');
+  },
+});
 
 export default defineConfig({
   plugins: [
@@ -16,19 +37,19 @@ export default defineConfig({
     dts({
       tsconfigPath: './tsconfig.build.json',
       entryRoot: 'src',
-      include: ['src/index.lite.ts', 'src/types/**/*.ts', 'src/vite-env.d.ts'],
+      include: ['src/index.lite.ts'],
       exclude: ['src/**/__tests__/**', 'src/**/*.test.*', 'src/test-setup.ts'],
       outDir: 'dist',
       skipDiagnostics: true,
     }),
+    rewriteLiteImportsPlugin(),
   ],
   build: {
     emptyOutDir: false,
     lib: {
       entry: resolve(__dirname, 'src/index.lite.ts'),
-      name: 'WorksCalendarLite',
-      formats: ['es', 'umd'],
-      fileName: (format) => `works-calendar-lite.${format}.js`,
+      formats: ['es'],
+      fileName: () => 'works-calendar-lite.es.js',
     },
     rollupOptions: {
       external: [
@@ -37,14 +58,6 @@ export default defineConfig({
         'react-map-gl', 'react-map-gl/maplibre',
         'exceljs', 'date-fns', 'lucide-react',
       ],
-      output: {
-        globals: {
-          react: 'React',
-          'react-dom': 'ReactDOM',
-          'date-fns': 'dateFns',
-          'lucide-react': 'LucideReact',
-        },
-      },
     },
   },
 });


### PR DESCRIPTION
ESM-only the distribution, fix subpath type-resolution under node16, and wire `attw` into CI + `prepublishOnly` so packaging regressions surface before publish.

- Drop UMD bundles + `require` exports; the README already advertises ESM-only and the UMD output's CJS branch contained ESM dynamic imports which attw flagged.
- Rewrite cross-tree relative imports in `dist/api/**`, `dist/types/**`, and `dist/integrations/**` `.d.ts` files to the package root, and append `.js` extensions to remaining relative specifiers so node16 ESM resolution succeeds.
- For the lite entry, drop `src/types/**/*.d.ts` from the integrations dts include (duplicated dist/index.d.ts), narrow lite dts include to the entry, and rewrite the rolled-up lite imports to the package root.
- Wrap CSS-only entries with `{ "default": "<file>.css" }` for clarity and exclude them from `attw` via `--exclude-entrypoints`.
- Use `attw --profile esm-only` so node10 / node16-CJS resolutions are ignored. Document supported runtime via `engines.node >= 18`.
- Add the build + package:check step to `.github/workflows/ci.yml` and to `prepublishOnly`.

## Summary
Describe exactly what this PR changes.

## Scope
- Stage: 
- Planned PR number in sprint: 
- Target files/directories: 
- Why this slice is isolated: 

## Lessons Learned Check (REQUIRED)
Confirm these were actively used while building this PR:

- [ ] PR is intentionally small and isolated
- [ ] Boundary typing was prioritized over internal perfection
- [ ] No silent spread of `any`
- [ ] Advisory root `tsc` was used to catch integration issues
- [ ] I did not assume “looks typed” means “safe”
- [ ] I stopped and isolated typing cascades instead of expanding scope

## Definition of Done (ALL REQUIRED)
This PR is not done unless every box is checked.

- [ ] `npm run type-check:strict` passes
- [ ] Root advisory `tsc --noEmit` passes
- [ ] Tests pass for touched scope at minimum
- [ ] No uncontrolled increase in `any`
- [ ] All new types are intentional and named
- [ ] Public interfaces and exported functions are explicitly typed
- [ ] PR scope matches the sprint plan with no scope creep
- [ ] Any new `any` has an adjacent justification comment
- [ ] No file-wide `: any`
- [ ] No implicit `any` in exported functions

## What Was Typed
List exactly what was typed in this PR.

- 
- 
- 

## What Was Intentionally Left Loose
List anything intentionally not tightened yet.

- 
- 
- 

## `any` Ledger (REQUIRED)
- New `any` added: 
- Existing `any` removed: 
- Net change: 

For every new `any`, explain why it is required and why a safer type was not used yet.

1. 
2. 
3. 

## Boundary Notes
Document any public seams, caller-protection choices, or compatibility decisions.

- 
- 
- 

## Risk Level
- [ ] Low
- [ ] Medium
- [ ] High

Why:

## Validation Evidence
Paste the exact commands run and a short result summary.

```bash
npm run type-check:strict
npx tsc --noEmit -p tsconfig.json
```

Test commands run:

```bash
# paste commands here
```

## Stop Conditions Check
If any item below happened, explain how scope was reduced before merge.

- [ ] `any` started spreading across files
- [ ] Root `tsc` broke repeatedly
- [ ] Types required cross-module rewrites
- [ ] Scope was reduced to keep the PR reviewable

Notes:

## Reviewer Focus
What should reviewers look at first?

- 
- 
- 
