### PR TITLE
feat(demo): model unload windows + driver HOS limits

### DIFF
--- a/demo/highways.ts
+++ b/demo/highways.ts
@@ -1,0 +1,142 @@
+/**
+ * Demo-only highway corridor graph.
+ *
+ * Pure data + lookup helpers that turn a (from-facility, to-facility) pair
+ * into an ordered list of lat/lng waypoints following the actual Interstate
+ * corridor. The dispatch view consumes these via the `getRouteWaypoints`
+ * prop and draws an SVG polyline instead of the straight-line / arch
+ * fallback, so a PHX → ELP leg traces real I-10 (PHX → TUS → ELP) instead
+ * of crow's-flighting through the desert.
+ *
+ * This belongs in the demo — the engine doesn't know about roads. Hosts
+ * shipping their own dispatch app can plug in OSRM / GraphHopper / a
+ * floor plan / great-circle, whatever fits their domain. The dispatch
+ * view only consumes the callback's output.
+ */
+
+export interface HighwayWaypoint {
+  /** Facility code if this point is one of our demo facilities, otherwise
+   *  a synthetic id naming the junction. */
+  readonly code: string;
+  readonly lat: number;
+  readonly lng: number;
+}
+
+/**
+ * Major interstate corridors in the SW US, ordered by drive sequence.
+ * Each entry lists the facility codes the corridor touches in one
+ * direction; the lookup transparently handles the reverse.
+ *
+ * Picked corridors to cover the 30 demo trucks' usual lanes:
+ *   - I-10  : LAX → PHX → TUS → ELP   (E/W spine)
+ *   - I-40  : BAR → KIN → FLG → ABQ   (E/W northern)
+ *   - I-15  : SAN → LAX(area) → BAR → LAS (N/S coast → desert)
+ *   - I-17  : PHX → FLG               (vertical AZ)
+ *   - I-8   : SAN → PHX               (southern E/W)
+ *   - US-93 : LAS → KIN → PHX         (NV → AZ shortcut)
+ */
+const FACILITY_LATLNG: Record<string, { lat: number; lng: number }> = {
+  PHX: { lat: 33.4484, lng: -112.074 },
+  TUS: { lat: 32.2226, lng: -110.9747 },
+  ABQ: { lat: 35.0844, lng: -106.6504 },
+  ELP: { lat: 31.7619, lng: -106.485 },
+  LAS: { lat: 36.1699, lng: -115.1398 },
+  LAX: { lat: 34.0522, lng: -118.2437 },
+  SAN: { lat: 32.7157, lng: -117.1611 },
+  FLG: { lat: 35.1983, lng: -111.6513 },
+  BAR: { lat: 34.8986, lng: -117.0173 },
+  KIN: { lat: 35.1894, lng: -114.053 },
+};
+
+function pt(code: string): HighwayWaypoint {
+  const ll = FACILITY_LATLNG[code];
+  if (!ll) throw new Error(`unknown facility code: ${code}`);
+  return { code, lat: ll.lat, lng: ll.lng };
+}
+
+export const HIGHWAYS: Record<string, readonly HighwayWaypoint[]> = {
+  'I-10':  [pt('LAX'), pt('PHX'), pt('TUS'), pt('ELP')],
+  'I-40':  [pt('BAR'), pt('KIN'), pt('FLG'), pt('ABQ')],
+  'I-15':  [pt('SAN'), pt('LAX'), pt('BAR'), pt('LAS')],
+  'I-17':  [pt('PHX'), pt('FLG')],
+  'I-8':   [pt('SAN'), pt('PHX')],
+  'US-93': [pt('LAS'), pt('KIN'), pt('PHX')],
+};
+
+/**
+ * Single-corridor lookup. Returns the slice of waypoints between (and
+ * including) `from` and `to` if they both live on the same corridor,
+ * with order flipped if the truck is going against the corridor's
+ * canonical direction. `null` means "no direct corridor" — caller can
+ * fall back to a composite path or a straight line.
+ */
+function getDirectCorridorPath(from: string, to: string): readonly HighwayWaypoint[] | null {
+  for (const corridor of Object.values(HIGHWAYS)) {
+    const fi = corridor.findIndex((p) => p.code === from);
+    const ti = corridor.findIndex((p) => p.code === to);
+    if (fi === -1 || ti === -1 || fi === ti) continue;
+    return fi < ti ? corridor.slice(fi, ti + 1) : corridor.slice(ti, fi + 1).reverse();
+  }
+  return null;
+}
+
+/**
+ * Build an adjacency map: facility → list of {neighbor, corridorPath}
+ * where corridorPath is the slice between them on some shared corridor.
+ * Multi-corridor routes are then a BFS through this graph.
+ */
+function buildAdjacency(): Map<string, Array<{ to: string; path: readonly HighwayWaypoint[] }>> {
+  const adj = new Map<string, Array<{ to: string; path: readonly HighwayWaypoint[] }>>();
+  for (const corridor of Object.values(HIGHWAYS)) {
+    for (let i = 0; i < corridor.length; i++) {
+      for (let j = i + 1; j < corridor.length; j++) {
+        const a = corridor[i]!.code;
+        const b = corridor[j]!.code;
+        const forward = corridor.slice(i, j + 1);
+        const reverse = [...forward].reverse();
+        if (!adj.has(a)) adj.set(a, []);
+        if (!adj.has(b)) adj.set(b, []);
+        adj.get(a)!.push({ to: b, path: forward });
+        adj.get(b)!.push({ to: a, path: reverse });
+      }
+    }
+  }
+  return adj;
+}
+
+const ADJACENCY = buildAdjacency();
+
+/**
+ * BFS the corridor graph for the fewest-hops path from `from` to `to`.
+ * Returns the stitched waypoint list (without duplicating shared
+ * junctions where two corridors meet) or `null` if no path exists.
+ */
+function findCompositePath(from: string, to: string): readonly HighwayWaypoint[] | null {
+  if (from === to) return null;
+  type Frontier = { code: string; path: readonly HighwayWaypoint[] };
+  const visited = new Set<string>([from]);
+  const queue: Frontier[] = [{ code: from, path: [pt(from)] }];
+  while (queue.length > 0) {
+    const { code, path } = queue.shift()!;
+    const neighbors = ADJACENCY.get(code) ?? [];
+    for (const { to: next, path: edge } of neighbors) {
+      if (visited.has(next)) continue;
+      visited.add(next);
+      // edge[0] === code (already in path), so skip the duplicate join.
+      const stitched = path.concat(edge.slice(1));
+      if (next === to) return stitched;
+      queue.push({ code: next, path: stitched });
+    }
+  }
+  return null;
+}
+
+/**
+ * Public API used by the dispatch view's `getRouteWaypoints` prop.
+ * Tries the cheap single-corridor lookup first, then BFS for composite
+ * routes. Returns the full polyline (from-end to to-end inclusive) so
+ * the renderer doesn't have to splice them in.
+ */
+export function getWaypoints(from: string, to: string): readonly HighwayWaypoint[] | null {
+  return getDirectCorridorPath(from, to) ?? findCompositePath(from, to);
+}

