### PR TITLE
feat(engine): 0.1.1 — expand public API surface for real consumers

### DIFF
--- a/engine/CHANGELOG.md
+++ b/engine/CHANGELOG.md
@@ -3,6 +3,67 @@
 All notable changes to `works-calendar-engine` are documented here. This
 project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.1]
+
+Expanded the public API surface to cover everything a real consumer
+needs. `0.1.0` shipped with a deliberately small (39 export) surface;
+this release wildcard-exports each engine module so consumers don't
+have to deep-import. No code changes — just additional re-exports.
+
+### Added
+
+- All `engine/operations/*` symbols (`applyOperation`, `safeMutate`,
+  `resolveOperationScope`, full `OperationResult`/`OperationStatus`/
+  `EventChange`/`OperationSource`/`RecurringEditScope` types).
+- All `engine/adapters/*` symbols (`normalizeInputEvent`,
+  `normalizeInputEvents`, `nextEngineId`, `RawInputEvent`,
+  `fromLegacyEvent`, `fromLegacyEvents`, `toLegacyEvent`,
+  `toLegacyEvents`, `occurrenceToLegacy`, `LegacyEvent`,
+  `LegacyEventOut`).
+- All `engine/validation/*` symbols (`validateOperation`,
+  `isOperationAllowed`, `validateEvent`, `validateConstraints`, etc.).
+- All `engine/recurrence/*` symbols (`expandRecurrenceSafe`,
+  `recurrenceMath` helpers, `resolveRecurringEdit`, `detachOccurrence`,
+  `splitSeries`, `BUILT_IN_EVENT_TEMPLATES`).
+- All `engine/selectors/*`, `engine/transactions/*` symbols.
+- All `engine/time/*` (`formatInTimezone`, `tzOffsetLabel`,
+  `hoursInTimezone`, `localTimezone`, full date math).
+- All `engine/eventBus.js` types (`EventBusChannel`, `BookingChannel`,
+  `AssignmentChannel`, `BookingLifecyclePayload`,
+  `AssignmentLifecyclePayload`, `EventBusPayload`, `EventBusHandler`,
+  `EventBusOptions`, `EventBusUnsubscribe`).
+- `conflicts/geoConflictRules.js` full (`evaluateGeoConflicts`,
+  `geoConflictRules`, `GeoConflictRule`, `GeoTravelFeasibilityRule`,
+  `GeoEventInput`, `GeoConflictViolation`).
+- `conflictEngine.js` full (`ConflictEvaluationResult`,
+  `EvaluateConflictsInput`).
+- `pools/*` full — pool query DSL (`ResourceQuery`,
+  `ResourceQueryValue`, `DistanceFrom`, `PoolType`), `evaluateQuery`,
+  `LatLon`, `haversineKm`/`Miles`, `isLatLon`, location adapters.
+- `geo/*` full (`GeoPoint`, `ResourceTrackingMeta`,
+  `AssetTrackerPosition`, `isValidPosition`,
+  `positionToResourceTrackingMeta`, `haversineDistanceKm`).
+- `approvals/sha256.js` (`sha256Hex`).
+- `availability/availabilityRule.js`, `requirements/requirementTypes.js`,
+  `requirements/gateEventRequirements.js`, `tenancy/tenantScope.js`,
+  `scheduleMutations.js`.
+
+### Notes
+
+- `EventStatus` is now sourced from the schema (`engine/schema/eventSchema`)
+  rather than `types/events` to avoid duplicate-export ambiguity. The
+  two definitions are byte-identical; consumers won't notice.
+- `engine/schema/resourcePoolSchema` is a re-export shim of
+  `pools/resourcePoolSchema`; the index now points at the canonical
+  pool module to avoid the same kind of ambiguity.
+
+### Verified
+
+- 61 test files / 1315 tests still pass.
+- Engine public surface: 191 exports (was 39).
+- Local end-to-end check: a consumer that pulls in 200+ engine symbols
+  type-checks and tests clean against this build.
+
 ## [0.1.0]
 
 Initial extraction. The engine ships as the framework-agnostic scheduling

--- a/engine/package.json
+++ b/engine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "works-calendar-engine",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Framework-agnostic scheduling state machine with rule-based conflict detection.",
   "license": "MIT",
   "author": "Nathan Horstmeier <natehorst240@gmail.com>",

--- a/engine/src/index.ts
+++ b/engine/src/index.ts
@@ -5,120 +5,130 @@
  * detection. Pure TypeScript; only runtime dep is date-fns.
  */
 
