### PR TITLE
fix(dispatch): unblur tiles, NOW→date dropdown, stable slider window,…

### DIFF
--- a/demo/main.tsx
+++ b/demo/main.tsx
@@ -32,6 +32,20 @@ const ASSETS = TRUCKS.map((t, i) => ({
   },
 }));
 
+// The static dataset is anchored at 2025-07-07 UTC for human-readability.
+// Shift every event by (today − anchor) at load so the demo always lands
+// on the current week — otherwise the slider window sits in 2025 and the
+// map is empty for anyone visiting the deployed demo.
+const DATASET_ANCHOR_MS = Date.UTC(2025, 6, 7); // months are 0-indexed
+const todayMidnight = new Date();
+todayMidnight.setUTCHours(0, 0, 0, 0);
+const DEMO_TIME_OFFSET_MS = todayMidnight.getTime() - DATASET_ANCHOR_MS;
+
+function shift(value: Date | string): Date {
+  const t = value instanceof Date ? value.getTime() : new Date(value).getTime();
+  return new Date(t + DEMO_TIME_OFFSET_MS);
+}
+
 // Flatten every truck's route legs into a single event stream. Each event
 // already carries `meta.lat/lng/facilityCode/facilityName/stopType` — the
 // convention the dispatch view's deriveData reader expects.
