### PR TITLE
fix(dispatch): make the per-asset Gantt actually informative

### DIFF
--- a/src/views/dispatch/DispatchBoard.tsx
+++ b/src/views/dispatch/DispatchBoard.tsx
@@ -213,7 +213,7 @@ export function DispatchBoard({
       </div>
 
       {/* Bottom: time slider + per-asset Gantt */}
-      <div className="h-36 flex-shrink-0">
+      <div className="h-44 flex-shrink-0">
         <TimeSlider
           selectedDate={selectedDate}
           onDateChange={setSelectedDate}

--- a/src/views/dispatch/TimeSlider.tsx
+++ b/src/views/dispatch/TimeSlider.tsx
@@ -161,13 +161,87 @@ export function TimeSlider({
 
       {/* Mini Gantt for the selected asset */}
       <div className="flex-1 flex flex-col overflow-hidden min-w-0">
-        <div className="px-3 pt-2 text-[10px] font-serif text-[#5a3e2b] uppercase tracking-wider">
-          {selectedAssetData
-            ? `${selectedAssetData.id} — ${selectedAssetData.name}`
-            : 'Select an asset to view route timeline'}
-        </div>
         {selectedAssetData ? (
           <>
+            {/* Title + active-leg one-liner. Tells dispatch who's driving,
+                 where the truck is, and what the next move is — readable
+                 even when the per-leg pills below are pixel-narrow. */}
+            <div className="px-3 pt-2 flex items-baseline gap-2 min-w-0">
+              <span
+                className="inline-block w-2 h-2 rounded-full flex-shrink-0"
+                style={{ background: selectedAssetData.color }}
+                aria-hidden
+              />
+              <span className="text-[10px] font-serif text-[#3d2b1f] uppercase tracking-wider truncate">
+                {selectedAssetData.id} — {selectedAssetData.name}
+              </span>
+              {selectedAssetData.driverName && (
+                <span className="text-[10px] text-[#5a3e2b] truncate">
+                  · {selectedAssetData.driverName}
+                </span>
+              )}
+            </div>
+            <div className="px-3 text-[10px] text-[#5a3e2b] truncate">
+              {(() => {
+                if (segments.length === 0) {
+                  return <span className="italic text-[#7a6e5b]">No legs in window</span>;
+                }
+                const tSel = selectedDate.getTime();
+                const active = segments.find(
+                  (s) =>
+                    s.from.time.getTime() <= tSel && tSel < s.to.time.getTime(),
+                );
+                const upcoming = segments.find((s) => s.from.time.getTime() > tSel);
+                const last = segments[segments.length - 1];
+                const fmtTime = (d: Date) =>
+                  d.toLocaleString('en-US', {
+                    month: 'short',
+                    day: 'numeric',
+                    hour: 'numeric',
+                    minute: '2-digit',
+                    hour12: true,
+                    timeZone: 'UTC',
+                  });
+                const fmtDuration = (ms: number) => {
+                  const mins = Math.max(0, Math.round(ms / 60_000));
+                  const h = Math.floor(mins / 60);
+                  const m = mins % 60;
+                  return h > 0 ? `${h}h ${m.toString().padStart(2, '0')}m` : `${m}m`;
+                };
+                if (active) {
+                  const remaining = fmtDuration(active.to.time.getTime() - tSel);
+                  return (
+                    <>
+                      <span className="font-bold text-[#3d2b1f]">En route </span>
+                      {active.from.facilityCode} → {active.to.facilityCode} ·
+                      <span className="font-bold"> {remaining}</span> to arrival ({fmtTime(active.to.time)})
+                    </>
+                  );
+                }
+                if (upcoming) {
+                  const until = fmtDuration(upcoming.from.time.getTime() - tSel);
+                  const drive = fmtDuration(
+                    upcoming.to.time.getTime() - upcoming.from.time.getTime(),
+                  );
+                  return (
+                    <>
+                      <span className="font-bold text-[#3d2b1f]">Next </span>
+                      {upcoming.from.facilityCode} → {upcoming.to.facilityCode} · departs {fmtTime(upcoming.from.time)} (in <span className="font-bold">{until}</span>) · {drive} drive
+                    </>
+                  );
+                }
+                if (last) {
+                  return (
+                    <>
+                      <span className="font-bold text-[#3d2b1f]">Last </span>
+                      {last.from.facilityCode} → {last.to.facilityCode} arrived {fmtTime(last.to.time)}
+                    </>
+                  );
+                }
+                return null;
+              })()}
+            </div>
+
             {/* Date headers strip — one cell per day, evenly distributed
                  across the timeline so bars align with their date column. */}
             <div className="flex border-b border-[#3d2b1f]/20 mt-1">
@@ -222,54 +296,88 @@ export function TimeSlider({
                 }}
                 aria-hidden
               />
-              {/* Route bars */}
-              {segments.map((seg, i) => {
-                const startHour =
-                  (seg.from.time.getTime() - origin.getTime()) / MS_PER_HOUR;
-                const endHour =
-                  (seg.to.time.getTime() - origin.getTime()) / MS_PER_HOUR;
+              {/* Route bars. Trucks visit one place at a time, so we stack
+                   them on a single lane and let the bar take the full row
+                   height — easier to read than the previous 3-lane SVG.
+                   Segments entirely outside the visible window are skipped;
+                   partially-visible ones are clipped to the window edges so
+                   the bar doesn't overrun (or hug) the gantt origin. */}
+              {(() => {
                 const totalHours = windowDays * HOURS_PER_DAY;
-                const leftPct = Math.max(0, (startHour / totalHours) * 100);
-                const widthPct = Math.max(
-                  0.6,
-                  ((endHour - startHour) / totalHours) * 100,
-                );
-                const isPast = seg.to.time.getTime() <= selectedDate.getTime();
-                const lane = i % 3;
-                const fromTime = seg.from.time.toLocaleString('en-US', {
-                  month: 'short',
-                  day: 'numeric',
-                  hour: 'numeric',
-                  hour12: true,
-                  timeZone: 'UTC',
-                });
-                const toTime = seg.to.time.toLocaleString('en-US', {
-                  month: 'short',
-                  day: 'numeric',
-                  hour: 'numeric',
-                  hour12: true,
-                  timeZone: 'UTC',
-                });
-                return (
-                  <button
-                    key={i}
-                    type="button"
-                    onClick={() => onDateChange(new Date(seg.from.time))}
-                    title={`${seg.from.facilityCode} → ${seg.to.facilityCode}\n${fromTime} – ${toTime}`}
-                    className="absolute rounded-sm text-[9px] font-medium text-white overflow-hidden whitespace-nowrap px-1 leading-[18px] border border-black/10 hover:ring-2 hover:ring-[#3d2b1f] hover:z-10 focus:outline-none focus:ring-2 focus:ring-[#3d2b1f] focus:z-10"
-                    style={{
-                      left: `${leftPct}%`,
-                      width: `${widthPct}%`,
-                      top: `${6 + lane * 22}px`,
-                      height: '18px',
-                      background: isPast ? selectedAssetData.color : '#999',
-                      opacity: isPast ? 0.95 : 0.55,
-                    }}
-                  >
-                    {seg.from.facilityCode}→{seg.to.facilityCode}
-                  </button>
-                );
-              })}
+                return segments
+                  .map((seg, i) => {
+                    const startHour =
+                      (seg.from.time.getTime() - origin.getTime()) / MS_PER_HOUR;
+                    const endHour =
+                      (seg.to.time.getTime() - origin.getTime()) / MS_PER_HOUR;
+                    if (endHour <= 0 || startHour >= totalHours) return null;
+                    const clippedStart = Math.max(0, startHour);
+                    const clippedEnd = Math.min(totalHours, endHour);
+                    const leftPct = (clippedStart / totalHours) * 100;
+                    const widthPct = Math.max(
+                      0.6,
+                      ((clippedEnd - clippedStart) / totalHours) * 100,
+                    );
+                    const isPast = seg.to.time.getTime() <= selectedDate.getTime();
+                    const isActive =
+                      seg.from.time.getTime() <= selectedDate.getTime() &&
+                      selectedDate.getTime() < seg.to.time.getTime();
+                    const fmt = (d: Date) =>
+                      d.toLocaleString('en-US', {
+                        month: 'short',
+                        day: 'numeric',
+                        hour: 'numeric',
+                        minute: '2-digit',
+                        hour12: true,
+                        timeZone: 'UTC',
+                      });
+                    const durMins = Math.max(
+                      0,
+                      Math.round(
+                        (seg.to.time.getTime() - seg.from.time.getTime()) / 60_000,
+                      ),
+                    );
+                    const durLabel =
+                      durMins >= 60
+                        ? `${Math.floor(durMins / 60)}h ${(durMins % 60)
+                            .toString()
+                            .padStart(2, '0')}m`
+                        : `${durMins}m`;
+                    const driverPart = selectedAssetData.driverName
+                      ? `\nDriver: ${selectedAssetData.driverName}`
+                      : '';
+                    return (
+                      <button
+                        key={i}
+                        type="button"
+                        onClick={() => onDateChange(new Date(seg.from.time))}
+                        title={`${seg.from.facilityCode} → ${seg.to.facilityCode}\n${fmt(seg.from.time)} – ${fmt(seg.to.time)} (${durLabel})${driverPart}`}
+                        className="absolute rounded-sm text-[10px] font-semibold text-white overflow-hidden whitespace-nowrap px-1.5 border border-black/15 hover:ring-2 hover:ring-[#3d2b1f] hover:z-10 focus:outline-none focus:ring-2 focus:ring-[#3d2b1f] focus:z-10"
+                        style={{
+                          left: `${leftPct}%`,
+                          width: `${widthPct}%`,
+                          top: '6px',
+                          bottom: '6px',
+                          background: isPast ? selectedAssetData.color : '#999',
+                          opacity: isPast ? 0.95 : 0.55,
+                          boxShadow: isActive
+                            ? '0 0 0 2px #3d2b1f inset, 0 0 0 1px #f5e6c8'
+                            : undefined,
+                          display: 'flex',
+                          alignItems: 'center',
+                          justifyContent: 'center',
+                          gap: '4px',
+                        }}
+                      >
+                        <span>
+                          {seg.from.facilityCode}→{seg.to.facilityCode}
+                        </span>
+                        <span className="opacity-80 font-normal">{durLabel}</span>
+                      </button>
+                    );
+                  })
+                  .filter(Boolean);
+              })()}
               {segments.length === 0 && (
                 <div className="absolute inset-0 flex items-center justify-center text-[10px] text-[#7a6e5b] italic">
                   No route segments in this window

--- a/src/views/dispatch/TimeSlider.tsx
+++ b/src/views/dispatch/TimeSlider.tsx
@@ -304,85 +304,94 @@ export function TimeSlider({
                    the bar doesn't overrun (or hug) the gantt origin. */}
               {(() => {
                 const totalHours = windowDays * HOURS_PER_DAY;
-                return segments
-                  .map((seg, i) => {
-                    const startHour =
-                      (seg.from.time.getTime() - origin.getTime()) / MS_PER_HOUR;
-                    const endHour =
-                      (seg.to.time.getTime() - origin.getTime()) / MS_PER_HOUR;
-                    if (endHour <= 0 || startHour >= totalHours) return null;
-                    const clippedStart = Math.max(0, startHour);
-                    const clippedEnd = Math.min(totalHours, endHour);
-                    const leftPct = (clippedStart / totalHours) * 100;
-                    const widthPct = Math.max(
-                      0.6,
-                      ((clippedEnd - clippedStart) / totalHours) * 100,
-                    );
-                    const isPast = seg.to.time.getTime() <= selectedDate.getTime();
-                    const isActive =
-                      seg.from.time.getTime() <= selectedDate.getTime() &&
-                      selectedDate.getTime() < seg.to.time.getTime();
-                    const fmt = (d: Date) =>
-                      d.toLocaleString('en-US', {
-                        month: 'short',
-                        day: 'numeric',
-                        hour: 'numeric',
-                        minute: '2-digit',
-                        hour12: true,
-                        timeZone: 'UTC',
-                      });
-                    const durMins = Math.max(
-                      0,
-                      Math.round(
-                        (seg.to.time.getTime() - seg.from.time.getTime()) / 60_000,
-                      ),
-                    );
-                    const durLabel =
-                      durMins >= 60
-                        ? `${Math.floor(durMins / 60)}h ${(durMins % 60)
-                            .toString()
-                            .padStart(2, '0')}m`
-                        : `${durMins}m`;
-                    const driverPart = selectedAssetData.driverName
-                      ? `\nDriver: ${selectedAssetData.driverName}`
-                      : '';
-                    return (
-                      <button
-                        key={i}
-                        type="button"
-                        onClick={() => onDateChange(new Date(seg.from.time))}
-                        title={`${seg.from.facilityCode} → ${seg.to.facilityCode}\n${fmt(seg.from.time)} – ${fmt(seg.to.time)} (${durLabel})${driverPart}`}
-                        className="absolute rounded-sm text-[10px] font-semibold text-white overflow-hidden whitespace-nowrap px-1.5 border border-black/15 hover:ring-2 hover:ring-[#3d2b1f] hover:z-10 focus:outline-none focus:ring-2 focus:ring-[#3d2b1f] focus:z-10"
-                        style={{
-                          left: `${leftPct}%`,
-                          width: `${widthPct}%`,
-                          top: '6px',
-                          bottom: '6px',
-                          background: isPast ? selectedAssetData.color : '#999',
-                          opacity: isPast ? 0.95 : 0.55,
-                          boxShadow: isActive
-                            ? '0 0 0 2px #3d2b1f inset, 0 0 0 1px #f5e6c8'
-                            : undefined,
-                          display: 'flex',
-                          alignItems: 'center',
-                          justifyContent: 'center',
-                          gap: '4px',
-                        }}
-                      >
-                        <span>
-                          {seg.from.facilityCode}→{seg.to.facilityCode}
-                        </span>
-                        <span className="opacity-80 font-normal">{durLabel}</span>
-                      </button>
-                    );
-                  })
-                  .filter(Boolean);
+                const bars = segments.flatMap((seg, i) => {
+                  const startHour =
+                    (seg.from.time.getTime() - origin.getTime()) / MS_PER_HOUR;
+                  const endHour =
+                    (seg.to.time.getTime() - origin.getTime()) / MS_PER_HOUR;
+                  if (endHour <= 0 || startHour >= totalHours) return [];
+                  const clippedStart = Math.max(0, startHour);
+                  const clippedEnd = Math.min(totalHours, endHour);
+                  const leftPct = (clippedStart / totalHours) * 100;
+                  const widthPct = Math.max(
+                    0.6,
+                    ((clippedEnd - clippedStart) / totalHours) * 100,
+                  );
+                  const isPast = seg.to.time.getTime() <= selectedDate.getTime();
+                  const isActive =
+                    seg.from.time.getTime() <= selectedDate.getTime() &&
+                    selectedDate.getTime() < seg.to.time.getTime();
+                  const fmt = (d: Date) =>
+                    d.toLocaleString('en-US', {
+                      month: 'short',
+                      day: 'numeric',
+                      hour: 'numeric',
+                      minute: '2-digit',
+                      hour12: true,
+                      timeZone: 'UTC',
+                    });
+                  const durMins = Math.max(
+                    0,
+                    Math.round(
+                      (seg.to.time.getTime() - seg.from.time.getTime()) / 60_000,
+                    ),
+                  );
+                  const durLabel =
+                    durMins >= 60
+                      ? `${Math.floor(durMins / 60)}h ${(durMins % 60)
+                          .toString()
+                          .padStart(2, '0')}m`
+                      : `${durMins}m`;
+                  const driverPart = selectedAssetData.driverName
+                    ? `\nDriver: ${selectedAssetData.driverName}`
+                    : '';
+                  return [
+                    <button
+                      key={i}
+                      type="button"
+                      onClick={() => onDateChange(new Date(seg.from.time))}
+                      title={`${seg.from.facilityCode} → ${seg.to.facilityCode}\n${fmt(seg.from.time)} – ${fmt(seg.to.time)} (${durLabel})${driverPart}`}
+                      className="absolute rounded-sm text-[10px] font-semibold text-white overflow-hidden whitespace-nowrap px-1.5 border border-black/15 hover:ring-2 hover:ring-[#3d2b1f] hover:z-10 focus:outline-none focus:ring-2 focus:ring-[#3d2b1f] focus:z-10"
+                      style={{
+                        left: `${leftPct}%`,
+                        width: `${widthPct}%`,
+                        top: '6px',
+                        bottom: '6px',
+                        background: isPast ? selectedAssetData.color : '#999',
+                        opacity: isPast ? 0.95 : 0.55,
+                        boxShadow: isActive
+                          ? '0 0 0 2px #3d2b1f inset, 0 0 0 1px #f5e6c8'
+                          : undefined,
+                        display: 'flex',
+                        alignItems: 'center',
+                        justifyContent: 'center',
+                        gap: '4px',
+                      }}
+                    >
+                      <span>
+                        {seg.from.facilityCode}→{seg.to.facilityCode}
+                      </span>
+                      <span className="opacity-80 font-normal">{durLabel}</span>
+                    </button>,
+                  ];
+                });
+                // Two empty cases worth distinguishing: the asset truly has
+                // no legs to show, vs. it has legs but every one of them was
+                // clipped out by the current window. The second case is easy
+                // to hit by scrubbing the slider far enough away, and going
+                // blank with no message leaves dispatchers wondering whether
+                // the data loaded.
+                if (bars.length === 0) {
+                  return (
+                    <div className="absolute inset-0 flex items-center justify-center text-[10px] text-[#7a6e5b] italic px-3 text-center">
+                      {segments.length === 0
+                        ? 'No route segments for this asset'
+                        : 'All legs are outside the visible window — scrub the slider to bring them into view'}
+                    </div>
+                  );
+                }
+                return bars;
               })()}
-              {segments.length === 0 && (
-                <div className="absolute inset-0 flex items-center justify-center text-[10px] text-[#7a6e5b] italic">
-                  No route segments in this window
-                </div>
-              )}
             </div>
           </>
         ) : (

--- a/src/views/dispatch/deriveData.ts
+++ b/src/views/dispatch/deriveData.ts
@@ -73,7 +73,13 @@ export function deriveDispatchData(
   // ── Assets ── union of declared assets and event.resource ids ──
   const assetIndex = new Map<string, DispatchAsset>();
   assets.forEach((a, i) => {
-    assetIndex.set(a.id, { id: a.id, name: a.label, color: pickColor(a.meta, i) });
+    const drv = a.meta?.['driverName'];
+    assetIndex.set(a.id, {
+      id: a.id,
+      name: a.label,
+      color: pickColor(a.meta, i),
+      ...(typeof drv === 'string' && drv ? { driverName: drv } : {}),
+    });
   });
   events.forEach((ev) => {
     const id = ev.resource;

--- a/src/views/dispatch/types.ts
+++ b/src/views/dispatch/types.ts
@@ -32,6 +32,10 @@ export interface DispatchAsset {
   readonly name: string;
   /** Render color for dots / breadcrumbs. */
   readonly color: string;
+  /** Optional human driver / operator name pulled from `asset.meta.driverName`.
+   *  Surfaced in the dispatch Gantt header so dispatchers can answer
+   *  "who's behind the wheel" at a glance. */
+  readonly driverName?: string;
 }
 
 export interface DispatchFacility {


### PR DESCRIPTION
The Gantt strip rendered every leg as a one-letter pill — the "FROM→TO" label was getting truncated to a single character because each leg was so narrow on a 14-day window (a six-hour drive is ~1.8% of the strip). Nothing on the bar told a dispatcher where the truck was going, when it would get there, who was driving, or how long the leg was, and codex flagged that off-window legs (before the origin) were still rendering at the left edge instead of being clipped.

- Add a one-line summary above the gantt that names the driver and describes what the truck is doing at the selected time: "En route PHX → LAS · 2h 15m to arrival (May 19 12:05 PM)", "Next PHX → LAS departs in 4h ...", or "Last LAS → PHX arrived ...".
- Collapse the route lane from a three-lane stack down to a single full-height lane so each pill is tall enough to read, and pack "FROM→TO duration" inside it. The active leg gets a dark inset ring so it pops out at a glance.
- Skip legs entirely outside the window (endHour <= 0 or startHour >= totalHours) and clamp partially-visible ones to the window edges before computing width — addresses the off-window rendering bug from review.
- Thread `driverName` from asset.meta through DispatchAsset so the header + tooltip can show who's driving without the slider needing a new prop. Bump the footer slot from h-36 to h-44 so the new summary line fits without squeezing the bars.

## Summary
Describe exactly what this PR changes.

## Scope
- Stage: 
- Planned PR number in sprint: 
- Target files/directories: 
- Why this slice is isolated: 

## Lessons Learned Check (REQUIRED)
Confirm these were actively used while building this PR:

- [ ] PR is intentionally small and isolated
- [ ] Boundary typing was prioritized over internal perfection
- [ ] No silent spread of `any`
- [ ] Advisory root `tsc` was used to catch integration issues
- [ ] I did not assume “looks typed” means “safe”
- [ ] I stopped and isolated typing cascades instead of expanding scope

## Definition of Done (ALL REQUIRED)
This PR is not done unless every box is checked.

- [ ] `npm run type-check:strict` passes
- [ ] Root advisory `tsc --noEmit` passes
- [ ] Tests pass for touched scope at minimum
- [ ] No uncontrolled increase in `any`
- [ ] All new types are intentional and named
- [ ] Public interfaces and exported functions are explicitly typed
- [ ] PR scope matches the sprint plan with no scope creep
- [ ] Any new `any` has an adjacent justification comment
- [ ] No file-wide `: any`
- [ ] No implicit `any` in exported functions

## What Was Typed
List exactly what was typed in this PR.

- 
- 
- 

## What Was Intentionally Left Loose
List anything intentionally not tightened yet.

- 
- 
- 

## `any` Ledger (REQUIRED)
- New `any` added: 
- Existing `any` removed: 
- Net change: 

For every new `any`, explain why it is required and why a safer type was not used yet.

1. 
2. 
3. 

## Boundary Notes
Document any public seams, caller-protection choices, or compatibility decisions.

- 
- 
- 

## Risk Level
- [ ] Low
- [ ] Medium
- [ ] High

Why:

## Validation Evidence
Paste the exact commands run and a short result summary.

```bash
npm run type-check:strict
npx tsc --noEmit -p tsconfig.json
```

Test commands run:

```bash
# paste commands here
```

## Stop Conditions Check
If any item below happened, explain how scope was reduced before merge.

- [ ] `any` started spreading across files
- [ ] Root `tsc` broke repeatedly
- [ ] Types required cross-module rewrites
- [ ] Scope was reduced to keep the PR reviewable

Notes:

## Reviewer Focus
What should reviewers look at first?

- 
- 
- 
