### PR TITLE
ci(publish): pass NPM_TOKEN to the publish step

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -26,3 +26,5 @@ jobs:
 
       - name: Publish
         run: npm publish --provenance --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary

The 0.9.0 publish run keeps 404ing at the final registry PUT:

```
npm error 404 Not Found - PUT https://registry.npmjs.org/works-calendar
The requested resource 'works-calendar@0.9.0' could not be found or
you do not have permission to access it.
```

Provenance signing succeeded (Sigstore transparency log entry got created),
so OIDC tokens *are* reaching npm — npm just doesn't accept the OIDC
identity for `works-calendar`. The trusted-publisher configuration on
npmjs.com either isn't set up or doesn't match this workflow's
(org / repo / workflow filename) triple.

`actions/setup-node` already wrote an `.npmrc` that reads
`${NODE_AUTH_TOKEN}`, but the publish step never set that env var, so
token-based auth wasn't being attempted at all.

## Fix

Wire `NPM_TOKEN` into the publish step. Token auth handles the registry
PUT while `id-token: write` is still granted so `--provenance` continues
to sign with the OIDC identity (provenance is now decoupled from auth
identity). Restores the working pattern from `4c689df`.

```diff
       - name: Publish
         run: npm publish --provenance --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
```

Trusted publishing can be re-enabled later once the npmjs.com side is
configured to accept this workflow's OIDC identity.

## Test plan

- [ ] Merge.
- [ ] Re-run `Publish to npm` workflow on `main` (workflow_dispatch).
- [ ] `npm view works-calendar version` returns `0.9.0`.

https://claude.ai/code/session_01JVeQsgZ2stxkHSpBF7G46c

---
_Generated by [Claude Code](https://claude.ai/code/session_01JVeQsgZ2stxkHSpBF7G46c)_