### PR TITLE
chore(packaging): widen lucide-react peer range; whitelist attw entries

### DIFF
--- a/package.json
+++ b/package.json
@@ -108,7 +108,7 @@
     "type-check:watch": "tsc --noEmit --project tsconfig.build.json --watch",
     "lint": "eslint src",
     "lint:fix": "eslint src --fix",
-    "package:check": "attw --pack . --profile esm-only --exclude-entrypoints ./styles ./styles/aviation ./styles/soft ./styles/minimal ./styles/corporate ./styles/forest ./styles/ocean ./styles/family ./styles/family/canvas ./styles/family/corporate ./styles/family/industrial ./styles/family/grid ./styles/family/ops ./styles/family/neon",
+    "package:check": "attw --pack . --profile esm-only --entrypoints . ./themes",
     "check": "npm run type-check && npm run lint && npm run test",
     "prepublishOnly": "npm run build && npm run package:check"
   },
@@ -116,7 +116,7 @@
     "@supabase/supabase-js": "^2.0.0",
     "date-fns": "^3.6.0",
     "exceljs": "^4.4.0",
-    "lucide-react": "^0.378.0",
+    "lucide-react": ">=0.378.0",
     "react": "^18.0.0 || ^19.0.0",
     "react-dom": "^18.0.0 || ^19.0.0"
   },


### PR DESCRIPTION
Two fixes from external package.json review on PR #668:

1. `lucide-react` peer range widened from `^0.378.0` to `>=0.378.0`. Caret on a `0.x.y` desugars to `>= 0.x.y < 0.(x+1).0` — so `^0.378.0` was effectively a pin to 0.378.x. Lucide ships frequently; the pin was causing peer-conflict noise for consumers on newer Lucide. Widening lets any 0.378+ work.

2. `package:check` switched from `--exclude-entrypoints` (15 manually- maintained CSS paths) to `--entrypoints . ./themes` (the only JS entries). Adding a new theme no longer requires updating this script. Verified attw still flags the same node16/bundler resolution checks on the JS entrypoints; the CSS-only entries are now ignored via auto-discovery rather than blacklist.

Both changes are install-surface only — no source impact, no breaking change for consumers on `^0.378.0` of Lucide, and the attw gating remains as strict for JS entries.

Other items from the same review (overrides, optional peer warnings, cross-env, vitest TZ) verified to be either incorrect or already- addressed. Reasoning documented in the PR thread.

https://claude.ai/code/session_01JVeQsgZ2stxkHSpBF7G46c

## Summary
Describe exactly what this PR changes.

## Scope
- Stage: 
- Planned PR number in sprint: 
- Target files/directories: 
- Why this slice is isolated: 

## Lessons Learned Check (REQUIRED)
Confirm these were actively used while building this PR:

- [ ] PR is intentionally small and isolated
- [ ] Boundary typing was prioritized over internal perfection
- [ ] No silent spread of `any`
- [ ] Advisory root `tsc` was used to catch integration issues
- [ ] I did not assume “looks typed” means “safe”
- [ ] I stopped and isolated typing cascades instead of expanding scope

## Definition of Done (ALL REQUIRED)
This PR is not done unless every box is checked.

- [ ] `npm run type-check:strict` passes
- [ ] Root advisory `tsc --noEmit` passes
- [ ] Tests pass for touched scope at minimum
- [ ] No uncontrolled increase in `any`
- [ ] All new types are intentional and named
- [ ] Public interfaces and exported functions are explicitly typed
- [ ] PR scope matches the sprint plan with no scope creep
- [ ] Any new `any` has an adjacent justification comment
- [ ] No file-wide `: any`
- [ ] No implicit `any` in exported functions

## What Was Typed
List exactly what was typed in this PR.

- 
- 
- 

## What Was Intentionally Left Loose
List anything intentionally not tightened yet.

- 
- 
- 

## `any` Ledger (REQUIRED)
- New `any` added: 
- Existing `any` removed: 
- Net change: 

For every new `any`, explain why it is required and why a safer type was not used yet.

1. 
2. 
3. 

## Boundary Notes
Document any public seams, caller-protection choices, or compatibility decisions.

- 
- 
- 

## Risk Level
- [ ] Low
- [ ] Medium
- [ ] High

Why:

## Validation Evidence
Paste the exact commands run and a short result summary.

```bash
npm run type-check:strict
npx tsc --noEmit -p tsconfig.json
```

Test commands run:

```bash
# paste commands here
```

## Stop Conditions Check
If any item below happened, explain how scope was reduced before merge.

- [ ] `any` started spreading across files
- [ ] Root `tsc` broke repeatedly
- [ ] Types required cross-module rewrites
- [ ] Scope was reduced to keep the PR reviewable

Notes:

## Reviewer Focus
What should reviewers look at first?

- 
- 
- 
