### PR TITLE
fix(eventModel): widen color bucket to reduce palette collisions (#652)

### DIFF
--- a/src/core/__tests__/eventModel.test.ts
+++ b/src/core/__tests__/eventModel.test.ts
@@ -105,6 +105,20 @@ describe('normalizeEvent', () => {
     expect(b1).toBe(b2);
   });
 
+  it('does not collapse all categories into the 8-color palette', () => {
+    // Issue #652 follow-up: bucket count is wider than the palette so most
+    // categories fall through to an HSL hue. If a regression narrowed the
+    // bucket back to the palette size, every color would start with "#".
+    const samples = Array.from({ length: 200 }, (_, i) => `bucket-test-${i}`);
+    const colors = samples.map(c => normalizeEvent(raw({ category: c })).color);
+    const paletteHits = colors.filter(c => c.startsWith('#')).length;
+    const hslHits = colors.filter(c => c.startsWith('hsl')).length;
+    expect(paletteHits).toBeLessThan(samples.length / 2);
+    expect(hslHits).toBeGreaterThan(samples.length / 2);
+    // And the HSL bucket should itself produce many distinct hues.
+    expect(new Set(colors.filter(c => c.startsWith('hsl'))).size).toBeGreaterThan(20);
+  });
+
   it('defaults status to "confirmed"', () => {
     expect(normalizeEvent(raw()).status).toBe('confirmed');
   });

--- a/src/core/eventModel.ts
+++ b/src/core/eventModel.ts
@@ -41,10 +41,19 @@ function hashCategory(s: string): number {
   return h >>> 0;
 }
 
+// Bucket count is much wider than the curated palette so a small set of
+// distinct categories almost never collides on the same palette color. The
+// remainder spills into a golden-angle hue, giving ~360 visually distinct
+// fallback colors without sharing state.
+const PALETTE_BUCKETS = 64;
+
 function categoryColor(cat: string | null | undefined): string {
   if (!cat) return CATEGORY_COLORS[0]!;
   const h = hashCategory(cat);
-  return CATEGORY_COLORS[h % CATEGORY_COLORS.length]!;
+  const bucket = h % PALETTE_BUCKETS;
+  if (bucket < CATEGORY_COLORS.length) return CATEGORY_COLORS[bucket]!;
+  const hue = Math.round((h * 137.508) % 360);
+  return `hsl(${hue}, 62%, 45%)`;
 }
 
 /**


### PR DESCRIPTION
Respond to Codex review on the previous commit: pure h % 8 collapses distinct categories onto the same palette color even in small datasets, which is a distinguishability regression vs. the old insertion-order map.

Bucket the hash into 64 slots: the first 8 hit the curated palette, the rest spill into a golden-angle HSL hue (~360 distinct colors). Stays pure and deterministic, but a handful of categories almost never collide. Adds a test that proves the bucket isn't collapsing back into the palette.

## Summary
Describe exactly what this PR changes.

## Scope
- Stage: 
- Planned PR number in sprint: 
- Target files/directories: 
- Why this slice is isolated: 

## Lessons Learned Check (REQUIRED)
Confirm these were actively used while building this PR:

- [ ] PR is intentionally small and isolated
- [ ] Boundary typing was prioritized over internal perfection
- [ ] No silent spread of `any`
- [ ] Advisory root `tsc` was used to catch integration issues
- [ ] I did not assume “looks typed” means “safe”
- [ ] I stopped and isolated typing cascades instead of expanding scope

## Definition of Done (ALL REQUIRED)
This PR is not done unless every box is checked.

- [ ] `npm run type-check:strict` passes
- [ ] Root advisory `tsc --noEmit` passes
- [ ] Tests pass for touched scope at minimum
- [ ] No uncontrolled increase in `any`
- [ ] All new types are intentional and named
- [ ] Public interfaces and exported functions are explicitly typed
- [ ] PR scope matches the sprint plan with no scope creep
- [ ] Any new `any` has an adjacent justification comment
- [ ] No file-wide `: any`
- [ ] No implicit `any` in exported functions

## What Was Typed
List exactly what was typed in this PR.

- 
- 
- 

## What Was Intentionally Left Loose
List anything intentionally not tightened yet.

- 
- 
- 

## `any` Ledger (REQUIRED)
- New `any` added: 
- Existing `any` removed: 
- Net change: 

For every new `any`, explain why it is required and why a safer type was not used yet.

1. 
2. 
3. 

## Boundary Notes
Document any public seams, caller-protection choices, or compatibility decisions.

- 
- 
- 

## Risk Level
- [ ] Low
- [ ] Medium
- [ ] High

Why:

## Validation Evidence
Paste the exact commands run and a short result summary.

```bash
npm run type-check:strict
npx tsc --noEmit -p tsconfig.json
```

Test commands run:

```bash
# paste commands here
```

## Stop Conditions Check
If any item below happened, explain how scope was reduced before merge.

- [ ] `any` started spreading across files
- [ ] Root `tsc` broke repeatedly
- [ ] Types required cross-module rewrites
- [ ] Scope was reduced to keep the PR reviewable

Notes:

## Reviewer Focus
What should reviewers look at first?

- 
- 
- 
