### PR TITLE
fix(eventModel): derive category colors deterministically (#652)

### DIFF
--- a/src/core/__tests__/eventModel.test.ts
+++ b/src/core/__tests__/eventModel.test.ts
@@ -83,6 +83,28 @@ describe('normalizeEvent', () => {
     expect(ev.color).toMatch(/^(#|hsl)/);
   });
 
+  it('derives the same color for the same category name regardless of call order', () => {
+    // Issue #652: color must not depend on the order categories are first seen
+    // across calendar instances. Seed with one ordering then check the target
+    // category against the reverse ordering — same input must yield same output.
+    normalizeEvent(raw({ category: 'A' }));
+    normalizeEvent(raw({ category: 'B' }));
+    const first = normalizeEvent(raw({ category: 'Target' })).color;
+    normalizeEvent(raw({ category: 'C' }));
+    normalizeEvent(raw({ category: 'D' }));
+    const second = normalizeEvent(raw({ category: 'Target' })).color;
+    expect(second).toBe(first);
+  });
+
+  it('derives colors deterministically from category name (no shared state)', () => {
+    const a1 = normalizeEvent(raw({ category: 'Meetings' })).color;
+    const b1 = normalizeEvent(raw({ category: 'PTO' })).color;
+    const a2 = normalizeEvent(raw({ category: 'Meetings' })).color;
+    const b2 = normalizeEvent(raw({ category: 'PTO' })).color;
+    expect(a1).toBe(a2);
+    expect(b1).toBe(b2);
+  });
+
   it('defaults status to "confirmed"', () => {
     expect(normalizeEvent(raw()).status).toBe('confirmed');
   });

--- a/src/core/eventModel.ts
+++ b/src/core/eventModel.ts
@@ -29,21 +29,22 @@ const CATEGORY_COLORS = [
   '#3b82f6','#f59e0b','#ef4444','#10b981',
   '#8b5cf6','#ec4899','#06b6d4','#f97316',
 ];
-const _catColorMap = new Map<string, string>();
-let _catColorIdx = 0;
+
+// FNV-1a 32-bit. Deterministic across instances and reloads — that's the whole
+// point of doing it this way instead of an insertion-order map.
+function hashCategory(s: string): number {
+  let h = 2166136261;
+  for (let i = 0; i < s.length; i++) {
+    h ^= s.charCodeAt(i);
+    h = Math.imul(h, 16777619);
+  }
+  return h >>> 0;
+}
+
 function categoryColor(cat: string | null | undefined): string {
   if (!cat) return CATEGORY_COLORS[0]!;
-  if (!_catColorMap.has(cat)) {
-    const idx = _catColorIdx++;
-    // Use the curated palette for the first 8 categories; beyond that derive
-    // colours via the golden-angle hue distribution so they stay visually
-    // distinct without ever repeating.
-    const color = idx < CATEGORY_COLORS.length
-      ? CATEGORY_COLORS[idx]!
-      : `hsl(${Math.round((idx * 137.508) % 360)}, 62%, 45%)`;
-    _catColorMap.set(cat, color);
-  }
-  return _catColorMap.get(cat)!;
+  const h = hashCategory(cat);
+  return CATEGORY_COLORS[h % CATEGORY_COLORS.length]!;
 }
 
 /**


### PR DESCRIPTION
Replace the module-scoped Map and counter with a pure FNV-1a hash of the category name. Two calendar instances on the same page now render the same color for the same category regardless of mount order, and colors are stable across reloads. Removes the cross-instance leak and test pollution caused by shared module state.

## Summary
Describe exactly what this PR changes.

## Scope
- Stage: 
- Planned PR number in sprint: 
- Target files/directories: 
- Why this slice is isolated: 

## Lessons Learned Check (REQUIRED)
Confirm these were actively used while building this PR:

- [ ] PR is intentionally small and isolated
- [ ] Boundary typing was prioritized over internal perfection
- [ ] No silent spread of `any`
- [ ] Advisory root `tsc` was used to catch integration issues
- [ ] I did not assume “looks typed” means “safe”
- [ ] I stopped and isolated typing cascades instead of expanding scope

## Definition of Done (ALL REQUIRED)
This PR is not done unless every box is checked.

- [ ] `npm run type-check:strict` passes
- [ ] Root advisory `tsc --noEmit` passes
- [ ] Tests pass for touched scope at minimum
- [ ] No uncontrolled increase in `any`
- [ ] All new types are intentional and named
- [ ] Public interfaces and exported functions are explicitly typed
- [ ] PR scope matches the sprint plan with no scope creep
- [ ] Any new `any` has an adjacent justification comment
- [ ] No file-wide `: any`
- [ ] No implicit `any` in exported functions

## What Was Typed
List exactly what was typed in this PR.

- 
- 
- 

## What Was Intentionally Left Loose
List anything intentionally not tightened yet.

- 
- 
- 

## `any` Ledger (REQUIRED)
- New `any` added: 
- Existing `any` removed: 
- Net change: 

For every new `any`, explain why it is required and why a safer type was not used yet.

1. 
2. 
3. 

## Boundary Notes
Document any public seams, caller-protection choices, or compatibility decisions.

- 
- 
- 

## Risk Level
- [ ] Low
- [ ] Medium
- [ ] High

Why:

## Validation Evidence
Paste the exact commands run and a short result summary.

```bash
npm run type-check:strict
npx tsc --noEmit -p tsconfig.json
```

Test commands run:

```bash
# paste commands here
```

## Stop Conditions Check
If any item below happened, explain how scope was reduced before merge.

- [ ] `any` started spreading across files
- [ ] Root `tsc` broke repeatedly
- [ ] Types required cross-module rewrites
- [ ] Scope was reduced to keep the PR reviewable

Notes:

## Reviewer Focus
What should reviewers look at first?

- 
- 
- 
