### PR TITLE
release: 0.9.1 (rebuild of 0.9.0 with correct dist/)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.9.1] — 2026-05-14
+
+Re-publish of 0.9.0. The 0.9.0 tarball on the registry was assembled from
+a stale local `dist/` (a pre-0.8.0 build) because the publish command used
+`--ignore-scripts`, which skipped `prepublishOnly` and therefore skipped
+`npm run build`. The shipped tarball was missing every lazy-loaded chunk,
+shipped a 2.5 KB `style.css` instead of the ~270 KB build output, and even
+included the `works-calendar.umd.js` file that was deleted in 0.9.0.
+
+This release is the actual 0.9.0 source tree rebuilt cleanly. No source or
+behavior changes vs. `[0.9.0]` — same code, correct `dist/`. 0.9.0 has been
+deprecated on the registry to redirect installers here.
+
+### Fixed (packaging)
+
+- `dist/style.css` now contains the full ~270 KB of component rules — every
+  hashed CSS-module class referenced by the JS bundle resolves.
+- All lazy-loaded view chunks (`AvailabilityForm`, `DayView`, `EventForm`,
+  `WorkflowBuilderModal`, …) ship in `dist/` alongside the entry bundle.
+- `dist/works-calendar.umd.js` is gone (it was supposed to be removed in
+  0.9.0; the 0.9.0 stale-dist accident shipped it anyway).
+
 ## [0.9.0] — 2026-05-13
 
 The "packaging + type-safety hardening" release. Tightens the published surface

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "works-calendar",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "works-calendar",
-      "version": "0.9.0",
+      "version": "0.9.1",
       "license": "MIT",
       "dependencies": {
         "fuse.js": "^7.3.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "works-calendar",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "Drop-in embeddable React calendar with filtering, scheduling workflows, themes, and external-form support.",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
## Why

`works-calendar@0.9.0` on npm is broken — the publish command used
`--ignore-scripts`, which skipped `prepublishOnly`, which is what would
have rebuilt `dist/` from the 0.9.0 source. The tarball that shipped:

- `dist/style.css` is **2.5 KB** (should be ~270 KB) — the hashed
  CSS-module class names the JS references have no rules to resolve to,
  so consumers render unstyled.
- Every lazy-loaded view chunk is missing (`AvailabilityForm-*.js`,
  `DayView-*.js`, `EventForm-*.js`, `WorkflowBuilderModal-*.js`, etc.).
- `dist/works-calendar.umd.js` is present — it was supposed to be deleted
  in 0.9.0 as part of the ESM-only switch.
- Tarball lists 30 files; a fresh build produces ~90.

The tarball is from a pre-0.8.0 local `dist/` that was never refreshed.

## What this PR does

Bumps `package.json` + `package-lock.json` to `0.9.1` and adds a
`[0.9.1]` CHANGELOG section explaining the re-publish.

**No source changes vs 0.9.0** — same code, correct artifacts.

## Publish plan (after merge)

```powershell
# Wipe stale build output (the root cause)
Remove-Item -Recurse -Force dist
Remove-Item -Recurse -Force node_modules
npm ci

# Build + verify
npm run build
npm run package:check

# Sanity check
Get-Item dist/style.css | Select-Object Length      # ~270000
Test-Path dist/works-calendar.umd.js                # False

# Publish — NO --ignore-scripts this time, let prepublishOnly run
npm publish --access public --userconfig=$env:USERPROFILE\.npmrc

# Deprecate 0.9.0
npm deprecate works-calendar@0.9.0 "Stale dist (missing styles + lazy chunks). Use 0.9.1+." --userconfig=$env:USERPROFILE\.npmrc
```

## Test plan

- [ ] Fresh `dist/` after `npm run build` has `style.css` > 200 KB.
- [ ] Fresh `dist/` has no `works-calendar.umd.js`.
- [ ] `npm pack --dry-run` reports `total files: ~90`.
- [ ] After publish, `npm view works-calendar@0.9.1` shows the
      correct file list.
- [ ] `npm view works-calendar@0.9.0 deprecated` returns the
      deprecation message.

https://claude.ai/code/session_01JVeQsgZ2stxkHSpBF7G46c

---
_Generated by [Claude Code](https://claude.ai/code/session_01JVeQsgZ2stxkHSpBF7G46c)_