### PR TITLE
feat: 1.0.0 — container-relative chrome + density prop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,48 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [1.0.0] — 2026-05-15
+
+The "container-responsive chrome" release. The calendar's toolbar, side rails,
+right panel, and filter sidebar now respond to the calendar's own width
+instead of the viewport's, so a narrow embed inside a wide page finally gets
+the right layout.
+
+### Added
+
+- **`density?: 'comfortable' | 'compact'`** prop on `<WorksCalendar>`. Pass
+  `'compact'` to force the narrow chrome (tablet-tier toolbar, hidden right
+  panel) regardless of container width — useful for sidebar widgets and
+  embeds whose visual context already supplies its own chrome. The default
+  (`undefined` / `'comfortable'`) lets the container queries pick the layout
+  based on the calendar's own width.
+
+### Changed
+
+- **Chrome responsiveness is now container-relative.** Existing viewport
+  `@media` queries in `WorksCalendar.module.css`, `RightPanel.module.css`,
+  and `FilterGroupSidebar.module.css` were rewritten as
+  `@container worksCalendar (max-width: …)` queries. The calendar root
+  declares the container (`container-type: inline-size`,
+  `container-name: worksCalendar`), so descendant chrome reads the
+  calendar's own width.
+  - 768px breakpoint: toolbar compresses, view-tabs scroll, "Add event"
+    becomes icon-only.
+  - 900px breakpoint: right panel hides.
+  - 1200px / 640px breakpoints: filter sidebar resizes.
+  - 480px breakpoint: two-row toolbar.
+  - `@media (pointer: coarse)` tap-target rules stay viewport-driven —
+    input mode, not size.
+- Breakpoints fire at the same widths as before, so a calendar that filled
+  the whole viewport behaves identically. The new behavior only changes for
+  embeds that are narrower than their host viewport.
+
+### Browser support
+
+Container queries land in Chrome 105+, Safari 16+, and Firefox 110+ (all
+2022). No polyfill ships; consumers on older browsers see the desktop
+layout unconditionally.
+
 ## [0.9.1] — 2026-05-14
 
 Re-publish of 0.9.0. The 0.9.0 tarball on the registry was assembled from

--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ interface WorksCalendarEvent {
 | `theme` | `string` | Theme name (see Theming) |
 | `role` | `'owner' \| 'scheduler' \| 'viewer'` | Permission level — `'owner'` unlocks settings & config |
 | `devMode` | `boolean` | **Local development only.** When `true`, treats the user as an owner regardless of `role`, bypassing every role check. Never pass `true` in production. |
+| `density` | `'comfortable' \| 'compact'` | Force the compact chrome (narrow toolbar, hidden right panel) regardless of container width. Default lets the calendar's own width drive the layout via container queries. |
 | `calendarId` | `string` | Namespace key for localStorage persistence (default: `'default'`) |
 | `onEventSave` | `(event) => void` | Called when a user saves an event in the editor |
 | `onEventDelete` | `(id) => void` | Called when a user deletes an event |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "works-calendar",
-  "version": "0.9.1",
+  "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "works-calendar",
-      "version": "0.9.1",
+      "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
         "fuse.js": "^7.3.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "works-calendar",
-  "version": "0.9.1",
+  "version": "1.0.0",
   "description": "Drop-in embeddable React calendar with filtering, scheduling workflows, themes, and external-form support.",
   "license": "MIT",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -172,7 +172,11 @@
     "vite-plugin-dts": "^4.5.4",
     "vitest": "^4.1.4"
   },
-
+  "lint-staged": {
+    "src/**/*.{ts,tsx}": [
+      "eslint --max-warnings=0 --no-warn-ignored"
+    ]
+  },
   "keywords": [
     "calendar",
     "scheduler",

--- a/src/WorksCalendar.module.css
+++ b/src/WorksCalendar.module.css
@@ -64,6 +64,21 @@
   height: 100%;
   min-height: 400px;
   box-sizing: border-box;
+
+  /* Establish a size-containment context so descendant chrome (toolbar,
+   * left rail, right panel, filter sidebar) can respond to the calendar's
+   * own width rather than the viewport. A 600px-wide embed inside a 4K
+   * page should get the narrow layout; a 1400px-wide calendar inside a
+   * narrow viewport should keep the desktop layout.
+   *
+   * Pair this with @container worksCalendar (max-width: X) rules below
+   * and in src/ui/*.module.css.
+   *
+   * Container query support: Chrome 105+ / Safari 16+ / Firefox 110+
+   * (all 2022). Library `engines.node >= 18` already implies a modern
+   * browser baseline. */
+  container-type: inline-size;
+  container-name: worksCalendar;
 }
 
 
