### PR TITLE
Claude/engine polish pre transfer

### DIFF
--- a/engine/.github/workflows/ci.yml
+++ b/engine/.github/workflows/ci.yml
@@ -28,8 +28,15 @@ jobs:
       - name: Build
         run: npm run build
 
-      - name: Package check (attw)
-        run: npx --yes -p @arethetypeswrong/cli attw --pack . --profile esm-only
-
+      # Node ESM smoke test: actually load the built package the way a
+      # consumer would and confirm the top-level export resolves. Catches the
+      # ERR_MODULE_NOT_FOUND class of bugs that bit us during extraction.
+      #
+      # @arethetypeswrong/cli would be a nice add here, but as of 0.18.2 its
+      # tarball extractor (fflate streaming Gunzip) drops all chunks except
+      # the last, which makes it crash on this package. Revisit if upstream
+      # ships a fix.
       - name: Node ESM smoke test
-        run: node -e "import('./dist/index.js').then(m => { if (!m.CalendarEngine) throw new Error('CalendarEngine missing'); console.log('OK — ' + Object.keys(m).length + ' exports'); })"
+        run: |
+          node -e "import('./dist/index.js').then(m => { if (!m.CalendarEngine) throw new Error('CalendarEngine export missing'); if (typeof m.evaluateConflicts !== 'function') throw new Error('evaluateConflicts export missing'); console.log('OK — ' + Object.keys(m).length + ' exports'); })"
+          node -e "import('./dist/index.js').then(({ evaluateConflicts }) => { const r = evaluateConflicts({ proposed: { id: 'a', start: new Date(), end: new Date(Date.now()+3600000), resource: 'x' }, events: [], rules: [{ id: 'r', type: 'resource-overlap', severity: 'hard' }] }); if (!r.allowed) throw new Error('expected allowed for empty events'); console.log('OK — evaluateConflicts callable end-to-end'); })"

--- a/engine/.github/workflows/ci.yml
+++ b/engine/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
         run: npm run build
 
       - name: Package check (attw)
-        run: npx --yes @arethetypeswrong/cli --pack . --profile esm-only
+        run: npx --yes -p @arethetypeswrong/cli attw --pack . --profile esm-only
 
       - name: Node ESM smoke test
         run: node -e "import('./dist/index.js').then(m => { if (!m.CalendarEngine) throw new Error('CalendarEngine missing'); console.log('OK — ' + Object.keys(m).length + ' exports'); })"

--- a/engine/tsconfig.build.json
+++ b/engine/tsconfig.build.json
@@ -3,8 +3,8 @@
   "compilerOptions": {
     "noEmit": false,
     "declaration": true,
-    "declarationMap": true,
-    "sourceMap": true,
+    "declarationMap": false,
+    "sourceMap": false,
     "outDir": "./dist",
     "rootDir": "./src"
   },


### PR DESCRIPTION
## Summary
Describe exactly what this PR changes.

## Scope
- Stage: 
- Planned PR number in sprint: 
- Target files/directories: 
- Why this slice is isolated: 

## Lessons Learned Check (REQUIRED)
Confirm these were actively used while building this PR:

- [ ] PR is intentionally small and isolated
- [ ] Boundary typing was prioritized over internal perfection
- [ ] No silent spread of `any`
- [ ] Advisory root `tsc` was used to catch integration issues
- [ ] I did not assume “looks typed” means “safe”
- [ ] I stopped and isolated typing cascades instead of expanding scope

## Definition of Done (ALL REQUIRED)
This PR is not done unless every box is checked.

- [ ] `npm run type-check:strict` passes
- [ ] Root advisory `tsc --noEmit` passes
- [ ] Tests pass for touched scope at minimum
- [ ] No uncontrolled increase in `any`
- [ ] All new types are intentional and named
- [ ] Public interfaces and exported functions are explicitly typed
- [ ] PR scope matches the sprint plan with no scope creep
- [ ] Any new `any` has an adjacent justification comment
- [ ] No file-wide `: any`
- [ ] No implicit `any` in exported functions

## What Was Typed
List exactly what was typed in this PR.

- 
- 
- 

## What Was Intentionally Left Loose
List anything intentionally not tightened yet.

- 
- 
- 

## `any` Ledger (REQUIRED)
- New `any` added: 
- Existing `any` removed: 
- Net change: 

For every new `any`, explain why it is required and why a safer type was not used yet.

1. 
2. 
3. 

## Boundary Notes
Document any public seams, caller-protection choices, or compatibility decisions.

- 
- 
- 

## Risk Level
- [ ] Low
- [ ] Medium
- [ ] High

Why:

## Validation Evidence
Paste the exact commands run and a short result summary.

```bash
npm run type-check:strict
npx tsc --noEmit -p tsconfig.json
```

Test commands run:

```bash
# paste commands here
```

## Stop Conditions Check
If any item below happened, explain how scope was reduced before merge.

- [ ] `any` started spreading across files
- [ ] Root `tsc` broke repeatedly
- [ ] Types required cross-module rewrites
- [ ] Scope was reduced to keep the PR reviewable

Notes:

## Reviewer Focus
What should reviewers look at first?

- 
- 
- 
