### PR TITLE
feat: add works-calendar-engine as runtime dep

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,8 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "fuse.js": "^7.3.0"
+        "fuse.js": "^7.3.0",
+        "works-calendar-engine": "^0.1.0"
       },
       "devDependencies": {
         "@arethetypeswrong/cli": "^0.18.2",
@@ -3727,7 +3728,6 @@
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-3.6.0.tgz",
       "integrity": "sha512-fRHTG8g/Gif+kSh50gaGEdToemgfj74aRX3swtiouboip5JDLAyDE9F11nHMIcvOaXeOC6D7SpNhi7uFyB7Uww==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -7432,6 +7432,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/works-calendar-engine": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/works-calendar-engine/-/works-calendar-engine-0.1.0.tgz",
+      "integrity": "sha512-CsfcAEs265zV/EkBAWQy5I+GTbcBiA5IVCszxw3XANb81qVaImCPErhvYDfSwDh9/Pgu5JeZL24jL4oUQJTfjg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "date-fns": "^3.6.0 || ^4.0.0"
       }
     },
     "node_modules/wrap-ansi": {

--- a/package.json
+++ b/package.json
@@ -129,7 +129,8 @@
     }
   },
   "dependencies": {
-    "fuse.js": "^7.3.0"
+    "fuse.js": "^7.3.0",
+    "works-calendar-engine": "^0.1.0"
   },
   "overrides": {
     "exceljs": {


### PR DESCRIPTION
Adds works-calendar-engine@^0.1.0 (the newly published package) as a runtime dependency. No call sites changed yet — this commit is the smoke test: prove the package installs cleanly from npm and doesn't disturb anything in the monolith.

Next commit (B): bulk-rewrite imports from src/core/engine/* and related engine-pure paths to point at 'works-calendar-engine', then delete the now-duplicate local copies.

Verification:
- node -e "import('works-calendar-engine')..." resolves 39 exports.
- tsc --noEmit --project tsconfig.build.json: clean.
- npm test: 235 files, 4326 tests, all passing.

https://claude.ai/code/session_015LsTZSAXPhm9fBYhd5EMEj

## Summary
Describe exactly what this PR changes.

## Scope
- Stage: 
- Planned PR number in sprint: 
- Target files/directories: 
- Why this slice is isolated: 

## Lessons Learned Check (REQUIRED)
Confirm these were actively used while building this PR:

- [ ] PR is intentionally small and isolated
- [ ] Boundary typing was prioritized over internal perfection
- [ ] No silent spread of `any`
- [ ] Advisory root `tsc` was used to catch integration issues
- [ ] I did not assume “looks typed” means “safe”
- [ ] I stopped and isolated typing cascades instead of expanding scope

## Definition of Done (ALL REQUIRED)
This PR is not done unless every box is checked.

- [ ] `npm run type-check:strict` passes
- [ ] Root advisory `tsc --noEmit` passes
- [ ] Tests pass for touched scope at minimum
- [ ] No uncontrolled increase in `any`
- [ ] All new types are intentional and named
- [ ] Public interfaces and exported functions are explicitly typed
- [ ] PR scope matches the sprint plan with no scope creep
- [ ] Any new `any` has an adjacent justification comment
- [ ] No file-wide `: any`
- [ ] No implicit `any` in exported functions

## What Was Typed
List exactly what was typed in this PR.

- 
- 
- 

## What Was Intentionally Left Loose
List anything intentionally not tightened yet.

- 
- 
- 

## `any` Ledger (REQUIRED)
- New `any` added: 
- Existing `any` removed: 
- Net change: 

For every new `any`, explain why it is required and why a safer type was not used yet.

1. 
2. 
3. 

## Boundary Notes
Document any public seams, caller-protection choices, or compatibility decisions.

- 
- 
- 

## Risk Level
- [ ] Low
- [ ] Medium
- [ ] High

Why:

## Validation Evidence
Paste the exact commands run and a short result summary.

```bash
npm run type-check:strict
npx tsc --noEmit -p tsconfig.json
```

Test commands run:

```bash
# paste commands here
```

## Stop Conditions Check
If any item below happened, explain how scope was reduced before merge.

- [ ] `any` started spreading across files
- [ ] Root `tsc` broke repeatedly
- [ ] Types required cross-module rewrites
- [ ] Scope was reduced to keep the PR reviewable

Notes:

## Reviewer Focus
What should reviewers look at first?

- 
- 
- 