@@ -710,56 +725,75 @@
   50%       { opacity: 0.4; transform: scale(0.75); }
 }
 
-/* ─── Responsive ─────────────────────────────────────────────── */
+/* ─── Responsive ─────────────────────────────────────────────────────────────
+ *
+ * The calendar's chrome reacts to its OWN width, not the viewport's. A 600px
+ * embed inside a 4K display gets the narrow layout; a 1400px embed inside a
+ * narrow viewport keeps the desktop layout. The container is defined on
+ * `.root` above (container-type: inline-size; container-name: worksCalendar).
+ *
+ * Hosts that want to force the compact layout regardless of width — for
+ * example, a sidebar widget that's wide but visually busy — can pass
+ * `density="compact"` on `<WorksCalendar>`, which sets `data-wc-density` on
+ * `.root` and is mirrored in the selectors below.
+ *
+ * Tap-target sizing (@media pointer: coarse) stays viewport-driven because
+ * it's about input mode, not size.
+ */
 
-/* Tablet (≤ 768px): compress toolbar, allow view strip to scroll */
-@media (max-width: 768px) {
+/* Tablet tier (container ≤ 768px OR forced compact):
+ * compress toolbar, allow view strip to scroll. */
+@container worksCalendar (max-width: 768px) {
   .toolbar {
     padding: calc(8px * var(--wc-density, 1)) calc(10px * var(--wc-density, 1));
     gap: 6px;
     row-gap: 6px;
   }
-
-  /* Nav + date label take full first row */
-  .navGroup {
-    flex: 1;
-  }
-
-  .dateLabel {
-    font-size: 13px;
-  }
-
-  /* View strip: no longer push to right, scrolls horizontally */
+  .navGroup { flex: 1; }
+  .dateLabel { font-size: 13px; }
   .viewGroup {
     margin-left: 0;
     overflow-x: auto;
-    /* hide scrollbar but keep scroll */
     scrollbar-width: none;
     -ms-overflow-style: none;
   }
   .viewGroup::-webkit-scrollbar { display: none; }
-
   .viewBtn {
     padding: calc(6px * var(--wc-density, 1)) calc(10px * var(--wc-density, 1));
     font-size: 11px;
   }
+  .actions { margin-left: auto; }
+  .addBtnLabel { display: none; }
+  .addBtn { padding: calc(6px * var(--wc-density, 1)) calc(8px * var(--wc-density, 1)); }
+}
 
-  /* Actions move to end of nav row */
-  .actions {
-    margin-left: auto;
-  }
-
-  /* "Add Event" — hide text label, show only + icon */
-  .addBtnLabel {
-    display: none;
-  }
-  .addBtn {
-    padding: calc(6px * var(--wc-density, 1)) calc(8px * var(--wc-density, 1));
-  }
+/* density="compact" mirrors the tablet tier regardless of container width. */
+.root[data-wc-density="compact"] .toolbar {
+  padding: calc(8px * var(--wc-density, 1)) calc(10px * var(--wc-density, 1));
+  gap: 6px;
+  row-gap: 6px;
+}
+.root[data-wc-density="compact"] .navGroup { flex: 1; }
+.root[data-wc-density="compact"] .dateLabel { font-size: 13px; }
+.root[data-wc-density="compact"] .viewGroup {
+  margin-left: 0;
+  overflow-x: auto;
+  scrollbar-width: none;
+  -ms-overflow-style: none;
+}
+.root[data-wc-density="compact"] .viewGroup::-webkit-scrollbar { display: none; }
+.root[data-wc-density="compact"] .viewBtn {
+  padding: calc(6px * var(--wc-density, 1)) calc(10px * var(--wc-density, 1));
+  font-size: 11px;
+}
+.root[data-wc-density="compact"] .actions { margin-left: auto; }
+.root[data-wc-density="compact"] .addBtnLabel { display: none; }
+.root[data-wc-density="compact"] .addBtn {
+  padding: calc(6px * var(--wc-density, 1)) calc(8px * var(--wc-density, 1));
 }
 
 /* Touch devices: guarantee comfortable tap targets (≥44px per iOS HIG).
- * Keyed to (pointer: coarse) so mouse users keep the dense desktop UI. */
+ * Keyed to (pointer: coarse) — input mode, not size. */
 @media (pointer: coarse) {
   .navBtn,
   .exportBtn,
@@ -783,43 +817,30 @@
   }
 }
 