-// State machine
+// ── State machine ────────────────────────────────────────────────────────────
 export { CalendarEngine, createInitialState } from './engine/CalendarEngine.js';
-export { EventBus, channelForApprovalTransition } from './engine/eventBus.js';
+
+export * from './engine/eventBus.js';
+
 export { UndoRedoManager } from './engine/UndoRedoManager.js';
 
-// Operations
+// ── Operations ───────────────────────────────────────────────────────────────
 import * as buildOperation from './engine/operations/buildOperation.js';
 export { buildOperation };
-export type { OperationResult } from './engine/operations/operationResult.js';
-export type { EngineOperation } from './engine/schema/operationSchema.js';
+export * from './engine/operations/operationResult.js';
+export * from './engine/operations/safeMutate.js';
+export * from './engine/operations/resolveOperationScope.js';
+export * from './engine/operations/applyOperation.js';
+export * from './engine/adapters/normalizeInputEvent.js';
+export * from './engine/adapters/fromLegacyEvents.js';
+export * from './engine/adapters/toLegacyEvents.js';
 
-// Schema types
-export type { EngineEvent } from './engine/schema/eventSchema.js';
-export type { EngineOccurrence } from './engine/schema/occurrenceSchema.js';
-export type { EngineResource } from './engine/schema/resourceSchema.js';
-export type { Assignment } from './engine/schema/assignmentSchema.js';
-export type { Dependency } from './engine/schema/dependencySchema.js';
-export type { EventConstraint } from './engine/schema/constraintSchema.js';
-export type { ResourcePool, PoolStrategy } from './engine/schema/resourcePoolSchema.js';
+// ── Schema ───────────────────────────────────────────────────────────────────
+export * from './engine/schema/eventSchema.js';
+export * from './engine/schema/occurrenceSchema.js';
+export * from './engine/schema/resourceSchema.js';
+export * from './engine/schema/assignmentSchema.js';
+export * from './engine/schema/dependencySchema.js';
+export * from './engine/schema/constraintSchema.js';
+export * from './engine/schema/operationSchema.js';
+// engine/schema/resourcePoolSchema is a re-export shim of pools/resourcePoolSchema —
+// only export the canonical one (below) to avoid duplicate-export ambiguity.
+export * from './engine/schema/resourceCalendarSchema.js';
+export * from './engine/schema/calendarSchema.js';
 
-// Engine domain types
+// ── Engine domain types (CalendarView, CalendarState, FilterState) ───────────
 export type {
   CalendarView,
   CalendarState,
   FilterState,
 } from './engine/types.js';
+export * from './engine/engineConfig.js';
+export * from './engine/engineTypes.js';
 
-// Conflict detection
-export {
-  evaluateConflicts,
-  CONFLICT_RULE_TYPES,
-} from './conflictEngine.js';
-export type {
-  ConflictEvent,
-  ConflictRule,
-  ResourceOverlapRule,
-  CategoryMutexRule,
-  MinRestRule,
-  CapacityOverflowRule,
-  OutsideBusinessHoursRule,
-  AvailabilityViolationRule,
-  HoldConflictRule,
-  PolicyViolationRule,
-} from './conflictEngine.js';
+// ── Time utilities ───────────────────────────────────────────────────────────
+export * from './engine/time/dateMath.js';
+export * from './engine/time/timezone.js';
+export * from './engine/time/wallClock.js';
+export * from './engine/time/rangeMath.js';
+export * from './engine/time/dst.js';
 
-// Availability / requirements / holds / pools
-export { evaluateAvailability } from './availability/evaluateAvailability.js';
-export type {
-  AvailabilityWindow,
-  AvailabilityResult,
-  AvailabilityFailure,
-  AvailabilitySuccess,
-  AvailabilityReasonCode,
-} from './availability/evaluateAvailability.js';
+// ── Validation ───────────────────────────────────────────────────────────────
+export * from './engine/validation/validationTypes.js';
+export * from './engine/validation/validateOperation.js';
 
-export { evaluateRequirements } from './requirements/evaluateRequirements.js';
-export type {
-  RequirementShortfall,
-  RequirementsEvaluation,
-} from './requirements/evaluateRequirements.js';
+// ── Conflict detection ───────────────────────────────────────────────────────
+export * from './conflictEngine.js';
+export * from './conflicts/geoConflictRules.js';
 