--- a/demo/main.tsx
+++ b/demo/main.tsx
@@ -48,61 +48,176 @@ const ASSETS = TRUCKS.map((t) => {
   };
 });
 
-// One event stream covers the whole demo. The dispatch board reads each
-// stop's `meta.lat/lng/facilityCode/stopType` to draw the truck on the
-// map; the Schedule / Base grids draw the driver's duty *shift* (start
-// of first stop → end of last stop on that calendar day), tagged with
-// category='shift' so the schedule-tab scope predicate lets them in.
-// The same resource id binds both records to the same driver/truck.
-const STOP_EVENTS: WorksCalendarEvent[] = TRUCK_ROUTES.flatMap((r) =>
-  r.events.map((ev) => ({
-    id: ev.id,
-    title: ev.title,
-    start: shift(ev.start),
-    end: shift(ev.end),
+// One event stream covers the whole demo, in three layers:
+//
+//   STOP_EVENTS — one per arrival/departure (zero duration). Carries the
+//     facility + lat/lng meta the dispatch board needs to plot breadcrumbs
+//     and conflict pulses on the map. Invisible in Month/Week/Day grids
+//     because they render bars and a zero-width bar has nothing to paint.
+//
+//   LEG_EVENTS — one per travel segment, start = depart, end = arrive.
+//     Carries from/to facility codes in meta. These ARE non-zero-duration
+//     so they render as bars in Month / Week / Day / Agenda and on the
+//     Base view's truck/driver rows. Deliberately *no* meta.facilityCode
+//     at the event root so the dispatch board's stop reader skips them.
+//
+//   SHIFT_EVENTS — one per driver per calendar day (category='shift').
+//     The Schedule view scope predicate (`isScheduleWorkflowEvent`) only
+//     admits events with this category, so these are what populate the
+//     driver shift bars; Month / Week / Day intentionally filter them
+//     back out so the leg events don't get duplicated there.
+//
+// Same trucks, same drivers, same facilities — one source of truth, three
+// projections that each tab consumes the slice it needs.
+
+// Real-world dispatch: each arrival has a dock dwell (unload) window
+// proportional to the load type. Two trucks landing on the same facility
+// with overlapping unload windows is the canonical dock conflict the
+// engine surfaces. Driver duty totals roll up off the same numbers.
+const UNLOAD_MINUTES_BY_TYPE: Record<string, number> = {
+  dry_van: 45,
+  reefer: 75,   // cold-chain handling
+  flatbed: 90,  // strapping + tarping
+};
+
+// FMCSA HOS caps used to flag duty-overrun and short-rest conflicts.
+const HOS_MAX_ON_DUTY_HOURS = 14;
+const HOS_MAX_DRIVING_HOURS = 11;
+const HOS_REST_REQUIRED_HOURS = 10;
+
+const STOP_EVENTS: WorksCalendarEvent[] = TRUCK_ROUTES.flatMap((r) => {
+  const unloadMin = UNLOAD_MINUTES_BY_TYPE[r.truck.type] ?? 60;
+  return r.events.map((ev) => {
+    const start = shift(ev.start);
+    const stopType = (ev.meta?.['stopType'] as string | undefined) ?? 'arrival';
+    // Arrivals dwell at the dock for unloadMin minutes — that's the
+    // window engine compares for dock conflicts. Departures stay
+    // zero-duration (they're instantaneous gate-out events).
+    const end = stopType === 'arrival'
+      ? new Date(start.getTime() + unloadMin * 60_000)
+      : shift(ev.end);
+    return {
+      id: ev.id,
+      title: ev.title,
+      start,
+      end,
+      allDay: false,
+      resource: ev.resource,
+      meta: {
+        ...ev.meta,
+        ...(stopType === 'arrival' ? { unloadMinutes: unloadMin, loadType: r.truck.type } : {}),
+      },
+    };
+  });
+});
+
+const LEG_EVENTS: WorksCalendarEvent[] = TRUCK_ROUTES.flatMap((r) => {
+  const driver = DRIVERS.find((d) => d.id === r.truck.id);
+  return r.segments.map((seg, i) => ({
+    id: `leg-${r.truck.id}-w${r.weekIndex}-${i}`,
+    title: `${seg.from} → ${seg.to}`,
+    start: shift(seg.depart),
+    end: shift(seg.arrive),
     allDay: false,
-    resource: ev.resource,
-    meta: ev.meta,
-  })),
-);
+    resource: r.truck.id,
+    category: 'delivery',
+    meta: {
+      kind: 'leg',
+      truckId: r.truck.id,
+      fromCode: seg.from,
+      toCode: seg.to,
+      fromLat: seg.fromLat,
+      fromLng: seg.fromLng,
+      toLat: seg.toLat,
+      toLng: seg.toLng,
+      distanceMiles: seg.distanceMiles,
+      status: seg.status,
+      base: r.truck.hub,
+      color: driver?.color,
+    },
+  }));
+});
 
 // Synthesize one duty-shift event per (driver × calendar day) from the
-// segment depart/arrive times so the Schedule + Base + Month / Week / Day
-// views light up with each driver's daily window. Categorising the shift
-// as 'shift' triggers the schedule-tab inclusion predicate (see
-// `isScheduleWorkflowEvent` in works-calendar-engine).
+// segment depart/arrive times so the Schedule view lights up with each
+// driver's daily window.
 function dayKey(date: Date): string {
   return `${date.getUTCFullYear()}-${date.getUTCMonth()}-${date.getUTCDate()}`;
 }
 
