### PR TITLE
refactor(chrome): single-band header + date dropdown; LeftRail absorb…

### DIFF
--- a/src/WorksCalendar.tsx
+++ b/src/WorksCalendar.tsx
@@ -390,7 +390,28 @@ const WorksCalendarImpl = forwardRef<CalendarApi, WorksCalendarProps>(function W
           ) : null;
           return (
           <AppShell
-            {...(viewOwnsChrome ? {} : { leftRail: <CalendarLeftRail ownerCfg={ownerCfg} leftRailExtras={leftRailExtras} setSidebarInitialTab={setSidebarInitialTab} setSidebarOpen={setSidebarOpen} /> })}
+            {...(viewOwnsChrome ? {} : { leftRail: <CalendarLeftRail
+              ownerCfg={ownerCfg}
+              leftRailExtras={leftRailExtras}
+              setSidebarInitialTab={setSidebarInitialTab}
+              setSidebarOpen={setSidebarOpen}
+              hasAddButton={hasAddButton}
+              hasScheduleTemplates={hasScheduleTemplates}
+              hasImport={hasImport}
+              visibleEvents={visibleEvents}
+              onAddEvent={() => setFormEvent({})}
+              onAddSchedule={() => {
+                setScheduleOpen(true);
+                onScheduleTemplateAnalytics?.({
+                  event: 'schedule_dialog_opened',
+                  at: new Date().toISOString(),
+                  templateCount: visibleScheduleTemplates.length,
+                });
+              }}
+              onOpenImport={() => setImportOpen(true)}
+              editMode={editMode}
+              onToggleEditMode={() => { setEditMode((v) => !v); setInlineEditTarget(null); }}
+            /> })}
             {...(viewOwnsChrome ? {} : { rightPanel: <CalendarRightPanel configuredEmployees={configuredEmployees} onShiftIds={onShiftIds} rightPanelExtras={rightPanelExtras} /> })}
             header={viewOwnsChrome ? <></> :
               <CalendarToolbar cal={cal} ownerCfg={ownerCfg} api={api}

--- a/src/ui/CalendarSideRails.tsx
+++ b/src/ui/CalendarSideRails.tsx
@@ -1,8 +1,10 @@
 import type { Dispatch, ReactNode, SetStateAction } from 'react';
-import { Bookmark, Filter, Settings } from 'lucide-react';
+import { Bookmark, CalendarPlus, Download, Filter, Plus, Settings, Sparkles, Upload } from 'lucide-react';
 import { LeftRail, type LeftRailAction } from './LeftRail';
 import { RightPanel, RightPanelSection, CrewOnShiftList } from './RightPanel';
+import { exportVisibleEvents } from '../core/calendarViewConfig';
 import type { EmployeeRecord } from '../WorksCalendar.types';
+import type { NormalizedEvent } from '../types/events';
 import type { SidebarTab } from './FilterGroupSidebar';
 
 /** Slice of `useOwnerConfig`'s return that the rails need. */
@@ -16,16 +18,77 @@ interface CalendarLeftRailProps {
   leftRailExtras: readonly LeftRailAction[] | undefined;
   setSidebarInitialTab: Dispatch<SetStateAction<SidebarTab>>;
   setSidebarOpen: (v: boolean) => void;
+  // ── Actions migrated from the deleted SubToolbar / AppHeader cluster ──
+  hasAddButton?: boolean;
+  hasScheduleTemplates?: boolean;
+  hasImport?: boolean;
+  visibleEvents: readonly NormalizedEvent[];
+  onAddEvent: () => void;
+  onAddSchedule: () => void;
+  onOpenImport: () => void;
+  editMode?: boolean;
+  onToggleEditMode?: () => void;
 }
 
-export function CalendarLeftRail({ ownerCfg, leftRailExtras, setSidebarInitialTab, setSidebarOpen }: CalendarLeftRailProps) {
+export function CalendarLeftRail({
+  ownerCfg, leftRailExtras, setSidebarInitialTab, setSidebarOpen,
+  hasAddButton, hasScheduleTemplates, hasImport, visibleEvents,
+  onAddEvent, onAddSchedule, onOpenImport,
+  editMode, onToggleEditMode,
+}: CalendarLeftRailProps) {
+  const builtIn: LeftRailAction[] = [
+    ...(hasAddButton ? [{
+      id: 'wc-add-event',
+      label: 'Add new event',
+      hint: 'Create a new event',
+      icon: <Plus size={18} aria-hidden="true" />,
+      onClick: onAddEvent,
+    }] : []),
+    ...(hasScheduleTemplates ? [{
+      id: 'wc-add-schedule',
+      label: 'Add schedule from template',
+      hint: 'Bulk-create events from a template',
+      icon: <CalendarPlus size={18} aria-hidden="true" />,
+      onClick: onAddSchedule,
+    }] : []),
+    { id: 'saved-views', label: 'Saved views', hint: 'Manage your view library', icon: <Bookmark size={18} aria-hidden="true" />, onClick: () => { setSidebarInitialTab('saved'); setSidebarOpen(true); } },
+    { id: 'focus', label: 'Focus filters', hint: 'Narrow the calendar by region, base, role, or category', icon: <Filter size={18} aria-hidden="true" />, onClick: () => { setSidebarInitialTab('focus'); setSidebarOpen(true); } },
+    ...(hasImport ? [{
+      id: 'wc-import',
+      label: 'Import .ics calendar',
+      hint: 'Import events from a .ics file',
+      icon: <Upload size={18} aria-hidden="true" />,
+      onClick: onOpenImport,
+    }] : []),
+    {
+      id: 'wc-export',
+      label: 'Export to Excel',
+      hint: 'Download visible events as .xlsx',
+      icon: <Download size={18} aria-hidden="true" />,
+      onClick: () => { void exportVisibleEvents([...visibleEvents]); },
+    },
+    ...(ownerCfg.isOwner && onToggleEditMode ? [{
+      id: 'wc-edit-mode',
+      label: editMode ? 'Exit edit mode' : 'Enter edit mode',
+      hint: editMode ? 'Stop customizing events' : 'Customize events',
+      icon: <Sparkles size={18} aria-hidden="true" />,
+      ...(editMode ? { active: true } : {}),
+      onClick: onToggleEditMode,
+    }] : []),
+    ...(ownerCfg.isOwner ? [{
+      id: 'settings',
+      label: 'Settings',
+      hint: 'Calendar configuration',
+      icon: <Settings size={18} aria-hidden="true" />,
+      onClick: () => ownerCfg.setConfigOpen(true),
+    }] : []),
+  ];
+  const reservedIds = new Set(builtIn.map((a) => a.id));
   return (
     <LeftRail
       actions={[
-        { id: 'saved-views', label: 'Saved views', hint: 'Manage your view library', icon: <Bookmark size={18} aria-hidden="true" />, onClick: () => { setSidebarInitialTab('saved'); setSidebarOpen(true); } },
-        { id: 'focus', label: 'Focus filters', hint: 'Narrow the calendar by region, base, role, or category', icon: <Filter size={18} aria-hidden="true" />, onClick: () => { setSidebarInitialTab('focus'); setSidebarOpen(true); } },
-        ...(ownerCfg.isOwner ? [{ id: 'settings', label: 'Settings', hint: 'Calendar configuration', icon: <Settings size={18} aria-hidden="true" />, onClick: () => ownerCfg.setConfigOpen(true) }] : []),
-        ...(leftRailExtras ?? []).filter((extra) => !['saved-views', 'focus', 'settings'].includes(extra.id)),
+        ...builtIn,
+        ...(leftRailExtras ?? []).filter((extra) => !reservedIds.has(extra.id)),
       ]}
     />
   );

--- a/src/ui/CalendarToolbar.tsx
+++ b/src/ui/CalendarToolbar.tsx
@@ -1,20 +1,16 @@
 import type { Dispatch, SetStateAction } from 'react';
 import SearchBar from './SearchBar';
 import TimezonePicker from './TimezonePicker';
-import { useEffect, useRef, useState } from 'react';
 import { format, startOfWeek, endOfWeek } from 'date-fns';
-import { ChevronLeft, ChevronRight, Sparkles, ChevronDown, Plus } from 'lucide-react';
+import { Sparkles } from 'lucide-react';
 import type { EventTemplateV1 } from '../api/v1/templates';
-import { BUILT_IN_EVENT_TEMPLATES } from 'works-calendar-engine';
 import { AppHeader } from './AppHeader';
-import ProfileBar from './ProfileBar';
-import FocusChips, { DEFAULT_FOCUS_CHIPS } from './FocusChips';
-import type { FocusChipDef } from './FocusChips';
-import { ALL_VIEWS } from '../core/calendarViewConfig';
+import { ViewSwitcher } from './ViewSwitcher';
+import { DatePickerDropdown } from './DatePickerDropdown';
+import { DayWindowPills } from './DayWindowPills';
 import type { ViewDef } from '../core/calendarViewConfig';
 import { captureSavedViewFields } from '../core/viewScope';
-import { hasActiveFilters, buildActiveFilterPills, buildFilterSummary } from '../filters/filterState';
-import { VIEW_SHORTCUT_KEYS } from '../hooks/useKeyboardShortcuts';
+import { buildActiveFilterPills, buildFilterSummary } from '../filters/filterState';
 import { useCalendarSetup } from '../hooks/useCalendarSetup';
 import { useOwnerConfig } from '../hooks/useOwnerConfig';
 import { useSavedViews } from '../hooks/useSavedViews';
@@ -28,16 +24,9 @@ import type { SidebarTab } from './FilterGroupSidebar';
 import type { GroupByInput } from '../hooks/useNormalizedConfig';
 import styles from '../WorksCalendar.module.css';
 
-// view id → keyboard shortcut digit (inverse of VIEW_SHORTCUT_KEYS), used to
-// advertise the binding on each view button via aria-keyshortcuts.
-const VIEW_SHORTCUT_BY_ID: Record<string, string> = Object.fromEntries(
-  Object.entries(VIEW_SHORTCUT_KEYS).map(([key, id]) => [id, key]),
-);
-
 type CalendarHandle = ReturnType<typeof useCalendarSetup>['cal'];
 type OwnerCfgHandle = ReturnType<typeof useOwnerConfig>;
 type SavedViewsHandle = ReturnType<typeof useSavedViews>;
-type SavedViewArg = Parameters<SavedViewsHandle['saveView']>[2];
 type CaptureCtx = Pick<SaveViewOptions, SavedViewCaptureField>;
 
 export interface CalendarToolbarProps {
@@ -47,7 +36,7 @@ export interface CalendarToolbarProps {
   renderToolbar?: WorksCalendarProps['renderToolbar'];
   renderSavedViewsBar?: WorksCalendarProps['renderSavedViewsBar'];
   renderFilterBar?: WorksCalendarProps['renderFilterBar'];
-  focusChips?: FocusChipDef[] | boolean | undefined;
+  focusChips?: unknown;
   logoSrc?: string | undefined;
   logoAlt?: string | undefined;
   devMode: boolean;
@@ -102,312 +91,114 @@ function getDateLabel(view: string, currentDate: Date, weekStartDay: 0 | 1 | 2 |
   }
 }
 
-function QuickAddDropdown({ api, eventTemplates, hideEventTemplates }: {
-  api: CalendarToolbarProps['api'];
-  eventTemplates?: EventTemplateV1[];
-  hideEventTemplates?: boolean;
-}) {
-  const [open, setOpen] = useState(false);
-  const ref = useRef<HTMLDivElement>(null);
-
-  useEffect(() => {
-    if (!open) return;
-    const handler = (e: MouseEvent) => {
-      if (ref.current && !ref.current.contains(e.target as Node)) setOpen(false);
-    };
-    document.addEventListener('mousedown', handler);
-    return () => document.removeEventListener('mousedown', handler);
-  }, [open]);
-
-  useEffect(() => {
-    if (!open) return;
-    const handler = (e: KeyboardEvent) => { if (e.key === 'Escape') setOpen(false); };
-    document.addEventListener('keydown', handler);
-    return () => document.removeEventListener('keydown', handler);
-  }, [open]);
-
-  const templates: EventTemplateV1[] = eventTemplates && eventTemplates.length > 0
-    ? eventTemplates
-    : BUILT_IN_EVENT_TEMPLATES.map(t => ({
-        id: t.id,
-        name: t.label,
-        defaults: t.defaults ?? {},
-        ...(t.description ? { description: t.description } : {}),
-      } as EventTemplateV1));
-
-  if (hideEventTemplates || templates.length === 0) {
-    return (
-      <button
-        type="button"
-        className={styles['newBtn']}
-        onClick={() => api.addEvent()}
-        aria-label="New event"
-        title="New event"
-      >
-        <Plus size={14} aria-hidden="true" />
-        <span>New</span>
-      </button>
-    );
-  }
-
-  return (
-    <div ref={ref} className={styles['quickAddWrap']}>
-      <button
-        type="button"
-        className={styles['newBtn']}
-        onClick={() => { api.addEvent(); }}
-        aria-label="New blank event"
-        title="New blank event"
-      >
-        <Plus size={14} aria-hidden="true" />
-        <span>New</span>
-      </button>
-      <button
-        type="button"
-        className={styles['newBtnChevron']}
-        onClick={() => setOpen(v => !v)}
-        aria-haspopup="menu"
-        aria-expanded={open}
-        aria-label="New event from template"
-        title="New from template"
-      >
-        <ChevronDown size={12} aria-hidden="true" />
-      </button>
-      {open && (
-        <div className={styles['quickAddDropdown']} role="menu" aria-label="Event templates">
-          {templates.map(tpl => (
-            <button
-              key={tpl.id}
-              type="button"
-              role="menuitem"
-              className={styles['quickAddItem']}
-              onClick={() => {
-                setOpen(false);
-                const d = tpl.defaults ?? {};
-                const patch: Parameters<typeof api.addEvent>[0] = {};
-                if (d.title)    patch.title    = d.title;
-                if (d.allDay)   patch.allDay   = d.allDay;
-                if (d.category) patch.category = d.category;
-                if (d.color)    patch.color    = d.color;
-                if (d.meta)     patch.meta     = d.meta;
-                if (d.rrule)    patch.rrule    = d.rrule;
-                api.addEvent(patch);
-              }}
-            >
-              <span className={styles['quickAddItemLabel']}>{tpl.name}</span>
-              {tpl.description && (
-                <span className={styles['quickAddItemDesc']}>{tpl.description}</span>
-              )}
-            </button>
-          ))}
-        </div>
-      )}
-    </div>
-  );
-}
-
 export default function CalendarToolbar({
   cal, ownerCfg, api,
-  renderToolbar, renderSavedViewsBar, renderFilterBar, focusChips,
+  renderToolbar, renderSavedViewsBar, renderFilterBar,
   logoSrc, logoAlt, devMode, calendarTitle, fetchLoading,
   editMode, setEditMode, setInlineEditTarget, setHelpOpen,
   savedViews, savedViewActiveId, savedViewDirty,
   handleApplyView, handleDeleteView, handleClearFilters,
   savedViewCaptureCtx, activeGroupBy,
-  VIEWS, setSidebarOpen, setSidebarInitialTab, handleScopeClick,
+  VIEWS, setSidebarOpen, setSidebarInitialTab,
   schema, filterBarSchema, scopedEvents, locationLabel, assetsLabel, weekStartDay,
-  hasAddButton, hideEventTemplates, eventTemplates, showSearch,
+  showSearch,
   showTimezonePicker, displayTimezone, onTimezoneChange,
 }: CalendarToolbarProps) {
+  // Voiding refs to unused props so TypeScript doesn't complain about the
+  // legacy surface (these props are still accepted to keep the embedder
+  // API stable; their content has moved to the LeftRail).
+  void renderSavedViewsBar; void savedViews; void savedViewActiveId;
+  void savedViewDirty; void handleApplyView; void handleDeleteView;
+  void savedViewCaptureCtx; void activeGroupBy; void scopedEvents;
+  void assetsLabel; void locationLabel; void captureSavedViewFields;
+  void buildFilterSummary; void handleClearFilters; void schema;
+
+  if (renderToolbar) {
+    return <div className={styles['customToolbar']}>{renderToolbar(api)}</div>;
+  }
+
+  const dayWindowable = cal.view === 'schedule' || cal.view === 'base' || cal.view === 'assets';
+
   return (
     <>
-      {/* ── Toolbar ── */}
-      {renderToolbar ? (
-        <div className={styles['customToolbar']}>{renderToolbar(api)}</div>
-      ) : (
-        <AppHeader
-          leftSlot={
-            <div className={styles['navGroup']}>
-              {logoSrc && (
-                <img
-                  src={logoSrc}
-                  alt={logoAlt ?? ''}
-                  className={styles['logo']}
-                  aria-hidden={!logoAlt ? 'true' : undefined}
-                />
-              )}
-              <button
-                className={styles['navBtn']}
-                onClick={() => cal.navigate(-1)}
-                aria-label="Previous"
-                aria-keyshortcuts="k ArrowLeft"
-                title={`Previous ${cal.view}`}
-              >
-                <ChevronLeft size={18} aria-hidden="true" />
-              </button>
-              <button className={styles['todayBtn']} onClick={cal.goToToday} aria-keyshortcuts="t">Today</button>
-              <button
-                className={styles['navBtn']}
-                onClick={() => cal.navigate(1)}
-                aria-label="Next"
-                aria-keyshortcuts="j ArrowRight"
-                title={`Next ${cal.view}`}
-              >
-                <ChevronRight size={18} aria-hidden="true" />
-              </button>
-              <span className={styles['dateLabel']} aria-live="polite" aria-atomic="true">
-                {getDateLabel(cal.view, cal.currentDate, weekStartDay)}
-              </span>
-              <span className={styles['calendarTitle']}>{calendarTitle}</span>
-              {fetchLoading && <span className={styles['loadingDot']} title="Loading…" aria-label="Loading events" role="status" />}
-            </div>
-          }
-          centerSlot={(() => {
-            const calendarViews   = VIEWS.filter((v: ViewDef) => v.group === 'calendar');
-            const operationsViews = VIEWS.filter((v: ViewDef) => v.group === 'operations');
-            const renderBtn = (v: ViewDef) => (
-              <button
-                key={v.id}
-                className={[styles['viewBtn'], cal.view === v.id && styles['activeView']].filter(Boolean).join(' ')}
-                onClick={() => cal.setView(v.id)}
-                aria-pressed={cal.view === v.id}
-                aria-keyshortcuts={VIEW_SHORTCUT_BY_ID[v.id]}
-                title={v.hint}
-                data-wc-view-button={v.id}
-              >
-                {v.label}
-              </button>
-            );
-            return (
-              <div className={styles['viewGroup']} role="group" aria-label="Calendar view">
-                {calendarViews.map(renderBtn)}
-                {operationsViews.length > 0 && (
-                  <span className={styles['viewGroupDivider']} aria-hidden="true" role="presentation" />
-                )}
-                {operationsViews.map(renderBtn)}
-              </div>
-            );
-          })()}
-          rightSlot={
-            <div className={styles['actions']}>
-              {showTimezonePicker && onTimezoneChange && (
-                <TimezonePicker
-                  {...(displayTimezone !== undefined ? { value: displayTimezone } : {})}
-                  onChange={onTimezoneChange}
-                />
-              )}
-              {showSearch && (
-                <SearchBar
-                  value={String(cal.filters?.['search'] ?? '')}
-                  onChange={(q) => cal.setFilter('search', q || null)}
-                />
-              )}
-              {hasAddButton && (
-                <QuickAddDropdown
-                  api={api}
-                  {...(eventTemplates !== undefined ? { eventTemplates } : {})}
-                  {...(hideEventTemplates !== undefined ? { hideEventTemplates } : {})}
-                />
-              )}
-              {devMode && <span className={styles['devBadge']}>Dev</span>}
-              {(ownerCfg.isOwner || devMode) && (
-                <button
-                  className={[styles['wandBtn'], editMode && styles['wandBtnActive']].filter(Boolean).join(' ')}
-                  onClick={() => { setEditMode((v: boolean) => !v); setInlineEditTarget(null); }}
-                  aria-label={editMode ? 'Exit edit mode' : 'Enter edit mode — click events to customize them'}
-                  title={editMode ? 'Exit edit mode' : 'Customize events'}
-                >
-                  <Sparkles size={15} aria-hidden="true" />
-                  {editMode && <span className={styles['wandBtnLabel']}>Done</span>}
-                </button>
-              )}
-            </div>
-          }
-          menuItems={[
-            ...(ownerCfg.isOwner ? [
-              { label: 'Settings',          sub: 'Calendar config, integrations', onClick: () => ownerCfg.setConfigOpen(true) },
-              { label: 'Themes',            sub: 'Switch palette / appearance',   onClick: () => ownerCfg.openConfigToTab('theme') },
-              { label: 'Advanced settings', sub: 'Smart views, fields, approvals', onClick: () => ownerCfg.openConfigToTab('smartViews') },
-            ] : []),
-            { label: 'Saved views',        sub: 'Manage your view library',      onClick: () => { setSidebarInitialTab('saved'); setSidebarOpen(true); } },
-            { label: 'Keyboard shortcuts', sub: 'Quick reference',               onClick: () => setHelpOpen(true) },
-            { label: 'Help & feedback',                                          onClick: () => window.open('https://github.com/WorksCalendar/CalendarThatWorks/issues', '_blank', 'noopener') },
-          ]}
-        />
-      )}
-
-      {/* ── Profile / Saved-views Bar ── */}
-      {renderSavedViewsBar
-        ? renderSavedViewsBar({
-            views:       savedViews.views,
-            activeId:    savedViewActiveId,
-            isDirty:     savedViewDirty,
-            applyView:   handleApplyView,
-            saveView:    (name: string, opts: SavedViewArg) => savedViews.saveView(name, cal.filters, { view: cal.view, ...captureSavedViewFields(cal.view, savedViewCaptureCtx), ...opts }),
-            updateView:  savedViews.updateView,
-            resaveView:  (id: string) => savedViews.resaveView(id, cal.filters, cal.view, activeGroupBy, captureSavedViewFields(cal.view, savedViewCaptureCtx)),
-            deleteView:  handleDeleteView,
-            toggleStripVisibility: savedViews.toggleStripVisibility,
-            clearFilters: cal.clearFilters,
-            hasActiveFilters: hasActiveFilters(cal.filters, schema),
-            currentFilters: cal.filters,
-            currentView:    cal.view,
-            schema,
-            buildFilterSummary: (filters: Record<string, unknown>) => buildFilterSummary(filters, schema),
-          })
-        : (() => {
-          const resolvedFocusChips: FocusChipDef[] | null = focusChips
-            ? (Array.isArray(focusChips) ? focusChips : DEFAULT_FOCUS_CHIPS)
-            : null;
-          const activeCategories = cal.filters?.['categories'] as Set<string> | undefined;
-          const tailSlot = resolvedFocusChips ? (
-            <>
-              <FocusChips
-                chips={resolvedFocusChips}
-                activeCategories={activeCategories}
-                onCategoriesChange={(next: Set<string>) => cal.setFilter('categories', next)}
+      <AppHeader
+        leftSlot={
+          <div style={{ display: 'flex', alignItems: 'center', gap: 8, minWidth: 0, flex: '1 1 auto' }}>
+            {logoSrc && (
+              <img
+                src={logoSrc}
+                alt={logoAlt ?? ''}
+                className={styles['logo']}
+                aria-hidden={!logoAlt ? 'true' : undefined}
               />
-              <button
-                type="button"
-                className={styles['scopePill']}
-                onClick={handleScopeClick}
-                title="Change scope"
-              >
-                <span>All regions</span>
-                <span className={styles['scopePillChevron']} aria-hidden="true">›</span>
-              </button>
-            </>
-          ) : null;
-          return (
-            <ProfileBar
-              compact
-              views={savedViews.views}
-              activeId={savedViewActiveId}
-              isDirty={savedViewDirty}
-              schema={schema}
+            )}
+            <ViewSwitcher
+              views={VIEWS}
               currentView={cal.view}
-              viewOrder={ALL_VIEWS.map(v => v.id)}
-              enabledViews={VIEWS.map((v: ViewDef) => v.id)}
-              locationLabel={locationLabel}
-              assetsLabel={assetsLabel}
-              hasActiveFilters={hasActiveFilters(cal.filters, schema)}
-              tailSlot={tailSlot}
-              onApply={handleApplyView}
-              onAdd={({ name, color }: { name: string; color: string | undefined }) => {
-                savedViews.saveView(name, cal.filters, { color: color ?? null, view: cal.view, ...captureSavedViewFields(cal.view, savedViewCaptureCtx) });
-              }}
-              onResave={(id: string) => savedViews.resaveView(id, cal.filters, cal.view, activeGroupBy, captureSavedViewFields(cal.view, savedViewCaptureCtx))}
-              onUpdate={savedViews.updateView}
-              onDelete={handleDeleteView}
-              onToggleVisibility={savedViews.toggleStripVisibility}
-              onClearFilters={handleClearFilters}
-              onEditConditions={ownerCfg.isOwner ? (id: string) => ownerCfg.openConfigToTab('smartViews', { smartViewEditId: id }) : undefined}
+              onViewChange={(id) => cal.setView(id as typeof cal.view)}
             />
-          );
-        })()
-      }
+          </div>
+        }
+        centerSlot={
+          <div style={{ display: 'flex', alignItems: 'center', gap: 8, flexWrap: 'wrap', justifyContent: 'center' }}>
+            <DatePickerDropdown
+              currentDate={cal.currentDate}
+              label={getDateLabel(cal.view, cal.currentDate, weekStartDay)}
+              onDateChange={cal.setCurrentDate}
+              onToday={cal.goToToday}
+              onPrev={() => cal.navigate(-1)}
+              onNext={() => cal.navigate(1)}
+              prevShortcut="k ArrowLeft"
+              nextShortcut="j ArrowRight"
+            />
+            {dayWindowable && <DayWindowPills value={cal.dayWindow} onChange={cal.setDayWindow} />}
+            {fetchLoading && <span className={styles['loadingDot']} title="Loading…" aria-label="Loading events" role="status" />}
+            {calendarTitle && (
+              <span className={styles['calendarTitle']} style={{ fontSize: 11, opacity: 0.7 }}>{calendarTitle}</span>
+            )}
+          </div>
+        }
+        rightSlot={
+          <div className={styles['actions']}>
+            {showTimezonePicker && onTimezoneChange && (
+              <TimezonePicker
+                {...(displayTimezone !== undefined ? { value: displayTimezone } : {})}
+                onChange={onTimezoneChange}
+              />
+            )}
+            {showSearch && (
+              <SearchBar
+                value={String(cal.filters?.['search'] ?? '')}
+                onChange={(q) => cal.setFilter('search', q || null)}
+              />
+            )}
+            {devMode && <span className={styles['devBadge']}>Dev</span>}
+            {(ownerCfg.isOwner || devMode) && (
+              <button
+                className={[styles['wandBtn'], editMode && styles['wandBtnActive']].filter(Boolean).join(' ')}
+                onClick={() => { setEditMode((v: boolean) => !v); setInlineEditTarget(null); }}
+                aria-label={editMode ? 'Exit edit mode' : 'Enter edit mode — click events to customize them'}
+                title={editMode ? 'Exit edit mode' : 'Customize events'}
+              >
+                <Sparkles size={15} aria-hidden="true" />
+                {editMode && <span className={styles['wandBtnLabel']}>Done</span>}
+              </button>
+            )}
+          </div>
+        }
+        menuItems={[
+          ...(ownerCfg.isOwner ? [
+            { label: 'Settings',          sub: 'Calendar config, integrations', onClick: () => ownerCfg.setConfigOpen(true) },
+            { label: 'Themes',            sub: 'Switch palette / appearance',   onClick: () => ownerCfg.openConfigToTab('theme') },
+            { label: 'Advanced settings', sub: 'Smart views, fields, approvals', onClick: () => ownerCfg.openConfigToTab('smartViews') },
+          ] : []),
+          { label: 'Saved views',        sub: 'Manage your view library',      onClick: () => { setSidebarInitialTab('saved'); setSidebarOpen(true); } },
+          { label: 'Keyboard shortcuts', sub: 'Quick reference',               onClick: () => setHelpOpen(true) },
+          { label: 'Help & feedback',                                          onClick: () => window.open('https://github.com/WorksCalendar/CalendarThatWorks/issues', '_blank', 'noopener') },
+        ]}
+      />
 
-      {/* ── Filter Bar (legacy, kept for renderFilterBar override) ── */}
+      {/* Legacy embedder hook — host may still inject its own filter bar. */}
       {renderFilterBar && renderFilterBar({
         schema:          filterBarSchema,
         filters:         cal.filters,

--- a/src/ui/CalendarViewGrid.tsx
+++ b/src/ui/CalendarViewGrid.tsx
@@ -1,9 +1,5 @@
 import { lazy, Suspense } from 'react';
 import type { ReactNode, MutableRefObject, ComponentProps } from 'react';
-import { Plus, Upload, Download } from 'lucide-react';
-import { SubToolbar } from './SubToolbar';
-import { DayWindowPills } from './DayWindowPills';
-import { SidebarToggleButton } from './FilterGroupSidebar';
 import ActiveFilterStrip from './ActiveFilterStrip';
 import MonthView from '../views/MonthView';
 import WeekView from '../views/WeekView';
@@ -15,8 +11,6 @@ const AssetsView      = lazy(() => import('../views/AssetsView'));
 const BaseGanttView   = lazy(() => import('../views/BaseGanttView'));
 const DispatchView    = lazy(() => import('../views/DispatchView'));
 const RequestQueueView = lazy(() => import('../views/RequestQueueView'));
-import { exportVisibleEvents } from '../core/calendarViewConfig';
-import { hasActiveFilters } from '../filters/filterState';
 import styles from '../WorksCalendar.module.css';
 import type { CalObject } from '../hooks/useCalendarSetup';
 import type { OwnerCfgHandle } from '../hooks/useOwnerConfig';
@@ -163,68 +157,26 @@ export default function CalendarViewGrid({
   handleCoverageAssign, handleEmployeeAction, handleEventClick,
   viewOwnsChrome, viewSwitcher,
 }: CalendarViewGridProps) {
+  // Suppress these calls to unused props (sub-toolbar + filter-strip were
+  // removed in favor of single-band header + left-rail actions, but the
+  // prop interface stays stable for the embedder API).
+  void hasAddButton; void hasScheduleTemplates; void hasImport;
+  void profileLabels; void visibleScheduleTemplates; void onScheduleTemplateAnalytics;
+  void sidebarOpen; void setSidebarOpen; void sidebarGroupLevels;
+  void setFormEvent; void setScheduleOpen; void setImportOpen;
+  void handleClearFilters;
   return (
     <div className={styles['mainPane']} data-wc-chrome={viewOwnsChrome ? 'view-owned' : undefined}>
       <div className={styles['calendarCard']} data-wc-chrome={viewOwnsChrome ? 'view-owned' : undefined}>
-        {!viewOwnsChrome && <SubToolbar
-          leftSlot={<>
-            <SidebarToggleButton
-              isOpen={sidebarOpen}
-              onClick={() => setSidebarOpen(!sidebarOpen)}
-              filterCount={hasActiveFilters(cal.filters as Record<string, unknown>, schema) ? 1 : 0}
-              groupCount={sidebarGroupLevels.length}
-            />
-            {hasAddButton && cal.view !== 'schedule' && (
-              <button
-                className={styles['addBtn']}
-                onClick={() => setFormEvent({})}
-                aria-label={`Add new ${profileLabels.event.toLowerCase()}`}
-                title={profileLabels.event === 'Event' ? undefined : `Create a new ${profileLabels.event.toLowerCase()}`}
-              >
-                <Plus size={14} aria-hidden="true" />
-                <span className={styles['addBtnLabel']}> New {profileLabels.event}</span>
-              </button>
-            )}
-            {hasAddButton && hasScheduleTemplates && (
-              <button
-                className={styles['addBtn']}
-                onClick={() => {
-                  setScheduleOpen(true);
-                  onScheduleTemplateAnalytics?.({
-                    event: 'schedule_dialog_opened',
-                    at: new Date().toISOString(),
-                    templateCount: visibleScheduleTemplates.length,
-                  });
-                }}
-                aria-label="Add schedule from template"
-              >
-                <Plus size={14} aria-hidden="true" /><span className={styles['addBtnLabel']}> Add Schedule</span>
-              </button>
-            )}
-          </>}
-          centerSlot={
-            (cal.view === 'schedule' || cal.view === 'base' || cal.view === 'assets')
-              ? <DayWindowPills value={cal.dayWindow} onChange={cal.setDayWindow} />
-              : null
-          }
-          rightSlot={<>
-            {hasImport && (
-              <button className={styles['exportBtn']} onClick={() => setImportOpen(true)} aria-label="Import .ics calendar">
-                <Upload size={15} aria-hidden="true" />
-              </button>
-            )}
-            <button className={styles['exportBtn']} onClick={() => exportVisibleEvents(visibleEvents)} aria-label="Export to Excel">
-              <Download size={15} aria-hidden="true" />
-            </button>
-          </>}
-        />}
-        {!viewOwnsChrome && <ActiveFilterStrip
-          filters={cal.filters as Record<string, unknown>}
-          schema={schema}
-          onChange={(key, value) => cal.setFilter(key, value)}
-          onClear={(key) => cal.clearFilter(key)}
-          onClearAll={handleClearFilters}
-        />}
+        {!viewOwnsChrome && (
+          <ActiveFilterStrip
+            filters={cal.filters as Record<string, unknown>}
+            schema={schema}
+            onChange={(key, value) => cal.setFilter(key, value)}
+            onClear={(key) => cal.clearFilter(key)}
+            onClearAll={handleClearFilters}
+          />
+        )}
         <div
           ref={swipeAreaRef}
           className={styles['viewArea']}

--- a/src/ui/DatePickerDropdown.tsx
+++ b/src/ui/DatePickerDropdown.tsx
@@ -1,0 +1,200 @@
+/**
+ * Compact date-picker dropdown for the calendar's top header band.
+ *
+ * Renders as a single button showing the active date label (formatted
+ * per view — month / week / day). Clicking opens a month grid: prev /
+ * next year navigation, twelve months in a 3×4 grid, plus a "Today"
+ * link. Selecting a month sets the calendar's currentDate to the 1st
+ * of that month and closes the dropdown.
+ *
+ * Replaces the prior multi-button cluster (<- / Today / -> / "June 2025")
+ * to free top-bar real estate at mobile widths. Aligned with the Dispatch
+ * board's single-row header pattern.
+ */
+import { useEffect, useRef, useState } from 'react';
+import { ChevronDown, ChevronLeft, ChevronRight } from 'lucide-react';
+
+const MONTH_LABELS = ['Jan','Feb','Mar','Apr','May','Jun','Jul','Aug','Sep','Oct','Nov','Dec'];
+
+export interface DatePickerDropdownProps {
+  /** Currently active date — drives the visible label + selected highlight. */
+  readonly currentDate: Date;
+  /** Pre-formatted label rendered on the closed button (e.g. "Jun 22 – 28, 2025"). */
+  readonly label: string;
+  /** Handler invoked when the user picks a month from the grid. */
+  readonly onDateChange: (date: Date) => void;
+  /** "Today" shortcut handler. */
+  readonly onToday: () => void;
+  /** Per-period nav arrows that keep working alongside the dropdown. */
+  readonly onPrev: () => void;
+  readonly onNext: () => void;
+  /** aria-keyshortcuts hints to surface the existing j/k/t bindings. */
+  readonly prevShortcut?: string;
+  readonly nextShortcut?: string;
+}
+
+export function DatePickerDropdown({
+  currentDate, label, onDateChange, onToday, onPrev, onNext,
+  prevShortcut, nextShortcut,
+}: DatePickerDropdownProps) {
+  const [open, setOpen] = useState(false);
+  // Year shown in the picker grid. Tracks currentDate while closed, but
+  // the user can flip years independently while the dropdown is open.
+  const [pickerYear, setPickerYear] = useState(() => currentDate.getFullYear());
+  const wrapRef = useRef<HTMLDivElement>(null);
+
+  // Close on outside click / Escape — mirrors AppHeader's hamburger.
+  useEffect(() => {
+    if (!open) return;
+    const onDocClick = (e: MouseEvent) => {
+      if (wrapRef.current && !wrapRef.current.contains(e.target as Node)) setOpen(false);
+    };
+    const onKey = (e: KeyboardEvent) => { if (e.key === 'Escape') setOpen(false); };
+    document.addEventListener('mousedown', onDocClick);
+    document.addEventListener('keydown', onKey);
+    return () => {
+      document.removeEventListener('mousedown', onDocClick);
+      document.removeEventListener('keydown', onKey);
+    };
+  }, [open]);
+
+  // Re-sync the picker year whenever the dropdown is re-opened, so users
+  // don't jump back to whatever year they were idly browsing last time.
+  useEffect(() => {
+    if (open) setPickerYear(currentDate.getFullYear());
+  }, [open, currentDate]);
+
+  const activeYear = currentDate.getFullYear();
+  const activeMonth = currentDate.getMonth();
+
+  return (
+    <div ref={wrapRef} style={{ position: 'relative', display: 'inline-flex', alignItems: 'center', gap: 4 }}>
+      <button
+        type="button"
+        onClick={onPrev}
+        aria-label="Previous period"
+        {...(prevShortcut ? { 'aria-keyshortcuts': prevShortcut } : {})}
+        style={navBtnStyle}
+      >
+        <ChevronLeft size={14} aria-hidden="true" />
+      </button>
+      <button
+        type="button"
+        onClick={() => setOpen(v => !v)}
+        aria-haspopup="dialog"
+        aria-expanded={open}
+        style={labelBtnStyle}
+      >
+        <span style={{ fontWeight: 700 }}>{label}</span>
+        <ChevronDown size={12} aria-hidden="true" />
+      </button>
+      <button
+        type="button"
+        onClick={onNext}
+        aria-label="Next period"
+        {...(nextShortcut ? { 'aria-keyshortcuts': nextShortcut } : {})}
+        style={navBtnStyle}
+      >
+        <ChevronRight size={14} aria-hidden="true" />
+      </button>
+      {open && (
+        <div
+          role="dialog"
+          aria-label="Pick a month"
+          style={{
+            position: 'absolute',
+            top: 'calc(100% + 4px)',
+            left: 0,
+            zIndex: 200,
+            minWidth: 240,
+            background: 'var(--wc-surface, #fff)',
+            border: '1px solid var(--wc-border, rgba(0,0,0,0.15))',
+            borderRadius: 8,
+            boxShadow: 'var(--wc-shadow, 0 8px 20px rgba(0,0,0,0.18))',
+            padding: 8,
+          }}
+        >
+          <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: 6 }}>
+            <button type="button" onClick={() => setPickerYear((y) => y - 1)} aria-label="Previous year" style={navBtnStyle}>
+              <ChevronLeft size={14} aria-hidden="true" />
+            </button>
+            <span style={{ fontWeight: 700, fontSize: 13 }}>{pickerYear}</span>
+            <button type="button" onClick={() => setPickerYear((y) => y + 1)} aria-label="Next year" style={navBtnStyle}>
+              <ChevronRight size={14} aria-hidden="true" />
+            </button>
+          </div>
+          <div style={{ display: 'grid', gridTemplateColumns: 'repeat(3, 1fr)', gap: 4 }}>
+            {MONTH_LABELS.map((m, i) => {
+              const isActive = pickerYear === activeYear && i === activeMonth;
+              return (
+                <button
+                  key={m}
+                  type="button"
+                  onClick={() => {
+                    onDateChange(new Date(pickerYear, i, 1));
+                    setOpen(false);
+                  }}
+                  style={{
+                    height: 28,
+                    border: 0,
+                    borderRadius: 4,
+                    background: isActive ? 'var(--wc-accent, #2563eb)' : 'transparent',
+                    color: isActive ? '#fff' : 'inherit',
+                    fontWeight: isActive ? 700 : 500,
+                    cursor: 'pointer',
+                    fontSize: 11,
+                  }}
+                >
+                  {m}
+                </button>
+              );
+            })}
+          </div>
+          <button
+            type="button"
+            onClick={() => { onToday(); setOpen(false); }}
+            style={{
+              marginTop: 6,
+              width: '100%',
+              height: 26,
+              border: '1px solid var(--wc-border, rgba(0,0,0,0.15))',
+              borderRadius: 4,
+              background: 'transparent',
+              cursor: 'pointer',
+              fontSize: 11,
+              fontWeight: 600,
+            }}
+          >
+            Today
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}
+
+const navBtnStyle: React.CSSProperties = {
+  display: 'inline-flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  width: 24,
+  height: 24,
+  padding: 0,
+  border: '1px solid var(--wc-border, rgba(0,0,0,0.15))',
+  borderRadius: 4,
+  background: 'transparent',
+  cursor: 'pointer',
+};
+
+const labelBtnStyle: React.CSSProperties = {
+  display: 'inline-flex',
+  alignItems: 'center',
+  gap: 4,
+  height: 24,
+  padding: '0 8px',
+  border: '1px solid var(--wc-border, rgba(0,0,0,0.15))',
+  borderRadius: 4,
+  background: 'var(--wc-surface-2, transparent)',
+  cursor: 'pointer',
+  fontSize: 12,
+};


### PR DESCRIPTION
…s cut buttons

Brings the standard calendar chrome in line with the Dispatch board's compact single-row pattern. Eliminates the ProfileBar (saved-views strip) and the in-card SubToolbar entirely.

New top band layout (AppHeader):
  - LEFT:    hamburger + ViewSwitcher (Month/Week/.../Dispatch)
  - CENTER:  DatePickerDropdown — single button labelled with the
             current period (e.g. "May 2026 v"), opens a month-grid
             picker with year nav + a Today shortcut. Prev/next arrows
             keep the j/k/Arrow shortcuts.
  - RIGHT:   Search / edit-mode toggle / timezone picker

Migrated to LeftRail (icon column) so nothing was dropped, just relocated:
  - Add new event (Plus)         — when hasAddButton
  - Add schedule from template   — when hasScheduleTemplates
  - Saved views (Bookmark)       — existing
  - Focus filters (Filter)       — existing
  - Import .ics (Upload)         — when hasImport
  - Export to Excel (Download)
  - Edit mode (Sparkles)         — when owner
  - Settings (gear)              — when owner

Built-in rail ids prefixed with `wc-` so embedder `leftRailExtras` entries using common ids ("export", "import", etc.) keep working unchanged.

Chrome-owning views (Dispatch) continue to suppress everything and slot the ViewSwitcher into their own header — unchanged from the prior commit.

## Summary
Describe exactly what this PR changes.

## Scope
- Stage: 
- Planned PR number in sprint: 
- Target files/directories: 
- Why this slice is isolated: 

## Lessons Learned Check (REQUIRED)
Confirm these were actively used while building this PR:

- [ ] PR is intentionally small and isolated
- [ ] Boundary typing was prioritized over internal perfection
- [ ] No silent spread of `any`
- [ ] Advisory root `tsc` was used to catch integration issues
- [ ] I did not assume “looks typed” means “safe”
- [ ] I stopped and isolated typing cascades instead of expanding scope

## Definition of Done (ALL REQUIRED)
This PR is not done unless every box is checked.

- [ ] `npm run type-check:strict` passes
- [ ] Root advisory `tsc --noEmit` passes
- [ ] Tests pass for touched scope at minimum
- [ ] No uncontrolled increase in `any`
- [ ] All new types are intentional and named
- [ ] Public interfaces and exported functions are explicitly typed
- [ ] PR scope matches the sprint plan with no scope creep
- [ ] Any new `any` has an adjacent justification comment
- [ ] No file-wide `: any`
- [ ] No implicit `any` in exported functions

## What Was Typed
List exactly what was typed in this PR.

- 
- 
- 

## What Was Intentionally Left Loose
List anything intentionally not tightened yet.

- 
- 
- 

## `any` Ledger (REQUIRED)
- New `any` added: 
- Existing `any` removed: 
- Net change: 

For every new `any`, explain why it is required and why a safer type was not used yet.

1. 
2. 
3. 

## Boundary Notes
Document any public seams, caller-protection choices, or compatibility decisions.

- 
- 
- 

## Risk Level
- [ ] Low
- [ ] Medium
- [ ] High

Why:

## Validation Evidence
Paste the exact commands run and a short result summary.

```bash
npm run type-check:strict
npx tsc --noEmit -p tsconfig.json
```

Test commands run:

```bash
# paste commands here
```

## Stop Conditions Check
If any item below happened, explain how scope was reduced before merge.

- [ ] `any` started spreading across files
- [ ] Root `tsc` broke repeatedly
- [ ] Types required cross-module rewrites
- [ ] Scope was reduced to keep the PR reviewable

Notes:

## Reviewer Focus
What should reviewers look at first?

- 
- 
- 
