### PR TITLE
feat(views/dispatch): OSM tile basemap + arched 3D breadcrumbs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ coverage/
 # Local-only npm auth (token, etc.). CI auth flows through actions/setup-node
 # which writes its own .npmrc at job time.
 .npmrc
+dispatch-current.png

--- a/src/WorksCalendar.module.css
+++ b/src/WorksCalendar.module.css
@@ -682,6 +682,13 @@
   padding: calc(12px * var(--wc-density, 1));
 }
 
+/* Views that own their full pane (e.g. dispatch) opt out of the
+ * card padding / border / radius / shadow so they read as immersive
+ * surfaces rather than a small framed widget. */
+.mainPane[data-wc-chrome="view-owned"] {
+  padding: 0;
+}
+
 /* Calendar card: bordered, rounded, shadowed surface that wraps the
  * sub-toolbar and the view grid. Tokens-only so per-theme overrides
  * (radius, shadow, border) apply automatically. */
@@ -695,6 +702,12 @@
   border-radius: var(--wc-radius);
   box-shadow: var(--wc-shadow);
   overflow: hidden;
+}
+
+.calendarCard[data-wc-chrome="view-owned"] {
+  border: 0;
+  border-radius: 0;
+  box-shadow: none;
 }
 
 .emptyStateWrap {

--- a/src/WorksCalendar.tsx
+++ b/src/WorksCalendar.tsx
@@ -34,6 +34,7 @@ import CalendarViewGrid          from './ui/CalendarViewGrid';
 import type { AssetTypeDef, RequirementTemplate } from './ui/SetupLanding';
 const SetupLanding = lazy(() => import('./ui/SetupLanding'));
 import { CalendarLeftRail, CalendarRightPanel } from './ui/CalendarSideRails';
+import { ViewSwitcher }                from './ui/ViewSwitcher';
 import SavedFlash                from './ui/SavedFlash';
 import CalendarErrorBoundary     from './ui/CalendarErrorBoundary';
 
@@ -378,10 +379,20 @@ const WorksCalendarImpl = forwardRef<CalendarApi, WorksCalendarProps>(function W
           <div className={styles['transientToast']} aria-hidden={!importFlash.flash}>
             <SavedFlash visible={importFlash.flash} label={importMsg} />
           </div>
+          {(() => {
+          // Views can opt into owning their full pane (no host header,
+          // rails, sub-toolbar) — the view paints everything and gets a
+          // ViewSwitcher node to slot into its own header.
+          const currentViewDef = VIEWS.find((v) => v.id === cal.view);
+          const viewOwnsChrome = currentViewDef?.ownsChrome === true;
+          const viewSwitcherForView = viewOwnsChrome ? (
+            <ViewSwitcher views={VIEWS} currentView={cal.view} onViewChange={(id) => cal.setView(id as typeof cal.view)} />
+          ) : null;
+          return (
           <AppShell
-            leftRail={<CalendarLeftRail ownerCfg={ownerCfg} leftRailExtras={leftRailExtras} setSidebarInitialTab={setSidebarInitialTab} setSidebarOpen={setSidebarOpen} />}
-            rightPanel={<CalendarRightPanel configuredEmployees={configuredEmployees} onShiftIds={onShiftIds} rightPanelExtras={rightPanelExtras} />}
-            header={
+            {...(viewOwnsChrome ? {} : { leftRail: <CalendarLeftRail ownerCfg={ownerCfg} leftRailExtras={leftRailExtras} setSidebarInitialTab={setSidebarInitialTab} setSidebarOpen={setSidebarOpen} /> })}
+            {...(viewOwnsChrome ? {} : { rightPanel: <CalendarRightPanel configuredEmployees={configuredEmployees} onShiftIds={onShiftIds} rightPanelExtras={rightPanelExtras} /> })}
+            header={viewOwnsChrome ? <></> :
               <CalendarToolbar cal={cal} ownerCfg={ownerCfg} api={api}
                 renderToolbar={renderToolbar} renderSavedViewsBar={renderSavedViewsBar} renderFilterBar={renderFilterBar}
                 focusChips={focusChips} logoSrc={logoSrc} logoAlt={logoAlt}
@@ -405,6 +416,7 @@ const WorksCalendarImpl = forwardRef<CalendarApi, WorksCalendarProps>(function W
             }
             main={<>
               <CalendarViewGrid cal={cal} ownerCfg={ownerCfg} perms={perms} schema={schema} filterBarSchema={filterBarSchema}
+                viewOwnsChrome={viewOwnsChrome} viewSwitcher={viewSwitcherForView}
                 sidebarOpen={sidebarOpen} setSidebarOpen={setSidebarOpen} sidebarGroupLevels={sidebarGroupLevels}
                 hasAddButton={hasAddButton} hasScheduleTemplates={hasScheduleTemplates} hasImport={hasImport}
                 profileLabels={profileLabels} visibleScheduleTemplates={visibleScheduleTemplates} onScheduleTemplateAnalytics={onScheduleTemplateAnalytics}
@@ -455,6 +467,8 @@ const WorksCalendarImpl = forwardRef<CalendarApi, WorksCalendarProps>(function W
               )}
             </>}
           />
+          );
+          })()}
 
           <FilterGroupSidebar
             open={sidebarOpen}

--- a/src/core/calendarViewConfig.ts
+++ b/src/core/calendarViewConfig.ts
@@ -21,7 +21,21 @@ export function opAnnouncement(op: AnnouncedOp): string {
 }
 
 export type ViewGroup = 'calendar' | 'operations';
-export type ViewDef = { id: ViewId; label: string; alwaysOn: boolean; hint?: string; group: ViewGroup };
+export type ViewDef = {
+  id: ViewId;
+  label: string;
+  alwaysOn: boolean;
+  hint?: string;
+  group: ViewGroup;
+  /**
+   * When true, the host calendar suppresses its own header, side rails, and
+   * sub-toolbar for this view — the view paints the full pane and is
+   * responsible for rendering its own view-switcher (passed in via the
+   * shared view props as `renderViewSwitcher`). Used for immersive views
+   * like the dispatch board where every pixel of host chrome is wasted.
+   */
+  ownsChrome?: boolean;
+};
 
 export const ALL_VIEWS: readonly ViewDef[] = [
   { id: 'month',    label: 'Month',    alwaysOn: true,  hint: 'Scheduled events — appointments, missions, PTO',                   group: 'calendar' },
@@ -31,7 +45,7 @@ export const ALL_VIEWS: readonly ViewDef[] = [
   { id: 'schedule', label: 'Schedule', alwaysOn: false, hint: 'Staffing — day/night shifts, on-call rotation, duty status',       group: 'calendar' },
   { id: 'base',     label: 'Base',     alwaysOn: false, hint: 'Gantt-style — employees, aircraft, and base events side by side', group: 'calendar' },
   { id: 'assets',   label: 'Assets',   alwaysOn: false,                                                                            group: 'operations' },
-  { id: 'dispatch', label: 'Dispatch', alwaysOn: false, hint: 'Fleet readiness at a moment in time — what can launch now?',      group: 'operations' },
+  { id: 'dispatch', label: 'Dispatch', alwaysOn: false, hint: 'Fleet readiness at a moment in time — what can launch now?',      group: 'operations', ownsChrome: true },
   { id: 'requests', label: 'Requests', alwaysOn: false, hint: 'Pending approval queue — approve, deny, or escalate requests',    group: 'operations' },
 ];
 

--- a/src/ui/CalendarViewGrid.tsx
+++ b/src/ui/CalendarViewGrid.tsx
@@ -135,6 +135,12 @@ export interface CalendarViewGridProps {
   handleCoverageAssign: (ev: NormalizedEvent, coveringEmployeeId: string | number | null | undefined) => void;
   handleEmployeeAction: (empId: EmployeeId, actionInput: string | EmployeeActionInput) => void;
   handleEventClick: (ev: NormalizedEvent) => void;
+  /** True when the current view paints its own full pane chrome. Skips
+   *  the SubToolbar + active-filter strip the standard views use. */
+  viewOwnsChrome?: boolean;
+  /** Ready-to-render view switcher node, passed to chrome-owning views
+   *  so they can slot it into their own header. */
+  viewSwitcher?: ReactNode;
 }
 
 export default function CalendarViewGrid({
@@ -155,11 +161,12 @@ export default function CalendarViewGrid({
   handleClearFilters, handleScheduleDateSelect, handlePoolDateSelect,
   handleEmployeeAddInternal, handleEmployeeDeleteInternal, handleShiftStatusChange,
   handleCoverageAssign, handleEmployeeAction, handleEventClick,
+  viewOwnsChrome, viewSwitcher,
 }: CalendarViewGridProps) {
   return (
-    <div className={styles['mainPane']}>
-      <div className={styles['calendarCard']}>
-        <SubToolbar
+    <div className={styles['mainPane']} data-wc-chrome={viewOwnsChrome ? 'view-owned' : undefined}>
+      <div className={styles['calendarCard']} data-wc-chrome={viewOwnsChrome ? 'view-owned' : undefined}>
+        {!viewOwnsChrome && <SubToolbar
           leftSlot={<>
             <SidebarToggleButton
               isOpen={sidebarOpen}
@@ -210,14 +217,14 @@ export default function CalendarViewGrid({
               <Download size={15} aria-hidden="true" />
             </button>
           </>}
-        />
-        <ActiveFilterStrip
+        />}
+        {!viewOwnsChrome && <ActiveFilterStrip
           filters={cal.filters as Record<string, unknown>}
           schema={schema}
           onChange={(key, value) => cal.setFilter(key, value)}
           onClear={(key) => cal.clearFilter(key)}
           onClearAll={handleClearFilters}
-        />
+        />}
         <div
           ref={swipeAreaRef}
           className={styles['viewArea']}
@@ -322,6 +329,7 @@ export default function CalendarViewGrid({
                   evaluateForMission: dispatchEvaluator,
                   onAssign: onDispatchAssign,
                   onAsOfChange: cal.setCurrentDate,
+                  viewSwitcher,
                 } as unknown as ComponentProps<typeof DispatchView>)} />
               )}
               {cal.view === 'requests' && (

--- a/src/ui/ViewSwitcher.tsx
+++ b/src/ui/ViewSwitcher.tsx
@@ -1,0 +1,89 @@
+/**
+ * Compact view-switcher pill row for views that own their own chrome
+ * (e.g. the dispatch board). Renders the same Month/Week/.../Dispatch
+ * tabs the host calendar's toolbar would, but in a tight inline pill
+ * suitable for slotting into a view's own header bar.
+ *
+ * Stays headless — accepts the view list + current selection + change
+ * handler, no calendar-context plumbing.
+ */
+import { useEffect, useRef } from 'react';
+import type { ViewDef } from '../core/calendarViewConfig';
+
+export interface ViewSwitcherProps {
+  readonly views: readonly ViewDef[];
+  readonly currentView: string;
+  readonly onViewChange: (id: string) => void;
+  /** Optional className for the outer container. */
+  readonly className?: string;
+}
+
+export function ViewSwitcher({ views, currentView, onViewChange, className }: ViewSwitcherProps) {
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const activeRef = useRef<HTMLButtonElement | null>(null);
+  // Keep the active tab visible when the switcher is narrow enough to
+  // scroll horizontally (mobile widths). Done manually instead of via
+  // scrollIntoView so the surrounding page scroll position isn't
+  // perturbed when the active tab lives off-screen on first render.
+  useEffect(() => {
+    const c = containerRef.current;
+    const b = activeRef.current;
+    if (!c || !b) return;
+    const target = b.offsetLeft - (c.clientWidth - b.offsetWidth) / 2;
+    c.scrollLeft = Math.max(0, target);
+  }, [currentView]);
+  return (
+    <div
+      ref={containerRef}
+      className={className}
+      role="group"
+      aria-label="Calendar view"
+      style={{
+        display: 'flex',
+        flex: '1 1 auto',
+        minWidth: 0,
+        alignItems: 'center',
+        gap: 2,
+        padding: 2,
+        border: '1px solid rgba(61, 43, 31, 0.2)',
+        borderRadius: 6,
+        background: 'rgba(245, 230, 200, 0.6)',
+        overflowX: 'auto',
+        scrollbarWidth: 'none',
+      }}
+    >
+      {views.map((v) => {
+        const active = v.id === currentView;
+        return (
+          <button
+            key={v.id}
+            ref={active ? activeRef : undefined}
+            type="button"
+            onClick={() => onViewChange(v.id)}
+            aria-pressed={active}
+            title={v.hint ?? v.label}
+            data-wc-view-button={v.id}
+            style={{
+              flex: '0 0 auto',
+              height: 22,
+              padding: '0 8px',
+              fontSize: 10,
+              fontWeight: 700,
+              letterSpacing: 0.5,
+              textTransform: 'uppercase',
+              border: 0,
+              borderRadius: 4,
+              cursor: 'pointer',
+              color: active ? '#f5e6c8' : '#3d2b1f',
+              background: active ? '#3d2b1f' : 'transparent',
+              fontFamily: 'inherit',
+              whiteSpace: 'nowrap',
+            }}
+          >
+            {v.label}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/views/DispatchView.tsx
+++ b/src/views/DispatchView.tsx
@@ -12,6 +12,7 @@
  * inert from the view's perspective — kept here as a stable type surface
  * until a major-version bump lets us remove them cleanly.
  */
+import type { ReactNode } from 'react';
 import type { NormalizedEvent } from 'works-calendar-engine';
 import { DispatchBoard, type DispatchAssetEntry } from './dispatch/DispatchBoard';
 
@@ -36,6 +37,8 @@ interface DispatchViewLooseProps {
   readonly events?: readonly NormalizedEvent[];
   readonly assets?: readonly DispatchAssetEntry[];
   readonly initialAsOf?: Date;
+  /** View-switcher node injected by the host when this view owns chrome. */
+  readonly viewSwitcher?: ReactNode;
   // Legacy props (employees, bases, missions, evaluateForMission, onAssign, …)
   // are accepted to keep CalendarViewGrid's existing wiring stable but ignored
   // by the new board. The dispatch view derives everything it renders from
@@ -51,6 +54,7 @@ export default function DispatchView(props: DispatchViewLooseProps) {
       events={events}
       assets={assets}
       {...(props.initialAsOf ? { initialDate: props.initialAsOf } : {})}
+      {...(props.viewSwitcher ? { viewSwitcher: props.viewSwitcher } : {})}
     />
   );
 }

--- a/src/views/dispatch/DispatchBoard.tsx
+++ b/src/views/dispatch/DispatchBoard.tsx
@@ -9,6 +9,7 @@
  * and hands them off here.
  */
 import { useMemo, useState } from 'react';
+import type { ReactNode } from 'react';
 import '../../styles/tailwind.css';
 import { TacticalMap } from './TacticalMap';
 import { AssetSidebar } from './AssetSidebar';
@@ -30,6 +31,9 @@ export interface DispatchBoardProps {
   readonly assets?: readonly DispatchAssetEntry[];
   /** Initial "now". Defaults to current wall clock. */
   readonly initialDate?: Date;
+  /** Optional view-switcher tabs to render inline in the board header,
+   *  used when the host calendar hands over its full chrome to this view. */
+  readonly viewSwitcher?: ReactNode;
 }
 
 const LAYERS: { id: MapLayer; label: string }[] = [
@@ -39,7 +43,7 @@ const LAYERS: { id: MapLayer; label: string }[] = [
   { id: '1k', label: '1k ft' },
 ];
 
-export function DispatchBoard({ events, assets = [], initialDate }: DispatchBoardProps) {
+export function DispatchBoard({ events, assets = [], initialDate, viewSwitcher }: DispatchBoardProps) {
   const [selectedDate, setSelectedDate] = useState<Date>(() => {
     if (initialDate) return initialDate;
     // Default: median event time so the slider lands inside the dataset's
@@ -73,12 +77,10 @@ export function DispatchBoard({ events, assets = [], initialDate }: DispatchBoar
   return (
     <div className="h-full w-full flex flex-col overflow-hidden" style={{ background: '#e8dcc8' }}>
       {/* Header */}
-      <header className="h-10 flex items-center justify-between px-4 border-b-2 border-[#3d2b1f]/30 bg-[#d4c4a8] flex-shrink-0">
-        <div className="flex items-center gap-3">
-          <h1 className="font-serif text-base font-bold text-[#3d2b1f] tracking-wider">
-            DISPATCH BOARD
-          </h1>
-          <span className="text-[10px] text-[#5a3e2b] font-mono">
+      <header className="h-10 flex items-center px-3 border-b-2 border-[#3d2b1f]/30 bg-[#d4c4a8] flex-shrink-0 gap-2">
+        <div className="flex items-center gap-2 min-w-0 flex-1">
+          {viewSwitcher}
+          <span className="text-[10px] text-[#5a3e2b] font-mono truncate hidden md:inline">
             {selectedDate.toLocaleDateString('en-US', {
               weekday: 'long',
               year: 'numeric',

--- a/src/views/dispatch/TacticalMap.tsx
+++ b/src/views/dispatch/TacticalMap.tsx
@@ -9,6 +9,7 @@
 import { useMemo } from 'react';
 import { project, DEFAULT_LAYER_BOUNDS } from './projection';
 import { positionAt } from './deriveData';
+import { DEFAULT_LAYER_ZOOM, tilesForBounds } from './tileLayer';
 import type {
   DispatchAsset,
   DispatchConflict,
@@ -28,6 +29,10 @@ interface Props {
   readonly selectedAsset: string | null;
   readonly onSelectAsset: (id: string) => void;
   readonly layer: MapLayer;
+  /** Render an OSM raster tile basemap underneath. Default true. */
+  readonly showTiles?: boolean;
+  /** Override the slippy-map tile URL ({z}/{x}/{y}). */
+  readonly tileUrl?: string;
 }
 
 const VW = 1000;
@@ -43,10 +48,20 @@ export function TacticalMap({
   selectedAsset,
   onSelectAsset,
   layer,
+  showTiles = true,
+  tileUrl,
 }: Props) {
   const bounds = DEFAULT_LAYER_BOUNDS[layer];
   const proj = (lat: number, lng: number): [number, number] =>
     project(bounds, lat, lng, VW, VH);
+
+  const tiles = useMemo(
+    () =>
+      showTiles
+        ? tilesForBounds(bounds, DEFAULT_LAYER_ZOOM[layer], tileUrl)
+        : [],
+    [bounds, layer, showTiles, tileUrl],
+  );
 
   const conflictsAtTime = useMemo(() => {
     const dayStart = new Date(
@@ -72,49 +87,139 @@ export function TacticalMap({
           <feTurbulence type="fractalNoise" baseFrequency="0.015" numOctaves={2} result="n" />
           <feDisplacementMap in="SourceGraphic" in2="n" scale={2} />
         </filter>
+        {/* Sepia/parchment wash applied to the OSM raster tiles so they
+            sit underneath the dispatch ink layer without fighting it. */}
+        <filter id="dispatch-tile-tone">
+          <feColorMatrix
+            type="matrix"
+            values="0.55 0.40 0.10 0 0.05
+                    0.45 0.45 0.10 0 0.05
+                    0.35 0.30 0.20 0 0.05
+                    0    0    0    1 0"
+          />
+        </filter>
+        {/* Soft drop shadow for the arched breadcrumbs to read as
+            lifted above the ground plane. */}
+        <filter id="dispatch-arch-shadow" x="-20%" y="-20%" width="140%" height="140%">
+          <feGaussianBlur in="SourceAlpha" stdDeviation={1.2} />
+          <feOffset dy={1.5} result="off" />
+          <feComponentTransfer>
+            <feFuncA type="linear" slope={0.35} />
+          </feComponentTransfer>
+          <feMerge>
+            <feMergeNode />
+            <feMergeNode in="SourceGraphic" />
+          </feMerge>
+        </filter>
       </defs>
 
       <rect width={VW} height={VH} fill="#e8dcc8" />
 
-      {/* Hand-traced background only renders for the region layer; other layers
-          get a dashed-bounds frame placeholder until per-layer SVGs land. */}
-      {layer === 'region' && (
-        <g filter="url(#dispatch-ink)" opacity={0.3}>
-          {/* AZ / NM / CA / NV outlines — first-pass tracings */}
-          <path d="M 380 380 L 420 200 L 520 180 L 580 380 L 520 520 L 420 500 Z" fill="none" stroke="#5a3e2b" strokeWidth={1.5} />
-          <path d="M 580 380 L 520 180 L 720 160 L 780 360 L 720 500 L 620 480 Z" fill="none" stroke="#5a3e2b" strokeWidth={1.5} />
-          <path d="M 80 100 L 180 80 L 220 200 L 180 400 L 100 500 L 60 400 Z" fill="none" stroke="#5a3e2b" strokeWidth={1.5} />
-          <path d="M 220 200 L 320 180 L 380 380 L 320 420 L 220 400 Z" fill="none" stroke="#5a3e2b" strokeWidth={1.5} />
-        </g>
-      )}
-      {layer !== 'region' && (
-        <g opacity={0.4}>
-          <rect x={20} y={20} width={VW - 40} height={VH - 40} fill="none" stroke="#5a3e2b" strokeWidth={1} strokeDasharray="6,4" />
-          <text x={VW / 2} y={50} textAnchor="middle" fontFamily="serif" fontSize={14} fill="#5a3e2b" letterSpacing={2}>
-            {layer.toUpperCase()} VIEW
-          </text>
+      {/* OSM raster tile basemap — each tile is placed by projecting its
+          NW/SE corners through the current layer's bounds. Wrapped in a
+          clip so tiles that overhang the viewBox don't bleed. */}
+      {tiles.length > 0 && (
+        <g filter="url(#dispatch-tile-tone)" opacity={0.75}>
+          {tiles.map((t) => {
+            const [x1, y1] = proj(t.nw.lat, t.nw.lng);
+            const [x2, y2] = proj(t.se.lat, t.se.lng);
+            const w = x2 - x1;
+            const h = y2 - y1;
+            return (
+              <image
+                key={`${t.z}-${t.x}-${t.y}`}
+                href={t.url}
+                x={x1}
+                y={y1}
+                width={w}
+                height={h}
+                preserveAspectRatio="none"
+                crossOrigin="anonymous"
+              />
+            );
+          })}
         </g>
       )}
 
-      {/* Breadcrumb segments — solid + colored for past travel, dashed + faded for future */}
+      {/* Layer-name watermark for the non-region zoom presets, since the
+          hand-traced state outlines are gone now. */}
+      {layer !== 'region' && (
+        <text
+          x={VW / 2}
+          y={36}
+          textAnchor="middle"
+          fontFamily="serif"
+          fontSize={12}
+          fill="#5a3e2b"
+          letterSpacing={2}
+          opacity={0.55}
+        >
+          {layer.toUpperCase()} VIEW
+        </text>
+      )}
+
+      {/* Breadcrumb segments — rendered as a quadratic Bezier arch that
+          lifts off the ground plane, giving an origin→destination "flight
+          path" feel without needing real road routing. Past legs render
+          solid + colored; future legs dashed + dim. A faint shadow ellipse
+          under each apex reinforces the 3D read. */}
       {assets.flatMap((asset) => {
         const segs = segmentsByAsset.get(asset.id) ?? [];
         const isSelected = asset.id === selectedAsset;
-        const opacity = selectedAsset ? (isSelected ? 1 : 0.015) : 0.35;
+        const baseOpacity = selectedAsset ? (isSelected ? 1 : 0.015) : 0.35;
         return segs.map((seg, i) => {
           const [x1, y1] = proj(seg.from.lat, seg.from.lng);
           const [x2, y2] = proj(seg.to.lat, seg.to.lng);
+          const dx = x2 - x1;
+          const dy = y2 - y1;
+          const len = Math.sqrt(dx * dx + dy * dy);
+          // Arch height scales with leg length, capped so cross-region
+          // hops don't balloon off-screen. Always bowed upward (−y).
+          const archH = Math.min(Math.max(len * 0.22, 12), 80);
+          const midX = (x1 + x2) / 2;
+          const midY = (y1 + y2) / 2;
+          // Perpendicular unit vector, biased upward (negative y) so the
+          // arch consistently lifts toward the top of the viewBox.
+          const nx = len === 0 ? 0 : -dy / len;
+          const ny = len === 0 ? -1 : dx / len;
+          const upBias = ny < 0 ? 1 : -1;
+          const cx = midX + nx * archH * upBias;
+          const cy = midY + ny * archH * upBias;
           const past = seg.to.time.getTime() <= selectedDate.getTime();
+          const stroke = isSelected ? 2.5 : 1.5;
+          const opacity = past
+            ? isSelected
+              ? 1
+              : (0.55 * baseOpacity) / 0.35
+            : isSelected
+              ? 0.55
+              : (0.18 * baseOpacity) / 0.35;
+          const d = `M ${x1} ${y1} Q ${cx} ${cy} ${x2} ${y2}`;
           return (
-            <line
-              key={`${asset.id}-${i}`}
-              x1={x1} y1={y1} x2={x2} y2={y2}
-              stroke={asset.color}
-              strokeWidth={isSelected ? 3 : 1.5}
-              strokeDasharray={past ? 'none' : '4,3'}
-              opacity={past ? (isSelected ? 1 : 0.5 * opacity / 0.35) : (isSelected ? 0.5 : 0.15 * opacity / 0.35)}
-              filter="url(#dispatch-ink)"
-            />
+            <g key={`${asset.id}-${i}`} opacity={opacity}>
+              {/* Ground shadow — slim ellipse along the great-circle base. */}
+              {(isSelected || !selectedAsset) && (
+                <line
+                  x1={x1}
+                  y1={y1}
+                  x2={x2}
+                  y2={y2}
+                  stroke="#3d2b1f"
+                  strokeWidth={0.8}
+                  strokeDasharray="1,4"
+                  opacity={0.25}
+                />
+              )}
+              <path
+                d={d}
+                fill="none"
+                stroke={asset.color}
+                strokeWidth={stroke}
+                strokeLinecap="round"
+                strokeDasharray={past ? 'none' : '5,4'}
+                filter={isSelected ? 'url(#dispatch-arch-shadow)' : 'url(#dispatch-ink)'}
+              />
+            </g>
           );
         });
       })}

--- a/src/views/dispatch/tileLayer.ts
+++ b/src/views/dispatch/tileLayer.ts
@@ -1,0 +1,88 @@
+/**
+ * OpenStreetMap raster tile helpers for the tactical map background.
+ *
+ * Computes the slippy-map tiles that cover a given lat/lng bounds at a
+ * chosen zoom, returning each tile's image URL plus its NW/SE lat/lng
+ * corners so the caller can project them into SVG coordinates and
+ * lay the tile as an <image> element.
+ *
+ * No dependencies. Tiles are served by OpenStreetMap's standard CDN
+ * — fine for demo / light embedded use; production hosts should swap
+ * in their own tile URL via the `tileUrl` template.
+ */
+
+import type { LayerBounds, MapLayer } from './types';
+
+export interface TileRect {
+  /** Image URL for this tile. */
+  readonly url: string;
+  /** NW corner lat/lng. */
+  readonly nw: { lat: number; lng: number };
+  /** SE corner lat/lng. */
+  readonly se: { lat: number; lng: number };
+  /** Slippy-map z / x / y — handy for keys and debugging. */
+  readonly z: number;
+  readonly x: number;
+  readonly y: number;
+}
+
+/** Per-layer default zoom — chosen to land ~6–25 tiles inside the bounds. */
+export const DEFAULT_LAYER_ZOOM: Record<MapLayer, number> = {
+  region: 5,
+  state: 6,
+  '5k': 9,
+  '1k': 12,
+};
+
+const DEFAULT_TILE_URL = 'https://tile.openstreetmap.org/{z}/{x}/{y}.png';
+
+function lng2tileX(lng: number, z: number): number {
+  return ((lng + 180) / 360) * 2 ** z;
+}
+
+function lat2tileY(lat: number, z: number): number {
+  const rad = (lat * Math.PI) / 180;
+  return ((1 - Math.log(Math.tan(rad) + 1 / Math.cos(rad)) / Math.PI) / 2) * 2 ** z;
+}
+
+function tileX2lng(x: number, z: number): number {
+  return (x / 2 ** z) * 360 - 180;
+}
+
+function tileY2lat(y: number, z: number): number {
+  const n = Math.PI - (2 * Math.PI * y) / 2 ** z;
+  return (180 / Math.PI) * Math.atan(0.5 * (Math.exp(n) - Math.exp(-n)));
+}
+
+export function tilesForBounds(
+  bounds: LayerBounds,
+  zoom: number,
+  tileUrl: string = DEFAULT_TILE_URL,
+): TileRect[] {
+  const xMin = Math.floor(lng2tileX(bounds.sw.lng, zoom));
+  const xMax = Math.floor(lng2tileX(bounds.ne.lng, zoom));
+  // y is inverted: NE lat → top tile, SW lat → bottom tile
+  const yMin = Math.floor(lat2tileY(bounds.ne.lat, zoom));
+  const yMax = Math.floor(lat2tileY(bounds.sw.lat, zoom));
+
+  const max = 2 ** zoom;
+  const tiles: TileRect[] = [];
+  for (let x = xMin; x <= xMax; x++) {
+    for (let y = yMin; y <= yMax; y++) {
+      const wrappedX = ((x % max) + max) % max;
+      if (y < 0 || y >= max) continue;
+      tiles.push({
+        url: tileUrl
+          .replace('{z}', String(zoom))
+          .replace('{x}', String(wrappedX))
+          .replace('{y}', String(y)),
+        nw: { lat: tileY2lat(y, zoom), lng: tileX2lng(x, zoom) },
+        se: { lat: tileY2lat(y + 1, zoom), lng: tileX2lng(x + 1, zoom) },
+        z: zoom,
+        x: wrappedX,
+        y,
+      });
+    }
+  }
+  return tiles;
+}

--- a/tests-e2e/calendar.smoke.spec.ts
+++ b/tests-e2e/calendar.smoke.spec.ts
@@ -17,6 +17,9 @@ test.describe('Calendar smoke tests', () => {
   });
 
   test('navigation toolbar is present', async ({ page }) => {
+    // The demo lands on a chrome-owning view (Dispatch); switch to a
+    // standard calendar view first to expose the host's navigation toolbar.
+    await page.getByRole('group', { name: 'Calendar view' }).getByRole('button', { name: 'Month' }).click();
     await expect(page.getByRole('toolbar', { name: 'Calendar navigation' })).toBeVisible();
   });
 
@@ -29,6 +32,9 @@ test.describe('Calendar smoke tests', () => {
   });
 
   test('can open the add-event dialog', async ({ page }) => {
+    // Add-event button lives in the standard chrome, which the dispatch
+    // landing view suppresses. Move to Month first.
+    await page.getByRole('group', { name: 'Calendar view' }).getByRole('button', { name: 'Month' }).click();
     await page.getByRole('button', { name: 'Add new event' }).click();
     await expect(page.getByRole('dialog')).toBeVisible();
     await page.getByRole('button', { name: 'Close' }).click();


### PR DESCRIPTION
Replaces the hand-traced state outlines and dashed-bounds placeholder
with a real raster tile basemap (OpenStreetMap by default, overridable
via tileUrl). Tiles are placed by projecting each tile's NW/SE corners
through the active layer's bounds, then washed through a sepia
feColorMatrix so they sit under the dispatch ink layer.

Breadcrumb segments now render as quadratic Bezier arches with a soft
drop shadow and a faint dashed ground line under each leg, giving an
origin→destination 3D feel without needing real road routing.

Adds showTiles / tileUrl props on TacticalMap so tests and hosts that
don't want network tile fetches can opt out.