### PR TITLE
feat(demo): one dataset, every tab — Schedule + Base now reflect the …

### DIFF
--- a/demo/main.tsx
+++ b/demo/main.tsx
@@ -1,36 +1,20 @@
 /**
  * works-calendar — public demo deployed to workscalendar.com.
  *
- * The calendar is the host. The dispatch board is just its 'dispatch'
- * view, fed the same events any other view would render. Switch to
- * Month / Week / Day in the toolbar to see the same fleet data
- * through a traditional calendar grid.
+ * One dataset, every tab. Trucks (assets), drivers (employees), facilities
+ * (bases) all share IDs / hub codes so the Month / Week / Schedule / Base /
+ * Assets / Dispatch tabs all read off the same source of truth. The
+ * dispatch board is just one window onto the fleet — switch tabs and you
+ * see the same trucks and drivers grouped a different way.
  */
 import React from 'react';
 import { createRoot } from 'react-dom/client';
 import { WorksCalendar } from '../src/index';
 import type { WorksCalendarEvent } from '../src/index';
-import { TRUCKS, TRUCK_ROUTES, FACILITIES } from './truckDemoData';
+import { TRUCKS, TRUCK_ROUTES, DRIVERS, BASES, REGIONS } from './truckDemoData';
 import '../src/styles/soft.css';
 
-// Truck colors — keyed by position in the TRUCKS roster so they stay
-// stable across reloads. Lifted from the original dispatch board demo.
-const FLEET_PALETTE = [
-  '#e74c3c', '#e67e22', '#f39c12', '#27ae60', '#2980b9',
-  '#8e44ad', '#c0392b', '#d35400', '#16a085', '#2c3e50',
-];
-
-const ASSETS = TRUCKS.map((t, i) => ({
-  id: t.id,
-  label: `${t.id} — ${t.name}`,
-  group: t.hub,
-  meta: {
-    color: FLEET_PALETTE[i % FLEET_PALETTE.length]!,
-    type: t.type,
-    capacity: t.capacity,
-    hub: t.hub,
-  },
-}));
+const CALENDAR_ID = 'dispatch-demo-v3';
 
 // The static dataset is anchored at 2025-07-07 UTC for human-readability.
 // Shift every event by (today − anchor) at load so the demo always lands
@@ -46,10 +30,31 @@ function shift(value: Date | string): Date {
   return new Date(t + DEMO_TIME_OFFSET_MS);
 }
 
