### PR TITLE
fix(dispatch): give the per-asset Gantt date headers and clickable pills

### DIFF
--- a/src/views/dispatch/TimeSlider.tsx
+++ b/src/views/dispatch/TimeSlider.tsx
@@ -153,91 +153,132 @@ export function TimeSlider({
               className="flex-1 text-center text-[7px]"
               style={{ color: d.isToday ? '#c0392b' : '#7a6e5b' }}
             >
-              {d.isToday ? 'TODAY' : d.label.split(' ')[0]}
+              {d.isToday ? 'TODAY' : d.date.getUTCDate()}
             </div>
           ))}
         </div>
       </div>
 
       {/* Mini Gantt for the selected asset */}
-      <div className="flex-1 px-3 py-2 overflow-hidden">
-        <div className="text-[10px] font-serif text-[#5a3e2b] uppercase tracking-wider mb-1">
+      <div className="flex-1 flex flex-col overflow-hidden min-w-0">
+        <div className="px-3 pt-2 text-[10px] font-serif text-[#5a3e2b] uppercase tracking-wider">
           {selectedAssetData
             ? `${selectedAssetData.id} — ${selectedAssetData.name}`
             : 'Select an asset to view route timeline'}
         </div>
         {selectedAssetData ? (
-          <svg
-            viewBox={`0 0 ${windowDays * HOURS_PER_DAY} 60`}
-            className="w-full h-full"
-            preserveAspectRatio="none"
-          >
-            {/* Day gridlines */}
-            {Array.from({ length: windowDays + 1 }, (_, i) => (
-              <line
-                key={i}
-                x1={i * HOURS_PER_DAY}
-                y1={0}
-                x2={i * HOURS_PER_DAY}
-                y2={60}
-                stroke="#3d2b1f"
-                strokeWidth={0.3}
-                opacity={0.2}
+          <>
+            {/* Date headers strip — one cell per day, evenly distributed
+                 across the timeline so bars align with their date column. */}
+            <div className="flex border-b border-[#3d2b1f]/20 mt-1">
+              {days.map((d) => (
+                <div
+                  key={d.index}
+                  className="flex-1 px-1 py-0.5 text-center border-r border-[#3d2b1f]/10 last:border-r-0 leading-tight"
+                  style={{ minWidth: 0 }}
+                >
+                  <div
+                    className="text-[9px] font-bold"
+                    style={{ color: d.isToday ? '#c0392b' : '#3d2b1f' }}
+                  >
+                    {d.date.getUTCDate()}
+                  </div>
+                  <div className="text-[7px] uppercase tracking-wide text-[#7a6e5b]">
+                    {d.date.toLocaleDateString('en-US', { weekday: 'short', timeZone: 'UTC' })}
+                  </div>
+                </div>
+              ))}
+            </div>
+
+            {/* Gantt body — bars positioned as % of the windowDays timeline.
+                 Day gridlines + today/selected cursors render as absolutely
+                 positioned overlays so bars and grid stay aligned. */}
+            <div className="flex-1 relative overflow-hidden">
+              {/* Day gridlines */}
+              {Array.from({ length: windowDays + 1 }, (_, i) => (
+                <div
+                  key={`grid-${i}`}
+                  className="absolute top-0 bottom-0 border-l border-[#3d2b1f]/15"
+                  style={{ left: `${(i / windowDays) * 100}%` }}
+                />
+              ))}
+              {/* Wall-clock "now" cursor (dashed red) */}
+              {todayIndex >= 0 && (
+                <div
+                  className="absolute top-0 bottom-0 border-l border-dashed border-[#c0392b]/60 pointer-events-none"
+                  style={{ left: `${(todayIndex / windowDays) * 100}%` }}
+                  aria-hidden
+                />
+              )}
+              {/* Selected-time cursor (solid black) */}
+              <div
+                className="absolute top-0 bottom-0 border-l-2 border-[#3d2b1f] pointer-events-none"
+                style={{
+                  left: `${
+                    ((currentDay * HOURS_PER_DAY + selectedDate.getUTCHours()) /
+                      (windowDays * HOURS_PER_DAY)) *
+                    100
+                  }%`,
+                }}
+                aria-hidden
               />
-            ))}
-            {/* "Now" cursor — wall-clock today, dashed red guide. Only
-                 drawn when today actually falls within the visible window. */}
-            {todayIndex >= 0 && (
-              <line
-                x1={todayIndex * HOURS_PER_DAY}
-                y1={0}
-                x2={todayIndex * HOURS_PER_DAY}
-                y2={60}
-                stroke="#c0392b"
-                strokeWidth={1}
-                opacity={0.5}
-                strokeDasharray="4,2"
-              />
-            )}
-            {/* Current selectedDate cursor — solid */}
-            {(() => {
-              const dayOffset = currentDay * HOURS_PER_DAY;
-              const x = dayOffset + selectedDate.getUTCHours();
-              return <line x1={x} y1={0} x2={x} y2={60} stroke="#3d2b1f" strokeWidth={1.5} />;
-            })()}
-            {/* Route bars */}
-            {segments.map((seg, i) => {
-              const startHour = (seg.from.time.getTime() - origin.getTime()) / MS_PER_HOUR;
-              const endHour = (seg.to.time.getTime() - origin.getTime()) / MS_PER_HOUR;
-              const isPast = seg.to.time.getTime() <= selectedDate.getTime();
-              return (
-                <g key={i}>
-                  <rect
-                    x={startHour}
-                    y={12 + (i % 3) * 16}
-                    width={Math.max(endHour - startHour, 2)}
-                    height={12}
-                    rx={2}
-                    fill={isPast ? selectedAssetData.color : '#999'}
-                    opacity={isPast ? 0.9 : 0.3}
-                  />
-                  {endHour - startHour > 20 && (
-                    <text
-                      x={startHour + 2}
-                      y={22 + (i % 3) * 16}
-                      fontSize={5}
-                      fill="#fff"
-                      fontFamily="sans-serif"
-                    >
-                      {seg.from.facilityCode}→{seg.to.facilityCode}
-                    </text>
-                  )}
-                </g>
-              );
-            })}
-          </svg>
+              {/* Route bars */}
+              {segments.map((seg, i) => {
+                const startHour =
+                  (seg.from.time.getTime() - origin.getTime()) / MS_PER_HOUR;
+                const endHour =
+                  (seg.to.time.getTime() - origin.getTime()) / MS_PER_HOUR;
+                const totalHours = windowDays * HOURS_PER_DAY;
+                const leftPct = Math.max(0, (startHour / totalHours) * 100);
+                const widthPct = Math.max(
+                  0.6,
+                  ((endHour - startHour) / totalHours) * 100,
+                );
+                const isPast = seg.to.time.getTime() <= selectedDate.getTime();
+                const lane = i % 3;
+                const fromTime = seg.from.time.toLocaleString('en-US', {
+                  month: 'short',
+                  day: 'numeric',
+                  hour: 'numeric',
+                  hour12: true,
+                  timeZone: 'UTC',
+                });
+                const toTime = seg.to.time.toLocaleString('en-US', {
+                  month: 'short',
+                  day: 'numeric',
+                  hour: 'numeric',
+                  hour12: true,
+                  timeZone: 'UTC',
+                });
+                return (
+                  <button
+                    key={i}
+                    type="button"
+                    onClick={() => onDateChange(new Date(seg.from.time))}
+                    title={`${seg.from.facilityCode} → ${seg.to.facilityCode}\n${fromTime} – ${toTime}`}
+                    className="absolute rounded-sm text-[9px] font-medium text-white overflow-hidden whitespace-nowrap px-1 leading-[18px] border border-black/10 hover:ring-2 hover:ring-[#3d2b1f] hover:z-10 focus:outline-none focus:ring-2 focus:ring-[#3d2b1f] focus:z-10"
+                    style={{
+                      left: `${leftPct}%`,
+                      width: `${widthPct}%`,
+                      top: `${6 + lane * 22}px`,
+                      height: '18px',
+                      background: isPast ? selectedAssetData.color : '#999',
+                      opacity: isPast ? 0.95 : 0.55,
+                    }}
+                  >
+                    {seg.from.facilityCode}→{seg.to.facilityCode}
+                  </button>
+                );
+              })}
+              {segments.length === 0 && (
+                <div className="absolute inset-0 flex items-center justify-center text-[10px] text-[#7a6e5b] italic">
+                  No route segments in this window
+                </div>
+              )}
+            </div>
+          </>
         ) : (
-          <div className="h-full flex items-center justify-center text-[10px] text-[#7a6e5b] italic">
+          <div className="flex-1 flex items-center justify-center text-[10px] text-[#7a6e5b] italic">
             Click an asset on the map or sidebar to see its route
           </div>
         )}


### PR DESCRIPTION
The mini Gantt that appears when you select an asset rendered as a
single SVG with viewBox 336×60 stretched via preserveAspectRatio="none",
which squashed the leg bars into thin grey rectangles with no labels
(text only rendered for legs over 20 hours). There was no date header at
all, and the day-tick row under the slider read "May May May TODAY May
…" because we were splitting the localized label on whitespace and
keeping the month token instead of the day number.

Convert the Gantt strip to flowed HTML: a date-header row with day
number + weekday under the title, gridlines and time cursors as
absolutely positioned overlays, and each route segment as a real button
with the from→to facility codes inline, a full hover/title tooltip
covering the time range, and an onClick that scrubs the time cursor to
the segment's start. Fix the day-tick row to show the day number.