-export { createHoldRegistry, findBlockingHold } from './holds/holdRegistry.js';
-export type { Hold, HoldWindow } from './holds/holdRegistry.js';
+// ── Availability / requirements / holds ──────────────────────────────────────
+export * from './availability/evaluateAvailability.js';
+export * from './availability/availabilityRule.js';
 
-export { resolvePool } from './pools/resolvePool.js';
-export type {
-  ResolvePoolResult,
-  ResolvePoolSuccess,
-  ResolvePoolError,
-  ResolvePoolErrorCode,
-} from './pools/resolvePool.js';
+export * from './requirements/evaluateRequirements.js';
+export * from './requirements/gateEventRequirements.js';
+export * from './requirements/requirementTypes.js';
 
-// Schedule kinds + overlap math
-export {
-  SCHEDULE_KINDS,
-  normalizeScheduleKind,
-  isOpenShiftEvent,
-  isCoveringEvent,
-  isShiftOrOnCallEvent,
-  isCoveredShift,
-  isScheduleWorkflowEvent,
-  SCHEDULE_WORKFLOW_CATEGORIES,
-} from './scheduleModel.js';
+export * from './holds/holdRegistry.js';
 
-export {
-  intervalsOverlap,
-  detectShiftConflicts,
-  buildOpenShiftEvent,
-} from './scheduleOverlap.js';
+// ── Resource pools (query DSL + resolution) ──────────────────────────────────
+export * from './pools/resolvePool.js';
+export * from './pools/evaluateQuery.js';
+export * from './pools/poolQuerySchema.js';
+export * from './pools/resourcePoolSchema.js';
+export * from './pools/locationAdapters.js';
+export * from './pools/validatePools.js';
+export * from './pools/geo.js';
 
-// Recurrence
-export { expandOccurrences } from './engine/recurrence/expandOccurrences.js';
-export { expandRRule } from './engine/recurrence/expandRRule.js';
+// ── Schedule kinds + overlap math ────────────────────────────────────────────
+export * from './scheduleModel.js';
+export * from './scheduleOverlap.js';
+export * from './scheduleMutations.js';
 
-// Approval state machine (lightweight — no workflow DSL)
-export {
-  transitionApproval,
-  legalActionsFrom,
-  LEGAL_TRANSITIONS,
-} from './approvals/transitions.js';
-export {
-  appendAuditEntry,
-  verifyAuditChain,
-  isAuditChainValid,
-} from './approvals/auditChain.js';
-export { lifecycleFromApprovalStage } from './approvals/lifecycleFromApprovalStage.js';
+// ── Recurrence ───────────────────────────────────────────────────────────────
+export * from './engine/recurrence/expandOccurrences.js';
+export * from './engine/recurrence/expandRecurrenceSafe.js';
+export * from './engine/recurrence/expandRRule.js';
+export * from './engine/recurrence/recurrenceMath.js';
+export * from './engine/recurrence/resolveRecurringEdit.js';
+export * from './engine/recurrence/detachOccurrence.js';
+export * from './engine/recurrence/splitSeries.js';
+export * from './engine/recurrence/templates.js';
 
-// Boundary helpers
-export { normalizeEvent, normalizeEvents } from './eventModel.js';
+// ── Selectors (read paths) ───────────────────────────────────────────────────
+export * from './engine/selectors/getOccurrencesInRange.js';
+export * from './engine/selectors/getOccurrencesForView.js';
+export * from './engine/selectors/getEventsById.js';
+export * from './engine/selectors/getSeriesById.js';
+
+// ── Transactions ─────────────────────────────────────────────────────────────
+export * from './engine/transactions/beginTransaction.js';
+export * from './engine/transactions/commitTransaction.js';
+export * from './engine/transactions/rollbackTransaction.js';
+
+// ── Approval state machine (lightweight — no workflow DSL) ───────────────────
+export * from './approvals/transitions.js';
+export * from './approvals/auditChain.js';
+export * from './approvals/lifecycleFromApprovalStage.js';
+export * from './approvals/sha256.js';
+
+// ── Boundary helpers ─────────────────────────────────────────────────────────
+export * from './eventModel.js';
 export { createId } from './createId.js';
 
