### PR TITLE
ci(publish): use Node 24 to avoid global npm upgrade race

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,11 +17,9 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '22'
+          node-version: '24'
           registry-url: 'https://registry.npmjs.org'
-
-      - name: Upgrade npm (required for trusted publishing)
-        run: npm install -g npm@latest
+          cache: 'npm'
 
       - name: Install dependencies
         run: npm ci


### PR DESCRIPTION
## Summary

The 0.9.0 publish workflow run failed with:

```
npm error code MODULE_NOT_FOUND
npm error Cannot find module 'promise-retry'
npm error Require stack:
npm error - .../npm/node_modules/@npmcli/arborist/lib/arborist/rebuild.js
...
```

Root cause: `publish.yml` was running `npm install -g npm@latest` on top of
the npm 10.x bundled with Node 22 to satisfy the `>= 11.5.1` requirement
for OIDC trusted publishing. npm is rewriting its own global bin while it
runs, and intermittently leaves arborist with un-installed transitive
deps (`promise-retry` here) — the next `npm ci` then dies.

## Fix

Switch to `node-version: '24'`. Node 24's bundled npm already satisfies
the trusted-publishing minimum, so we can drop the in-place upgrade step
entirely. Also enable `cache: 'npm'` so re-runs don't refetch the full
dep tree.

```diff
       - uses: actions/setup-node@v4
         with:
-          node-version: '22'
+          node-version: '24'
           registry-url: 'https://registry.npmjs.org'
-
-      - name: Upgrade npm (required for trusted publishing)
-        run: npm install -g npm@latest
+          cache: 'npm'
```

## Test plan

- [ ] Merge → re-run `Publish to npm` workflow on `main` (workflow_dispatch
      or re-publish the `v0.9.0` release).
- [ ] Confirm `Install dependencies` step succeeds.
- [ ] Confirm `npm publish --provenance --access public` lands `0.9.0` on
      the registry.

https://claude.ai/code/session_01JVeQsgZ2stxkHSpBF7G46c

---
_Generated by [Claude Code](https://claude.ai/code/session_01JVeQsgZ2stxkHSpBF7G46c)_