### PR TITLE
fix(demo): enable Dispatch view by default + bump calendarId

### DIFF
--- a/demo/main.tsx
+++ b/demo/main.tsx
@@ -51,7 +51,7 @@ function DemoApp() {
   return (
     <div style={{ height: '100vh', width: '100vw', overflow: 'hidden' }}>
       <WorksCalendar
-        calendarId="dispatch-demo"
+        calendarId="dispatch-demo-v2"
         initialView="dispatch"
         events={FLEET_EVENTS}
         assets={ASSETS}

--- a/src/core/configSchema.ts
+++ b/src/core/configSchema.ts
@@ -104,7 +104,7 @@ export const DEFAULT_CONFIG: Record<string, unknown> = {
     // Which view tabs are visible in the top bar. 'month' and 'week' are
     // always on regardless of this list. Owners toggle the rest from Setup
     // or ConfigPanel → Views.
-    enabledViews: ['day', 'agenda', 'schedule', 'base', 'assets'],
+    enabledViews: ['day', 'agenda', 'schedule', 'base', 'assets', 'dispatch'],
   },
 
   // Filter UI labels editable by owner/dev


### PR DESCRIPTION
The toolbar didn't show a Dispatch tab and \`initialView=\"dispatch\"\` fell through to Agenda — the default \`config.display.enabledViews\` in configSchema.ts didn't include 'dispatch'. Returning visitors also had a stale localStorage config keyed by the old calendarId that pinned their enabledViews even after this fix.

Two changes:
- configSchema.ts: add 'dispatch' to default enabledViews. New consumers (and any consumer without saved localStorage) get the Dispatch tab in the top bar.
- demo/main.tsx: bump calendarId 'dispatch-demo' → 'dispatch-demo-v2'. Invalidates the stale localStorage so existing workscalendar.com visitors re-hydrate from DEFAULT_CONFIG with the dispatch tab on.

Note on date sync: WorksCalendar's currentDate state starts at real \"now\" (May 2026); the truck dataset lives in July 2025. The dispatch view sidesteps this — its internal selectedDate defaults to the median of provided events. But switching to Month / Week / Day in the toolbar shows \"no events\" until the user navigates back to July 2025. Exposing an \`initialDate\` prop on WorksCalendar would fix this; deferred to a follow-up since the dispatch landing experience works.

Verified: tsc clean, 164 test files / 2832 tests pass, build:demo clean.

https://claude.ai/code/session_015LsTZSAXPhm9fBYhd5EMEj

## Summary
Describe exactly what this PR changes.

## Scope
- Stage: 
- Planned PR number in sprint: 
- Target files/directories: 
- Why this slice is isolated: 

## Lessons Learned Check (REQUIRED)
Confirm these were actively used while building this PR:

- [ ] PR is intentionally small and isolated
- [ ] Boundary typing was prioritized over internal perfection
- [ ] No silent spread of `any`
- [ ] Advisory root `tsc` was used to catch integration issues
- [ ] I did not assume “looks typed” means “safe”
- [ ] I stopped and isolated typing cascades instead of expanding scope

## Definition of Done (ALL REQUIRED)
This PR is not done unless every box is checked.

- [ ] `npm run type-check:strict` passes
- [ ] Root advisory `tsc --noEmit` passes
- [ ] Tests pass for touched scope at minimum
- [ ] No uncontrolled increase in `any`
- [ ] All new types are intentional and named
- [ ] Public interfaces and exported functions are explicitly typed
- [ ] PR scope matches the sprint plan with no scope creep
- [ ] Any new `any` has an adjacent justification comment
- [ ] No file-wide `: any`
- [ ] No implicit `any` in exported functions

## What Was Typed
List exactly what was typed in this PR.

- 
- 
- 

## What Was Intentionally Left Loose
List anything intentionally not tightened yet.

- 
- 
- 

## `any` Ledger (REQUIRED)
- New `any` added: 
- Existing `any` removed: 
- Net change: 

For every new `any`, explain why it is required and why a safer type was not used yet.

1. 
2. 
3. 

## Boundary Notes
Document any public seams, caller-protection choices, or compatibility decisions.

- 
- 
- 

## Risk Level
- [ ] Low
- [ ] Medium
- [ ] High

Why:

## Validation Evidence
Paste the exact commands run and a short result summary.

```bash
npm run type-check:strict
npx tsc --noEmit -p tsconfig.json
```

Test commands run:

```bash
# paste commands here
```

## Stop Conditions Check
If any item below happened, explain how scope was reduced before merge.

- [ ] `any` started spreading across files
- [ ] Root `tsc` broke repeatedly
- [ ] Types required cross-module rewrites
- [ ] Scope was reduced to keep the PR reviewable

Notes:

## Reviewer Focus
What should reviewers look at first?

- 
- 
- 
