### PR TITLE
chore(demo/app): swap engine dep from file: to ^0.1.2

### DIFF
--- a/demo/app/package-lock.json
+++ b/demo/app/package-lock.json
@@ -53,7 +53,7 @@
         "sonner": "^2.0.7",
         "tailwind-merge": "^3.4.0",
         "vaul": "^1.1.2",
-        "works-calendar-engine": "file:../../engine",
+        "works-calendar-engine": "^0.1.2",
         "zod": "^4.3.5"
       },
       "devDependencies": {
@@ -75,24 +75,6 @@
         "typescript": "~5.9.3",
         "typescript-eslint": "^8.46.4",
         "vite": "^7.2.4"
-      }
-    },
-    "../../engine": {
-      "name": "works-calendar-engine",
-      "version": "0.1.0",
-      "license": "MIT",
-      "devDependencies": {
-        "@types/node": "^20.19.39",
-        "cross-env": "^10.1.0",
-        "date-fns": "^3.6.0",
-        "typescript": "^5.9.3",
-        "vitest": "^4.1.4"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "date-fns": "^3.6.0 || ^4.0.0"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -8266,8 +8248,16 @@
       }
     },
     "node_modules/works-calendar-engine": {
-      "resolved": "../../engine",
-      "link": true
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/works-calendar-engine/-/works-calendar-engine-0.1.2.tgz",
+      "integrity": "sha512-lcZvM16qbJU3XN3i8/RGdVikabpogJLh6zomofJZJhJdd6Cj953QAKeorAhOwUwLpcOVzoPj2OWBIhVH1ctDGA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "date-fns": "^3.6.0 || ^4.0.0"
+      }
     },
     "node_modules/yallist": {
       "version": "3.1.1",

--- a/demo/app/package.json
+++ b/demo/app/package.json
@@ -55,7 +55,7 @@
     "sonner": "^2.0.7",
     "tailwind-merge": "^3.4.0",
     "vaul": "^1.1.2",
-    "works-calendar-engine": "file:../../engine",
+    "works-calendar-engine": "^0.1.2",
     "zod": "^4.3.5"
   },
   "devDependencies": {


### PR DESCRIPTION
The dispatch board's package.json still pointed at file:../../engine — the staging directory that was deleted in 27d137b. Vercel's install naturally fails to resolve it.

Bump to the published works-calendar-engine@^0.1.2. Verified locally: npm install clean, vite build clean (313 KB gzipped 99 KB).

https://claude.ai/code/session_015LsTZSAXPhm9fBYhd5EMEj

## Summary
Describe exactly what this PR changes.

## Scope
- Stage: 
- Planned PR number in sprint: 
- Target files/directories: 
- Why this slice is isolated: 

## Lessons Learned Check (REQUIRED)
Confirm these were actively used while building this PR:

- [ ] PR is intentionally small and isolated
- [ ] Boundary typing was prioritized over internal perfection
- [ ] No silent spread of `any`
- [ ] Advisory root `tsc` was used to catch integration issues
- [ ] I did not assume “looks typed” means “safe”
- [ ] I stopped and isolated typing cascades instead of expanding scope

## Definition of Done (ALL REQUIRED)
This PR is not done unless every box is checked.

- [ ] `npm run type-check:strict` passes
- [ ] Root advisory `tsc --noEmit` passes
- [ ] Tests pass for touched scope at minimum
- [ ] No uncontrolled increase in `any`
- [ ] All new types are intentional and named
- [ ] Public interfaces and exported functions are explicitly typed
- [ ] PR scope matches the sprint plan with no scope creep
- [ ] Any new `any` has an adjacent justification comment
- [ ] No file-wide `: any`
- [ ] No implicit `any` in exported functions

## What Was Typed
List exactly what was typed in this PR.

- 
- 
- 

## What Was Intentionally Left Loose
List anything intentionally not tightened yet.

- 
- 
- 

## `any` Ledger (REQUIRED)
- New `any` added: 
- Existing `any` removed: 
- Net change: 

For every new `any`, explain why it is required and why a safer type was not used yet.

1. 
2. 
3. 

## Boundary Notes
Document any public seams, caller-protection choices, or compatibility decisions.

- 
- 
- 

## Risk Level
- [ ] Low
- [ ] Medium
- [ ] High

Why:

## Validation Evidence
Paste the exact commands run and a short result summary.

```bash
npm run type-check:strict
npx tsc --noEmit -p tsconfig.json
```

Test commands run:

```bash
# paste commands here
```

## Stop Conditions Check
If any item below happened, explain how scope was reduced before merge.

- [ ] `any` started spreading across files
- [ ] Root `tsc` broke repeatedly
- [ ] Types required cross-module rewrites
- [ ] Scope was reduced to keep the PR reviewable

Notes:

## Reviewer Focus
What should reviewers look at first?

- 
- 
- 