+// Per-driver, per-day duty totals. `dutyHours` is wall-clock on-duty time
+// (first depart → last arrive + last unload); `drivingHours` is the sum of
+// the actual leg durations. Either crossing its HOS cap is what surfaces
+// the HOS-violation badge on the dispatch sidebar.
+interface ShiftAggregate {
+  start: Date;
+  end: Date;
+  drivingHours: number;
+  lastArrive: Date;
+}
+
 const SHIFT_EVENTS: WorksCalendarEvent[] = TRUCK_ROUTES.flatMap((r) => {
   const driverId = r.truck.id;
-  const byDay = new Map<string, { start: Date; end: Date }>();
+  const unloadMin = UNLOAD_MINUTES_BY_TYPE[r.truck.type] ?? 60;
+  const byDay = new Map<string, ShiftAggregate>();
   for (const seg of r.segments) {
     const depart = shift(seg.depart);
     const arrive = shift(seg.arrive);
+    const drive = (arrive.getTime() - depart.getTime()) / 3_600_000;
     const key = dayKey(depart);
     const existing = byDay.get(key);
     if (!existing) {
-      byDay.set(key, { start: depart, end: arrive });
+      byDay.set(key, { start: depart, end: arrive, drivingHours: drive, lastArrive: arrive });
     } else {
       if (depart < existing.start) existing.start = depart;
-      if (arrive > existing.end) existing.end = arrive;
+      if (arrive > existing.end) {
+        existing.end = arrive;
+        existing.lastArrive = arrive;
+      }
+      existing.drivingHours += drive;
     }
   }
-  return Array.from(byDay.entries()).map(([key, win]) => ({
-    id: `shift-${driverId}-${key}`,
-    title: `${r.truck.name} — duty`,
-    start: win.start,
-    end: win.end,
-    allDay: false,
-    resource: driverId,
-    category: 'shift',
-    meta: { kind: 'shift', truckId: driverId, base: r.truck.hub },
-  }));
+  // Track prior-day shift end so we can flag short-rest violations
+  // (< HOS_REST_REQUIRED_HOURS between consecutive shifts).
+  const ordered = Array.from(byDay.entries()).sort((a, b) => a[1].start.getTime() - b[1].start.getTime());
+  let prevEndPlusUnload: number | null = null;
+  return ordered.map(([key, win]) => {
+    const shiftEnd = new Date(win.lastArrive.getTime() + unloadMin * 60_000);
+    const dutyHours = (shiftEnd.getTime() - win.start.getTime()) / 3_600_000;
+    const restGapHours = prevEndPlusUnload === null
+      ? null
+      : (win.start.getTime() - prevEndPlusUnload) / 3_600_000;
+    prevEndPlusUnload = shiftEnd.getTime();
+    const hosFlags: string[] = [];
+    if (dutyHours > HOS_MAX_ON_DUTY_HOURS) hosFlags.push('on-duty-over');
+    if (win.drivingHours > HOS_MAX_DRIVING_HOURS) hosFlags.push('driving-over');
+    if (restGapHours !== null && restGapHours < HOS_REST_REQUIRED_HOURS) hosFlags.push('short-rest');
+    return {
+      id: `shift-${driverId}-${key}`,
+      title: `${r.truck.name} — duty${hosFlags.length > 0 ? ' (HOS)' : ''}`,
+      start: win.start,
+      end: shiftEnd,
+      allDay: false,
+      resource: driverId,
+      category: 'shift',
+      meta: {
+        kind: 'shift',
+        truckId: driverId,
+        base: r.truck.hub,
+        dutyHours: Math.round(dutyHours * 10) / 10,
+        drivingHours: Math.round(win.drivingHours * 10) / 10,
+        restGapHours: restGapHours === null ? null : Math.round(restGapHours * 10) / 10,
+        hosCapHours: HOS_MAX_ON_DUTY_HOURS,
+        drivingCapHours: HOS_MAX_DRIVING_HOURS,
+        restRequiredHours: HOS_REST_REQUIRED_HOURS,
+        hosFlags,
+        hosViolation: hosFlags.length > 0,
+      },
+    };
+  });
 });
 
-const FLEET_EVENTS: WorksCalendarEvent[] = [...STOP_EVENTS, ...SHIFT_EVENTS];
+const FLEET_EVENTS: WorksCalendarEvent[] = [...STOP_EVENTS, ...LEG_EVENTS, ...SHIFT_EVENTS];
 
 // Seed the calendar's owner config so the Base + Schedule views have a
 // bases/regions registry to draw rows from. The config layer is normally

