### PR TITLE
feat(scheduler): travel-mode time-to-arrive (car / walking / aircraft)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- **Travel-mode "time to arrive" for the resource scheduler.** The engine's
+  single-speed `geo-travel-feasibility` model is cloned into three modes —
+  `car`, `walking`, and a phase-based `aircraft` performance profile (taxi →
+  climb → cruise → descent → taxi). New public API: `estimateTravelMinutes`,
+  `effectiveSpeedKph`, `resolveTravelProfile`, the `CAR_PROFILE` /
+  `WALKING_PROFILE` / aircraft presets (`LIGHT_PISTON`, `TURBOPROP`,
+  `BUSINESS_JET`, `AIRLINER`, `AIRCRAFT_PROFILES`), and the mode-aware
+  feasibility evaluator `evaluateTravelFeasibility` / `travelFeasibilityRule`.
+  The dispatch view now annotates each leg with a modeled estimate (resolved
+  from `event.meta.travelMode` / `asset.meta.travelMode`, default `car`) and
+  surfaces it next to the scheduled clock time. See `docs/TravelModes.md`.
+
 ## [2.0.0] — 2026-05-20
 
 The "embeddable for real" release. The headline is a breaking change to how

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- **Loosened mandatory chrome — toolbar, view tabs, left rail, and right
+  panel are now optional.** Each region can be hidden via a new `show*` prop
+  (`showToolbar`, `showViewSwitcher`, `showLeftRail`, `showRightPanel`) or
+  persisted in config under `display.chrome.*`. The setup wizard's Review
+  step and ConfigPanel → *Layout & Labels* → *Panels & chrome* both expose
+  the toggles, and `CalendarConfig.settings.chrome` round-trips through
+  `parseConfig` / `serializeConfig`. Resolution order is prop > saved config
+  > `true`, so existing calendars keep their full layout unchanged. See
+  `docs/CalendarConfig.md`.
 - **Travel-mode "time to arrive" for the resource scheduler.** The engine's
   single-speed `geo-travel-feasibility` model is cloned into three modes —
   `car`, `walking`, and a phase-based `aircraft` performance profile (taxi →

--- a/docs/CalendarConfig.md
+++ b/docs/CalendarConfig.md
@@ -144,7 +144,33 @@ returns `{ config, errors: [], dropped: 0 }` for any valid
 | `pools`          | `ResourcePool[]`                            | Same shape as the runtime pool definitions. Manual / query / hybrid types all round-trip. |
 | `requirements`   | `{ eventType, requires: ({role,count}\|{pool,count})[] }[]` | Templates declaring what each event type needs. **Not yet consumed by the runtime engine** — the type lives here so the wizard's output round-trips losslessly. |
 | `events`         | `{ id, title, start, end, eventType?, resourceId?, resourcePoolId?, meta? }[]` | Seed events for demos / config-driven setup. ISO 8601 strings on the wire; the runtime parses them when loading. |
-| `settings`       | `{ conflictMode?, timezone? }`              | `conflictMode` is whitelisted to `block` / `soft` / `off`. Not yet enforced at runtime. |
+| `settings`       | `{ conflictMode?, timezone?, chrome? }`     | `conflictMode` is whitelisted to `block` / `soft` / `off`. `chrome` toggles layout regions (see below). Not yet enforced at runtime. |
+
+### `settings.chrome` — layout regions
+
+`chrome` controls which top-level UI regions render. Each flag defaults to
+`true` (shown) when omitted, so a calendar with no `chrome` block keeps the
+full layout.
+
+| Flag           | Region |
+|----------------|--------|
+| `toolbar`      | The top toolbar / header bar (title, navigation, search, filters, view controls). |
+| `viewSwitcher` | The Month / Week / Day / … view tabs. |
+| `leftRail`     | The left icon rail (Add / Saved views / Focus / Settings). |
+| `rightPanel`   | The right panel (region map + crew on shift). |
+
+```json
+{ "settings": { "chrome": { "leftRail": false, "rightPanel": false } } }
+```
+
+At runtime these map onto `display.chrome.*` in the persisted owner config
+(editable from the setup wizard's Review step and ConfigPanel → *Layout &
+Labels* → *Panels & chrome*). The host can also override any region
+per-render with the matching `show*` prop on `WorksCalendar`
+(`showToolbar`, `showViewSwitcher`, `showLeftRail`, `showRightPanel`).
+Resolution order is **prop > persisted config > `true`**. A view that owns
+its own chrome (e.g. Dispatch) still suppresses the host toolbar/rails on
+its own regardless of these flags.
 
 ## Industry profile presets
 

--- a/docs/Conflicts.md
+++ b/docs/Conflicts.md
@@ -293,6 +293,14 @@ interface GeoConflictViolation {
 
 > **Note:** `evaluateGeoConflicts` is not called by `validateOperation` inside the engine. Call it independently after each engine commit, or in a pre-save check, and attach locations to events via `attachLocations` or a location adapter.
 
+### Multi-mode travel ("time to arrive" by car / walking / aircraft)
+
+`geo-travel-feasibility` uses a single `maxSpeedKph`. When you need
+mode-aware "time to arrive" — driving vs. walking vs. a phase-based aircraft
+performance profile — use `evaluateTravelFeasibility` and the travel-mode
+estimator. Same `GeoEventInput` shape, same semantics, per-mode profiles.
+See [TravelModes.md](./TravelModes.md).
+
 ---
 
 ## Requirements engine

--- a/docs/TravelModes.md
+++ b/docs/TravelModes.md
@@ -1,0 +1,103 @@
+# Travel-mode "time to arrive"
+
+The engine ships a single-speed travel model — the `geo-travel-feasibility`
+rule (see [Conflicts.md](./Conflicts.md#geo-conflict-detection)) — that
+divides the straight-line distance between two events by one `maxSpeedKph`
+to decide whether a resource can physically make the trip in the available
+gap.
+
+That's enough to stop a jet from being booked in two cities an hour apart,
+but the resource scheduler dispatches with mixed fleets that move very
+differently. This module clones that maps-style "time to arrive" math and
+grows it into three modes:
+
+| Mode | Model |
+| --- | --- |
+| `car` | great-circle × route factor ÷ average speed + a flat access overhead |
+| `walking` | same shape as car, slower, gentler path factor, no overhead |
+| `aircraft` | phase-based performance profile: taxi → climb → cruise → descent → taxi |
+
+The aircraft model is the reason a single `maxSpeedKph` isn't enough: a
+50 km hop and a 5000 km haul get realistically different *effective* speeds
+because taxi, climb, and descent dominate short legs and the aircraft never
+reaches cruise.
+
+## Estimating a leg
+
+```ts
+import {
+  estimateTravelMinutes,
+  CAR_PROFILE,
+  WALKING_PROFILE,
+  AIRLINER,
+} from 'works-calendar';
+
+const SEA = { lat: 47.45, lon: -122.31 };
+const DEN = { lat: 39.86, lon: -104.67 }; // ~1644 km
+
+estimateTravelMinutes(SEA, DEN, CAR_PROFILE);     // ≈ 1424 min (road + overhead)
+estimateTravelMinutes(SEA, DEN, WALKING_PROFILE); // ≈ 23 700 min
+estimateTravelMinutes(SEA, DEN, AIRLINER);        // ≈ 158 min (taxi + climb + cruise + descent + taxi)
+```
+
+`estimateTravelMinutes` returns `Infinity` when the coordinates can't yield
+a finite distance — treat that as "unknown".
+
+### Profiles
+
+`CAR_PROFILE` and `WALKING_PROFILE` are `SurfaceTravelProfile`s. Aircraft
+ship as `AircraftPerformanceProfile` presets — `LIGHT_PISTON`, `TURBOPROP`,
+`BUSINESS_JET`, `AIRLINER` — also available by id in `AIRCRAFT_PROFILES`.
+Pass your own profile object for real performance data.
+
+`resolveTravelProfile(mode)` turns a loose string (`'car'`, `'walking'`,
+`'aircraft'`, or an aircraft profile id like `'turboprop'`) into a profile,
+falling back to `CAR_PROFILE` for anything unknown. This is what the
+dispatch view uses to read `event.meta.travelMode` / `asset.meta.travelMode`.
+
+## Feasibility checking
+
+`evaluateTravelFeasibility` is the mode-aware sibling of
+`evaluateGeoConflicts` — same signature, same coord resolution, same
+"overlap is `resource-overlap`'s job, not ours" carve-out — but it reasons
+about a full `TravelProfile` instead of one speed.
+
+```ts
+import { evaluateTravelFeasibility, travelFeasibilityRule } from 'works-calendar';
+
+const rule = travelFeasibilityRule('truck-travel', 'car', { severity: 'soft' });
+
+const violations = evaluateTravelFeasibility([rule], proposed, others);
+// violations[0].details = { mode, profileLabel, distanceKm, requiredGapMinutes, actualGapMinutes }
+```
+
+Events use the engine's `GeoEventInput` shape (coordinates via
+`meta.coords` `{ lat, lon }` or top-level `meta.lat/lon|lng`), so anything
+already feeding `evaluateGeoConflicts` points here with no translation.
+
+### Bridging back to the engine rule
+
+`effectiveSpeedKph(from, to, profile)` returns the door-to-door average
+speed a profile implies for a given leg. Feed it as `maxSpeedKph` on a
+`geo-travel-feasibility` rule and the existing engine pipeline reproduces
+this profile's timing for that leg.
+
+## In the dispatch view
+
+`deriveDispatchData(events, assets, defaultTravelMode = 'car')` annotates
+each `DispatchSegment` with an `estimate` (`{ mode, profileLabel, minutes }`)
+computed from the leg's distance and the resolved travel mode:
+
+1. the departing stop's `event.meta.travelMode` (per-leg override), else
+2. the asset's `meta.travelMode`, else
+3. `defaultTravelMode`.
+
+The dispatch time slider surfaces the estimate next to the scheduled clock
+time ("… · 2h 30m drive · est 2h 38m by car") and in each leg's tooltip, so
+a dispatcher can see at a glance whether a leg is padded or physically tight.
+
+## References
+
+- `src/core/travel/travelProfiles.ts` — profiles + estimator
+- `src/core/travel/travelFeasibility.ts` — `evaluateTravelFeasibility`
+- `src/views/dispatch/deriveData.ts` — segment estimate wiring

--- a/src/WorksCalendar.tsx
+++ b/src/WorksCalendar.tsx
@@ -145,6 +145,10 @@ const WorksCalendarImpl = forwardRef<CalendarApi, WorksCalendarProps>(function W
     showMiniCalendar        = false,
     showCalendarLegend      = false,
     showOfflineIndicator    = false,
+    showToolbar,
+    showLeftRail,
+    showRightPanel,
+    showViewSwitcher,
     hideEventTemplates       = false,
     eventTemplates,
     eventResourceSuggestions,
@@ -386,12 +390,21 @@ const WorksCalendarImpl = forwardRef<CalendarApi, WorksCalendarProps>(function W
           // ViewSwitcher node to slot into its own header.
           const currentViewDef = VIEWS.find((v) => v.id === cal.view);
           const viewOwnsChrome = currentViewDef?.ownsChrome === true;
-          const viewSwitcherForView = viewOwnsChrome ? (
+          // Chrome visibility: explicit show* prop wins, else the persisted
+          // display.chrome setting, else true (full chrome — historical default).
+          const chromeCfg = (ownerCfg.config?.['display'] as { chrome?: Record<string, unknown> } | undefined)?.chrome;
+          const resolveChrome = (prop: boolean | undefined, key: string): boolean =>
+            prop ?? (typeof chromeCfg?.[key] === 'boolean' ? (chromeCfg[key] as boolean) : true);
+          const chromeLeftRail     = resolveChrome(showLeftRail, 'leftRail');
+          const chromeRightPanel   = resolveChrome(showRightPanel, 'rightPanel');
+          const chromeToolbar      = resolveChrome(showToolbar, 'toolbar');
+          const chromeViewSwitcher = resolveChrome(showViewSwitcher, 'viewSwitcher');
+          const viewSwitcherForView = viewOwnsChrome && chromeViewSwitcher ? (
             <ViewSwitcher views={VIEWS} currentView={cal.view} onViewChange={(id) => cal.setView(id as typeof cal.view)} />
           ) : null;
           return (
           <AppShell
-            {...(viewOwnsChrome ? {} : { leftRail: <CalendarLeftRail
+            {...(viewOwnsChrome || !chromeLeftRail ? {} : { leftRail: <CalendarLeftRail
               ownerCfg={ownerCfg}
               leftRailExtras={leftRailExtras}
               setSidebarInitialTab={setSidebarInitialTab}
@@ -413,9 +426,10 @@ const WorksCalendarImpl = forwardRef<CalendarApi, WorksCalendarProps>(function W
               editMode={editMode}
               onToggleEditMode={() => { setEditMode((v) => !v); setInlineEditTarget(null); }}
             /> })}
-            {...(viewOwnsChrome || !hasRightPanelContent(configuredEmployees, rightPanelExtras) ? {} : { rightPanel: <CalendarRightPanel configuredEmployees={configuredEmployees} onShiftIds={onShiftIds} rightPanelExtras={rightPanelExtras} /> })}
-            header={viewOwnsChrome ? <></> :
+            {...(viewOwnsChrome || !chromeRightPanel || !hasRightPanelContent(configuredEmployees, rightPanelExtras) ? {} : { rightPanel: <CalendarRightPanel configuredEmployees={configuredEmployees} onShiftIds={onShiftIds} rightPanelExtras={rightPanelExtras} /> })}
+            header={viewOwnsChrome || !chromeToolbar ? <></> :
               <CalendarToolbar cal={cal} ownerCfg={ownerCfg} api={api}
+                showViewSwitcher={chromeViewSwitcher}
                 renderToolbar={renderToolbar} renderSavedViewsBar={renderSavedViewsBar} renderFilterBar={renderFilterBar}
                 focusChips={focusChips} logoSrc={logoSrc} logoAlt={logoAlt}
                 devMode={devMode} calendarTitle={calendarTitle} fetchLoading={fetchLoading}

--- a/src/WorksCalendar.types.ts
+++ b/src/WorksCalendar.types.ts
@@ -54,6 +54,17 @@ export type WorksCalendarConfig = {
     dayEnd?: number;
     showWeekNumbers?: boolean;
     enlargeMonthRowOnHover?: boolean;
+    /**
+     * Which top-level chrome regions render. Each flag defaults to `true`
+     * when omitted (full chrome). The matching `show*` props on
+     * `WorksCalendar` override these per-render when provided.
+     */
+    chrome?: {
+      leftRail?: boolean;
+      rightPanel?: boolean;
+      toolbar?: boolean;
+      viewSwitcher?: boolean;
+    };
     [key: string]: unknown;
   };
   /** Filter UI label overrides (group labels for Categories/People/Sources/More). */
@@ -279,6 +290,23 @@ export type WorksCalendarProps = {
   showCalendarLegend?: boolean;
   /** Show a banner when the browser reports no network connectivity. */
   showOfflineIndicator?: boolean;
+  /**
+   * Chrome visibility overrides. Each defaults to the persisted
+   * `display.chrome.*` setting (editable via the setup wizard / ConfigPanel),
+   * then to `true` (full chrome). Pass `false` to force a region off
+   * regardless of the saved config — e.g. embedding the calendar inside a
+   * host that already provides its own toolbar or side navigation.
+   *
+   * Note: a view that "owns its chrome" (e.g. Dispatch) still suppresses the
+   * host toolbar/rails on its own; these props only widen what's hidden.
+   */
+  showToolbar?: boolean;
+  /** Show the left icon rail (Add / Saved views / Focus / Settings). */
+  showLeftRail?: boolean;
+  /** Show the right panel (region map + crew on shift). */
+  showRightPanel?: boolean;
+  /** Show the Month / Week / Day / … view-switcher tabs. */
+  showViewSwitcher?: boolean;
   /**
    * Host-defined quick-create event templates surfaced in the toolbar "New from template" dropdown.
    * Each template pre-fills the EventForm via api.addEvent(defaults).

--- a/src/__tests__/WorksCalendar.chromeVisibility.test.tsx
+++ b/src/__tests__/WorksCalendar.chromeVisibility.test.tsx
@@ -1,0 +1,85 @@
+// @vitest-environment happy-dom
+/**
+ * Chrome visibility controls (loosening the previously-mandatory layout).
+ *
+ * Four regions can now be hidden — the left icon rail, the right panel, the
+ * top toolbar, and the view-switcher tabs — via either:
+ *   - explicit `show*` props on WorksCalendar, or
+ *   - the persisted `display.chrome.*` config (set by the setup wizard /
+ *     ConfigPanel).
+ *
+ * Resolution order is: explicit prop > persisted config > true (full chrome).
+ * These tests pin each region's prop toggle, the config path, and the
+ * prop-wins-over-config precedence. Everything defaults to "shown" so an
+ * untouched calendar keeps its historical full-chrome layout.
+ */
+import { afterEach, describe, expect, it } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import React from 'react';
+
+import { WorksCalendar } from '../WorksCalendar.tsx';
+
+function seedConfig(calendarId: string, config: Record<string, unknown>) {
+  localStorage.setItem(`wc-config-${calendarId}`, JSON.stringify(config));
+}
+
+afterEach(() => {
+  localStorage.clear();
+});
+
+const viewTabs = (c: HTMLElement) => c.querySelectorAll('[data-wc-view-button]');
+
+describe('WorksCalendar chrome visibility — defaults', () => {
+  it('renders all chrome by default', () => {
+    const { container } = render(<WorksCalendar calendarId="chrome-default" events={[]} />);
+    expect(screen.getByRole('button', { name: 'Saved views' })).toBeInTheDocument();
+    expect(viewTabs(container).length).toBeGreaterThan(0);
+  });
+});
+
+describe('WorksCalendar chrome visibility — props', () => {
+  it('showLeftRail={false} hides the left rail', () => {
+    render(<WorksCalendar calendarId="chrome-norail" events={[]} showLeftRail={false} />);
+    expect(screen.queryByRole('button', { name: 'Saved views' })).not.toBeInTheDocument();
+  });
+
+  it('showViewSwitcher={false} hides the view tabs but keeps the rest of the toolbar', () => {
+    const { container } = render(
+      <WorksCalendar calendarId="chrome-notabs" events={[]} showViewSwitcher={false} />,
+    );
+    expect(viewTabs(container).length).toBe(0);
+    // The left rail is independent and still renders.
+    expect(screen.getByRole('button', { name: 'Saved views' })).toBeInTheDocument();
+  });
+
+  it('showToolbar={false} hides the toolbar (and the tabs inside it)', () => {
+    const { container } = render(
+      <WorksCalendar calendarId="chrome-notoolbar" events={[]} showToolbar={false} />,
+    );
+    expect(viewTabs(container).length).toBe(0);
+    // Rail is a separate region — still present.
+    expect(screen.getByRole('button', { name: 'Saved views' })).toBeInTheDocument();
+  });
+});
+
+describe('WorksCalendar chrome visibility — persisted config', () => {
+  it('honors display.chrome.leftRail = false from saved config', () => {
+    seedConfig('chrome-cfg-rail', { display: { chrome: { leftRail: false } } });
+    render(<WorksCalendar calendarId="chrome-cfg-rail" events={[]} />);
+    expect(screen.queryByRole('button', { name: 'Saved views' })).not.toBeInTheDocument();
+  });
+
+  it('honors display.chrome.viewSwitcher = false from saved config', () => {
+    seedConfig('chrome-cfg-tabs', { display: { chrome: { viewSwitcher: false } } });
+    const { container } = render(<WorksCalendar calendarId="chrome-cfg-tabs" events={[]} />);
+    expect(viewTabs(container).length).toBe(0);
+  });
+
+  it('an explicit prop overrides the saved config', () => {
+    // Config says hide the rail; the prop forces it back on.
+    seedConfig('chrome-override', { display: { chrome: { leftRail: false } } });
+    render(<WorksCalendar calendarId="chrome-override" events={[]} showLeftRail={true} />);
+    expect(screen.getByRole('button', { name: 'Saved views' })).toBeInTheDocument();
+  });
+});

--- a/src/core/config/__tests__/serializeConfig.test.ts
+++ b/src/core/config/__tests__/serializeConfig.test.ts
@@ -199,4 +199,22 @@ describe('serializeConfig + parseConfig — round-trip', () => {
     expect(round.config).toEqual({})
     expect(round.errors).toEqual([])
   })
+
+  it('round-trips settings.chrome flags losslessly', () => {
+    const config: CalendarConfig = {
+      settings: {
+        chrome: { leftRail: false, rightPanel: false, toolbar: true, viewSwitcher: false },
+      },
+    }
+    const round = parseConfig(JSON.parse(JSON.stringify(serializeConfig(config))))
+    expect(round.errors).toEqual([])
+    expect(round.config).toEqual(config)
+  })
+
+  it('drops non-boolean chrome flags rather than carrying garbage through', () => {
+    const round = parseConfig({
+      settings: { chrome: { leftRail: false, rightPanel: 'nope', bogus: 1 } },
+    })
+    expect(round.config.settings?.chrome).toEqual({ leftRail: false })
+  })
 })

--- a/src/core/config/calendarConfig.ts
+++ b/src/core/config/calendarConfig.ts
@@ -130,6 +130,27 @@ export interface ConfigSettings {
   readonly conflictMode?: 'block' | 'soft' | 'off'
   /** IANA timezone identifier (e.g. "America/Denver"). */
   readonly timezone?: string
+  /** Which top-level UI chrome regions render. See `ChromeSettings`. */
+  readonly chrome?: ChromeSettings
+}
+
+/**
+ * Which top-level UI chrome regions render. Every flag defaults to `true`
+ * (full chrome) when omitted, so an absent `chrome` block — or an absent
+ * individual flag — means "show it", preserving the calendar's historical
+ * always-on layout. Hosts loosen the layout by setting flags to `false`,
+ * either through the setup wizard / ConfigPanel or the matching
+ * `show*` props on `WorksCalendar`.
+ */
+export interface ChromeSettings {
+  /** The left icon rail (Add / Saved views / Focus / Settings). */
+  readonly leftRail?: boolean
+  /** The right panel (region map + crew on shift). */
+  readonly rightPanel?: boolean
+  /** The top toolbar/header band (title, nav, search, filters, view controls). */
+  readonly toolbar?: boolean
+  /** The Month / Week / Day / … view-switcher tabs. */
+  readonly viewSwitcher?: boolean
 }
 
 /**

--- a/src/core/config/parseConfig.ts
+++ b/src/core/config/parseConfig.ts
@@ -325,6 +325,14 @@ function parseSettings(raw: unknown, errors: string[]): ConfigSettings | null {
     }
   }
   if (typeof raw['timezone'] === 'string') out.timezone = raw['timezone']
+  if (isObject(raw['chrome'])) {
+    const c = raw['chrome']
+    const chrome: { -readonly [K in keyof NonNullable<ConfigSettings['chrome']>]: boolean } = {}
+    for (const key of ['leftRail', 'rightPanel', 'toolbar', 'viewSwitcher'] as const) {
+      if (typeof c[key] === 'boolean') chrome[key] = c[key]
+    }
+    out.chrome = chrome
+  }
   return out
 }
 

--- a/src/core/config/serializeConfig.ts
+++ b/src/core/config/serializeConfig.ts
@@ -96,5 +96,6 @@ function serializeSettings(s: ConfigSettings): Record<string, unknown> {
   const out: Record<string, unknown> = {}
   if (s.conflictMode !== undefined) out['conflictMode'] = s.conflictMode
   if (s.timezone     !== undefined) out['timezone']     = s.timezone
+  if (s.chrome       !== undefined) out['chrome']       = { ...s.chrome }
   return out
 }

--- a/src/core/travel/__tests__/travelFeasibility.test.ts
+++ b/src/core/travel/__tests__/travelFeasibility.test.ts
@@ -1,0 +1,162 @@
+import { describe, it, expect } from 'vitest';
+import {
+  evaluateTravelFeasibility,
+  travelFeasibilityRule,
+  type TravelFeasibilityRule,
+} from '../travelFeasibility';
+import type { GeoEventInput } from 'works-calendar-engine';
+
+const SEA = { lat: 47.45, lon: -122.31 };
+const DEN = { lat: 39.86, lon: -104.67 }; // ~1644 km from SEA
+const NEAR_SEA = { lat: 47.5, lon: -122.31 }; // ~5.6 km from SEA
+
+function evt(
+  id: string,
+  start: string,
+  end: string,
+  resource: string | null,
+  coords: { lat: number; lon: number } | null,
+  category?: string,
+): GeoEventInput {
+  return {
+    id,
+    start,
+    end,
+    resource,
+    ...(category ? { category } : {}),
+    meta: coords ? { coords } : {},
+  };
+}
+
+const CAR_RULE = travelFeasibilityRule('car', 'car');
+const AIR_RULE = travelFeasibilityRule('air', 'airliner');
+
+describe('evaluateTravelFeasibility', () => {
+  it('flags a leg that is too short to drive', () => {
+    const proposed = evt('p', '2026-04-20T12:00', '2026-04-20T13:00', 'rig-1', SEA);
+    const other = evt('o', '2026-04-20T13:30', '2026-04-20T14:30', 'rig-1', DEN);
+    const v = evaluateTravelFeasibility([CAR_RULE], proposed, [other]);
+    expect(v.length).toBe(1);
+    expect(v[0]!.details.mode).toBe('car');
+    expect(v[0]!.details.distanceKm).toBeGreaterThan(1500);
+    expect(v[0]!.details.actualGapMinutes).toBe(30);
+    // 1644 km * 1.3 / 90 kph ≈ 1424 min required
+    expect(v[0]!.details.requiredGapMinutes).toBeGreaterThan(1000);
+  });
+
+  it('the same leg is feasible by air with the same gap', () => {
+    // 6h gap — too short to drive 1644 km, fine for an airliner.
+    const proposed = evt('p', '2026-04-20T12:00', '2026-04-20T13:00', 'tail-1', SEA);
+    const other = evt('o', '2026-04-20T19:00', '2026-04-20T20:00', 'tail-1', DEN);
+    expect(evaluateTravelFeasibility([AIR_RULE], proposed, [other])).toEqual([]);
+    // ...but driving it in 6h is still infeasible:
+    const drivingProposed = { ...proposed, resource: 'rig-1' };
+    const drivingOther = { ...other, resource: 'rig-1' };
+    expect(
+      evaluateTravelFeasibility([CAR_RULE], drivingProposed, [drivingOther]).length,
+    ).toBe(1);
+  });
+
+  it('passes when the gap comfortably exceeds travel time', () => {
+    const proposed = evt('p', '2026-04-20T12:00', '2026-04-20T13:00', 'rig-1', SEA);
+    const other = evt('o', '2026-04-22T00:00', '2026-04-22T01:00', 'rig-1', DEN);
+    expect(evaluateTravelFeasibility([CAR_RULE], proposed, [other])).toEqual([]);
+  });
+
+  it('does not fire when events overlap in time (resource-overlap territory)', () => {
+    const proposed = evt('p', '2026-04-20T12:00', '2026-04-20T18:00', 'rig-1', SEA);
+    const other = evt('o', '2026-04-20T14:00', '2026-04-20T20:00', 'rig-1', DEN);
+    expect(evaluateTravelFeasibility([CAR_RULE], proposed, [other])).toEqual([]);
+  });
+
+  it('honors minGapMinutes (turnaround) even at zero distance', () => {
+    const rule = travelFeasibilityRule('turn', 'aircraft', { minGapMinutes: 45 });
+    const proposed = evt('p', '2026-04-20T12:00', '2026-04-20T13:00', 'tail-1', SEA);
+    const other = evt('o', '2026-04-20T13:10', '2026-04-20T14:00', 'tail-1', SEA);
+    const v = evaluateTravelFeasibility([rule], proposed, [other]);
+    expect(v.length).toBe(1);
+    expect(v[0]!.details.requiredGapMinutes).toBe(45);
+    expect(v[0]!.details.actualGapMinutes).toBe(10);
+  });
+
+  it('skips events on a different resource', () => {
+    const proposed = evt('p', '2026-04-20T12:00', '2026-04-20T13:00', 'rig-1', SEA);
+    const other = evt('o', '2026-04-20T13:30', '2026-04-20T14:30', 'rig-2', DEN);
+    expect(evaluateTravelFeasibility([CAR_RULE], proposed, [other])).toEqual([]);
+  });
+
+  it('skips self', () => {
+    const proposed = evt('same', '2026-04-20T12:00', '2026-04-20T13:00', 'rig-1', SEA);
+    const other = evt('same', '2026-04-20T13:30', '2026-04-20T14:30', 'rig-1', DEN);
+    expect(evaluateTravelFeasibility([CAR_RULE], proposed, [other])).toEqual([]);
+  });
+
+  it('skips when either resource is null', () => {
+    const proposed = evt('p', '2026-04-20T12:00', '2026-04-20T13:00', null, SEA);
+    const other = evt('o', '2026-04-20T13:30', '2026-04-20T14:30', 'rig-1', DEN);
+    expect(evaluateTravelFeasibility([CAR_RULE], proposed, [other])).toEqual([]);
+  });
+
+  it('skips when proposed has no coordinates', () => {
+    const proposed = evt('p', '2026-04-20T12:00', '2026-04-20T13:00', 'rig-1', null);
+    const other = evt('o', '2026-04-20T13:30', '2026-04-20T14:30', 'rig-1', DEN);
+    expect(evaluateTravelFeasibility([CAR_RULE], proposed, [other])).toEqual([]);
+  });
+
+  it('skips when other has no coordinates', () => {
+    const proposed = evt('p', '2026-04-20T12:00', '2026-04-20T13:00', 'rig-1', SEA);
+    const other = evt('o', '2026-04-20T13:30', '2026-04-20T14:30', 'rig-1', null);
+    expect(evaluateTravelFeasibility([CAR_RULE], proposed, [other])).toEqual([]);
+  });
+
+  it('respects ignoreCategories', () => {
+    const rule: TravelFeasibilityRule = { ...CAR_RULE, ignoreCategories: ['ferry'] };
+    const proposed = evt('p', '2026-04-20T12:00', '2026-04-20T13:00', 'rig-1', SEA, 'ferry');
+    const other = evt('o', '2026-04-20T13:30', '2026-04-20T14:30', 'rig-1', DEN);
+    expect(evaluateTravelFeasibility([rule], proposed, [other])).toEqual([]);
+  });
+
+  it('returns empty when rules is empty', () => {
+    const proposed = evt('p', '2026-04-20T12:00', '2026-04-20T13:00', 'rig-1', SEA);
+    const other = evt('o', '2026-04-20T13:30', '2026-04-20T14:30', 'rig-1', DEN);
+    expect(evaluateTravelFeasibility([], proposed, [other])).toEqual([]);
+  });
+
+  it('uses hard severity when the rule specifies it', () => {
+    const rule = travelFeasibilityRule('car-hard', 'car', { severity: 'hard' });
+    const proposed = evt('p', '2026-04-20T12:00', '2026-04-20T13:00', 'rig-1', SEA);
+    const other = evt('o', '2026-04-20T13:30', '2026-04-20T14:30', 'rig-1', DEN);
+    const v = evaluateTravelFeasibility([rule], proposed, [other]);
+    expect(v[0]!.severity).toBe('hard');
+  });
+
+  it('a short walkable leg with a tight gap is flagged for walking but not for car', () => {
+    // ~5.6 km. Walking ≈ 67 min; a 20 min gap fails walking, passes car.
+    const proposed = evt('p', '2026-04-20T12:00', '2026-04-20T13:00', 'crew-1', SEA);
+    const other = evt('o', '2026-04-20T13:20', '2026-04-20T14:00', 'crew-1', NEAR_SEA);
+    const walk = travelFeasibilityRule('walk', 'walking');
+    expect(evaluateTravelFeasibility([walk], proposed, [other]).length).toBe(1);
+    expect(evaluateTravelFeasibility([CAR_RULE], proposed, [other])).toEqual([]);
+  });
+
+  it('resolves coords from direct meta.lat/lng', () => {
+    const proposed: GeoEventInput = {
+      id: 'p', start: '2026-04-20T12:00', end: '2026-04-20T13:00', resource: 'rig-1',
+      meta: { lat: SEA.lat, lng: SEA.lon },
+    };
+    const other: GeoEventInput = {
+      id: 'o', start: '2026-04-20T13:30', end: '2026-04-20T14:30', resource: 'rig-1',
+      meta: { lat: DEN.lat, lng: DEN.lon },
+    };
+    expect(evaluateTravelFeasibility([CAR_RULE], proposed, [other]).length).toBe(1);
+  });
+
+  it('returns no violation on an unparseable timestamp', () => {
+    const proposed: GeoEventInput = {
+      id: 'p', start: 'not-a-date', end: '2026-04-20T13:00', resource: 'rig-1',
+      meta: { coords: SEA },
+    };
+    const other = evt('o', '2026-04-20T13:30', '2026-04-20T14:30', 'rig-1', DEN);
+    expect(evaluateTravelFeasibility([CAR_RULE], proposed, [other])).toEqual([]);
+  });
+});

--- a/src/core/travel/__tests__/travelProfiles.test.ts
+++ b/src/core/travel/__tests__/travelProfiles.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect } from 'vitest';
+import {
+  estimateTravelMinutes,
+  effectiveSpeedKph,
+  resolveTravelProfile,
+  CAR_PROFILE,
+  WALKING_PROFILE,
+  AIRLINER,
+  LIGHT_PISTON,
+  AIRCRAFT_PROFILES,
+  TRAVEL_PROFILE_BY_MODE,
+} from '../travelProfiles';
+import { haversineKm, type LatLon } from 'works-calendar-engine';
+
+// SEA ↔ DEN ≈ 1644 km; a 1 km hop for short-leg behavior.
+const SEA: LatLon = { lat: 47.45, lon: -122.31 };
+const DEN: LatLon = { lat: 39.86, lon: -104.67 };
+const NEAR_SEA: LatLon = { lat: 47.46, lon: -122.31 }; // ~1.1 km north
+
+describe('resolveTravelProfile', () => {
+  it('maps mode strings to the right preset', () => {
+    expect(resolveTravelProfile('car')).toBe(CAR_PROFILE);
+    expect(resolveTravelProfile('walking')).toBe(WALKING_PROFILE);
+    expect(resolveTravelProfile('aircraft')).toBe(TRAVEL_PROFILE_BY_MODE.aircraft);
+  });
+
+  it('resolves aircraft profile ids', () => {
+    expect(resolveTravelProfile('turboprop')).toBe(AIRCRAFT_PROFILES.turboprop);
+    expect(resolveTravelProfile('light-piston')).toBe(LIGHT_PISTON);
+  });
+
+  it('falls back to car for unknown/empty', () => {
+    expect(resolveTravelProfile(undefined)).toBe(CAR_PROFILE);
+    expect(resolveTravelProfile('')).toBe(CAR_PROFILE);
+    expect(resolveTravelProfile('teleport')).toBe(CAR_PROFILE);
+  });
+});
+
+describe('estimateTravelMinutes — surface modes', () => {
+  it('walking is much slower than driving for the same leg', () => {
+    const car = estimateTravelMinutes(SEA, DEN, CAR_PROFILE);
+    const walk = estimateTravelMinutes(SEA, DEN, WALKING_PROFILE);
+    expect(walk).toBeGreaterThan(car * 5);
+  });
+
+  it('car applies route factor + fixed overhead', () => {
+    const km = haversineKm(SEA, DEN);
+    const expected = (km * CAR_PROFILE.routeFactor) / CAR_PROFILE.averageKph * 60 +
+      CAR_PROFILE.fixedOverheadMinutes;
+    expect(estimateTravelMinutes(SEA, DEN, CAR_PROFILE)).toBeCloseTo(expected, 5);
+  });
+
+  it('walking has zero fixed overhead', () => {
+    const km = haversineKm(SEA, DEN);
+    const expected = (km * WALKING_PROFILE.routeFactor) / WALKING_PROFILE.averageKph * 60;
+    expect(estimateTravelMinutes(SEA, DEN, WALKING_PROFILE)).toBeCloseTo(expected, 5);
+  });
+});
+
+describe('estimateTravelMinutes — aircraft performance profile', () => {
+  it('includes taxi overhead even for a near-zero leg', () => {
+    const minutes = estimateTravelMinutes(SEA, SEA, AIRLINER);
+    expect(minutes).toBeCloseTo(AIRLINER.taxiOutMinutes + AIRLINER.taxiInMinutes, 5);
+  });
+
+  it('a short hop never reaches cruise → effective speed well below cruise', () => {
+    // ~1.1 km leg. Effective speed should be a tiny fraction of cruise
+    // because taxi dominates and only climb/descent speeds apply.
+    const eff = effectiveSpeedKph(SEA, NEAR_SEA, AIRLINER);
+    expect(eff).toBeGreaterThan(0);
+    expect(eff).toBeLessThan(AIRLINER.cruiseKph / 4);
+  });
+
+  it('a long haul approaches cruise speed', () => {
+    const far: LatLon = { lat: 47.45, lon: -10 }; // very long leg from SEA
+    const eff = effectiveSpeedKph(SEA, far, AIRLINER);
+    expect(eff).toBeGreaterThan(AIRLINER.cruiseKph * 0.7);
+    expect(eff).toBeLessThanOrEqual(AIRLINER.cruiseKph);
+  });
+
+  it('a jet is faster than a light piston over the same leg', () => {
+    const jet = estimateTravelMinutes(SEA, DEN, AIRLINER);
+    const piston = estimateTravelMinutes(SEA, DEN, LIGHT_PISTON);
+    expect(jet).toBeLessThan(piston);
+  });
+
+  it('all three modes order as walking > car > aircraft for a long leg', () => {
+    const walk = estimateTravelMinutes(SEA, DEN, WALKING_PROFILE);
+    const car = estimateTravelMinutes(SEA, DEN, CAR_PROFILE);
+    const air = estimateTravelMinutes(SEA, DEN, AIRLINER);
+    expect(walk).toBeGreaterThan(car);
+    expect(car).toBeGreaterThan(air);
+  });
+});
+
+describe('effectiveSpeedKph edge cases', () => {
+  it('returns 0 for a zero-distance leg', () => {
+    expect(effectiveSpeedKph(SEA, SEA, CAR_PROFILE)).toBe(0);
+  });
+});

--- a/src/core/travel/index.ts
+++ b/src/core/travel/index.ts
@@ -1,0 +1,8 @@
+/**
+ * Travel-mode "time to arrive" estimation for the resource scheduler.
+ *
+ * - `travelProfiles` — car / walking / aircraft profiles + the estimator.
+ * - `travelFeasibility` — the mode-aware sibling of `evaluateGeoConflicts`.
+ */
+export * from './travelProfiles';
+export * from './travelFeasibility';

--- a/src/core/travel/travelFeasibility.ts
+++ b/src/core/travel/travelFeasibility.ts
@@ -1,0 +1,182 @@
+/**
+ * Mode-aware travel feasibility — the multi-mode sibling of the engine's
+ * `evaluateGeoConflicts`.
+ *
+ * The engine's `geo-travel-feasibility` rule asks "given one max speed,
+ * is there enough of a gap to physically get between these two events?".
+ * This clones that exact shape and semantics (same coord resolution, same
+ * signed-gap math, same "overlap is resource-overlap territory, not ours"
+ * carve-out) but swaps the single `maxSpeedKph` for a full `TravelProfile`
+ * — so the resource scheduler can ask the same question per car, walking,
+ * or aircraft performance profile.
+ *
+ * Reuses the engine's `GeoEventInput` shape verbatim so a host already
+ * feeding `evaluateGeoConflicts` can point the same events at this with no
+ * translation layer.
+ */
+import { haversineKm, type GeoEventInput, type LatLon } from 'works-calendar-engine';
+import {
+  estimateTravelMinutes,
+  resolveTravelProfile,
+  type TravelMode,
+  type TravelProfile,
+} from './travelProfiles';
+
+export interface TravelFeasibilityRule {
+  readonly id: string;
+  readonly type: 'travel-feasibility';
+  /** The mode/profile this rule reasons about. */
+  readonly profile: TravelProfile;
+  /** Defaults to `'soft'`, matching `geo-travel-feasibility`. */
+  readonly severity?: 'soft' | 'hard';
+  /** Minimum gap to enforce regardless of distance (turnaround/handoff). */
+  readonly minGapMinutes?: number;
+  /** Skip the rule when the proposed event's category is in this list. */
+  readonly ignoreCategories?: readonly string[];
+}
+
+export interface TravelFeasibilityViolation {
+  readonly rule: string;
+  readonly severity: 'soft' | 'hard';
+  readonly message: string;
+  readonly conflictingEventId: string;
+  readonly details: {
+    readonly type: 'travel-feasibility';
+    readonly mode: TravelMode;
+    readonly profileLabel: string;
+    readonly distanceKm: number;
+    readonly requiredGapMinutes: number;
+    readonly actualGapMinutes: number;
+  };
+}
+
+/**
+ * Convenience: build a `TravelFeasibilityRule` from a loose mode string
+ * (e.g. `'car'`, `'turboprop'`). Mirrors the ergonomics of constructing a
+ * `geo-travel-feasibility` rule inline.
+ */
+export function travelFeasibilityRule(
+  id: string,
+  mode: string,
+  opts: Omit<TravelFeasibilityRule, 'id' | 'type' | 'profile'> = {},
+): TravelFeasibilityRule {
+  return { id, type: 'travel-feasibility', profile: resolveTravelProfile(mode), ...opts };
+}
+
+/**
+ * Evaluate travel feasibility for a proposed event against others on the
+ * same resource. Signature and return shape mirror `evaluateGeoConflicts`.
+ */
+export function evaluateTravelFeasibility(
+  rules: readonly TravelFeasibilityRule[],
+  proposed: GeoEventInput,
+  others: readonly GeoEventInput[],
+): readonly TravelFeasibilityViolation[] {
+  if (rules.length === 0) return [];
+  const proposedCoords = readCoords(proposed);
+  if (!proposedCoords) return [];
+
+  const violations: TravelFeasibilityViolation[] = [];
+  for (const rule of rules) {
+    if (
+      rule.ignoreCategories &&
+      proposed.category &&
+      rule.ignoreCategories.includes(proposed.category)
+    ) {
+      continue;
+    }
+    for (const other of others) {
+      if (other.id === proposed.id) continue;
+      if (other.resource == null || proposed.resource == null) continue;
+      if (other.resource !== proposed.resource) continue;
+      const v = evaluateOne(rule, proposed, proposedCoords, other);
+      if (v) violations.push(v);
+    }
+  }
+  return violations;
+}
+
+function evaluateOne(
+  rule: TravelFeasibilityRule,
+  proposed: GeoEventInput,
+  proposedCoords: LatLon,
+  other: GeoEventInput,
+): TravelFeasibilityViolation | null {
+  const otherCoords = readCoords(other);
+  if (!otherCoords) return null;
+
+  const travelMinutes = estimateTravelMinutes(proposedCoords, otherCoords, rule.profile);
+  const minGapMinutes = rule.minGapMinutes ?? 0;
+  const requiredGapMinutes = Math.max(travelMinutes, minGapMinutes);
+  if (!Number.isFinite(requiredGapMinutes) || requiredGapMinutes <= 0) return null;
+
+  const gapMinutes = signedGapMinutes(proposed, other);
+  if (gapMinutes === null) return null;
+  // Negative gap = events overlap in time; that's resource-overlap's job.
+  if (gapMinutes < 0) return null;
+  if (gapMinutes >= requiredGapMinutes) return null;
+
+  const distanceKm = haversineKm(proposedCoords, otherCoords);
+
+  return {
+    rule: rule.id,
+    severity: rule.severity ?? 'soft',
+    message:
+      `Travel infeasible by ${rule.profile.label.toLowerCase()}: ` +
+      `${distanceKm.toFixed(0)} km in ${gapMinutes.toFixed(0)} min ` +
+      `(needs ≥${requiredGapMinutes.toFixed(0)} min).`,
+    conflictingEventId: other.id,
+    details: {
+      type: 'travel-feasibility',
+      mode: rule.profile.mode,
+      profileLabel: rule.profile.label,
+      distanceKm,
+      requiredGapMinutes,
+      actualGapMinutes: gapMinutes,
+    },
+  };
+}
+
+// ─── Helpers (cloned from the engine's geo evaluator) ─────────────────────────
+
+function signedGapMinutes(a: GeoEventInput, b: GeoEventInput): number | null {
+  const aStart = toEpochMs(a.start);
+  const aEnd = toEpochMs(a.end);
+  const bStart = toEpochMs(b.start);
+  const bEnd = toEpochMs(b.end);
+  if (aStart === null || aEnd === null || bStart === null || bEnd === null) return null;
+  if (aEnd <= bStart) return (bStart - aEnd) / 60_000;
+  if (bEnd <= aStart) return (aStart - bEnd) / 60_000;
+  return -(Math.min(aEnd, bEnd) - Math.max(aStart, bStart)) / 60_000;
+}
+
+function toEpochMs(value: Date | string | number): number | null {
+  if (value instanceof Date) return Number.isFinite(value.getTime()) ? value.getTime() : null;
+  if (typeof value === 'number') return Number.isFinite(value) ? value : null;
+  const t = Date.parse(value);
+  return Number.isFinite(t) ? t : null;
+}
+
+function readCoords(ev: GeoEventInput): LatLon | null {
+  const meta = ev.meta;
+  if (!meta) return null;
+  const direct = meta['coords'];
+  if (direct && typeof direct === 'object') {
+    const c = direct as Record<string, unknown>;
+    const lat = c['lat'];
+    const lon = c['lon'] ?? c['lng'];
+    if (typeof lat === 'number' && typeof lon === 'number' && finitePair(lat, lon)) {
+      return { lat, lon };
+    }
+  }
+  const lat = meta['lat'];
+  const lon = meta['lon'] ?? meta['lng'];
+  if (typeof lat === 'number' && typeof lon === 'number' && finitePair(lat, lon)) {
+    return { lat, lon };
+  }
+  return null;
+}
+
+function finitePair(a: number, b: number): boolean {
+  return Number.isFinite(a) && Number.isFinite(b);
+}

--- a/src/core/travel/travelProfiles.ts
+++ b/src/core/travel/travelProfiles.ts
@@ -1,0 +1,259 @@
+/**
+ * Travel-mode "time to arrive" profiles.
+ *
+ * The engine ships a single-speed travel model (`geo-travel-feasibility`,
+ * see `Conflicts.md`): straight-line distance ÷ one `maxSpeedKph` → travel
+ * minutes. That's enough to flag "this jet can't be in two cities an hour
+ * apart", but it can't tell a dispatcher how long the *same* leg takes by
+ * car versus on foot versus in a Caravan, and it badly overestimates the
+ * speed of a short flight (where taxi, climb, and descent dominate and the
+ * aircraft never reaches cruise).
+ *
+ * This module clones that maps-style "time to arrive" math and grows it
+ * into three modes the resource scheduler actually dispatches with:
+ *
+ *   - `car`     — road travel: cruise speed + a route-winding factor +
+ *                 a fixed parking/access overhead.
+ *   - `walking` — same shape as car, slower, with a gentler path factor.
+ *   - `aircraft`— a phase-based performance profile (taxi → climb →
+ *                 cruise → descent → taxi). Short hops are split between
+ *                 climb and descent and never credit cruise speed, which
+ *                 is the whole reason a single `maxSpeedKph` is wrong for
+ *                 aviation.
+ *
+ * Pure functions, no React, no network — the same posture as the engine's
+ * geo helpers it builds on (`haversineKm`).
+ */
+import { haversineKm, type LatLon } from 'works-calendar-engine';
+
+export type TravelMode = 'car' | 'walking' | 'aircraft';
+
+/**
+ * Surface travel (car, walking). Distance is the great-circle distance
+ * scaled by `routeFactor` (real roads/paths are longer than a crow's
+ * flight), divided by `averageKph`, plus a flat overhead for things that
+ * don't scale with distance (parking, getting to the trailhead).
+ */
+export interface SurfaceTravelProfile {
+  readonly mode: 'car' | 'walking';
+  readonly label: string;
+  /** Sustained average speed in km/h. */
+  readonly averageKph: number;
+  /** Multiplier applied to straight-line distance to approximate the
+   *  real path. 1.0 = perfectly straight; ~1.3 is typical for roads. */
+  readonly routeFactor: number;
+  /** Flat minutes added regardless of distance (parking, access). */
+  readonly fixedOverheadMinutes: number;
+}
+
+/**
+ * Aircraft performance profile. Travel time is the sum of distinct flight
+ * phases rather than one cruise speed, so a 50 km hop and a 5000 km haul
+ * get realistically different effective speeds.
+ *
+ * The horizontal distance nominally spent climbing/descending is
+ * `climbDistanceKm` / `descentDistanceKm`. Anything left over is flown at
+ * `cruiseKph`. When the leg is shorter than climb + descent combined, the
+ * whole distance is split between the two phases in proportion to their
+ * nominal lengths and cruise is never reached.
+ */
+export interface AircraftPerformanceProfile {
+  readonly mode: 'aircraft';
+  readonly label: string;
+  readonly cruiseKph: number;
+  readonly climbKph: number;
+  readonly descentKph: number;
+  /** Horizontal distance covered while climbing to cruise altitude. */
+  readonly climbDistanceKm: number;
+  /** Horizontal distance covered while descending from cruise. */
+  readonly descentDistanceKm: number;
+  /** Taxi-out (gate → runway) minutes. */
+  readonly taxiOutMinutes: number;
+  /** Taxi-in (runway → gate) minutes. */
+  readonly taxiInMinutes: number;
+}
+
+export type TravelProfile = SurfaceTravelProfile | AircraftPerformanceProfile;
+
+// ─── Surface presets ────────────────────────────────────────────────────────
+
+export const CAR_PROFILE: SurfaceTravelProfile = {
+  mode: 'car',
+  label: 'Car',
+  averageKph: 90,
+  routeFactor: 1.3,
+  fixedOverheadMinutes: 5,
+};
+
+export const WALKING_PROFILE: SurfaceTravelProfile = {
+  mode: 'walking',
+  label: 'Walking',
+  averageKph: 5,
+  routeFactor: 1.2,
+  fixedOverheadMinutes: 0,
+};
+
+// ─── Aircraft presets ─────────────────────────────────────────────────────────
+//
+// Round, defensible numbers for common categories. Hosts with real
+// performance data should pass their own `AircraftPerformanceProfile`.
+
+export const LIGHT_PISTON: AircraftPerformanceProfile = {
+  mode: 'aircraft',
+  label: 'Light piston',
+  cruiseKph: 230,
+  climbKph: 150,
+  descentKph: 200,
+  climbDistanceKm: 15,
+  descentDistanceKm: 20,
+  taxiOutMinutes: 8,
+  taxiInMinutes: 5,
+};
+
+export const TURBOPROP: AircraftPerformanceProfile = {
+  mode: 'aircraft',
+  label: 'Turboprop',
+  cruiseKph: 550,
+  climbKph: 350,
+  descentKph: 450,
+  climbDistanceKm: 60,
+  descentDistanceKm: 80,
+  taxiOutMinutes: 10,
+  taxiInMinutes: 6,
+};
+
+export const BUSINESS_JET: AircraftPerformanceProfile = {
+  mode: 'aircraft',
+  label: 'Business jet',
+  cruiseKph: 800,
+  climbKph: 500,
+  descentKph: 650,
+  climbDistanceKm: 120,
+  descentDistanceKm: 150,
+  taxiOutMinutes: 12,
+  taxiInMinutes: 7,
+};
+
+export const AIRLINER: AircraftPerformanceProfile = {
+  mode: 'aircraft',
+  label: 'Airliner',
+  cruiseKph: 880,
+  climbKph: 550,
+  descentKph: 700,
+  climbDistanceKm: 200,
+  descentDistanceKm: 250,
+  taxiOutMinutes: 15,
+  taxiInMinutes: 8,
+};
+
+/** Built-in aircraft profiles, keyed by a stable id for host pickers. */
+export const AIRCRAFT_PROFILES = {
+  'light-piston': LIGHT_PISTON,
+  turboprop: TURBOPROP,
+  'business-jet': BUSINESS_JET,
+  airliner: AIRLINER,
+} as const;
+
+export type AircraftProfileId = keyof typeof AIRCRAFT_PROFILES;
+
+/** Default aircraft profile when a mode is `aircraft` but no profile is named. */
+export const DEFAULT_AIRCRAFT_PROFILE: AircraftPerformanceProfile = AIRLINER;
+
+/** Default profile for each mode, used when only a mode (no full profile) is known. */
+export const TRAVEL_PROFILE_BY_MODE: Readonly<Record<TravelMode, TravelProfile>> = {
+  car: CAR_PROFILE,
+  walking: WALKING_PROFILE,
+  aircraft: DEFAULT_AIRCRAFT_PROFILE,
+};
+
+/**
+ * Resolve a `TravelProfile` from a loose mode string (e.g. read off
+ * `event.meta.travelMode`). Unknown / missing values fall back to `car`,
+ * matching the most common dispatch default. An aircraft profile id
+ * (`'turboprop'`, `'airliner'`, …) also resolves here.
+ */
+export function resolveTravelProfile(
+  mode: string | null | undefined,
+): TravelProfile {
+  if (!mode) return CAR_PROFILE;
+  if (mode in AIRCRAFT_PROFILES) {
+    return AIRCRAFT_PROFILES[mode as AircraftProfileId];
+  }
+  if (mode === 'car' || mode === 'walking' || mode === 'aircraft') {
+    return TRAVEL_PROFILE_BY_MODE[mode];
+  }
+  return CAR_PROFILE;
+}
+
+// ─── Estimation ───────────────────────────────────────────────────────────────
+
+/** Minutes to cover `km` at `kph`. 0 km → 0; non-positive speed → Infinity. */
+function legMinutes(km: number, kph: number): number {
+  if (km <= 0) return 0;
+  if (kph <= 0) return Infinity;
+  return (km / kph) * 60;
+}
+
+function surfaceMinutes(greatCircleKm: number, p: SurfaceTravelProfile): number {
+  const pathKm = greatCircleKm * p.routeFactor;
+  return legMinutes(pathKm, p.averageKph) + p.fixedOverheadMinutes;
+}
+
+function aircraftMinutes(distanceKm: number, p: AircraftPerformanceProfile): number {
+  const taxi = p.taxiOutMinutes + p.taxiInMinutes;
+  const climbDescentKm = p.climbDistanceKm + p.descentDistanceKm;
+
+  // Short hop: the leg is shorter than the nominal climb + descent, so the
+  // aircraft never levels off at cruise. Split the distance between the two
+  // phases in proportion to their nominal lengths.
+  if (distanceKm <= climbDescentKm) {
+    const totalNominal = climbDescentKm > 0 ? climbDescentKm : 1;
+    const climbKm = distanceKm * (p.climbDistanceKm / totalNominal);
+    const descentKm = distanceKm * (p.descentDistanceKm / totalNominal);
+    return taxi + legMinutes(climbKm, p.climbKph) + legMinutes(descentKm, p.descentKph);
+  }
+
+  const cruiseKm = distanceKm - climbDescentKm;
+  return (
+    taxi +
+    legMinutes(p.climbDistanceKm, p.climbKph) +
+    legMinutes(cruiseKm, p.cruiseKph) +
+    legMinutes(p.descentDistanceKm, p.descentKph)
+  );
+}
+
+/**
+ * Estimate "time to arrive" in minutes between two coordinates for a
+ * given travel profile. Returns `Infinity` when the coordinates can't
+ * yield a finite distance (the caller should treat that as "unknown").
+ */
+export function estimateTravelMinutes(
+  from: LatLon,
+  to: LatLon,
+  profile: TravelProfile,
+): number {
+  const greatCircleKm = haversineKm(from, to);
+  if (!Number.isFinite(greatCircleKm)) return Infinity;
+  return profile.mode === 'aircraft'
+    ? aircraftMinutes(greatCircleKm, profile)
+    : surfaceMinutes(greatCircleKm, profile);
+}
+
+/**
+ * Effective door-to-door average speed (km/h) for a profile over a given
+ * straight-line distance. This is the bridge back to the engine's
+ * single-speed `geo-travel-feasibility` rule: feed the result as
+ * `maxSpeedKph` and the existing geo pipeline reproduces this profile's
+ * timing for that leg. Returns 0 when the leg is degenerate.
+ */
+export function effectiveSpeedKph(
+  from: LatLon,
+  to: LatLon,
+  profile: TravelProfile,
+): number {
+  const distanceKm = haversineKm(from, to);
+  if (!Number.isFinite(distanceKm) || distanceKm <= 0) return 0;
+  const minutes = estimateTravelMinutes(from, to, profile);
+  if (!Number.isFinite(minutes) || minutes <= 0) return 0;
+  return distanceKm / (minutes / 60);
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -245,7 +245,7 @@ export type {
   CalendarConfig, ConfigLabels, ConfigResourceType, ConfigRole,
   ConfigResource, ConfigRequirement, ConfigRequirementSlot,
   ConfigRequirementSeverity,
-  ConfigSeedEvent, ConfigSettings,
+  ConfigSeedEvent, ConfigSettings, ChromeSettings,
 } from './core/config/calendarConfig';
 export { validateConfig } from './core/config/validateConfig';
 export type {

--- a/src/index.ts
+++ b/src/index.ts
@@ -282,6 +282,33 @@ export type {
   GeoEventInput, GeoConflictViolation,
 } from 'works-calendar-engine';
 
+// ── Travel-mode "time to arrive" — car / walking / aircraft profiles ────────
+export {
+  estimateTravelMinutes,
+  effectiveSpeedKph,
+  resolveTravelProfile,
+  CAR_PROFILE,
+  WALKING_PROFILE,
+  LIGHT_PISTON,
+  TURBOPROP,
+  BUSINESS_JET,
+  AIRLINER,
+  AIRCRAFT_PROFILES,
+  DEFAULT_AIRCRAFT_PROFILE,
+  TRAVEL_PROFILE_BY_MODE,
+  evaluateTravelFeasibility,
+  travelFeasibilityRule,
+} from './core/travel';
+export type {
+  TravelMode,
+  TravelProfile,
+  SurfaceTravelProfile,
+  AircraftPerformanceProfile,
+  AircraftProfileId,
+  TravelFeasibilityRule,
+  TravelFeasibilityViolation,
+} from './core/travel';
+
 export { evaluateConflicts, CONFLICT_RULE_TYPES } from 'works-calendar-engine';
 export type {
   ConflictRule,

--- a/src/ui/CalendarToolbar.tsx
+++ b/src/ui/CalendarToolbar.tsx
@@ -68,6 +68,8 @@ export interface CalendarToolbarProps {
   hideEventTemplates?: boolean;
   eventTemplates?: EventTemplateV1[];
   showSearch?: boolean;
+  /** Render the view-switcher tabs in the toolbar. Defaults to `true`. */
+  showViewSwitcher?: boolean;
   showTimezonePicker?: boolean;
   displayTimezone?: string;
   onTimezoneChange?: (tz: string) => void;
@@ -102,6 +104,7 @@ export default function CalendarToolbar({
   VIEWS, setSidebarOpen, setSidebarInitialTab,
   schema, filterBarSchema, scopedEvents, locationLabel, assetsLabel, weekStartDay,
   showSearch,
+  showViewSwitcher = true,
   showTimezonePicker, displayTimezone, onTimezoneChange,
 }: CalendarToolbarProps) {
   // Voiding refs to unused props so TypeScript doesn't complain about the
@@ -132,11 +135,13 @@ export default function CalendarToolbar({
                 aria-hidden={!logoAlt ? 'true' : undefined}
               />
             )}
-            <ViewSwitcher
-              views={VIEWS}
-              currentView={cal.view}
-              onViewChange={(id) => cal.setView(id as typeof cal.view)}
-            />
+            {showViewSwitcher && (
+              <ViewSwitcher
+                views={VIEWS}
+                currentView={cal.view}
+                onViewChange={(id) => cal.setView(id as typeof cal.view)}
+              />
+            )}
           </div>
         }
         centerSlot={

--- a/src/ui/ConfigPanel.tsx
+++ b/src/ui/ConfigPanel.tsx
@@ -107,6 +107,7 @@ const SEARCH_INDEX: Array<{ label: string; keywords?: string; tabId: string }> =
   { label: 'Day view end hour',             tabId: 'display',    keywords: 'business hours range' },
   { label: 'Show week numbers',             tabId: 'display' },
   { label: 'Enlarge month row on hover',    tabId: 'display' },
+  { label: 'Panels & chrome',               tabId: 'display',    keywords: 'toolbar header left rail right panel view tabs hide show layout chrome' },
   { label: 'Filter group labels',           tabId: 'display',    keywords: 'rename categories people sources more' },
   { label: 'Location label (Base / Region)', tabId: 'team',      keywords: 'rename base station region' },
   { label: 'Asset label (Aircraft / Vehicle / Equipment)', tabId: 'team', keywords: 'rename asset aircraft vehicle equipment fleet' },
@@ -2110,6 +2111,12 @@ function DisplayTab({ config, onUpdate }: ConfigPanelSectionProps) {
     set('enabledViews', next);
   };
 
+  // Chrome (panels & bars) — every flag defaults to "shown" (true) when
+  // absent, so an untouched calendar keeps its full layout.
+  const chrome = (d.chrome ?? {}) as Record<string, unknown>;
+  const setChrome = (key: string, on: boolean) =>
+    set('chrome', { ...chrome, [key]: on });
+
   return (
     <div className={styles['section']}>
       <div className={styles['formRow']}>
@@ -2200,6 +2207,26 @@ function DisplayTab({ config, onUpdate }: ConfigPanelSectionProps) {
         />
         <span className={styles['toggleTrack']} />
       </label>
+
+      {/* ── Panels & chrome ── */}
+      <p className={styles['fieldGroupLabel']} style={{ marginTop: 12 }}>Panels &amp; chrome</p>
+      <p className={styles['sectionDesc']}>Turn off layout regions you don&apos;t need — handy when embedding the calendar inside a host that already provides its own toolbar or navigation. (The host app can also override these per-page via the <code>show*</code> props.)</p>
+      {[
+        { key: 'toolbar',      label: 'Top toolbar / header bar' },
+        { key: 'viewSwitcher', label: 'View tabs (Month / Week / Day …)' },
+        { key: 'leftRail',     label: 'Left icon rail' },
+        { key: 'rightPanel',   label: 'Right panel (map + crew on shift)' },
+      ].map(c => (
+        <label key={c.key} className={styles['toggle']}>
+          <span>{c.label}</span>
+          <input
+            type="checkbox"
+            checked={chrome[c.key] !== false}
+            onChange={e => setChrome(c.key, e.target.checked)}
+          />
+          <span className={styles['toggleTrack']} />
+        </label>
+      ))}
 
       <div className={styles['section']} style={{ paddingTop: 12 }}>
         <p className={styles['sectionDesc']}>Rename the grouped filter dropdown buttons shown to users.</p>

--- a/src/ui/wizard/ConfigWizard.tsx
+++ b/src/ui/wizard/ConfigWizard.tsx
@@ -718,6 +718,36 @@ function ReviewStep({
         </label>
       </fieldset>
 
+      <fieldset className={styles['fieldset']}>
+        <legend className={styles['legend']}>Layout &amp; chrome</legend>
+        <p className={styles['hint']}>
+          Choose which layout regions the calendar renders. Everything is on by
+          default; turn a region off to slim the calendar down (e.g. when the
+          host app supplies its own toolbar or navigation).
+        </p>
+        {([
+          { key: 'toolbar',      label: 'Top toolbar / header bar' },
+          { key: 'viewSwitcher', label: 'View tabs (Month / Week / Day …)' },
+          { key: 'leftRail',     label: 'Left icon rail' },
+          { key: 'rightPanel',   label: 'Right panel (map + crew on shift)' },
+        ] as const).map(c => {
+          const chrome = settings.chrome ?? {}
+          return (
+            <label key={c.key} className={styles['settingRow']}>
+              <span className={styles['settingLabel']}>{c.label}</span>
+              <input
+                type="checkbox"
+                checked={chrome[c.key] !== false}
+                onChange={(e: ChangeEvent<HTMLInputElement>) => setSettings({
+                  ...settings,
+                  chrome: { ...chrome, [c.key]: e.target.checked },
+                })}
+              />
+            </label>
+          )
+        })}
+      </fieldset>
+
       <fieldset className={styles['fieldset']} data-testid="wizard-validation">
         <legend className={styles['legend']}>
           Validation {validation.ok ? <span className={styles['okPill']}>OK</span> : <span className={styles['errPill']}>{validation.issues.length} issue{validation.issues.length === 1 ? '' : 's'}</span>}

--- a/src/ui/wizard/__tests__/ConfigWizard.test.tsx
+++ b/src/ui/wizard/__tests__/ConfigWizard.test.tsx
@@ -273,6 +273,23 @@ describe('ConfigWizard — Review step', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Finish' }))
     expect(onComplete).toHaveBeenCalledWith({ profile: 'scheduling' })
   })
+
+  it('Layout toggles write settings.chrome into the completed config', () => {
+    const onComplete = vi.fn()
+    render(<ConfigWizard
+      initialConfig={{ profile: 'custom' }}
+      onComplete={onComplete} onCancel={vi.fn()}
+    />)
+    fireEvent.click(screen.getByRole('button', { name: /5.+Review/ }))
+    // Chrome flags default to checked (shown); turn two off.
+    fireEvent.click(screen.getByRole('checkbox', { name: 'Left icon rail' }))
+    fireEvent.click(screen.getByRole('checkbox', { name: 'Right panel (map + crew on shift)' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Finish' }))
+    expect(onComplete).toHaveBeenCalledWith({
+      profile: 'custom',
+      settings: { chrome: { leftRail: false, rightPanel: false } },
+    })
+  })
 })
 
 describe('ConfigWizard — Finish gating (#460)', () => {

--- a/src/views/dispatch/TimeSlider.tsx
+++ b/src/views/dispatch/TimeSlider.tsx
@@ -233,10 +233,13 @@ export function TimeSlider({
                   const drive = fmtDuration(
                     upcoming.to.time.getTime() - upcoming.from.time.getTime(),
                   );
+                  const est = upcoming.estimate
+                    ? ` · est ${fmtDuration(upcoming.estimate.minutes * 60_000)} by ${upcoming.estimate.profileLabel.toLowerCase()}`
+                    : '';
                   return (
                     <>
                       <span className="font-bold text-[#3d2b1f]">Next </span>
-                      {upcoming.from.facilityCode} → {upcoming.to.facilityCode} · departs {fmtTime(upcoming.from.time)} (in <span className="font-bold">{until}</span>) · {drive} drive
+                      {upcoming.from.facilityCode} → {upcoming.to.facilityCode} · departs {fmtTime(upcoming.from.time)} (in <span className="font-bold">{until}</span>) · {drive} drive{est}
                     </>
                   );
                 }
@@ -355,12 +358,23 @@ export function TimeSlider({
                   const driverPart = selectedAssetData.driverName
                     ? `\nDriver: ${selectedAssetData.driverName}`
                     : '';
+                  const estPart = seg.estimate
+                    ? `\nEst: ${
+                        seg.estimate.minutes >= 60
+                          ? `${Math.floor(seg.estimate.minutes / 60)}h ${Math.round(
+                              seg.estimate.minutes % 60,
+                            )
+                              .toString()
+                              .padStart(2, '0')}m`
+                          : `${Math.round(seg.estimate.minutes)}m`
+                      } by ${seg.estimate.profileLabel.toLowerCase()}`
+                    : '';
                   return [
                     <button
                       key={i}
                       type="button"
                       onClick={() => onDateChange(new Date(seg.from.time))}
-                      title={`${seg.from.facilityCode} → ${seg.to.facilityCode}\n${fmt(seg.from.time)} – ${fmt(seg.to.time)} (${durLabel})${driverPart}`}
+                      title={`${seg.from.facilityCode} → ${seg.to.facilityCode}\n${fmt(seg.from.time)} – ${fmt(seg.to.time)} (${durLabel})${estPart}${driverPart}`}
                       className="absolute rounded-sm text-[10px] font-semibold text-white overflow-hidden whitespace-nowrap px-1.5 border border-black/15 hover:ring-2 hover:ring-[#3d2b1f] hover:z-10 focus:outline-none focus:ring-2 focus:ring-[#3d2b1f] focus:z-10"
                       style={{
                         left: `${leftPct}%`,

--- a/src/views/dispatch/deriveData.ts
+++ b/src/views/dispatch/deriveData.ts
@@ -13,11 +13,13 @@
  * for their domain (planes, crews, drones).
  */
 import type { NormalizedEvent } from 'works-calendar-engine';
+import { estimateTravelMinutes, resolveTravelProfile } from '../../core/travel';
 import type {
   DispatchAsset,
   DispatchFacility,
   DispatchSegment,
   DispatchStop,
+  TravelEstimate,
 } from './types';
 
 /** Stable color fallback when an asset doesn't supply meta.color. */
@@ -66,14 +68,49 @@ export interface DerivedDispatchData {
   readonly segmentsByAsset: ReadonlyMap<string, DispatchSegment[]>;
 }
 
+/**
+ * Resolve a leg's travel mode: the departing stop's `event.meta.travelMode`
+ * wins (per-leg override), otherwise the asset-level default supplied by the
+ * caller. Lets a mixed fleet (trucks + a courier plane) model each leg with
+ * the right profile.
+ */
+function legTravelMode(
+  from: DispatchStop,
+  assetModes: ReadonlyMap<string, string>,
+  defaultMode: string,
+): string {
+  const perEvent = from.event.meta?.['travelMode'];
+  if (typeof perEvent === 'string' && perEvent) return perEvent;
+  return assetModes.get(from.assetId) ?? defaultMode;
+}
+
+function computeEstimate(
+  from: DispatchStop,
+  to: DispatchStop,
+  mode: string,
+): TravelEstimate | undefined {
+  const profile = resolveTravelProfile(mode);
+  const minutes = estimateTravelMinutes(
+    { lat: from.lat, lon: from.lng },
+    { lat: to.lat, lon: to.lng },
+    profile,
+  );
+  if (!Number.isFinite(minutes)) return undefined;
+  return { mode: profile.mode, profileLabel: profile.label, minutes };
+}
+
 export function deriveDispatchData(
   events: readonly NormalizedEvent[],
   assets: readonly RawAssetEntry[] = [],
+  defaultTravelMode = 'car',
 ): DerivedDispatchData {
   // ── Assets ── union of declared assets and event.resource ids ──
   const assetIndex = new Map<string, DispatchAsset>();
+  const assetModes = new Map<string, string>();
   assets.forEach((a, i) => {
     const drv = a.meta?.['driverName'];
+    const mode = a.meta?.['travelMode'];
+    if (typeof mode === 'string' && mode) assetModes.set(a.id, mode);
     assetIndex.set(a.id, {
       id: a.id,
       name: a.label,
@@ -139,7 +176,8 @@ export function deriveDispatchData(
       const b = stops[i + 1]!;
       if (a.facilityCode === b.facilityCode) continue;
       if (a.kind !== 'departure') continue;
-      segs.push({ assetId, from: a, to: b });
+      const estimate = computeEstimate(a, b, legTravelMode(a, assetModes, defaultTravelMode));
+      segs.push({ assetId, from: a, to: b, ...(estimate ? { estimate } : {}) });
     }
     segmentsByAsset.set(assetId, segs);
   }

--- a/src/views/dispatch/types.ts
+++ b/src/views/dispatch/types.ts
@@ -9,6 +9,7 @@
  */
 
 import type { NormalizedEvent } from 'works-calendar-engine';
+import type { TravelMode } from '../../core/travel';
 
 // ── Layer projection ────────────────────────────────────────────────────────
 
@@ -58,11 +59,25 @@ export interface DispatchStop {
   readonly kind: 'departure' | 'arrival';
 }
 
+/**
+ * A modeled "time to arrive" for a leg, computed from the leg's distance
+ * and the asset's travel profile (car / walking / aircraft). Independent of
+ * the scheduled clock gap — comparing the two tells a dispatcher whether a
+ * leg is padded or physically infeasible.
+ */
+export interface TravelEstimate {
+  readonly mode: TravelMode;
+  readonly profileLabel: string;
+  readonly minutes: number;
+}
+
 /** One leg between two consecutive stops on the same asset. */
 export interface DispatchSegment {
   readonly assetId: string;
   readonly from: DispatchStop;
   readonly to: DispatchStop;
+  /** Modeled travel time for the leg; omitted when it can't be computed. */
+  readonly estimate?: TravelEstimate;
 }
 
 /** A pairwise conflict at a facility — produced by the engine, rendered here. */


### PR DESCRIPTION
Clone the engine's single-speed geo-travel-feasibility model into three
travel modes for the resource scheduler:

- car / walking: great-circle x route-factor / average-speed + overhead
- aircraft: phase-based performance profile (taxi -> climb -> cruise ->
  descent -> taxi), so short hops never credit cruise speed

Adds estimateTravelMinutes, effectiveSpeedKph, resolveTravelProfile,
profile presets, and evaluateTravelFeasibility (the mode-aware sibling of
evaluateGeoConflicts, same GeoEventInput shape and semantics).

The dispatch view annotates each leg with a modeled estimate (resolved
from event/asset meta.travelMode, default car) and surfaces it next to the
scheduled clock time and in leg tooltips.

Docs: docs/TravelModes.md, linked from Conflicts.md.

https://claude.ai/code/session_016K36JUkD6MaeYTtwqJMJ33