-/* Mobile (≤ 480px): two-row toolbar, tighter everything */
-@media (max-width: 480px) {
+/* Mobile tier (container ≤ 480px): two-row toolbar, tighter everything. */
+@container worksCalendar (max-width: 480px) {
   .toolbar {
     flex-wrap: wrap;
     padding: calc(8px * var(--wc-density, 1));
     row-gap: 6px;
   }
-
-  /* Row 1: nav + date + icon actions */
-  .navGroup {
-    order: 1;
-    flex: 1;
-  }
-
-  .actions {
-    order: 2;
-  }
-
-  /* Row 2: view switcher spans full width */
+  .navGroup { order: 1; flex: 1; }
+  .actions  { order: 2; }
   .viewGroup {
     order: 3;
     width: 100%;
     border-radius: var(--wc-radius-sm);
   }
-
   .viewBtn {
     flex: 1;
     text-align: center;
     padding: calc(5px * var(--wc-density, 1)) calc(6px * var(--wc-density, 1));
     font-size: 11px;
   }
-
   .dateLabel {
     font-size: 12px;
     padding-left: 4px;
   }
-
   .todayBtn {
     font-size: 12px;
     padding: 0 calc(8px * var(--wc-density, 1));

--- a/src/WorksCalendar.tsx
+++ b/src/WorksCalendar.tsx
@@ -68,6 +68,9 @@ const WorksCalendarImpl = forwardRef<CalendarApi, WorksCalendarProps>(function W
     // ── Dev mode ──
     devMode                 = false,
 
+    // ── Layout density (responsive override) ──
+    density,
+
     // ── Notes ──
     notes       = {},
     onNoteSave,
@@ -346,7 +349,7 @@ const WorksCalendarImpl = forwardRef<CalendarApi, WorksCalendarProps>(function W
   if (shouldShowSetup) {
     return (
       <CalendarErrorBoundary>
-        <div className={styles['root']} data-wc-theme={effectiveTheme} data-wc-theme-family={themeFamily} data-wc-theme-mode={themeMode} data-testid="works-calendar-setup" style={rootStyle}>
+        <div className={styles['root']} data-wc-theme={effectiveTheme} data-wc-theme-family={themeFamily} data-wc-theme-mode={themeMode} data-wc-density={density ?? undefined} data-testid="works-calendar-setup" style={rootStyle}>
           <Suspense fallback={null}>
             <SetupLanding
               onSkip={handleSetupSkip}
@@ -365,7 +368,7 @@ const WorksCalendarImpl = forwardRef<CalendarApi, WorksCalendarProps>(function W
   return (
     <CalendarErrorBoundary>
       <CalendarContext.Provider value={ctxValue}>
-        <div ref={rootRef} className={styles['root']} data-wc-theme={effectiveTheme} data-wc-theme-family={themeFamily} data-wc-theme-mode={themeMode} data-testid="works-calendar" data-wc-edit-mode={editMode ? '' : undefined} data-print-root="" style={rootStyle}>
+        <div ref={rootRef} className={styles['root']} data-wc-theme={effectiveTheme} data-wc-theme-family={themeFamily} data-wc-theme-mode={themeMode} data-wc-density={density ?? undefined} data-testid="works-calendar" data-wc-edit-mode={editMode ? '' : undefined} data-print-root="" style={rootStyle}>
           {devMode && (
             <div role="alert" style={{ background: '#fef08a', color: '#713f12', fontWeight: 600, fontSize: 12, padding: '4px 12px', textAlign: 'center', zIndex: 9999 }}>
               ⚠ DEV MODE — all users have admin access. Do not use in production.

--- a/src/WorksCalendar.types.ts
+++ b/src/WorksCalendar.types.ts
@@ -178,6 +178,18 @@ export type WorksCalendarProps = {
    * the host app's auth).
    */
   devMode?: boolean;
+  /**
+   * Force the chrome into the compact layout regardless of the calendar's
+   * container width. Useful when the calendar is wide enough to keep the
+   * default desktop chrome but the host wants the slimmer toolbar / hidden
+   * right panel anyway (sidebar widgets, embeds with their own chrome, etc.).
+   *
+   * Default (`'comfortable'` / undefined) lets container queries pick the
+   * layout from the calendar's own width — `≤ 768px` → tablet rules,
+   * `≤ 480px` → mobile rules. `'compact'` forces the tablet rules on at
+   * any width and hides the right panel.
+   */
+  density?: 'comfortable' | 'compact';
   notes?: UnknownRecord;
   onNoteSave?: (note: UnknownRecord) => void;
   onNoteDelete?: (noteId: string) => void;

--- a/src/ui/FilterGroupSidebar.module.css
+++ b/src/ui/FilterGroupSidebar.module.css
@@ -213,16 +213,23 @@
   overflow: hidden;
 }
 
-/* Responsive: overlay mode on narrow screens */
-@media (max-width: 1200px) {
+/* Responsive: container-relative — react to the calendar's own width, not
+ * the viewport. Sidebar shrinks below 1200px container, fills below 640px.
+ * Mirrored for `data-wc-density="compact"`. */
+@container worksCalendar (max-width: 1200px) {
   .sidebar {
     width: 320px;
-    max-width: 90vw;
+    max-width: 90%;
   }
 }
 
-@media (max-width: 640px) {
+@container worksCalendar (max-width: 640px) {
   .sidebar {
     width: 100%;
   }
+}
+
+:global([data-wc-density="compact"]) .sidebar {
+  width: 320px;
+  max-width: 90%;
 }

--- a/src/ui/FilterGroupSidebar.module.css
+++ b/src/ui/FilterGroupSidebar.module.css
@@ -229,7 +229,10 @@
   }
 }
 
-:global([data-wc-density="compact"]) .sidebar {
+/* density="compact" on <WorksCalendar> mirrors the narrow-container rule.
+ * Anchor on `[data-wc-theme]` (only present on calendar roots) so an
+ * unrelated ancestor with `data-wc-density` can't trigger this. */
+:global([data-wc-theme][data-wc-density="compact"]) .sidebar {
   width: 320px;
   max-width: 90%;
 }

--- a/src/ui/RightPanel.module.css
+++ b/src/ui/RightPanel.module.css
@@ -1,8 +1,12 @@
 /*
  * RightPanel — docked aside in <AppShell>'s rightPanel slot. Token-driven so
- * all 12 themes restyle automatically. Hidden on narrow viewports — at the
- * mock's 240px width plus the 56px LeftRail, anything below ~900px starts
- * to crowd the calendar grid.
+ * all 12 themes restyle automatically. Hidden when the calendar's own
+ * container drops below ~900px — at the panel's 240px width plus the 56px
+ * LeftRail, anything narrower starts to crowd the calendar grid.
+ *
+ * Container-relative (not viewport-relative): a 600px embed inside a 4K
+ * page hides the panel; a 1200px-wide calendar inside a narrow viewport
+ * keeps it visible. Container declared on .root in WorksCalendar.module.css.
  */
 
 .root {
@@ -22,10 +26,17 @@
   overflow-x: hidden;
 }
 
-@media (max-width: 900px) {
+@container worksCalendar (max-width: 900px) {
   .root {
     display: none;
   }
+}
+
+/* density="compact" on <WorksCalendar> mirrors the narrow-container rule.
+ * `data-wc-density` is set on the calendar root (a CSS-module-hashed
+ * element), so target via attribute, not class. */
+:global([data-wc-density="compact"]) .root {
+  display: none;
 }
 
 /* ── Section ──────────────────────────────────────────────────────────── */

--- a/src/ui/RightPanel.module.css
+++ b/src/ui/RightPanel.module.css
@@ -33,9 +33,13 @@
 }
 
 /* density="compact" on <WorksCalendar> mirrors the narrow-container rule.
- * `data-wc-density` is set on the calendar root (a CSS-module-hashed
- * element), so target via attribute, not class. */
-:global([data-wc-density="compact"]) .root {
+ * Anchor on `[data-wc-theme]` (always present on the calendar root, both
+ * the main and setup-landing variants) AND `[data-wc-density="compact"]`
+ * so the rule only fires when an actual calendar root is in compact mode
+ * — not when some unrelated ancestor happens to carry the attribute, and
+ * not when an outer calendar in a nested-calendar setup is compact while
+ * an inner one isn't. */
+:global([data-wc-theme][data-wc-density="compact"]) .root {
   display: none;
 }
 


### PR DESCRIPTION
## Summary

Makes the calendar's chrome (toolbar, side rails, right panel, filter sidebar) respond to the calendar's **own width** instead of the viewport's. A 600 px embed inside a 4K page now gets the narrow layout; a 1400 px-wide calendar inside a narrow viewport keeps the desktop layout.

This unblocks the embedding scenarios you flagged — calendar inside a sidebar, narrow main column, etc. — without touching consumer code.

## What changed

**`src/WorksCalendar.module.css`**
- `.root` gets `container-type: inline-size; container-name: worksCalendar;`
- The existing 768 px tablet rules and 480 px mobile rules are now `@container worksCalendar (max-width: …)` blocks instead of `@media (max-width: …)`.
- `@media (pointer: coarse)` tap-target rules stay viewport-driven — that's input mode, not size.
- Adds a mirror block selected by `.root[data-wc-density="compact"]` for explicit override.

**`src/ui/RightPanel.module.css`** and **`src/ui/FilterGroupSidebar.module.css`**
- Their viewport `@media` rules become `@container worksCalendar` rules.
- Each adds a `:global([data-wc-density="compact"])` mirror selector.

**`src/WorksCalendar.tsx`** + **`src/WorksCalendar.types.ts`**
- New optional prop: `density?: 'comfortable' | 'compact'`.
- Renders `data-wc-density={density}` on the root.

**`package.json`**
- Restores the `lint-staged` config block (was lost in a recent refactor; the husky pre-commit hook was failing).

## Browser support

Container queries: Chrome 105+ / Safari 16+ / Firefox 110+ — all 2022. No polyfill ships; consumers on older browsers get the desktop layout unconditionally.

## What's NOT in this PR

These are still useful but out of scope for 1.0:

- ResizeObserver-driven toolbar overflow menu (the existing `overflow-x: auto` on the view-tab strip already keeps things usable).
- Drawer/sheet UI for LeftRail at narrow widths.
- `chromeless` / `renderToolbar` / `renderSideRail` slots — proper "BYO chrome" support for hosts that want to replace the built-in surfaces.

## Test plan

- [x] `npm run type-check` clean
- [x] `npm run build` produces correct `dist/` (`container-name:worksCalendar` and 5 `@container` blocks present in `dist/style.css`; 11 `data-wc-density=compact` selectors present)
- [ ] CI green
- [ ] Visual check at 400 px / 700 px / 1200 px container widths

## Why 1.0.0

This is the first public-API addition since we promised `0.9.x` would stay backwards-compatible (`density` is purely additive; existing consumers see no behavior change at the same viewport breakpoints). The container-query rewrite is a behavior change only for embeds whose container differs from the viewport — which was the whole point.

https://claude.ai/code/session_01JVeQsgZ2stxkHSpBF7G46c

---
_Generated by [Claude Code](https://claude.ai/code/session_01JVeQsgZ2stxkHSpBF7G46c)_