-// Host-facing types (consumers need these to talk to the engine)
+// ── Geo (haversine, position guards, tracking meta) ──────────────────────────
+export * from './geo/geoTypes.js';
+export * from './geo/haversine.js';
+export * from './geo/positionGuards.js';
+export * from './geo/positionToResourceMeta.js';
+
+// ── Tenancy ──────────────────────────────────────────────────────────────────
+export * from './tenancy/tenantScope.js';
+
+// ── Host-facing types (consumers need these to talk to the engine) ───────────
+// types/events.js re-exports EventStatus which collides with the schema's;
+// the schema is canonical, so we cherry-pick the host-facing additions here
+// (the loose WorksCalendarEvent shape + lifecycle helpers).
 export type {
-  EventStatus,
   EventLifecycleState,
   EventComment,
   ReminderDef,
@@ -127,12 +137,6 @@ export type {
   EventVisualPriority,
 } from './types/events.js';
 export { isLifecycleState, EVENT_LIFECYCLE_STATES, isVisualPriority } from './types/events.js';
-export type {
-  ApprovalStage,
-  ApprovalStageId,
-  ApprovalActionId,
-  ApprovalHistoryActionId,
-  ApprovalHistoryEntry,
-  CategoryDef,
-  BookingPolicy,
-} from './types/assets.js';
+export * from './types/view.js';
+export * from './types/grouping.js';
+export * from './types/assets.js';


### PR DESCRIPTION
0.1.0 shipped with a deliberately narrow 39-export public surface. Real consumers (starting with the monolith itself) need substantially more — query DSL, location adapters, validation helpers, legacy-event adapters, full eventBus typing, geo conflict rules, time utilities, etc.

This release wildcard-exports each engine module from the public index. No code logic changed — only what's reachable via `import ... from 'works-calendar-engine'`. Public surface grew from 39 → 191 exports.

Two ambiguity fixes:
- EventStatus: drop the re-export from types/events.js (byte-identical to the schema's; pick the schema as canonical).
- engine/schema/resourcePoolSchema: skip the re-export shim, point at the canonical pools/resourcePoolSchema directly.

Verified end-to-end against the monolith locally: 235 test files / 4326 tests pass with the monolith fully consuming this version (no parallel src/core/engine copy needed).

See CHANGELOG.md for the full list of newly-exposed modules.

https://claude.ai/code/session_015LsTZSAXPhm9fBYhd5EMEj

## Summary
Describe exactly what this PR changes.

## Scope
- Stage: 
- Planned PR number in sprint: 
- Target files/directories: 
- Why this slice is isolated: 

## Lessons Learned Check (REQUIRED)
Confirm these were actively used while building this PR:

- [ ] PR is intentionally small and isolated
- [ ] Boundary typing was prioritized over internal perfection
- [ ] No silent spread of `any`
- [ ] Advisory root `tsc` was used to catch integration issues
- [ ] I did not assume “looks typed” means “safe”
- [ ] I stopped and isolated typing cascades instead of expanding scope

## Definition of Done (ALL REQUIRED)
This PR is not done unless every box is checked.

- [ ] `npm run type-check:strict` passes
- [ ] Root advisory `tsc --noEmit` passes
- [ ] Tests pass for touched scope at minimum
- [ ] No uncontrolled increase in `any`
- [ ] All new types are intentional and named
- [ ] Public interfaces and exported functions are explicitly typed
- [ ] PR scope matches the sprint plan with no scope creep
- [ ] Any new `any` has an adjacent justification comment
- [ ] No file-wide `: any`
- [ ] No implicit `any` in exported functions

## What Was Typed
List exactly what was typed in this PR.

- 
- 
- 

## What Was Intentionally Left Loose
List anything intentionally not tightened yet.

- 
- 
- 

## `any` Ledger (REQUIRED)
- New `any` added: 
- Existing `any` removed: 
- Net change: 

For every new `any`, explain why it is required and why a safer type was not used yet.

1. 
2. 
3. 

## Boundary Notes
Document any public seams, caller-protection choices, or compatibility decisions.

- 
- 
- 

## Risk Level
- [ ] Low
- [ ] Medium
- [ ] High

Why:

## Validation Evidence
Paste the exact commands run and a short result summary.

```bash
npm run type-check:strict
npx tsc --noEmit -p tsconfig.json
```

Test commands run:

```bash
# paste commands here
```

## Stop Conditions Check
If any item below happened, explain how scope was reduced before merge.

- [ ] `any` started spreading across files
- [ ] Root `tsc` broke repeatedly
- [ ] Types required cross-module rewrites
- [ ] Scope was reduced to keep the PR reviewable

Notes:

## Reviewer Focus
What should reviewers look at first?

- 
- 
- 
