### PR TITLE
fix(dispatch): no more crash switching region → 5k / 1k layers

### DIFF
--- a/src/views/dispatch/TacticalMap.tsx
+++ b/src/views/dispatch/TacticalMap.tsx
@@ -159,7 +159,15 @@ export function TacticalMap({
           lifts off the ground plane, giving an origin→destination "flight
           path" feel without needing real road routing. Past legs render
           solid + colored; future legs dashed + dim. A faint shadow ellipse
-          under each apex reinforces the 3D read. */}
+          under each apex reinforces the 3D read.
+
+          Off-screen culling: at zoomed-in layers (5k / 1k) most segments
+          have endpoints far outside the viewBox. The arches still need to
+          render when they cross the visible area, but segments whose
+          entire bounding box sits beyond a generous margin are dropped.
+          Avoids painting hundreds of paths with multi-thousand-pixel
+          coordinates — combined with the SVG ink filter that was crashing
+          iOS Safari when switching from region → 5k. */}
       {assets.flatMap((asset) => {
         const segs = segmentsByAsset.get(asset.id) ?? [];
         const isSelected = asset.id === selectedAsset;
@@ -167,6 +175,14 @@ export function TacticalMap({
         return segs.map((seg, i) => {
           const [x1, y1] = proj(seg.from.lat, seg.from.lng);
           const [x2, y2] = proj(seg.to.lat, seg.to.lng);
+          const MARGIN = 200;
+          const minX = Math.min(x1, x2);
+          const maxX = Math.max(x1, x2);
+          const minY = Math.min(y1, y2);
+          const maxY = Math.max(y1, y2);
+          if (maxX < -MARGIN || minX > VW + MARGIN || maxY < -MARGIN || minY > VH + MARGIN) {
+            return null;
+          }
           const dx = x2 - x1;
           const dy = y2 - y1;
           const len = Math.sqrt(dx * dx + dy * dy);
@@ -214,7 +230,7 @@ export function TacticalMap({
                 strokeWidth={stroke}
                 strokeLinecap="round"
                 strokeDasharray={past ? 'none' : '5,4'}
-                filter={isSelected ? 'url(#dispatch-arch-shadow)' : 'url(#dispatch-ink)'}
+                {...(isSelected ? { filter: 'url(#dispatch-arch-shadow)' } : {})}
               />
             </g>
           );


### PR DESCRIPTION
Two changes to the breadcrumb arch renderer that together kill the mobile-Safari crash reported when zooming from the region layer into a tighter projection:

1. Cull off-screen segments. At 5k / 1k bounds most legs (PHX→LAS, PHX→SAN, etc.) project to coordinates thousands of pixels outside the 1000×800 viewBox. Skip any segment whose entire bounding box sits beyond a 200px safety margin. Reduces path count from ~290 at region to ~170 at 5k and ~127 at 1k.

2. Drop the dispatch-ink SVG filter from unselected breadcrumbs. SVG filters allocate a filter region the size of the painted element's bounding box; a path running from (-3431, 934) to (481, 401) made iOS Safari try to allocate a multi-megapixel feTurbulence buffer per segment, which OOMed the page. Selected paths still get the lighter dispatch-arch-shadow filter; unselected render as plain colored strokes.

## Summary
Describe exactly what this PR changes.

## Scope
- Stage: 
- Planned PR number in sprint: 
- Target files/directories: 
- Why this slice is isolated: 

## Lessons Learned Check (REQUIRED)
Confirm these were actively used while building this PR:

- [ ] PR is intentionally small and isolated
- [ ] Boundary typing was prioritized over internal perfection
- [ ] No silent spread of `any`
- [ ] Advisory root `tsc` was used to catch integration issues
- [ ] I did not assume “looks typed” means “safe”
- [ ] I stopped and isolated typing cascades instead of expanding scope

## Definition of Done (ALL REQUIRED)
This PR is not done unless every box is checked.

- [ ] `npm run type-check:strict` passes
- [ ] Root advisory `tsc --noEmit` passes
- [ ] Tests pass for touched scope at minimum
- [ ] No uncontrolled increase in `any`
- [ ] All new types are intentional and named
- [ ] Public interfaces and exported functions are explicitly typed
- [ ] PR scope matches the sprint plan with no scope creep
- [ ] Any new `any` has an adjacent justification comment
- [ ] No file-wide `: any`
- [ ] No implicit `any` in exported functions

## What Was Typed
List exactly what was typed in this PR.

- 
- 
- 

## What Was Intentionally Left Loose
List anything intentionally not tightened yet.

- 
- 
- 

## `any` Ledger (REQUIRED)
- New `any` added: 
- Existing `any` removed: 
- Net change: 

For every new `any`, explain why it is required and why a safer type was not used yet.

1. 
2. 
3. 

## Boundary Notes
Document any public seams, caller-protection choices, or compatibility decisions.

- 
- 
- 

## Risk Level
- [ ] Low
- [ ] Medium
- [ ] High

Why:

## Validation Evidence
Paste the exact commands run and a short result summary.

```bash
npm run type-check:strict
npx tsc --noEmit -p tsconfig.json
```

Test commands run:

```bash
# paste commands here
```

## Stop Conditions Check
If any item below happened, explain how scope was reduced before merge.

- [ ] `any` started spreading across files
- [ ] Root `tsc` broke repeatedly
- [ ] Types required cross-module rewrites
- [ ] Scope was reduced to keep the PR reviewable

Notes:

## Reviewer Focus
What should reviewers look at first?

- 
- 
- 
