### PR TITLE
build(dts): include ambient .d.ts files in subpath + lite emits

### DIFF
--- a/vite.integrations.config.ts
+++ b/vite.integrations.config.ts
@@ -59,10 +59,18 @@ export default defineConfig({
     dts({
       tsconfigPath: './tsconfig.build.json',
       entryRoot: 'src',
-      include: ['src/integrations/**/*.ts', 'src/integrations/**/*.tsx', 'src/api/**/*.ts'],
+      include: [
+        'src/integrations/**/*.ts',
+        'src/integrations/**/*.tsx',
+        'src/api/**/*.ts',
+        // Ambient-only declarations (CSS module shims, `--*` CSSProperties,
+        // virtual: PWA register). Pure ambient — no concrete exports, so
+        // they don't duplicate anything from `dist/index.d.ts`.
+        'src/types/**/*.d.ts',
+        'src/vite-env.d.ts',
+      ],
       exclude: ['src/**/__tests__/**', 'src/**/*.test.*'],
       outDir: 'dist',
-      skipDiagnostics: true,
       // No rollupTypes here — the subpath module imports types from
       // the main library (`../core/pools/locationAdapters`), and
       // rolling them up duplicates declarations already shipped in

--- a/vite.lite.config.ts
+++ b/vite.lite.config.ts
@@ -45,10 +45,16 @@ export default defineConfig({
     dts({
       tsconfigPath: './tsconfig.build.json',
       entryRoot: 'src',
-      include: ['src/index.lite.ts'],
+      include: [
+        'src/index.lite.ts',
+        // Ambient-only declarations (CSS module shims, `--*` CSSProperties,
+        // virtual: PWA register). Pure ambient — no concrete exports, so
+        // they don't duplicate anything from `dist/index.d.ts`.
+        'src/types/**/*.d.ts',
+        'src/vite-env.d.ts',
+      ],
       exclude: ['src/**/__tests__/**', 'src/**/*.test.*', 'src/test-setup.ts'],
       outDir: 'dist',
-      skipDiagnostics: true,
     }),
     rewriteLiteImportsPlugin(),
   ],


### PR DESCRIPTION
The publish run failed during `npm run build`'s second and third passes (integrations and lite):

    src/integrations/asset-map-widget.tsx:19:20 - error TS2307:
      Cannot find module './asset-map-widget.module.css' or its
      corresponding type declarations.
    src/WorksCalendar.tsx:40:20 - error TS2307: Cannot find module
      './WorksCalendar.module.css' or its corresponding type declarations.
    src/views/DayView.tsx:193:35 - error TS2353: Object literal may only
      specify known properties, and '--ev-color' does not exist in type
      'Properties<...>'.
    ...

Two compounding causes:

1. PR #648 narrowed the `dts({ include })` patterns for both subpath configs, which dropped `src/types/**/*.d.ts` — losing the ambient `declare module '*.module.css'` and `react-augment.d.ts` CSS-variable extension. The main `vite.config.ts` was unaffected (its include is `src/**/*.{ts,tsx}`).
2. `skipDiagnostics: true` was removed in vite-plugin-dts v4, so the resulting TS2307 / TS2353 errors leak straight through.

Restore the ambient declarations by adding `src/types/**/*.d.ts` and `src/vite-env.d.ts` to both subpath include lists. These files are pure ambient — no concrete exports — so they don't re-introduce the duplicate-declaration issue PR #648 was trying to avoid. Also drop the now-no-op `skipDiagnostics: true` from the integrations config.

Verified locally: all three vite passes (main / integrations / lite) complete green; `npm run package:check` (attw) still clean.

https://claude.ai/code/session_01JVeQsgZ2stxkHSpBF7G46c

## Summary
Describe exactly what this PR changes.

## Scope
- Stage: 
- Planned PR number in sprint: 
- Target files/directories: 
- Why this slice is isolated: 

## Lessons Learned Check (REQUIRED)
Confirm these were actively used while building this PR:

- [ ] PR is intentionally small and isolated
- [ ] Boundary typing was prioritized over internal perfection
- [ ] No silent spread of `any`
- [ ] Advisory root `tsc` was used to catch integration issues
- [ ] I did not assume “looks typed” means “safe”
- [ ] I stopped and isolated typing cascades instead of expanding scope

## Definition of Done (ALL REQUIRED)
This PR is not done unless every box is checked.

- [ ] `npm run type-check:strict` passes
- [ ] Root advisory `tsc --noEmit` passes
- [ ] Tests pass for touched scope at minimum
- [ ] No uncontrolled increase in `any`
- [ ] All new types are intentional and named
- [ ] Public interfaces and exported functions are explicitly typed
- [ ] PR scope matches the sprint plan with no scope creep
- [ ] Any new `any` has an adjacent justification comment
- [ ] No file-wide `: any`
- [ ] No implicit `any` in exported functions

## What Was Typed
List exactly what was typed in this PR.

- 
- 
- 

## What Was Intentionally Left Loose
List anything intentionally not tightened yet.

- 
- 
- 

## `any` Ledger (REQUIRED)
- New `any` added: 
- Existing `any` removed: 
- Net change: 

For every new `any`, explain why it is required and why a safer type was not used yet.

1. 
2. 
3. 

## Boundary Notes
Document any public seams, caller-protection choices, or compatibility decisions.

- 
- 
- 

## Risk Level
- [ ] Low
- [ ] Medium
- [ ] High

Why:

## Validation Evidence
Paste the exact commands run and a short result summary.

```bash
npm run type-check:strict
npx tsc --noEmit -p tsconfig.json
```

Test commands run:

```bash
# paste commands here
```

## Stop Conditions Check
If any item below happened, explain how scope was reduced before merge.

- [ ] `any` started spreading across files
- [ ] Root `tsc` broke repeatedly
- [ ] Types required cross-module rewrites
- [ ] Scope was reduced to keep the PR reviewable

Notes:

## Reviewer Focus
What should reviewers look at first?

- 
- 
- 