@@ -39,8 +53,8 @@ const FLEET_EVENTS: WorksCalendarEvent[] = TRUCK_ROUTES.flatMap((r) =>
   r.events.map((ev) => ({
     id: ev.id,
     title: ev.title,
-    start: ev.start,
-    end: ev.end,
+    start: shift(ev.start),
+    end: shift(ev.end),
     allDay: false,
     resource: ev.resource,
     meta: ev.meta,

--- a/src/ui/CalendarViewGrid.tsx
+++ b/src/ui/CalendarViewGrid.tsx
@@ -280,6 +280,12 @@ export default function CalendarViewGrid({
                   missions: dispatchMissions,
                   evaluateForMission: dispatchEvaluator,
                   onAssign: onDispatchAssign,
+                  // Share `cal.currentDate` with the dispatch board so the
+                  // calendar's source of truth flows both ways — scrubbing
+                  // the dispatch slider updates the date that Month / Week /
+                  // Day all read from, and vice-versa.
+                  currentDate: cal.currentDate,
+                  onCurrentDateChange: cal.setCurrentDate,
                   onAsOfChange: cal.setCurrentDate,
                   viewSwitcher,
                 } as unknown as ComponentProps<typeof DispatchView>)} />

--- a/src/views/DispatchView.tsx
+++ b/src/views/DispatchView.tsx
@@ -37,6 +37,10 @@ interface DispatchViewLooseProps {
   readonly events?: readonly NormalizedEvent[];
   readonly assets?: readonly DispatchAssetEntry[];
   readonly initialAsOf?: Date;
+  /** Host calendar's currentDate, fed through so the slider and the
+   *  Month/Week/Day views share a single source of truth. */
+  readonly currentDate?: Date;
+  readonly onCurrentDateChange?: (d: Date) => void;
   /** View-switcher node injected by the host when this view owns chrome. */
   readonly viewSwitcher?: ReactNode;
   // Legacy props (employees, bases, missions, evaluateForMission, onAssign, …)
@@ -54,6 +58,8 @@ export default function DispatchView(props: DispatchViewLooseProps) {
       events={events}
       assets={assets}
       {...(props.initialAsOf ? { initialDate: props.initialAsOf } : {})}
+      {...(props.currentDate ? { currentDate: props.currentDate } : {})}
+      {...(props.onCurrentDateChange ? { onCurrentDateChange: props.onCurrentDateChange } : {})}
       {...(props.viewSwitcher ? { viewSwitcher: props.viewSwitcher } : {})}
     />
   );

--- a/src/views/dispatch/DispatchBoard.tsx
+++ b/src/views/dispatch/DispatchBoard.tsx
@@ -16,6 +16,7 @@ import { AssetSidebar } from './AssetSidebar';
 import { TimeSlider } from './TimeSlider';
 import { deriveDispatchData } from './deriveData';
 import { deriveConflicts } from './deriveConflicts';
+import { DatePickerDropdown } from '../../ui/DatePickerDropdown';
 import type { MapLayer } from './types';
 import type { NormalizedEvent } from 'works-calendar-engine';
 
@@ -80,17 +81,33 @@ export function DispatchBoard({ events, assets = [], initialDate, viewSwitcher }
       <header className="h-10 flex items-center px-3 border-b-2 border-[#3d2b1f]/30 bg-[#d4c4a8] flex-shrink-0 gap-2">
         <div className="flex items-center gap-2 min-w-0 flex-1">
           {viewSwitcher}
-          <span className="text-[10px] text-[#5a3e2b] font-mono truncate hidden md:inline">
-            {selectedDate.toLocaleDateString('en-US', {
-              weekday: 'long',
-              year: 'numeric',
-              month: 'long',
+          <DatePickerDropdown
+            currentDate={selectedDate}
+            label={selectedDate.toLocaleDateString('en-US', {
+              month: 'short',
               day: 'numeric',
-              hour: 'numeric',
-              minute: '2-digit',
+              year: 'numeric',
               timeZone: 'UTC',
             })}
-          </span>
+            onDateChange={(d) => {
+              // Preserve the current hour/minute when picking a new month —
+              // we want to scrub to the same time-of-day in a different week.
+              const next = new Date(d);
+              next.setUTCHours(selectedDate.getUTCHours(), selectedDate.getUTCMinutes(), 0, 0);
+              setSelectedDate(next);
+            }}
+            onToday={() => setSelectedDate(new Date())}
+            onPrev={() => {
+              const d = new Date(selectedDate);
+              d.setUTCDate(d.getUTCDate() - 1);
+              setSelectedDate(d);
+            }}
+            onNext={() => {
+              const d = new Date(selectedDate);
+              d.setUTCDate(d.getUTCDate() + 1);
+              setSelectedDate(d);
+            }}
+          />
         </div>
         <div className="flex items-center gap-4">
           {todayConflicts.length > 0 && (
@@ -103,13 +120,6 @@ export function DispatchBoard({ events, assets = [], initialDate, viewSwitcher }
             </div>
           )}
           <div className="flex gap-1">
-            <button
-              type="button"
-              className="h-6 text-[10px] px-2 bg-transparent border border-[#3d2b1f]/30 text-[#3d2b1f] hover:bg-[#3d2b1f]/10 rounded-sm"
-              onClick={() => setSelectedDate(new Date())}
-            >
-              NOW
-            </button>
             <button
               type="button"
               className="h-6 text-[10px] px-2 bg-transparent border border-[#3d2b1f]/30 text-[#3d2b1f] hover:bg-[#3d2b1f]/10 rounded-sm"

--- a/src/views/dispatch/DispatchBoard.tsx
+++ b/src/views/dispatch/DispatchBoard.tsx
@@ -30,8 +30,15 @@ export interface DispatchAssetEntry {
 export interface DispatchBoardProps {
   readonly events: readonly NormalizedEvent[];
   readonly assets?: readonly DispatchAssetEntry[];
-  /** Initial "now". Defaults to current wall clock. */
+  /** Initial "now" — only consulted when no controlled `currentDate` is
+   *  supplied. Defaults to current wall clock. */
   readonly initialDate?: Date;
+  /** Controlled "as of" timestamp. When provided, the board uses this as
+   *  its single source of truth and any slider / date-picker change
+   *  emits via `onCurrentDateChange`. Keeps the dispatch view in sync
+   *  with the host calendar's currentDate when both are rendered. */
+  readonly currentDate?: Date;
+  readonly onCurrentDateChange?: (d: Date) => void;
   /** Optional view-switcher tabs to render inline in the board header,
    *  used when the host calendar hands over its full chrome to this view. */
   readonly viewSwitcher?: ReactNode;
@@ -44,8 +51,11 @@ const LAYERS: { id: MapLayer; label: string }[] = [
   { id: '1k', label: '1k ft' },
 ];
 
-export function DispatchBoard({ events, assets = [], initialDate, viewSwitcher }: DispatchBoardProps) {
-  const [selectedDate, setSelectedDate] = useState<Date>(() => {
+export function DispatchBoard({
+  events, assets = [], initialDate, currentDate, onCurrentDateChange, viewSwitcher,
+}: DispatchBoardProps) {
+  const [uncontrolledDate, setUncontrolledDate] = useState<Date>(() => {
+    if (currentDate) return currentDate;
     if (initialDate) return initialDate;
     // Default: median event time so the slider lands inside the dataset's
     // window. Falls through to real "now" only when there are no events.
@@ -53,6 +63,11 @@ export function DispatchBoard({ events, assets = [], initialDate, viewSwitcher }
     const sorted = [...events].map((e) => e.start.getTime()).sort((a, b) => a - b);
     return new Date(sorted[Math.floor(sorted.length / 2)]!);
   });
+  const selectedDate = currentDate ?? uncontrolledDate;
+  const setSelectedDate = (next: Date) => {
+    if (onCurrentDateChange) onCurrentDateChange(next);
+    if (currentDate === undefined) setUncontrolledDate(next);
+  };
   const [selectedAsset, setSelectedAsset] = useState<string | null>(null);
   const [layer, setLayer] = useState<MapLayer>('region');
 

--- a/src/views/dispatch/TacticalMap.tsx
+++ b/src/views/dispatch/TacticalMap.tsx
@@ -87,17 +87,6 @@ export function TacticalMap({
           <feTurbulence type="fractalNoise" baseFrequency="0.015" numOctaves={2} result="n" />
           <feDisplacementMap in="SourceGraphic" in2="n" scale={2} />
         </filter>
-        {/* Sepia/parchment wash applied to the OSM raster tiles so they
-            sit underneath the dispatch ink layer without fighting it. */}
-        <filter id="dispatch-tile-tone">
-          <feColorMatrix
-            type="matrix"
-            values="0.55 0.40 0.10 0 0.05
-                    0.45 0.45 0.10 0 0.05
-                    0.35 0.30 0.20 0 0.05
-                    0    0    0    1 0"
-          />
-        </filter>
         {/* Soft drop shadow for the arched breadcrumbs to read as
             lifted above the ground plane. */}
         <filter id="dispatch-arch-shadow" x="-20%" y="-20%" width="140%" height="140%">
@@ -116,29 +105,37 @@ export function TacticalMap({
       <rect width={VW} height={VH} fill="#e8dcc8" />
 
       {/* OSM raster tile basemap — each tile is placed by projecting its
-          NW/SE corners through the current layer's bounds. Wrapped in a
-          clip so tiles that overhang the viewBox don't bleed. */}
+          NW/SE corners through the current layer's bounds. Tiles render
+          in their natural OSM colors so labels stay legible; a translucent
+          warm overlay below the data layer ties them to the dispatch
+          parchment palette without softening the map text. */}
       {tiles.length > 0 && (
-        <g filter="url(#dispatch-tile-tone)" opacity={0.75}>
-          {tiles.map((t) => {
-            const [x1, y1] = proj(t.nw.lat, t.nw.lng);
-            const [x2, y2] = proj(t.se.lat, t.se.lng);
-            const w = x2 - x1;
-            const h = y2 - y1;
-            return (
-              <image
-                key={`${t.z}-${t.x}-${t.y}`}
-                href={t.url}
-                x={x1}
-                y={y1}
-                width={w}
-                height={h}
-                preserveAspectRatio="none"
-                crossOrigin="anonymous"
-              />
-            );
-          })}
-        </g>
+        <>
+          <g>
+            {tiles.map((t) => {
+              const [x1, y1] = proj(t.nw.lat, t.nw.lng);
+              const [x2, y2] = proj(t.se.lat, t.se.lng);
+              const w = x2 - x1;
+              const h = y2 - y1;
+              return (
+                <image
+                  key={`${t.z}-${t.x}-${t.y}`}
+                  href={t.url}
+                  x={x1}
+                  y={y1}
+                  width={w}
+                  height={h}
+                  preserveAspectRatio="none"
+                  crossOrigin="anonymous"
+                  style={{ imageRendering: 'auto' }}
+                />
+              );
+            })}
+          </g>
+          {/* Faint parchment wash — pulls the OSM palette toward the
+              dispatch theme without blurring the underlying labels. */}
+          <rect width={VW} height={VH} fill="#e8dcc8" opacity={0.22} />
+        </>
       )}
 
       {/* Layer-name watermark for the non-region zoom presets, since the

--- a/src/views/dispatch/TimeSlider.tsx
+++ b/src/views/dispatch/TimeSlider.tsx
@@ -9,7 +9,7 @@
  * (default 14 days) and origin date are configurable via props so
  * the slider doesn't hardcode the truck demo's July 2025 baseline.
  */
-import { useMemo } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { Slider } from './Slider';
 import type { DispatchAsset, DispatchSegment } from './types';
 
@@ -38,13 +38,42 @@ export function TimeSlider({
   windowOrigin,
   windowDays = 14,
 }: Props) {
-  const origin = useMemo<Date>(() => {
+  // Anchor the window once and only re-anchor when the consumer overrides
+  // it explicitly OR the current selection scrubs outside the visible
+  // range. Recomputing origin on every selectedDate change made the
+  // window track the thumb, pinning the slider position visually even
+  // though the underlying date was advancing.
+  const [origin, setOrigin] = useState<Date>(() => {
     if (windowOrigin) return windowOrigin;
     const d = new Date(selectedDate);
-    d.setUTCDate(d.getUTCDate() - 4);
+    d.setUTCDate(d.getUTCDate() - Math.floor(windowDays / 2));
     d.setUTCHours(0, 0, 0, 0);
     return d;
-  }, [windowOrigin, selectedDate]);
+  });
+  // Sync to an externally-supplied origin if it changes.
+  useEffect(() => {
+    if (windowOrigin) setOrigin(windowOrigin);
+  }, [windowOrigin]);
+  // Re-anchor if the selection scrubs outside the current window — keeps
+  // the thumb on-screen when the calendar jumps to a far-away date.
+  useEffect(() => {
+    const diffDays = Math.floor((selectedDate.getTime() - origin.getTime()) / MS_PER_DAY);
+    if (diffDays < 0 || diffDays >= windowDays) {
+      const d = new Date(selectedDate);
+      d.setUTCDate(d.getUTCDate() - Math.floor(windowDays / 2));
+      d.setUTCHours(0, 0, 0, 0);
+      setOrigin(d);
+    }
+  }, [selectedDate, origin, windowDays]);
+
+  // Index that today's wall-clock date falls on within the window — used
+  // for the dashed red "now" cursor and the bottom-row TODAY tick.
+  const todayIndex = useMemo(() => {
+    const t = new Date();
+    t.setUTCHours(0, 0, 0, 0);
+    const diff = Math.floor((t.getTime() - origin.getTime()) / MS_PER_DAY);
+    return diff >= 0 && diff < windowDays ? diff : -1;
+  }, [origin, windowDays]);
 
   const days = useMemo(
     () =>
@@ -55,10 +84,10 @@ export function TimeSlider({
           index: i,
           date: d,
           label: d.toLocaleDateString('en-US', { month: 'short', day: 'numeric', timeZone: 'UTC' }),
-          isToday: i === Math.floor(windowDays / 2 - 3),
+          isToday: i === todayIndex,
         };
       }),
-    [origin, windowDays],
+    [origin, windowDays, todayIndex],
   );
 
   const currentDay = useMemo(() => {
@@ -156,18 +185,20 @@ export function TimeSlider({
                 opacity={0.2}
               />
             ))}
-            {/* "Now" cursor (interpreted as the originally-loaded "today" at the
-                 midpoint of the window) — dashed red guide */}
-            <line
-              x1={Math.floor(windowDays / 2 - 3) * HOURS_PER_DAY}
-              y1={0}
-              x2={Math.floor(windowDays / 2 - 3) * HOURS_PER_DAY}
-              y2={60}
-              stroke="#c0392b"
-              strokeWidth={1}
-              opacity={0.5}
-              strokeDasharray="4,2"
-            />
+            {/* "Now" cursor — wall-clock today, dashed red guide. Only
+                 drawn when today actually falls within the visible window. */}
+            {todayIndex >= 0 && (
+              <line
+                x1={todayIndex * HOURS_PER_DAY}
+                y1={0}
+                x2={todayIndex * HOURS_PER_DAY}
+                y2={60}
+                stroke="#c0392b"
+                strokeWidth={1}
+                opacity={0.5}
+                strokeDasharray="4,2"
+              />
+            )}
             {/* Current selectedDate cursor — solid */}
             {(() => {
               const dayOffset = currentDay * HOURS_PER_DAY;


### PR DESCRIPTION
… demo on today

Four-part fix to the dispatch view that was reported on the deployed demo:

1. Tile basemap clarity — the sepia feColorMatrix wash was muddying OSM labels and saturating the whole basemap. Replaced with a translucent parchment rect rendered above the tiles, which keeps text crisp while still tying the basemap to the dispatch palette.

2. NOW button → DatePickerDropdown — the bare "NOW" button only jumped to wall-clock today and gave no way to scrub to an arbitrary date. Swapped for the shared DatePickerDropdown component used on the main calendar header: prev/next arrows, current period label, and a month-grid picker with year nav + Today shortcut.

3. Stable slider window — TimeSlider was recomputing `origin` from selectedDate on every render, so dragging the day slider re-anchored the window around the new selection and the thumb stayed visually pinned at the center. Now origin is local state, anchored once on mount, and only re-anchored when the selection scrubs outside the visible 14-day window. The TODAY tick uses wall-clock today instead of a hard-coded index.

4. Demo dataset on current dates — the static truckDemoData payload is anchored at 2025-07-07 for human-readability. main.tsx now shifts every event by `(today − anchor)` at load so visitors to the deployed demo see breadcrumbs / conflicts on today's week instead of an empty map.

## Summary
Describe exactly what this PR changes.

## Scope
- Stage: 
- Planned PR number in sprint: 
- Target files/directories: 
- Why this slice is isolated: 

## Lessons Learned Check (REQUIRED)
Confirm these were actively used while building this PR:

- [ ] PR is intentionally small and isolated
- [ ] Boundary typing was prioritized over internal perfection
- [ ] No silent spread of `any`
- [ ] Advisory root `tsc` was used to catch integration issues
- [ ] I did not assume “looks typed” means “safe”
- [ ] I stopped and isolated typing cascades instead of expanding scope

## Definition of Done (ALL REQUIRED)
This PR is not done unless every box is checked.

- [ ] `npm run type-check:strict` passes
- [ ] Root advisory `tsc --noEmit` passes
- [ ] Tests pass for touched scope at minimum
- [ ] No uncontrolled increase in `any`
- [ ] All new types are intentional and named
- [ ] Public interfaces and exported functions are explicitly typed
- [ ] PR scope matches the sprint plan with no scope creep
- [ ] Any new `any` has an adjacent justification comment
- [ ] No file-wide `: any`
- [ ] No implicit `any` in exported functions

## What Was Typed
List exactly what was typed in this PR.

- 
- 
- 

## What Was Intentionally Left Loose
List anything intentionally not tightened yet.

- 
- 
- 

## `any` Ledger (REQUIRED)
- New `any` added: 
- Existing `any` removed: 
- Net change: 

For every new `any`, explain why it is required and why a safer type was not used yet.

1. 
2. 
3. 

## Boundary Notes
Document any public seams, caller-protection choices, or compatibility decisions.

- 
- 
- 

## Risk Level
- [ ] Low
- [ ] Medium
- [ ] High

Why:

## Validation Evidence
Paste the exact commands run and a short result summary.

```bash
npm run type-check:strict
npx tsc --noEmit -p tsconfig.json
```

Test commands run:

```bash
# paste commands here
```

## Stop Conditions Check
If any item below happened, explain how scope was reduced before merge.

- [ ] `any` started spreading across files
- [ ] Root `tsc` broke repeatedly
- [ ] Types required cross-module rewrites
- [ ] Scope was reduced to keep the PR reviewable

Notes:

## Reviewer Focus
What should reviewers look at first?

- 
- 
- 
