### PR TITLE
ci: drop committed .npmrc; rename `ci` script to `check`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,7 @@ playwright-report/
 .playwright-mcp/
 demo-dist/
 coverage/
+
+# Local-only npm auth (token, etc.). CI auth flows through actions/setup-node
+# which writes its own .npmrc at job time.
+.npmrc

--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,0 @@
-//registry.npmjs.org/:_authToken=${NPM_TOKEN}

--- a/package.json
+++ b/package.json
@@ -109,9 +109,9 @@
     "lint": "eslint src",
     "lint:fix": "eslint src --fix",
     "package:check": "attw --pack . --profile esm-only --exclude-entrypoints ./styles ./styles/aviation ./styles/soft ./styles/minimal ./styles/corporate ./styles/forest ./styles/ocean ./styles/family ./styles/family/canvas ./styles/family/corporate ./styles/family/industrial ./styles/family/grid ./styles/family/ops ./styles/family/neon",
-    "ci": "npm run type-check && npm run lint && npm run test",
+    "check": "npm run type-check && npm run lint && npm run test",
     "prepare": "husky",
-    "prepublishOnly": "npm run ci && npm run build && npm run package:check"
+    "prepublishOnly": "npm run check && npm run build && npm run package:check"
   },
   "peerDependencies": {
     "@supabase/supabase-js": "^2.0.0",


### PR DESCRIPTION
## Why

Code review on PR #664 flagged two real (if non-blocking) smells:

1. The committed `.npmrc` (with `${NPM_TOKEN}`) coexisting with `publish.yml`'s
   `NODE_AUTH_TOKEN` env. They don't actively collide at runtime —
   `actions/setup-node` rewrites `.npmrc` with `${NODE_AUTH_TOKEN}` before
   `npm publish` reads it — but two different env-var names referencing the
   same secret in two different files is confusing for anyone reading the
   repo. Local-publish flows have to ignore the committed file via
   `--userconfig`, which is awkward.
2. The `ci` npm-script name collides with `npm ci` (clean install). Reading
   `prepublishOnly: "npm run ci && npm run build …"` is genuinely
   ambiguous — does it install? (No: it runs type-check + lint + test.)

Neither caused any of the recent 0.9.x publish failures (those were OIDC
trusted-publisher setup, then `--ignore-scripts` stale `dist`, then
Windows TZ test failures — see PR #664 and PR #665). But cleaning these up
before 0.9.1 lands makes the surface easier to reason about for the next
release.

## Changes

- Delete the committed `.npmrc`. Auth is now entirely driven by
  `actions/setup-node` + `NODE_AUTH_TOKEN` in the publish workflow.
  Local-publish flows write their own token into `~/.npmrc` via `npm login`.
- Add `.npmrc` to `.gitignore` so a token file can live in the repo
  directory without being committed.
- Rename `scripts.ci` → `scripts.check`. Update `prepublishOnly` to call
  `npm run check`.
- Only one repo reference to the old name existed (in `prepublishOnly`).
  No workflow / README / husky references needed updates.

## Test plan

- [x] `npm run check` succeeds locally (4326/4326 tests green).
- [ ] CI runs `type-check`, `lint`, `npm test` as separate steps — no
      reference to the renamed script — so CI is unaffected.
- [ ] After merge, `npm publish` (local) should continue working with
      `--userconfig=$env:USERPROFILE\.npmrc` since the committed `.npmrc`
      no longer overrides.

https://claude.ai/code/session_01JVeQsgZ2stxkHSpBF7G46c

---
_Generated by [Claude Code](https://claude.ai/code/session_01JVeQsgZ2stxkHSpBF7G46c)_