### PR TITLE
fix: 8 bugs from the repo bug-scrub

### DIFF
--- a/src/hooks/useFetchEvents.ts
+++ b/src/hooks/useFetchEvents.ts
@@ -9,6 +9,7 @@
  */
 import { useState, useEffect, useRef, useMemo } from 'react';
 import {
+  startOfDay, endOfDay,
   startOfWeek, endOfWeek,
   startOfMonth, endOfMonth,
   addDays,
@@ -22,11 +23,19 @@ function visibleRange(view: string, currentDate: Date, weekStartDay: 0 | 1 | 2 |
         start: startOfWeek(currentDate, { weekStartsOn: weekStartDay }),
         end:   endOfWeek(currentDate,   { weekStartsOn: weekStartDay }),
       };
-    case 'day':
-      return { start: currentDate, end: addDays(currentDate, 1) };
+    case 'day': {
+      // Anchor to midnight so the fetch always covers the full visible day
+      // regardless of what time-of-day `currentDate` happens to carry.
+      const s = startOfDay(currentDate);
+      return { start: s, end: endOfDay(s) };
+    }
     case 'schedule': {
+      // Schedule view renders six full weeks (42 cells). The previous bound
+      // of `addDays(s, 7 * 6 - 1)` landed on midnight of the 42nd cell and
+      // dropped any event later that day, so extend to end-of-day on the
+      // final cell.
       const s = startOfWeek(startOfMonth(currentDate), { weekStartsOn: weekStartDay });
-      return { start: s, end: addDays(s, 7 * 6 - 1) };
+      return { start: s, end: endOfDay(addDays(s, 7 * 6 - 1)) };
     }
     case 'month':
     case 'agenda':

--- a/src/hooks/useOccurrences.ts
+++ b/src/hooks/useOccurrences.ts
@@ -36,10 +36,18 @@ export function useOccurrences(events: NormalizedEvent[], rangeStart: Date, rang
 
       const starts = expandRRule(ev.start, ev.rrule, exdates, expStart, expEnd);
 
-      starts.forEach((start, i) => {
+      starts.forEach((start) => {
+        // Derive a stable per-occurrence id from the start instant rather
+        // than the array index. The index shifts every time the visible
+        // window scrolls — the first occurrence in March is occurrence #4
+        // when you scroll to January — so an index-based id used to swap
+        // which physical occurrence inherited the parent's `ev.id`. Hosts
+        // keying selection / focus / audit links by id would silently map
+        // to a different occurrence after navigation, and React keys
+        // churned for the entire series.
         result.push({
           ...ev,
-          id:          i === 0 ? ev.id : `${ev.id}-r${i}`,
+          id:          `${ev.id}-r${start.getTime()}`,
           start,
           end:         new Date(start.getTime() + durationMs),
           _recurring:  true,

--- a/src/views/AgendaView.tsx
+++ b/src/views/AgendaView.tsx
@@ -83,8 +83,11 @@ export default function AgendaView({
         const dayMs = startOfDay(day).getTime();
         const dayEvents = events.filter((e) => {
           const startMs = startOfDay(e.start).getTime();
-          // All-day events use iCal exclusive DTEND; timed events use their real end.
-          const endDayDate = e.allDay ? displayEndDay(e) : e.end;
+          // Use displayEndDay for both flavors so Agenda and Month agree on
+          // the last day a timed event "occupies" — previously Agenda used
+          // the raw end, which disagreed with Month's UTC-midnight-rollback
+          // logic for timed events ending exactly at UTC midnight.
+          const endDayDate = displayEndDay(e);
           const endMs = Math.max(startOfDay(endDayDate).getTime(), startMs);
           return dayMs >= startMs && dayMs <= endMs;
         });

--- a/src/views/ScheduleView.tsx
+++ b/src/views/ScheduleView.tsx
@@ -36,6 +36,7 @@ import {
   differenceInCalendarDays, startOfDay, addDays, min, max,
 } from 'date-fns';
 import { useCalendarContext, resolveColor } from '../core/CalendarContext';
+import { displayEndDay } from '../core/layout';
 import EmployeeActionCard from '../ui/EmployeeActionCard';
 import styles from './ScheduleView.module.css';
 import { buildGroupTree } from '../hooks/useGrouping.ts';
@@ -165,8 +166,12 @@ function employeeColor(emp: TimelineEmployee, idx: number) {
 }
 
 function assignLanes(events: LooseEvent[], monthStart: Date, monthEnd: Date) {
+  // Use `displayEndDay` so iCal-style all-day events with exclusive DTEND
+  // (DTEND=Jan 4 means coverage Jan 1–3) draw the right lane span. Using
+  // `e.end` directly drew one extra day per all-day event and inflated
+  // lane counts whenever a host feed honored iCal's exclusive end.
   const clipped = events
-    .filter(e => startOfDay(e.start) <= monthEnd && startOfDay(e.end) >= monthStart)
+    .filter(e => startOfDay(e.start) <= monthEnd && startOfDay(displayEndDay(e)) >= monthStart)
     .map(e => ({
       ...e,
       _dayStart: differenceInCalendarDays(
@@ -174,7 +179,7 @@ function assignLanes(events: LooseEvent[], monthStart: Date, monthEnd: Date) {
         monthStart,
       ),
       _dayEnd: differenceInCalendarDays(
-        min([startOfDay(e.end), monthEnd]),
+        min([startOfDay(displayEndDay(e)), monthEnd]),
         monthStart,
       ),
     }))

--- a/src/views/dispatch/AssetSidebar.tsx
+++ b/src/views/dispatch/AssetSidebar.tsx
@@ -6,6 +6,7 @@
  * Ported from `demo/app/src/components/TruckSidebar.tsx`. Renamed for
  * the asset-agnostic positioning.
  */
+import { startOfDay, endOfDay } from 'date-fns';
 import { positionAt } from './deriveData';
 import type {
   DispatchAsset,
@@ -33,14 +34,16 @@ export function AssetSidebar({
   selectedAsset,
   onSelectAsset,
 }: Props) {
-  const dayStart = new Date(
-    Date.UTC(selectedDate.getUTCFullYear(), selectedDate.getUTCMonth(), selectedDate.getUTCDate()),
-  );
-  const dayEnd = new Date(dayStart.getTime() + 86_400_000);
+  // Bucket conflicts in the viewer's wall-clock day so the sidebar's
+  // CONFLICT badges line up with what the dispatcher would call "today",
+  // not the UTC day of the cursor.
+  const dayStartMs = startOfDay(selectedDate).getTime();
+  const dayEndMs = endOfDay(selectedDate).getTime();
 
-  const todayConflicts = conflicts.filter(
-    (c) => c.timeA.getTime() >= dayStart.getTime() && c.timeA.getTime() < dayEnd.getTime(),
-  );
+  const todayConflicts = conflicts.filter((c) => {
+    const t = c.timeA.getTime();
+    return t >= dayStartMs && t <= dayEndMs;
+  });
   const conflictedAssets = new Set<string>();
   for (const c of todayConflicts) {
     conflictedAssets.add(c.assetA);

--- a/src/views/dispatch/DispatchBoard.tsx
+++ b/src/views/dispatch/DispatchBoard.tsx
@@ -123,16 +123,19 @@ export function DispatchBoard({
   // conflict badge. Reads shift-class events (kind === 'shift') emitted
   // by the host alongside the stop / leg event streams.
   const hosByAsset = useMemo(() => {
-    const dayStart = new Date(
-      Date.UTC(selectedDate.getUTCFullYear(), selectedDate.getUTCMonth(), selectedDate.getUTCDate()),
-    );
-    const dayEnd = new Date(dayStart.getTime() + 86_400_000);
+    // Use the viewer's wall-clock day so HOS flags and the dock-conflict
+    // badges (which already bucket by startOfDay/endOfDay) agree on what
+    // "today" means — otherwise a late-evening shift would surface as a
+    // conflict on day X and an HOS risk on day X+1.
+    const dayStartMs = startOfDay(selectedDate).getTime();
+    const dayEndMs = endOfDay(selectedDate).getTime();
     const map = new Map<string, { dutyHours: number; drivingHours: number; flags: string[] }>();
     for (const ev of events) {
       const meta = (ev.meta ?? {}) as Record<string, unknown>;
       if (meta['kind'] !== 'shift') continue;
       const start = ev.start instanceof Date ? ev.start : new Date(ev.start as string);
-      if (start.getTime() < dayStart.getTime() || start.getTime() >= dayEnd.getTime()) continue;
+      const t = start.getTime();
+      if (t < dayStartMs || t > dayEndMs) continue;
       const flags = Array.isArray(meta['hosFlags']) ? (meta['hosFlags'] as string[]) : [];
       const dutyHours = typeof meta['dutyHours'] === 'number' ? (meta['dutyHours'] as number) : 0;
       const drivingHours = typeof meta['drivingHours'] === 'number' ? (meta['drivingHours'] as number) : 0;

--- a/src/views/dispatch/DispatchBoard.tsx
+++ b/src/views/dispatch/DispatchBoard.tsx
@@ -8,8 +8,9 @@
  * adapter pulls normalized events + assets from the calendar context
  * and hands them off here.
  */
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import type { ReactNode } from 'react';
+import { startOfDay, endOfDay } from 'date-fns';
 import '../../styles/tailwind.css';
 import { TacticalMap } from './TacticalMap';
 import { AssetSidebar } from './AssetSidebar';
@@ -63,8 +64,26 @@ export function DispatchBoard({
     const sorted = [...events].map((e) => e.start.getTime()).sort((a, b) => a - b);
     return new Date(sorted[Math.floor(sorted.length / 2)]!);
   });
+  // Track whether the uncontrolled default still represents the mount-time
+  // guess, so we can re-anchor once events arrive asynchronously. Hosts that
+  // load events via `fetchEvents` were getting the real-clock default (no
+  // events at mount) and never re-anchoring — the slider window then sat
+  // months away from the actual data and the map looked empty.
+  const userAnchoredRef = useRef<boolean>(
+    currentDate !== undefined || initialDate !== undefined || events.length > 0,
+  );
+  useEffect(() => {
+    if (userAnchoredRef.current) return;
+    if (events.length === 0) return;
+    const sorted = [...events].map((e) => e.start.getTime()).sort((a, b) => a - b);
+    setUncontrolledDate(new Date(sorted[Math.floor(sorted.length / 2)]!));
+    userAnchoredRef.current = true;
+  }, [events]);
   const selectedDate = currentDate ?? uncontrolledDate;
   const setSelectedDate = (next: Date) => {
+    // Any deliberate scrub locks in the user's choice — don't override it
+    // when a later batch of events trickles in.
+    userAnchoredRef.current = true;
     if (onCurrentDateChange) onCurrentDateChange(next);
     if (currentDate === undefined) setUncontrolledDate(next);
   };
@@ -78,11 +97,15 @@ export function DispatchBoard({
   );
 
   const todayConflicts = useMemo(() => {
-    const dayStart = new Date(
-      Date.UTC(selectedDate.getUTCFullYear(), selectedDate.getUTCMonth(), selectedDate.getUTCDate()),
-    );
-    const dayEnd = new Date(dayStart.getTime() + 86_400_000);
-    return conflicts.filter((c) => c.timeA.getTime() >= dayStart.getTime() && c.timeA.getTime() < dayEnd.getTime());
+    // Bucket conflicts by the viewer's wall-clock day rather than the UTC
+    // day — a 23:30 PHX conflict belongs in the dispatcher's "today" even
+    // when its UTC instant has rolled to tomorrow.
+    const dayStart = startOfDay(selectedDate).getTime();
+    const dayEnd = endOfDay(selectedDate).getTime();
+    return conflicts.filter((c) => {
+      const t = c.timeA.getTime();
+      return t >= dayStart && t <= dayEnd;
+    });
   }, [conflicts, selectedDate]);
 
   const conflictFacilities = useMemo(

--- a/src/views/dispatch/TimeSlider.tsx
+++ b/src/views/dispatch/TimeSlider.tsx
@@ -68,10 +68,20 @@ export function TimeSlider({
 
   // Index that today's wall-clock date falls on within the window — used
   // for the dashed red "now" cursor and the bottom-row TODAY tick.
+  //
+  // The grid columns are UTC-aligned, but "today" should mean the viewer's
+  // wall-clock today. For a user east of UTC after local midnight (but
+  // before UTC midnight), the UTC-of-now is still yesterday's column and
+  // the TODAY marker would land in the wrong spot. Use the viewer's local
+  // calendar components to build the matching UTC-midnight key instead.
   const todayIndex = useMemo(() => {
-    const t = new Date();
-    t.setUTCHours(0, 0, 0, 0);
-    const diff = Math.floor((t.getTime() - origin.getTime()) / MS_PER_DAY);
+    const now = new Date();
+    const localTodayUtcMidnight = Date.UTC(
+      now.getFullYear(),
+      now.getMonth(),
+      now.getDate(),
+    );
+    const diff = Math.floor((localTodayUtcMidnight - origin.getTime()) / MS_PER_DAY);
     return diff >= 0 && diff < windowDays ? diff : -1;
   }, [origin, windowDays]);
 

--- a/src/views/dispatch/deriveData.ts
+++ b/src/views/dispatch/deriveData.ts
@@ -123,7 +123,14 @@ export function deriveDispatchData(
     list.sort((a, b) => a.time.getTime() - b.time.getTime());
   }
 
-  // ── Segments ── pair adjacent stops that move between facilities
+  // ── Segments ── pair adjacent stops that move between facilities.
+  // A real drive leg is anchored by a departure at A: from = departure,
+  // to = the next stop at a different facility. If we paired arrival-at-A
+  // with arrival-at-B directly, the resulting interval would include all
+  // the dwell time at A and the dispatch view would show a phantom
+  // "En route 4h to arrival" for a truck that was actually parked. Hosts
+  // that only emit arrival stops therefore get no synthetic drive bars —
+  // which is honest, since we don't know when the truck actually moved.
   const segmentsByAsset = new Map<string, DispatchSegment[]>();
   for (const [assetId, stops] of stopsByAsset) {
     const segs: DispatchSegment[] = [];
@@ -131,6 +138,7 @@ export function deriveDispatchData(
       const a = stops[i]!;
       const b = stops[i + 1]!;
       if (a.facilityCode === b.facilityCode) continue;
+      if (a.kind !== 'departure') continue;
       segs.push({ assetId, from: a, to: b });
     }
     segmentsByAsset.set(assetId, segs);


### PR DESCRIPTION
Severe
- useFetchEvents day view used `currentDate` (today + now-of-day) as the fetch start and `addDays(currentDate, 1)` as the end, so opening the day view at 14:30 fetched [today 14:30, tomorrow 14:30] and missed every morning event on the visible day. Anchor both bounds with startOfDay / endOfDay.
- useOccurrences assigned `i === 0 ? ev.id : '${ev.id}-r${i}'`, but `i` is the index *within the visible window* — scrolling to a different month silently re-points `ev.id` at a different physical occurrence and churns React keys for the entire series. Derive the per-occurrence id from the occurrence's start instant so it stays stable across nav.
- DispatchBoard's uncontrolled `selectedDate` ran its median-of-events default exactly once at mount, so any async fetchEvents host loaded events *after* the lazy init and the board anchored on real-now — empty map, zero conflicts, looks broken. Track a userAnchoredRef and re-anchor on the first non-empty events batch (without clobbering a user scrub).

Moderate
- TimeSlider built `todayIndex` from `t.setUTCHours(0,0,0,0)` against a UTC-aligned origin, so a viewer east of UTC after local midnight saw the TODAY tick and the dashed "now" cursor on yesterday's column. Build the UTC-midnight key from the viewer's local calendar parts so the marker lands on the column the user thinks of as today. Same shape of fix in DispatchBoard.todayConflicts and AssetSidebar's dayStart/dayEnd — both now bucket by the viewer's wall-clock day via startOfDay/endOfDay, so 23:30-local conflicts aren't binned into the wrong dispatcher day.
- AgendaView and MonthView disagreed on the last day a timed event occupied: Agenda used `startOfDay(e.end)` (local), Month used `displayEndDay` (UTC, with the at-UTC-midnight rollback). Route Agenda through displayEndDay too.
- useFetchEvents schedule range was `addDays(s, 7*6 - 1)` — midnight of the 42nd cell, dropping anything that happens later that day even though the grid renders six full weeks. Extend to end-of-day on the final cell.

Minor
- ScheduleView.assignLanes used `e.end` to compute lane spans, so iCal all-day events with exclusive DTEND drew one extra day and inflated lane count. Switch to displayEndDay to match Month / Agenda.
- deriveDispatchData paired every adjacent different-facility stop into a drive segment, so a host that records only arrivals would produce phantom "En route" bars spanning the dwell time at the origin facility. Require the FROM stop to be a 'departure' so a real drive window anchors each segment.

## Summary
Describe exactly what this PR changes.

## Scope
- Stage: 
- Planned PR number in sprint: 
- Target files/directories: 
- Why this slice is isolated: 

## Lessons Learned Check (REQUIRED)
Confirm these were actively used while building this PR:

- [ ] PR is intentionally small and isolated
- [ ] Boundary typing was prioritized over internal perfection
- [ ] No silent spread of `any`
- [ ] Advisory root `tsc` was used to catch integration issues
- [ ] I did not assume “looks typed” means “safe”
- [ ] I stopped and isolated typing cascades instead of expanding scope

## Definition of Done (ALL REQUIRED)
This PR is not done unless every box is checked.

- [ ] `npm run type-check:strict` passes
- [ ] Root advisory `tsc --noEmit` passes
- [ ] Tests pass for touched scope at minimum
- [ ] No uncontrolled increase in `any`
- [ ] All new types are intentional and named
- [ ] Public interfaces and exported functions are explicitly typed
- [ ] PR scope matches the sprint plan with no scope creep
- [ ] Any new `any` has an adjacent justification comment
- [ ] No file-wide `: any`
- [ ] No implicit `any` in exported functions

## What Was Typed
List exactly what was typed in this PR.

- 
- 
- 

## What Was Intentionally Left Loose
List anything intentionally not tightened yet.

- 
- 
- 

## `any` Ledger (REQUIRED)
- New `any` added: 
- Existing `any` removed: 
- Net change: 

For every new `any`, explain why it is required and why a safer type was not used yet.

1. 
2. 
3. 

## Boundary Notes
Document any public seams, caller-protection choices, or compatibility decisions.

- 
- 
- 

## Risk Level
- [ ] Low
- [ ] Medium
- [ ] High

Why:

## Validation Evidence
Paste the exact commands run and a short result summary.

```bash
npm run type-check:strict
npx tsc --noEmit -p tsconfig.json
```

Test commands run:

```bash
# paste commands here
```

## Stop Conditions Check
If any item below happened, explain how scope was reduced before merge.

- [ ] `any` started spreading across files
- [ ] Root `tsc` broke repeatedly
- [ ] Types required cross-module rewrites
- [ ] Scope was reduced to keep the PR reviewable

Notes:

## Reviewer Focus
What should reviewers look at first?

- 
- 
- 