-// Flatten every truck's route legs into a single event stream. Each event
-// already carries `meta.lat/lng/facilityCode/facilityName/stopType` — the
-// convention the dispatch view's deriveData reader expects.
-const FLEET_EVENTS: WorksCalendarEvent[] = TRUCK_ROUTES.flatMap((r) =>
+const ASSETS = TRUCKS.map((t) => {
+  const driver = DRIVERS.find((d) => d.id === t.id);
+  return {
+    id: t.id,
+    label: `${t.id} — ${t.name}`,
+    group: t.hub,
+    meta: {
+      color: driver?.color,
+      type: t.type,
+      capacity: t.capacity,
+      base: t.hub,
+      hub: t.hub,
+      driverId: t.id,
+      driverName: driver?.name ?? '',
+    },
+  };
+});
+
+// One event stream covers the whole demo. The dispatch board reads each
+// stop's `meta.lat/lng/facilityCode/stopType` to draw the truck on the
+// map; the Schedule / Base grids draw the driver's duty *shift* (start
+// of first stop → end of last stop on that calendar day), tagged with
+// category='shift' so the schedule-tab scope predicate lets them in.
+// The same resource id binds both records to the same driver/truck.
+const STOP_EVENTS: WorksCalendarEvent[] = TRUCK_ROUTES.flatMap((r) =>
   r.events.map((ev) => ({
     id: ev.id,
     title: ev.title,
@@ -61,14 +66,86 @@ const FLEET_EVENTS: WorksCalendarEvent[] = TRUCK_ROUTES.flatMap((r) =>
   })),
 );
 
+// Synthesize one duty-shift event per (driver × calendar day) from the
+// segment depart/arrive times so the Schedule + Base + Month / Week / Day
+// views light up with each driver's daily window. Categorising the shift
+// as 'shift' triggers the schedule-tab inclusion predicate (see
+// `isScheduleWorkflowEvent` in works-calendar-engine).
+function dayKey(date: Date): string {
+  return `${date.getUTCFullYear()}-${date.getUTCMonth()}-${date.getUTCDate()}`;
+}
+
+const SHIFT_EVENTS: WorksCalendarEvent[] = TRUCK_ROUTES.flatMap((r) => {
+  const driverId = r.truck.id;
+  const byDay = new Map<string, { start: Date; end: Date }>();
+  for (const seg of r.segments) {
+    const depart = shift(seg.depart);
+    const arrive = shift(seg.arrive);
+    const key = dayKey(depart);
+    const existing = byDay.get(key);
+    if (!existing) {
+      byDay.set(key, { start: depart, end: arrive });
+    } else {
+      if (depart < existing.start) existing.start = depart;
+      if (arrive > existing.end) existing.end = arrive;
+    }
+  }
+  return Array.from(byDay.entries()).map(([key, win]) => ({
+    id: `shift-${driverId}-${key}`,
+    title: `${r.truck.name} — duty`,
+    start: win.start,
+    end: win.end,
+    allDay: false,
+    resource: driverId,
+    category: 'shift',
+    meta: { kind: 'shift', truckId: driverId, base: r.truck.hub },
+  }));
+});
+
+const FLEET_EVENTS: WorksCalendarEvent[] = [...STOP_EVENTS, ...SHIFT_EVENTS];
+
+// Seed the calendar's owner config so the Base + Schedule views have a
+// bases/regions registry to draw rows from. The config layer is normally
+// editable through the in-app gear panel + persisted to localStorage; for
+// the demo we just write straight to the same localStorage key on boot so
+// the data is there before WorksCalendar's first render.
+try {
+  const key = `wc-config-${CALENDAR_ID}`;
+  if (typeof window !== 'undefined' && !window.localStorage.getItem(key)) {
+    window.localStorage.setItem(
+      key,
+      JSON.stringify({
+        title: 'Fleet Dispatch Demo',
+        team: {
+          locationLabel: 'Base',
+          assetsLabel: 'Truck',
+          roles: ['Driver', 'Dispatcher', 'Mechanic'],
+          bases: BASES.map((b) => ({ id: b.id, name: b.name, regionId: b.regionId })),
+          regions: REGIONS,
+        },
+      }),
+    );
+  }
+} catch {
+  // localStorage unavailable (private mode / SSR) — fall through; the
+  // tabs that read bases/regions will just render empty.
+}
+
 function DemoApp() {
   return (
     <div style={{ height: '100vh', width: '100vw', overflow: 'hidden' }}>
       <WorksCalendar
-        calendarId="dispatch-demo-v2"
+        calendarId={CALENDAR_ID}
         initialView="dispatch"
         events={FLEET_EVENTS}
         assets={ASSETS}
+        employees={DRIVERS.map((d) => ({
+          id: d.id,
+          name: d.name,
+          base: d.base,
+          role: d.role,
+          color: d.color,
+        }))}
         showCalendarLegend={false}
         showOfflineIndicator={false}
       />

--- a/demo/truckDemoData.ts
+++ b/demo/truckDemoData.ts
@@ -90,6 +90,76 @@ export const TRUCKS: DemoTruck[] = [
   { id: "T030", name: "Long Haul 5 (ELP-PHX)", hub: "ELP", type: "dry_van", capacity: 28000 },
 ];
 
+// ── Drivers ────────────────────────────────────────────────────────────────
+// Driver ids deliberately match their truck id so the existing event stream
+// (which carries `resource: truckId`) lands cleanly on the driver row when
+// the schedule view renders. One human per truck — the demo doesn't try to
+// model relief drivers / pool rotations yet.
+
+export interface DemoDriver {
+  /** Matches the assigned truck id. */
+  id: string;
+  name: string;
+  /** Hub code — matches the truck's hub and the facility code that anchors
+   *  this driver to a base on the Base / Schedule tabs. */
+  base: string;
+  role: string;
+  /** Cumulative on-duty hours for the current day. Surfaces the FMCSA
+   *  11-hour duty cap when the request-matching flow lands later. */
+  dutyHoursToday: number;
+  color: string;
+}
+
+const FLEET_PALETTE = [
+  '#e74c3c', '#e67e22', '#f39c12', '#27ae60', '#2980b9',
+  '#8e44ad', '#c0392b', '#d35400', '#16a085', '#2c3e50',
+];
+
+const DRIVER_NAMES = [
+  'Alex Rivera', 'Bailey Chen', 'Carlos Mendez', 'Dana Park', 'Evan Brooks',
+  'Frankie Doyle', 'Gabriela Reyes', 'Hank Sullivan', 'Imani Webb', 'Jordan Liu',
+  'Kara Whitfield', 'Leo Tanaka', 'Maya Singh', 'Nico Alvarado', 'Olivia Kerr',
+  'Priya Nair', 'Quinn Hollis', 'Rosa Mireles', 'Sam Okafor', 'Tess Calderon',
+  'Umar Khalid', 'Vince Petrosian', 'Wendy Brock', 'Xander Vega', 'Yui Nakamura',
+  'Zane Hartwell', 'Adriana Cole', 'Beto Aguirre', 'Cleo Whitman', 'Diego Salas',
+];
+
+export const DRIVERS: DemoDriver[] = TRUCKS.map((t, i) => ({
+  id: t.id,
+  name: DRIVER_NAMES[i % DRIVER_NAMES.length]!,
+  base: t.hub,
+  role: 'Driver',
+  // Deterministic spread so the duty-hours column reads differently per
+  // driver without making the demo non-reproducible.
+  dutyHoursToday: Math.round(((i * 37) % 110) / 10),
+  color: FLEET_PALETTE[i % FLEET_PALETTE.length]!,
+}));
+
+// ── Bases ────────────────────────────────────────────────────────────────
+// Hub facilities promoted to first-class "bases" so the Base Gantt view +
+// Schedule view can group drivers/trucks by their home location, and so the
+// host calendar's filter sidebar has a real base list to show.
+
+export interface DemoBase {
+  id: string;
+  name: string;
+  regionId: string;
+  lat: number;
+  lng: number;
+}
+
+export const REGIONS = [
+  { id: 'sw', name: 'Southwest US' },
+];
+
+export const BASES: DemoBase[] = Object.values(FACILITIES).map((f) => ({
+  id: f.code,
+  name: f.name,
+  regionId: 'sw',
+  lat: f.lat,
+  lng: f.lng,
+}));
+
 export const TRUCK_ROUTES: TruckRoute[] = [
   {
     truck: TRUCKS.find(t => t.id === "T001")!,


### PR DESCRIPTION
…fleet

Up to now the demo only fed events into the Dispatch tab; Schedule and Base were blank because the dataset had no drivers, no bases, no regions, and no shift-class events for the schedule-tab scope predicate to admit.

Demo data additions:
  - DRIVERS — one human per truck, id deliberately matches the truck id so the existing route stops flow into the driver row when the schedule view filters events by `resource === employee.id`. Each driver carries a base (= truck hub), role 'Driver', deterministic dutyHoursToday, and matching color.
  - BASES — the 10 facility records lifted into first-class bases so the Base + Schedule views have a registry to lane events against.
  - REGIONS — single 'Southwest US' region; all bases roll up to it.

Demo main.tsx changes:
  - Seeds `wc-config-<calendarId>` localStorage with team.bases, team.regions, team.roles, locationLabel='Base', assetsLabel='Truck' on first load so the Base + Schedule + filter sidebar pick those up before WorksCalendar's first render.
  - Passes employees={DRIVERS} as a top-level prop.
  - Synthesises one duty-shift event per (driver × calendar day) from the segment depart/arrive times, tagged `category: 'shift'` and `meta.kind: 'shift'` so the schedule-tab scope predicate (`isScheduleWorkflowEvent`) lets them through. Stop events still flow into Dispatch unchanged; shift events have no lat/lng so the dispatch view filters them out cleanly.
  - Bumps calendarId so old localStorage doesn't shadow the new seed.

Result: Schedule shows orange driver-shift bars per driver per day, Base shows the regional rollup with each base's trucks and people, Trucks (Assets) shows the truck registry, Dispatch unchanged. All four read from the same trucks/drivers/bases/events source.

## Summary
Describe exactly what this PR changes.

## Scope
- Stage: 
- Planned PR number in sprint: 
- Target files/directories: 
- Why this slice is isolated: 

## Lessons Learned Check (REQUIRED)
Confirm these were actively used while building this PR:

- [ ] PR is intentionally small and isolated
- [ ] Boundary typing was prioritized over internal perfection
- [ ] No silent spread of `any`
- [ ] Advisory root `tsc` was used to catch integration issues
- [ ] I did not assume “looks typed” means “safe”
- [ ] I stopped and isolated typing cascades instead of expanding scope

## Definition of Done (ALL REQUIRED)
This PR is not done unless every box is checked.

- [ ] `npm run type-check:strict` passes
- [ ] Root advisory `tsc --noEmit` passes
- [ ] Tests pass for touched scope at minimum
- [ ] No uncontrolled increase in `any`
- [ ] All new types are intentional and named
- [ ] Public interfaces and exported functions are explicitly typed
- [ ] PR scope matches the sprint plan with no scope creep
- [ ] Any new `any` has an adjacent justification comment
- [ ] No file-wide `: any`
- [ ] No implicit `any` in exported functions

## What Was Typed
List exactly what was typed in this PR.

- 
- 
- 

## What Was Intentionally Left Loose
List anything intentionally not tightened yet.

- 
- 
- 

## `any` Ledger (REQUIRED)
- New `any` added: 
- Existing `any` removed: 
- Net change: 

For every new `any`, explain why it is required and why a safer type was not used yet.

1. 
2. 
3. 

## Boundary Notes
Document any public seams, caller-protection choices, or compatibility decisions.

- 
- 
- 

## Risk Level
- [ ] Low
- [ ] Medium
- [ ] High

Why:

## Validation Evidence
Paste the exact commands run and a short result summary.

```bash
npm run type-check:strict
npx tsc --noEmit -p tsconfig.json
```

Test commands run:

```bash
# paste commands here
```

## Stop Conditions Check
If any item below happened, explain how scope was reduced before merge.

- [ ] `any` started spreading across files
- [ ] Root `tsc` broke repeatedly
- [ ] Types required cross-module rewrites
- [ ] Scope was reduced to keep the PR reviewable

Notes:

## Reviewer Focus
What should reviewers look at first?

- 
- 
- 