--- a/demo/main.tsx
+++ b/demo/main.tsx
@@ -88,23 +88,23 @@ const HOS_REST_REQUIRED_HOURS = 10;
 const STOP_EVENTS: WorksCalendarEvent[] = TRUCK_ROUTES.flatMap((r) => {
   const unloadMin = UNLOAD_MINUTES_BY_TYPE[r.truck.type] ?? 60;
   return r.events.map((ev) => {
-    const start = shift(ev.start);
     const stopType = (ev.meta?.['stopType'] as string | undefined) ?? 'arrival';
-    // Arrivals dwell at the dock for unloadMin minutes — that's the
-    // window engine compares for dock conflicts. Departures stay
-    // zero-duration (they're instantaneous gate-out events).
-    const end = stopType === 'arrival'
-      ? new Date(start.getTime() + unloadMin * 60_000)
-      : shift(ev.end);
+    // Stops stay zero-duration so they don't surface as extra bars in
+    // Month/Week/Day/Agenda (those scopes only filter out schedule-class
+    // events). The dwell window for dock-conflict detection lives in
+    // `meta.unloadMinutes` and is read by deriveConflicts on the dispatch
+    // side. `meta.kind: 'stop'` lets a host disambiguate these from the
+    // leg/shift records sharing the same stream.
     return {
       id: ev.id,
       title: ev.title,
-      start,
-      end,
+      start: shift(ev.start),
+      end: shift(ev.end),
       allDay: false,
       resource: ev.resource,
       meta: {
         ...ev.meta,
+        kind: 'stop',
         ...(stopType === 'arrival' ? { unloadMinutes: unloadMin, loadType: r.truck.type } : {}),
       },
     };

--- a/demo/main.tsx
+++ b/demo/main.tsx
@@ -12,6 +12,7 @@ import { createRoot } from 'react-dom/client';
 import { WorksCalendar } from '../src/index';
 import type { WorksCalendarEvent } from '../src/index';
 import { TRUCKS, TRUCK_ROUTES, DRIVERS, BASES, REGIONS } from './truckDemoData';
+import { getWaypoints } from './highways';
 import '../src/styles/soft.css';
 
 const CALENDAR_ID = 'dispatch-demo-v3';
@@ -261,6 +262,14 @@ function DemoApp() {
           role: d.role,
           color: d.color,
         }))}
+        // Demo-side highway corridor lookup. The dispatch view falls
+        // back to a straight-line / arch breadcrumb when this returns
+        // null, so it's safe to leave undefined for hosts that don't
+        // ship their own routing data.
+        getRouteWaypoints={(from, to) => {
+          const wps = getWaypoints(from, to);
+          return wps ? wps.map((w) => ({ lat: w.lat, lng: w.lng })) : null;
+        }}
         showCalendarLegend={false}
         showOfflineIndicator={false}
       />

--- a/src/WorksCalendar.tsx
+++ b/src/WorksCalendar.tsx
@@ -132,6 +132,7 @@ const WorksCalendarImpl = forwardRef<CalendarApi, WorksCalendarProps>(function W
     dispatchMissions,
     dispatchEvaluator,
     onDispatchAssign,
+    getRouteWaypoints,
     emptyState,
 
     // ── Filter schema ──
@@ -457,6 +458,7 @@ const WorksCalendarImpl = forwardRef<CalendarApi, WorksCalendarProps>(function W
                 renderAssetLocation={renderAssetLocation} renderPoolLocation={renderPoolLocation} renderAssetBadges={renderAssetBadges}
                 dispatchMissions={dispatchMissions} dispatchEvaluator={dispatchEvaluator}
                 onDispatchAssign={onDispatchAssign} onApprovalAction={onApprovalAction} canRequestAsset={canRequestAsset}
+                getRouteWaypoints={getRouteWaypoints}
                 setFormEvent={setFormEvent} setScheduleOpen={setScheduleOpen} setImportOpen={setImportOpen}
                 setAssetRequestOpen={setAssetRequestOpen} setActiveGroupBy={setActiveGroupBy}
                 handleClearFilters={handleClearFilters} handleScheduleDateSelect={handleScheduleDateSelect}

--- a/src/WorksCalendar.types.ts
+++ b/src/WorksCalendar.types.ts
@@ -306,6 +306,15 @@ export type WorksCalendarProps = {
   locationProvider?: LocationProvider;
   categoriesConfig?: Record<string, unknown>;
   assets?: { id: string; label: string; group?: string; meta?: Record<string, unknown> }[];
+  /**
+   * Dispatch view: lookup from a (from, to) facility-code pair to an
+   * ordered list of lat/lng waypoints. When provided and the lookup
+   * returns a non-empty path, the dispatch board's breadcrumb traces
+   * those waypoints as an SVG polyline (e.g. following I-10) instead
+   * of the default straight-line / 3D-arch fallback. Pure presentation
+   * concern — the engine never sees it.
+   */
+  getRouteWaypoints?: (fromCode: string, toCode: string) => readonly { lat: number; lng: number }[] | null;
   strictAssetFiltering?: boolean;
   assetRequestCategories?: string[];
   onConflictCheck?: (event: WorksCalendarEvent, candidate: WorksCalendarEvent) => Promise<unknown>;

--- a/src/ui/CalendarViewGrid.tsx
+++ b/src/ui/CalendarViewGrid.tsx
@@ -112,6 +112,7 @@ export interface CalendarViewGridProps {
   dispatchMissions: DispatchMissionCandidate[] | undefined;
   dispatchEvaluator: DispatchEvaluator | undefined;
   onDispatchAssign: ((assetId: string, missionId: string | null, asOf: Date) => void) | undefined;
+  getRouteWaypoints?: WorksCalendarProps['getRouteWaypoints'];
   onApprovalAction: WorksCalendarProps['onApprovalAction'];
   canRequestAsset: boolean;
   // Handlers
@@ -150,7 +151,7 @@ export default function CalendarViewGrid({
   categoriesConfig, rawPools, strictAssetFiltering, resolveResourceLabel,
   activeAssetsZoom, setActiveAssetsZoom, activeAssetsCollapsed, setActiveAssetsCollapsed,
   effectiveLocationProvider, renderAssetLocation, renderPoolLocation, renderAssetBadges,
-  dispatchMissions, dispatchEvaluator, onDispatchAssign, onApprovalAction, canRequestAsset,
+  dispatchMissions, dispatchEvaluator, onDispatchAssign, getRouteWaypoints, onApprovalAction, canRequestAsset,
   setFormEvent, setScheduleOpen, setImportOpen, setAssetRequestOpen, setActiveGroupBy,
   handleClearFilters, handleScheduleDateSelect, handlePoolDateSelect,
   handleEmployeeAddInternal, handleEmployeeDeleteInternal, handleShiftStatusChange,
@@ -286,6 +287,7 @@ export default function CalendarViewGrid({
                   // Day all read from, and vice-versa.
                   currentDate: cal.currentDate,
                   onCurrentDateChange: cal.setCurrentDate,
+                  getRouteWaypoints,
                   onAsOfChange: cal.setCurrentDate,
                   viewSwitcher,
                 } as unknown as ComponentProps<typeof DispatchView>)} />

--- a/src/views/DispatchView.tsx
+++ b/src/views/DispatchView.tsx
@@ -43,6 +43,11 @@ interface DispatchViewLooseProps {
   readonly onCurrentDateChange?: (d: Date) => void;
   /** View-switcher node injected by the host when this view owns chrome. */
   readonly viewSwitcher?: ReactNode;
+  /** Optional host-provided route-waypoint lookup (e.g. highway corridors).
+   *  When present and a leg's from/to pair resolves to a waypoint list,
+   *  the dispatch map draws a polyline through those points; otherwise the
+   *  arch / straight-line fallback is used. */
+  readonly getRouteWaypoints?: (fromCode: string, toCode: string) => readonly { lat: number; lng: number }[] | null;
   // Legacy props (employees, bases, missions, evaluateForMission, onAssign, …)
   // are accepted to keep CalendarViewGrid's existing wiring stable but ignored
   // by the new board. The dispatch view derives everything it renders from
@@ -61,6 +66,7 @@ export default function DispatchView(props: DispatchViewLooseProps) {
       {...(props.currentDate ? { currentDate: props.currentDate } : {})}
       {...(props.onCurrentDateChange ? { onCurrentDateChange: props.onCurrentDateChange } : {})}
       {...(props.viewSwitcher ? { viewSwitcher: props.viewSwitcher } : {})}
+      {...(props.getRouteWaypoints ? { getRouteWaypoints: props.getRouteWaypoints } : {})}
     />
   );
 }

--- a/src/views/dispatch/AssetSidebar.tsx
+++ b/src/views/dispatch/AssetSidebar.tsx
@@ -14,6 +14,16 @@ import type {
   DispatchStop,
 } from './types';
 
+const HOS_FLAG_LABEL: Record<string, string> = {
+  'on-duty-over': 'Over 14h on-duty cap',
+  'driving-over': 'Over 11h driving cap',
+  'short-rest': 'Under 10h rest from prior shift',
+};
+
+function hosFlagsToTooltip(flags: readonly string[]): string {
+  return flags.map((f) => HOS_FLAG_LABEL[f] ?? f).join(' · ');
+}
+
 interface Props {
   readonly assets: readonly DispatchAsset[];
   readonly facilities: readonly DispatchFacility[];
@@ -22,6 +32,14 @@ interface Props {
   readonly selectedDate: Date;
   readonly selectedAsset: string | null;
   readonly onSelectAsset: (id: string) => void;
+  /** Per-asset HOS / duty-day summary for the selected day. When a row's
+   *  entry has `flags.length > 0`, an HOS RISK badge renders alongside the
+   *  conflict badge and surfaces the specific cap that's over. */
+  readonly hosByAsset?: ReadonlyMap<string, {
+    readonly dutyHours: number;
+    readonly drivingHours: number;
+    readonly flags: readonly string[];
+  }>;
 }
 
 export function AssetSidebar({
@@ -32,6 +50,7 @@ export function AssetSidebar({
   selectedDate,
   selectedAsset,
   onSelectAsset,
+  hosByAsset,
 }: Props) {
   const dayStart = new Date(
     Date.UTC(selectedDate.getUTCFullYear(), selectedDate.getUTCMonth(), selectedDate.getUTCDate()),
@@ -58,6 +77,13 @@ export function AssetSidebar({
         <div className="flex gap-2 mt-1 text-[10px] text-[#5a3e2b]">
           <span>{assets.length} active</span>
           <span className="text-[#c0392b] font-bold">{conflictedAssets.size} conflicted</span>
+          {hosByAsset && (() => {
+            let hosCount = 0;
+            for (const v of hosByAsset.values()) if (v.flags.length > 0) hosCount++;
+            return hosCount > 0 ? (
+              <span className="text-[#b7791f] font-bold">{hosCount} HOS risk</span>
+            ) : null;
+          })()}
         </div>
       </div>
 
@@ -67,6 +93,8 @@ export function AssetSidebar({
             const pos = positionAt(stopsByAsset.get(asset.id), selectedDate);
             const fac = pos?.facilityCode ? facilitiesByCode.get(pos.facilityCode) : null;
             const hasConflict = conflictedAssets.has(asset.id);
+            const hos = hosByAsset?.get(asset.id);
+            const hosViolation = (hos?.flags.length ?? 0) > 0;
             const isSelected = selectedAsset === asset.id;
 
             return (
@@ -87,7 +115,7 @@ export function AssetSidebar({
                     style={{ backgroundColor: asset.color }}
                   />
                   <div className="flex-1 min-w-0">
-                    <div className="flex items-center gap-1">
+                    <div className="flex items-center gap-1 flex-wrap">
                       <span className={`text-[11px] font-bold truncate ${isSelected ? 'text-white' : 'text-[#3d2b1f]'}`}>
                         {asset.id}
                       </span>
@@ -96,12 +124,25 @@ export function AssetSidebar({
                           CONFLICT
                         </span>
                       )}
+                      {hosViolation && (
+                        <span
+                          className="text-[9px] bg-[#b7791f] text-white px-1 rounded"
+                          title={hosFlagsToTooltip(hos?.flags ?? [])}
+                        >
+                          HOS
+                        </span>
+                      )}
                     </div>
                     <div className={`text-[10px] truncate ${isSelected ? 'text-white/80' : 'text-[#5a3e2b]'}`}>
                       {asset.name}
                     </div>
                     <div className={`text-[9px] mt-0.5 ${isSelected ? 'text-white/60' : 'text-[#7a6e5b]'}`}>
                       {pos?.moving ? 'En route' : fac ? `@ ${fac.code}` : 'Unknown'}
+                      {hos && (
+                        <span className={`ml-1.5 ${isSelected ? 'text-white/50' : 'text-[#7a6e5b]'}`}>
+                          · {hos.drivingHours}h drive / {hos.dutyHours}h duty
+                        </span>
+                      )}
                     </div>
                   </div>
                 </div>

--- a/src/views/dispatch/AssetSidebar.tsx
+++ b/src/views/dispatch/AssetSidebar.tsx
@@ -60,11 +60,21 @@ export function AssetSidebar({
   const todayConflicts = conflicts.filter(
     (c) => c.timeA.getTime() >= dayStart.getTime() && c.timeA.getTime() < dayEnd.getTime(),
   );
-  const conflictedAssets = new Set<string>();
+  // Pick the earliest conflict per asset so the sidebar can name the
+  // specific facility + time instead of stamping a generic "CONFLICT"
+  // word on every other row.
+  const firstConflictByAsset = new Map<string, DispatchConflict>();
   for (const c of todayConflicts) {
-    conflictedAssets.add(c.assetA);
-    conflictedAssets.add(c.assetB);
+    for (const id of [c.assetA, c.assetB]) {
+      const existing = firstConflictByAsset.get(id);
+      if (!existing || c.timeA.getTime() < existing.timeA.getTime()) {
+        firstConflictByAsset.set(id, c);
+      }
+    }
   }
+  const conflictedAssets = new Set(firstConflictByAsset.keys());
+  const fmtConflictTime = (d: Date) =>
+    d.toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit', timeZone: 'UTC', hour12: false });
 
   const facilitiesByCode = new Map(facilities.map((f) => [f.code, f]));
 
@@ -93,6 +103,7 @@ export function AssetSidebar({
             const pos = positionAt(stopsByAsset.get(asset.id), selectedDate);
             const fac = pos?.facilityCode ? facilitiesByCode.get(pos.facilityCode) : null;
             const hasConflict = conflictedAssets.has(asset.id);
+            const firstConflict = firstConflictByAsset.get(asset.id);
             const hos = hosByAsset?.get(asset.id);
             const hosViolation = (hos?.flags.length ?? 0) > 0;
             const isSelected = selectedAsset === asset.id;
@@ -119,9 +130,12 @@ export function AssetSidebar({
                       <span className={`text-[11px] font-bold truncate ${isSelected ? 'text-white' : 'text-[#3d2b1f]'}`}>
                         {asset.id}
                       </span>
-                      {hasConflict && (
-                        <span className="text-[9px] bg-[#c0392b] text-white px-1 rounded">
-                          CONFLICT
+                      {hasConflict && firstConflict && (
+                        <span
+                          className="text-[9px] bg-[#c0392b] text-white px-1 rounded"
+                          title={`Dock conflict with ${firstConflict.assetA === asset.id ? firstConflict.assetB : firstConflict.assetA} at ${firstConflict.facilityCode}`}
+                        >
+                          @ {firstConflict.facilityCode} {fmtConflictTime(firstConflict.timeA)}
                         </span>
                       )}
                       {hosViolation && (

--- a/src/views/dispatch/DispatchBoard.tsx
+++ b/src/views/dispatch/DispatchBoard.tsx
@@ -90,6 +90,30 @@ export function DispatchBoard({
     [todayConflicts],
   );
 
+  // Roll up driver HOS / duty-day totals for the currently-selected day so
+  // the sidebar can surface FMCSA-style violations alongside the dock
+  // conflict badge. Reads shift-class events (kind === 'shift') emitted
+  // by the host alongside the stop / leg event streams.
+  const hosByAsset = useMemo(() => {
+    const dayStart = new Date(
+      Date.UTC(selectedDate.getUTCFullYear(), selectedDate.getUTCMonth(), selectedDate.getUTCDate()),
+    );
+    const dayEnd = new Date(dayStart.getTime() + 86_400_000);
+    const map = new Map<string, { dutyHours: number; drivingHours: number; flags: string[] }>();
+    for (const ev of events) {
+      const meta = (ev.meta ?? {}) as Record<string, unknown>;
+      if (meta['kind'] !== 'shift') continue;
+      const start = ev.start instanceof Date ? ev.start : new Date(ev.start as string);
+      if (start.getTime() < dayStart.getTime() || start.getTime() >= dayEnd.getTime()) continue;
+      const flags = Array.isArray(meta['hosFlags']) ? (meta['hosFlags'] as string[]) : [];
+      const dutyHours = typeof meta['dutyHours'] === 'number' ? (meta['dutyHours'] as number) : 0;
+      const drivingHours = typeof meta['drivingHours'] === 'number' ? (meta['drivingHours'] as number) : 0;
+      const key = ev.resource ?? '';
+      if (key) map.set(key, { dutyHours, drivingHours, flags });
+    }
+    return map;
+  }, [events, selectedDate]);
+
   return (
     <div className="h-full w-full flex flex-col overflow-hidden" style={{ background: '#e8dcc8' }}>
       {/* Header */}
@@ -157,6 +181,7 @@ export function DispatchBoard({
             selectedDate={selectedDate}
             selectedAsset={selectedAsset}
             onSelectAsset={setSelectedAsset}
+            hosByAsset={hosByAsset}
           />
         </div>
 

--- a/src/views/dispatch/DispatchBoard.tsx
+++ b/src/views/dispatch/DispatchBoard.tsx
@@ -42,6 +42,10 @@ export interface DispatchBoardProps {
   /** Optional view-switcher tabs to render inline in the board header,
    *  used when the host calendar hands over its full chrome to this view. */
   readonly viewSwitcher?: ReactNode;
+  /** Optional host-provided route-waypoint lookup. When present and the
+   *  lookup returns a non-empty list for a leg's `from`/`to` facility
+   *  codes, the breadcrumb traces those waypoints as a polyline. */
+  readonly getRouteWaypoints?: (fromCode: string, toCode: string) => readonly { lat: number; lng: number }[] | null;
 }
 
 const LAYERS: { id: MapLayer; label: string }[] = [
@@ -53,6 +57,7 @@ const LAYERS: { id: MapLayer; label: string }[] = [
 
 export function DispatchBoard({
   events, assets = [], initialDate, currentDate, onCurrentDateChange, viewSwitcher,
+  getRouteWaypoints,
 }: DispatchBoardProps) {
   const [uncontrolledDate, setUncontrolledDate] = useState<Date>(() => {
     if (currentDate) return currentDate;
@@ -196,6 +201,7 @@ export function DispatchBoard({
             selectedAsset={selectedAsset}
             onSelectAsset={setSelectedAsset}
             layer={layer}
+            {...(getRouteWaypoints ? { getRouteWaypoints } : {})}
           />
 
           {/* Layer switcher */}

--- a/src/views/dispatch/TacticalMap.tsx
+++ b/src/views/dispatch/TacticalMap.tsx
@@ -100,6 +100,17 @@ export function TacticalMap({
             <feMergeNode in="SourceGraphic" />
           </feMerge>
         </filter>
+        {/* Glow ring for conflict pulses — a wide red diffusion that
+            survives behind the dashed outline so the alert reads from
+            across the screen rather than disappearing under route
+            breadcrumbs. */}
+        <filter id="dispatch-conflict-glow" x="-100%" y="-100%" width="300%" height="300%">
+          <feGaussianBlur in="SourceGraphic" stdDeviation={5} result="glow" />
+          <feMerge>
+            <feMergeNode in="glow" />
+            <feMergeNode in="SourceGraphic" />
+          </feMerge>
+        </filter>
       </defs>
 
       <rect width={VW} height={VH} fill="#e8dcc8" />
@@ -237,31 +248,6 @@ export function TacticalMap({
         });
       })}
 
-      {/* Conflict pulses at facilities with engine-detected violations today */}
-      {(() => {
-        const byFac: Record<string, number> = {};
-        for (const c of conflictsAtTime) {
-          byFac[c.facilityCode] = (byFac[c.facilityCode] ?? 0) + 1;
-        }
-        return Object.entries(byFac).map(([code, count]) => {
-          const fac = facilities.find((f) => f.code === code);
-          if (!fac) return null;
-          const [x, y] = proj(fac.lat, fac.lng);
-          return (
-            <g key={`conflict-${code}`}>
-              <circle cx={x} cy={y} r={20} fill="none" stroke="#c0392b" strokeWidth={2} strokeDasharray="4,3" opacity={0.4}>
-                <animate attributeName="r" values="16;24;16" dur="2s" repeatCount="indefinite" />
-                <animate attributeName="opacity" values="0.4;0.15;0.4" dur="2s" repeatCount="indefinite" />
-              </circle>
-              <circle cx={x} cy={y} r={10} fill="#c0392b" opacity={0.9} stroke="#fff" strokeWidth={1.5} />
-              <text y={y - 14} x={x} textAnchor="middle" fontSize={9} fill="#c0392b" fontWeight="bold" fontFamily="sans-serif">
-                {count}
-              </text>
-            </g>
-          );
-        });
-      })()}
-
       {/* Facility anchors */}
       {facilities.map((fac) => {
         const [x, y] = proj(fac.lat, fac.lng);
@@ -297,23 +283,59 @@ export function TacticalMap({
             }}
             style={{ cursor: 'pointer', opacity: selectedAsset ? (isSelected ? 1 : 0.15) : 1 }}
           >
+            <title>{`${asset.id} — ${asset.name}\n${pos.moving ? 'En route' : `@ ${pos.facilityCode ?? 'unknown'}`}`}</title>
             <circle
-              r={isSelected ? 12 : selectedAsset ? 4 : 7}
+              r={isSelected ? 12 : selectedAsset ? 5 : 8}
               fill={color}
               stroke="#fff"
-              strokeWidth={isSelected ? 3 : 1.5}
-              filter="url(#dispatch-ink)"
+              strokeWidth={isSelected ? 3 : 2}
             >
               {isSelected && <animate attributeName="r" values="10;14;10" dur="1.5s" repeatCount="indefinite" />}
             </circle>
-            {(isSelected || !selectedAsset) && (
-              <text y={-16} textAnchor="middle" fontFamily="sans-serif" fontSize={isSelected ? 11 : 9} fill="#3d2b1f" fontWeight="bold">
+            {/* Label only on the selected truck — without this, 30 ids float
+                on top of each other and the map turns into typographic
+                confetti. Hover state surfaces the id via the <title>. */}
+            {isSelected && (
+              <text y={-16} textAnchor="middle" fontFamily="sans-serif" fontSize={11} fill="#3d2b1f" fontWeight="bold">
                 {asset.id}
               </text>
             )}
           </g>
         );
       })}
+
+      {/* Conflict pulses rendered LAST so they overlay every breadcrumb,
+          facility label, and truck marker. Without this they vanish under
+          the route spaghetti and a dispatcher can scan past an active
+          dock collision without realising it. Bigger radius + glow filter
+          push the alert past the ambient parchment noise. */}
+      {(() => {
+        const byFac: Record<string, number> = {};
+        for (const c of conflictsAtTime) {
+          byFac[c.facilityCode] = (byFac[c.facilityCode] ?? 0) + 1;
+        }
+        return (
+          <g filter="url(#dispatch-conflict-glow)">
+            {Object.entries(byFac).map(([code, count]) => {
+              const fac = facilities.find((f) => f.code === code);
+              if (!fac) return null;
+              const [x, y] = proj(fac.lat, fac.lng);
+              return (
+                <g key={`conflict-${code}`}>
+                  <circle cx={x} cy={y} r={30} fill="none" stroke="#c0392b" strokeWidth={3} strokeDasharray="5,3" opacity={0.9}>
+                    <animate attributeName="r" values="26;34;26" dur="2s" repeatCount="indefinite" />
+                    <animate attributeName="opacity" values="0.9;0.55;0.9" dur="2s" repeatCount="indefinite" />
+                  </circle>
+                  <circle cx={x} cy={y} r={12} fill="#c0392b" opacity={1} stroke="#fff" strokeWidth={2} />
+                  <text y={y + 3} x={x} textAnchor="middle" fontSize={10} fill="#fff" fontWeight="bold" fontFamily="sans-serif">
+                    {count}
+                  </text>
+                </g>
+              );
+            })}
+          </g>
+        );
+      })()}
     </svg>
   );
 }

--- a/src/views/dispatch/TacticalMap.tsx
+++ b/src/views/dispatch/TacticalMap.tsx
@@ -33,6 +33,11 @@ interface Props {
   readonly showTiles?: boolean;
   /** Override the slippy-map tile URL ({z}/{x}/{y}). */
   readonly tileUrl?: string;
+  /** Host-provided waypoint lookup for road-following breadcrumbs.
+   *  Returns the ordered list of lat/lng points (endpoints inclusive)
+   *  the leg passes through. When null/missing, the leg falls back to a
+   *  3D quadratic-arch breadcrumb between the two endpoint stops. */
+  readonly getRouteWaypoints?: (fromCode: string, toCode: string) => readonly { lat: number; lng: number }[] | null;
 }
 
 const VW = 1000;
@@ -50,6 +55,7 @@ export function TacticalMap({
   layer,
   showTiles = true,
   tileUrl,
+  getRouteWaypoints,
 }: Props) {
   const bounds = DEFAULT_LAYER_BOUNDS[layer];
   const proj = (lat: number, lng: number): [number, number] =>
@@ -166,19 +172,20 @@ export function TacticalMap({
         </text>
       )}
 
-      {/* Breadcrumb segments — rendered as a quadratic Bezier arch that
-          lifts off the ground plane, giving an origin→destination "flight
-          path" feel without needing real road routing. Past legs render
-          solid + colored; future legs dashed + dim. A faint shadow ellipse
-          under each apex reinforces the 3D read.
+      {/* Breadcrumb segments. When the host supplies `getRouteWaypoints`
+          and the leg's from/to pair resolves to a road-corridor path
+          with at least one intermediate stop, render the route as an
+          SVG polyline tracing those waypoints (so a PHX→ELP leg follows
+          I-10 through TUS instead of crow's-flighting). Otherwise fall
+          back to the prior quadratic-arch breadcrumb — lifts off the
+          ground plane, gives an origin→destination "flight path" feel
+          without needing real road routing.
 
-          Off-screen culling: at zoomed-in layers (5k / 1k) most segments
-          have endpoints far outside the viewBox. The arches still need to
-          render when they cross the visible area, but segments whose
-          entire bounding box sits beyond a generous margin are dropped.
-          Avoids painting hundreds of paths with multi-thousand-pixel
-          coordinates — combined with the SVG ink filter that was crashing
-          iOS Safari when switching from region → 5k. */}
+          Off-screen culling: at zoomed-in layers (5k / 1k) most legs
+          have endpoints far outside the viewBox; drop any whose entire
+          bounding box sits beyond a generous margin. Avoids painting
+          hundreds of paths with multi-thousand-pixel coordinates +
+          stops iOS Safari OOMing on the filter region. */}
       {assets.flatMap((asset) => {
         const segs = segmentsByAsset.get(asset.id) ?? [];
         const isSelected = asset.id === selectedAsset;
@@ -194,21 +201,6 @@ export function TacticalMap({
           if (maxX < -MARGIN || minX > VW + MARGIN || maxY < -MARGIN || minY > VH + MARGIN) {
             return null;
           }
-          const dx = x2 - x1;
-          const dy = y2 - y1;
-          const len = Math.sqrt(dx * dx + dy * dy);
-          // Arch height scales with leg length, capped so cross-region
-          // hops don't balloon off-screen. Always bowed upward (−y).
-          const archH = Math.min(Math.max(len * 0.22, 12), 80);
-          const midX = (x1 + x2) / 2;
-          const midY = (y1 + y2) / 2;
-          // Perpendicular unit vector, biased upward (negative y) so the
-          // arch consistently lifts toward the top of the viewBox.
-          const nx = len === 0 ? 0 : -dy / len;
-          const ny = len === 0 ? -1 : dx / len;
-          const upBias = ny < 0 ? 1 : -1;
-          const cx = midX + nx * archH * upBias;
-          const cy = midY + ny * archH * upBias;
           const past = seg.to.time.getTime() <= selectedDate.getTime();
           const stroke = isSelected ? 2.5 : 1.5;
           const opacity = past
@@ -218,11 +210,38 @@ export function TacticalMap({
             : isSelected
               ? 0.55
               : (0.18 * baseOpacity) / 0.35;
-          const d = `M ${x1} ${y1} Q ${cx} ${cy} ${x2} ${y2}`;
+
+          // Try the host's waypoint lookup first. A path with more than
+          // two points means the corridor pulled in intermediates worth
+          // drawing; two-or-fewer points reduces to a straight line and
+          // we prefer the arch fallback for visual interest.
+          const waypoints = getRouteWaypoints?.(seg.from.facilityCode, seg.to.facilityCode) ?? null;
+          const followsRoad = !!waypoints && waypoints.length > 2;
+          let d: string;
+          if (followsRoad && waypoints) {
+            const projected = waypoints.map((w) => proj(w.lat, w.lng));
+            d = `M ${projected[0]![0]} ${projected[0]![1]}` +
+              projected.slice(1).map(([x, y]) => ` L ${x} ${y}`).join('');
+          } else {
+            const dx = x2 - x1;
+            const dy = y2 - y1;
+            const len = Math.sqrt(dx * dx + dy * dy);
+            const archH = Math.min(Math.max(len * 0.22, 12), 80);
+            const midX = (x1 + x2) / 2;
+            const midY = (y1 + y2) / 2;
+            const nx = len === 0 ? 0 : -dy / len;
+            const ny = len === 0 ? -1 : dx / len;
+            const upBias = ny < 0 ? 1 : -1;
+            const cx = midX + nx * archH * upBias;
+            const cy = midY + ny * archH * upBias;
+            d = `M ${x1} ${y1} Q ${cx} ${cy} ${x2} ${y2}`;
+          }
           return (
             <g key={`${asset.id}-${i}`} opacity={opacity}>
-              {/* Ground shadow — slim ellipse along the great-circle base. */}
-              {(isSelected || !selectedAsset) && (
+              {/* Ground shadow — slim guide along the straight base
+                  between facility endpoints. Only drawn for arch legs;
+                  road-following legs already lay flat. */}
+              {!followsRoad && (isSelected || !selectedAsset) && (
                 <line
                   x1={x1}
                   y1={y1}
@@ -240,6 +259,7 @@ export function TacticalMap({
                 stroke={asset.color}
                 strokeWidth={stroke}
                 strokeLinecap="round"
+                strokeLinejoin="round"
                 strokeDasharray={past ? 'none' : '5,4'}
                 {...(isSelected ? { filter: 'url(#dispatch-arch-shadow)' } : {})}
               />

--- a/src/views/dispatch/deriveConflicts.ts
+++ b/src/views/dispatch/deriveConflicts.ts
@@ -3,11 +3,13 @@
  * and reshape the result into a flat `DispatchConflict[]` keyed by
  * facility code + asset pair.
  *
- * The convention: each stop is treated as a dock-hold event with a
- * 2-hour occupancy window starting at the stop time. Facilities are
- * `EngineResource`s with `capacity = 1` (any two overlapping stops at
- * the same facility = conflict). Hosts that model differently can
- * supply their own rule set and skip this helper.
+ * Each arrival is treated as a dock-hold event. The occupancy window
+ * defaults to 2 hours but the host can override per-stop by writing
+ * `meta.unloadMinutes` on the underlying event (load-type-specific
+ * unload durations: dry-van ≈ 45m, reefer ≈ 75m, flatbed ≈ 90m). The
+ * trucking demo uses this to surface realistic dock collisions.
+ * Facilities are `EngineResource`s with `capacity = 1` (any two
+ * overlapping stops at the same facility = conflict).
  */
 import {
   evaluateConflicts,
@@ -17,7 +19,7 @@ import {
 } from 'works-calendar-engine';
 import type { DispatchConflict, DispatchFacility, DispatchStop } from './types';
 
-const DOCK_HOLD_MS = 2 * 3600_000;
+const DEFAULT_DOCK_HOLD_MS = 2 * 3600_000;
 
 const CAPACITY_RULE: CapacityOverflowRule = {
   id: 'dispatch-facility-capacity',
@@ -42,10 +44,14 @@ export function deriveConflicts(
   for (const stops of stopsByAsset.values()) {
     for (const stop of stops) {
       if (stop.kind !== 'arrival') continue;
+      const unloadMinutes = stop.event.meta?.['unloadMinutes'];
+      const holdMs = typeof unloadMinutes === 'number' && unloadMinutes > 0
+        ? unloadMinutes * 60_000
+        : DEFAULT_DOCK_HOLD_MS;
       arrivals.push({
         id: `arr-${counter++}`,
         start: stop.time,
-        end: new Date(stop.time.getTime() + DOCK_HOLD_MS),
+        end: new Date(stop.time.getTime() + holdMs),
         resource: stop.facilityCode,
         assetId: stop.assetId,
       });


### PR DESCRIPTION
Both are real-world dispatch constraints the conflict engine needs in the data to actually showcase its strengths. Previous demo had stops as zero-duration pings and shifts with no duty/driving accounting, so the "are there conflicts?" answer was effectively pre-computed by the hand-authored truck routes rather than emerging from the engine running over realistic data.

Unload window per arrival (in demo/main.tsx STOP_EVENTS):
  - dry_van: 45 min
  - reefer:  75 min  (cold-chain dwell)
  - flatbed: 90 min  (strapping + tarping) Arrival events now span [arrive, arrive + unloadMin] instead of being zero-duration; the dispatch board's truck stays parked at the dock for that window and the engine's pairwise dock-conflict check finally has overlapping intervals to compare. Drove the conflict count from 8 to 31 with the same routes — those collisions were always implicit.

Driver duty-day stats per shift (SHIFT_EVENTS):
  - meta.dutyHours       — wall-clock first-depart → last-arrive+unload
  - meta.drivingHours    — sum of leg durations
  - meta.restGapHours    — gap to prior shift on the same driver
  - meta.hosFlags        — any of:
        on-duty-over     (> 14h on-duty)
        driving-over     (> 11h driving)
        short-rest       (< 10h rest from prior shift end)
  - meta.hosViolation    — convenience boolean

DispatchBoard rolls those numbers up per asset for the selected day and hands them to AssetSidebar as `hosByAsset`. The sidebar header now shows "N HOS risk" alongside "N conflicted", each row gets a yellow HOS badge when over cap with a tooltip naming the specific flag, and the row sub- line includes the live drive/duty totals ("12.2h drive / 14.9h duty").

Same source of truth — the shift events flow from the unified event stream the Schedule and Base tabs already render, so the HOS picture lines up across views.

## Summary
Describe exactly what this PR changes.

## Scope
- Stage: 
- Planned PR number in sprint: 
- Target files/directories: 
- Why this slice is isolated: 

## Lessons Learned Check (REQUIRED)
Confirm these were actively used while building this PR:

- [ ] PR is intentionally small and isolated
- [ ] Boundary typing was prioritized over internal perfection
- [ ] No silent spread of `any`
- [ ] Advisory root `tsc` was used to catch integration issues
- [ ] I did not assume “looks typed” means “safe”
- [ ] I stopped and isolated typing cascades instead of expanding scope

## Definition of Done (ALL REQUIRED)
This PR is not done unless every box is checked.

- [ ] `npm run type-check:strict` passes
- [ ] Root advisory `tsc --noEmit` passes
- [ ] Tests pass for touched scope at minimum
- [ ] No uncontrolled increase in `any`
- [ ] All new types are intentional and named
- [ ] Public interfaces and exported functions are explicitly typed
- [ ] PR scope matches the sprint plan with no scope creep
- [ ] Any new `any` has an adjacent justification comment
- [ ] No file-wide `: any`
- [ ] No implicit `any` in exported functions

## What Was Typed
List exactly what was typed in this PR.

- 
- 
- 

## What Was Intentionally Left Loose
List anything intentionally not tightened yet.

- 
- 
- 

## `any` Ledger (REQUIRED)
- New `any` added: 
- Existing `any` removed: 
- Net change: 

For every new `any`, explain why it is required and why a safer type was not used yet.

1. 
2. 
3. 

## Boundary Notes
Document any public seams, caller-protection choices, or compatibility decisions.

- 
- 
- 

## Risk Level
- [ ] Low
- [ ] Medium
- [ ] High

Why:

## Validation Evidence
Paste the exact commands run and a short result summary.

```bash
npm run type-check:strict
npx tsc --noEmit -p tsconfig.json
```

Test commands run:

```bash
# paste commands here
```

## Stop Conditions Check
If any item below happened, explain how scope was reduced before merge.

- [ ] `any` started spreading across files
- [ ] Root `tsc` broke repeatedly
- [ ] Types required cross-module rewrites
- [ ] Scope was reduced to keep the PR reviewable

Notes:

## Reviewer Focus
What should reviewers look at first?

- 
- 
- 
